### PR TITLE
Evaluate test triggers for PRs and pushes

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -8,9 +8,7 @@ on:
       - '**'
   push:
     branches:
-      - main
-      - master
-      - 'claude/**'
+      - 'claude/**'  # Only test development branches; main/master tested in docker-build-push.yml
 
 permissions:
   contents: read


### PR DESCRIPTION
Eliminates duplicate test execution when merging PRs:
- pr-tests.yml now only runs on PRs and claude/** branches
- docker-build-push.yml handles testing on main/master pushes
- Saves ~60-80 seconds and GitHub Actions minutes per merge

Before: Tests ran twice (pr-tests.yml + docker-build-push.yml)
After: Tests run once per workflow trigger

Defense in depth maintained: docker-build-push.yml still validates before deployment, catching any issues if branch protection bypassed.