### PR TITLE
Upgrade Go version to 1.23 across repo

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.23'
           cache-dependency-path: homeautomation-go/go.sum
 
       - name: Download dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -525,6 +525,6 @@ A: MUST test with `-race` flag and run integration tests. Protect WebSocket writ
 ---
 
 **Last Updated**: 2025-11-15
-**Go Version**: 1.21
+**Go Version**: 1.23
 **Project Status**: MVP Complete, Integration Testing Added, Parallel Testing Phase
 

--- a/GOLANG_DESIGN.md
+++ b/GOLANG_DESIGN.md
@@ -934,7 +934,7 @@ client.CallService("media_player", "play_media", map[string]interface{}{
 
 **Dockerfile:**
 ```dockerfile
-FROM golang:1.21-alpine AS builder
+FROM golang:1.23-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
@@ -1214,7 +1214,7 @@ homeautomation/
 ```go.mod
 module homeautomation
 
-go 1.21
+go 1.23
 
 require (
     github.com/gorilla/websocket v1.5.0   // WebSocket client for HA

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -361,7 +361,7 @@ homeautomation-go/
 **File:** `README.md`
 
 - ✅ **4.6** Create comprehensive guide:
-  - Prerequisites (Go 1.21+)
+  - Prerequisites (Go 1.23+)
   - Setup instructions
   - Environment configuration
   - Running the demo

--- a/homeautomation-go/DOCKER.md
+++ b/homeautomation-go/DOCKER.md
@@ -49,7 +49,7 @@ docker run --rm -it \
 
 The Dockerfile uses a multi-stage build for optimal image size:
 
-1. **Builder stage**: Uses `golang:1.25.3-alpine` to compile the Go binary
+1. **Builder stage**: Uses `golang:1.23-alpine` to compile the Go binary
 2. **Runtime stage**: Uses minimal `alpine:latest` with only the compiled binary
 
 ### Image Size
@@ -295,7 +295,7 @@ The GitHub Actions workflow (`.github/workflows/docker-build-push.yml`) performs
 
 ```bash
 # Check Go version matches
-go version  # Should be 1.25.3
+go version  # Should be 1.23
 
 # Clean and rebuild
 make clean-go

--- a/homeautomation-go/Dockerfile
+++ b/homeautomation-go/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25.3-alpine AS builder
+FROM golang:1.23-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates

--- a/homeautomation-go/README.md
+++ b/homeautomation-go/README.md
@@ -44,7 +44,7 @@ The system manages 28 state variables across 3 types (27 synced with HA + 1 loca
 
 ## Prerequisites
 
-- Go 1.21 or higher
+- Go 1.23 or higher
 - Home Assistant instance with WebSocket API enabled
 - Long-lived access token from Home Assistant
 

--- a/homeautomation-go/go.mod
+++ b/homeautomation-go/go.mod
@@ -1,6 +1,6 @@
 module homeautomation
 
-go 1.21
+go 1.23
 
 require (
 	github.com/gorilla/websocket v1.5.0

--- a/homeautomation-go/test/integration/Dockerfile
+++ b/homeautomation-go/test/integration/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for integration tests
-FROM golang:1.21-alpine AS builder
+FROM golang:1.23-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Update Go version across all files to use Go 1.23:
- go.mod: Update Go version to 1.23
- Dockerfiles: Update base images to golang:1.23-alpine
- GitHub Actions: Update go-version to 1.23
- Documentation: Update all version references

All tests pass with Go 1.23 (unit and integration tests).