### PR TITLE
Fix environment variables in container deployment

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: ./homeautomation-go
+          context: .
           file: ./homeautomation-go/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/homeautomation-go/.env.example
+++ b/homeautomation-go/.env.example
@@ -1,3 +1,7 @@
 HA_URL=wss://home-assistant.nickborgers.net/api/websocket
 HA_TOKEN=your_token_here
 READ_ONLY=false
+
+# Optional: Override config directory path
+# Default: Auto-detects ./configs (container) or ../configs (local dev)
+# CONFIG_DIR=./configs

--- a/homeautomation-go/Dockerfile
+++ b/homeautomation-go/Dockerfile
@@ -7,11 +7,11 @@ RUN apk add --no-cache git ca-certificates
 WORKDIR /build
 
 # Copy go mod files and download dependencies
-COPY go.mod go.sum ./
+COPY homeautomation-go/go.mod homeautomation-go/go.sum ./
 RUN go mod download
 
 # Copy source code
-COPY . .
+COPY homeautomation-go/ .
 
 # Build the application
 # CGO_ENABLED=0 for static binary (better for Alpine)
@@ -37,6 +37,9 @@ COPY --from=builder /build/homeautomation .
 
 # Copy example env file for reference
 COPY --from=builder /build/.env.example .
+
+# Copy config files from repository root
+COPY configs ./configs
 
 # Change ownership
 RUN chown -R homeautomation:homeautomation /app


### PR DESCRIPTION
The application was crashing in Docker with "no such file or directory" when trying to load energy_config.yaml. This was caused by two issues:

1. Config files were not copied into the Docker image
2. Hardcoded relative path "../configs/" didn't work in containerized environment

Changes:
- Updated Docker build context from ./homeautomation-go to repository root
- Modified Dockerfile to copy configs directory from repo root
- Added smart config path detection in cmd/main.go:
  * Uses CONFIG_DIR env var if set
  * Auto-detects ./configs (container) or ../configs (local dev)
  * Logs the detected path for debugging
- Updated .env.example to document CONFIG_DIR variable
- Updated docker-build-push.yml workflow to use new build context

The fix maintains backward compatibility with local development while properly supporting containerized deployments.

Resolves the "Failed to start Energy State Manager" crash on container startup.