### PR TITLE
Investigate missing CI tests in pull request

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -2,9 +2,19 @@ name: PR Tests
 
 on:
   pull_request:
-    branches: [ '*' ]
+    branches:
+      - main
+      - master
+      - '**'
   push:
-    branches: [ '*' ]
+    branches:
+      - main
+      - master
+      - 'claude/**'
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   go-tests:


### PR DESCRIPTION
Problem: PR #15 did not run CI tests despite PR #12 adding the pr-tests.yml workflow.

Root cause: The workflow used `branches: [ '*' ]` syntax which may not work correctly for pull_request triggers in GitHub Actions.

Changes:
- Replace `branches: [ '*' ]` with explicit branch list:
  - main, master (primary branches)
  - '**' (wildcard for all other branches)
- Limit push triggers to main/master and claude/* branches
- Add explicit permissions block (contents: read, pull-requests: read)

This ensures the workflow runs reliably on all PRs targeting any branch.

Fixes: Missing CI test runs on PRs
Related: PR #12 (added workflow), PR #15 (missing tests)