### PR TITLE
Decouple music tests

### DIFF
--- a/homeautomation-go/cmd/main.go
+++ b/homeautomation-go/cmd/main.go
@@ -275,7 +275,7 @@ func startMusicManager(client ha.HAClient, stateManager *state.Manager, logger *
 		zap.Int("music_modes", len(musicConfig.Music)))
 
 	// Create and start music manager
-	musicManager := music.NewManager(client, stateManager, musicConfig, logger, readOnly)
+	musicManager := music.NewManager(client, stateManager, musicConfig, logger, readOnly, nil)
 	if err := musicManager.Start(); err != nil {
 		return fmt.Errorf("failed to start music manager: %w", err)
 	}

--- a/homeautomation-go/internal/plugins/music/manager_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_test.go
@@ -134,8 +134,13 @@ func TestMusicManager_SelectAppropriateMusicMode(t *testing.T) {
 				},
 			}
 
+			// Use a fixed time provider with a Monday (not Sunday) for testing
+			// This ensures tests are independent of what day they run on
+			fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC) // Monday, January 6, 2025
+			timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+
 			// Create manager
-			manager := NewManager(mockHA, stateMgr, config, logger, true)
+			manager := NewManager(mockHA, stateMgr, config, logger, true, timeProvider)
 
 			// Set up initial state
 			if err := stateMgr.SetBool("isAnyoneHome", tt.isAnyoneHome); err != nil {
@@ -173,7 +178,12 @@ func TestMusicManager_DetermineMusicModeFromDayPhase(t *testing.T) {
 	logger := zap.NewNop()
 	stateMgr := state.NewManager(mockHA, logger, false)
 	config := &MusicConfig{}
-	manager := NewManager(mockHA, stateMgr, config, logger, true)
+
+	// Use a fixed time provider with a Monday (not Sunday) for testing
+	fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC) // Monday, January 6, 2025
+	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+
+	manager := NewManager(mockHA, stateMgr, config, logger, true, timeProvider)
 
 	tests := []struct {
 		dayPhase          string
@@ -192,11 +202,6 @@ func TestMusicManager_DetermineMusicModeFromDayPhase(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.dayPhase+"_"+tt.currentMusicType, func(t *testing.T) {
-			// Skip Sunday test for morning (handled separately)
-			if tt.dayPhase == "morning" && time.Now().Weekday() == time.Sunday {
-				t.Skip("Skipping morning test on Sunday")
-			}
-
 			result := manager.determineMusicModeFromDayPhase(tt.dayPhase, tt.currentMusicType)
 			if result != tt.expectedMusicMode {
 				t.Errorf("For dayPhase=%s, currentMusicType=%s: expected %s, got %s",
@@ -223,7 +228,11 @@ func TestMusicManager_StateChangeHandling(t *testing.T) {
 		},
 	}
 
-	manager := NewManager(mockHA, stateMgr, config, logger, true)
+	// Use a fixed time provider with a Monday (not Sunday) for testing
+	fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC) // Monday, January 6, 2025
+	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+
+	manager := NewManager(mockHA, stateMgr, config, logger, true, timeProvider)
 
 	// Set initial state
 	if err := stateMgr.SetBool("isAnyoneHome", true); err != nil {


### PR DESCRIPTION
Add TimeProvider interface to allow tests to inject fixed time values, making tests independent of the day they run on.

Changes:
- Add TimeProvider interface and implementations (RealTimeProvider, FixedTimeProvider)
- Update Manager struct to use TimeProvider instead of time.Now()
- Update NewManager to accept TimeProvider parameter (defaults to RealTimeProvider)
- Update all test call sites to use FixedTimeProvider with Monday date
- Remove t.Skip() workaround for Sunday morning test failures

This fixes the TestMusicManager_SelectAppropriateMusicMode/Morning_-_morning_mode test failure that occurred when tests ran on Sundays.

All tests now pass regardless of current day.