### PR TITLE
fix: Escape dots in tab IDs for CSS selectors in screenshot capture

### DIFF
--- a/.automated-rendering/screenshot-capture/tests/capture-screenshots-of-all-tabs.ts
+++ b/.automated-rendering/screenshot-capture/tests/capture-screenshots-of-all-tabs.ts
@@ -71,7 +71,8 @@ test('Capture screenshot of the entire scrollable webpage', async ({page}) => {
         // Log that we're working this tab ID and flow name
         console.log(`Working tab ${this_tab_id}, ${this_flow_name}`)
         // Select the tab by clicking its tab element by id
-        await page.click(`#${this_tab_id}`)
+        // Escape dots in the tab ID for CSS selector (dots are interpreted as class selectors)
+        await page.click(`#${this_tab_id.replace(/\./g, '\\.')}`)
         // Wait for the chart to show up
         await expect(page.locator('#red-ui-workspace-chart')).toBeVisible({timeout: 1000})
         // There's this little thingy that I want to fade away before we screenshot, but don't want to go find the id for

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@ This document provides guidance for AI agents and developers working on this hom
 
 This repository contains a home automation system that is migrating from Node-RED to Golang for improved type safety, testability, and maintainability.
 
+To see the current NodeRed behaviors look in:
+* flows.json
+* ./automated-rendering/screenshot-capture/screenshots after running `make generate-screenshots`
+
 ### Repository Structure
 
 ```


### PR DESCRIPTION
## Summary
- Fixed `make generate-screenshots` command that was failing on tabs with dots in their IDs
- Tab ID `red-ui-tab-7cf51b2b-7d36.456b.a850.94a24ee0d39a` was causing CSS parsing error
- Added regex replacement to escape dots in CSS selectors: `.replace(/\./g, '\\.')`
- Updated AGENTS.md to document screenshot location

## Test plan
- [x] Ran `make generate-screenshots` - all 16 screenshots generated successfully
- [x] Verified screenshots include the previously failing tab (null.png)
- [x] All Playwright tests pass (1/1 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)