### PR TITLE
Reduce pre-commit log output verbosity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,28 +128,20 @@ clean-go:
 #pre-commit: @ Run all pre-commit checks (format, lint, build, tests)
 pre-commit:
 	@echo "🔍 Running pre-commit checks..."
-	@echo "📝 Step 1/6: Formatting code..."
+	@echo "📝 Step 1/4: Formatting code..."
 	cd homeautomation-go && gofmt -w .
 	@echo "✅ Code formatted"
 	@echo ""
-	@echo "🔎 Step 2/6: Running static analysis (go vet)..."
+	@echo "🔎 Step 2/4: Running static analysis (go vet)..."
 	cd homeautomation-go && go vet ./...
 	@echo "✅ Static analysis passed"
 	@echo ""
-	@echo "🔨 Step 3/6: Building all packages..."
+	@echo "🔨 Step 3/4: Building all packages..."
 	cd homeautomation-go && go build ./...
 	@echo "✅ Build successful"
 	@echo ""
-	@echo "🧪 Step 4/6: Running all tests..."
-	cd homeautomation-go && go test ./...
-	@echo "✅ All tests passed"
-	@echo ""
-	@echo "🏁 Step 5/6: Running tests with race detector..."
+	@echo "🧪 Step 4/4: Running all tests with race detector..."
 	cd homeautomation-go && go test -race ./...
-	@echo "✅ Race detector tests passed"
-	@echo ""
-	@echo "🔬 Step 6/6: Running integration tests explicitly..."
-	cd homeautomation-go && go test -v -race ./test/integration/...
-	@echo "✅ Integration tests passed"
+	@echo "✅ All tests passed (including integration tests)"
 	@echo ""
 	@echo "🎉 All pre-commit checks passed! Ready to commit."


### PR DESCRIPTION
The pre-commit target was running tests three times:
1. go test ./... (all tests)
2. go test -race ./... (all tests with race detector)
3. go test -v -race ./test/integration/... (integration tests again)

This caused:
- Excessive execution time (~90-120s vs ~55s now)
- Tremendous log output from verbose flag
- Integration tests ran 3 times total

Changes:
- Consolidated to single test run with race detection
- Removed verbose flag to reduce log spam
- Simplified from 6 steps to 4 steps
- Tests still run with -race flag (most comprehensive)
- All tests (unit + integration) still execute once

Result: ~40% faster execution, cleaner output, no duplication