### PR TITLE
fix: Implement PR review findings for Lighting and Music plugins

### DIFF
--- a/homeautomation-go/internal/plugins/lighting/manager_test.go
+++ b/homeautomation-go/internal/plugins/lighting/manager_test.go
@@ -264,10 +264,10 @@ func TestActivateScene(t *testing.T) {
 	assert.Equal(t, 1, len(calls))
 
 	call := calls[0]
-	assert.Equal(t, "hue", call.Domain)
-	assert.Equal(t, "hue_activate_scene", call.Service)
-	assert.Equal(t, "Living Room", call.Data["group_name"])
-	assert.Equal(t, "Morning", call.Data["scene_name"])
+	assert.Equal(t, "scene", call.Domain)
+	assert.Equal(t, "turn_on", call.Service)
+	assert.Equal(t, "scene.living_room_morning", call.Data["entity_id"])
+	assert.Equal(t, "living_room_2", call.Data["area_id"])
 	assert.Equal(t, 30, call.Data["transition"])
 }
 
@@ -330,7 +330,11 @@ func TestEvaluateAndActivateRoom(t *testing.T) {
 		{
 			name: "Room should turn off",
 			setupState: func() {
+				// Set OFF condition to true
 				_ = stateManager.SetBool("isEveryoneAsleep", true)
+				// Make sure ON conditions are false
+				_ = stateManager.SetBool("isAnyoneHome", false)
+				_ = stateManager.SetBool("isTVPlaying", true) // OnIfFalse should be false
 			},
 			roomIndex:         0,
 			dayPhase:          "Night",
@@ -346,8 +350,8 @@ func TestEvaluateAndActivateRoom(t *testing.T) {
 			},
 			roomIndex:         0,
 			dayPhase:          "Morning",
-			expectedService:   "hue_activate_scene",
-			expectedDomain:    "hue",
+			expectedService:   "turn_on",
+			expectedDomain:    "scene",
 			shouldCallService: true,
 		},
 	}
@@ -359,7 +363,7 @@ func TestEvaluateAndActivateRoom(t *testing.T) {
 
 			tt.setupState()
 			room := &config.Rooms[tt.roomIndex]
-			manager.evaluateAndActivateRoom(room, tt.dayPhase)
+			manager.evaluateAndActivateRoom(room, tt.dayPhase, "")
 
 			calls := mockClient.GetServiceCalls()
 			if tt.shouldCallService {

--- a/homeautomation-go/internal/plugins/music/manager_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_test.go
@@ -41,13 +41,13 @@ func TestMusicManager_SelectAppropriateMusicMode(t *testing.T) {
 			description:       "Sleep mode has highest priority",
 		},
 		{
-			name:              "Morning - morning mode",
+			name:              "Morning - day mode (no wake-up event)",
 			isAnyoneHome:      true,
 			isAnyoneAsleep:    false,
 			dayPhase:          "morning",
 			currentMusicType:  "",
-			expectedMusicType: "morning",
-			description:       "Morning phase triggers morning music",
+			expectedMusicType: "day",
+			description:       "Morning phase without wake-up event triggers day music",
 		},
 		{
 			name:              "Day - day mode",
@@ -190,7 +190,7 @@ func TestMusicManager_DetermineMusicModeFromDayPhase(t *testing.T) {
 		currentMusicType  string
 		expectedMusicMode string
 	}{
-		{"morning", "", "morning"},
+		{"morning", "", "day"},         // Morning without wake-up event = day music
 		{"day", "", "day"},
 		{"sunset", "", "evening"},
 		{"dusk", "", "evening"},
@@ -202,7 +202,7 @@ func TestMusicManager_DetermineMusicModeFromDayPhase(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.dayPhase+"_"+tt.currentMusicType, func(t *testing.T) {
-			result := manager.determineMusicModeFromDayPhase(tt.dayPhase, tt.currentMusicType)
+			result := manager.determineMusicModeFromDayPhase(tt.dayPhase, tt.currentMusicType, "", false)
 			if result != tt.expectedMusicMode {
 				t.Errorf("For dayPhase=%s, currentMusicType=%s: expected %s, got %s",
 					tt.dayPhase, tt.currentMusicType, tt.expectedMusicMode, result)


### PR DESCRIPTION
## Summary

This PR addresses all critical and medium priority issues identified in PR_REVIEW_FINDINGS.md to ensure the Go implementation accurately matches Node-RED behavior.

## Critical Issues Fixed ❌ → ✅

### 1. Lighting Control ON/OFF Precedence (PR #29)
**Severity:** CRITICAL  
**Impact:** Lights would turn OFF when they should turn ON (opposite behavior)

- **Issue**: OFF condition took precedence over ON condition
- **Fix**: Reversed order - ON now takes precedence over OFF (matches Node-RED)
- **Location**: `homeautomation-go/internal/plugins/lighting/manager.go:237-248`

### 2. Lighting Control Service Calls (PR #29)
**Severity:** HIGH  
**Impact:** Different Home Assistant service API - may not activate scenes correctly

- **Issue**: Used `hue.hue_activate_scene` service instead of `scene.turn_on`
- **Fix**: Now uses `scene.turn_on` with constructed entity IDs (e.g., `scene.primary_suite_evening`)
- **Implementation**: Added `toSnakeCase()` helper function to match Node-RED's entity construction
- **Location**: `homeautomation-go/internal/plugins/lighting/manager.go:356-424`

## Medium Priority Issues Fixed ⚠️ → ✅

### 3. Music Plugin Morning Music Trigger Logic (PR #30)
**Severity:** MEDIUM  
**Impact:** Morning music plays on ANY state change during morning phase, not just wake-up events

- **Issue**: Morning music played during entire morning phase
- **Fix**: Morning music ONLY plays on wake-up events (isAnyoneAsleep: true → false)
- **Implementation**: 
  - Added wake-up event detection in `handleStateChange()`
  - Created `selectAppropriateMusicModeWithContext()` with trigger tracking
  - Falls back to "day" music during morning phase when not a wake-up event
- **Location**: `homeautomation-go/internal/plugins/music/manager.go:110-202`

### 4. Lighting Control Topic Relevance Check (PR #29)
**Severity:** MEDIUM  
**Impact:** Inefficient - re-evaluates ALL rooms on EVERY state change

- **Issue**: No filtering based on which variable changed
- **Fix**: Added `isTopicRelevant()` to check if trigger variable affects each room
- **Behavior**: Only evaluates rooms where the changed variable appears in conditions
- **Special cases**: dayPhase and sunevent changes always affect all rooms (like "reset" in Node-RED)
- **Location**: `homeautomation-go/internal/plugins/lighting/manager.go:261-283`

## Minor Issues Fixed ⚠️ → ✅

### 5. Dynamic Parameter for Nook Room (PR #29)
**Severity:** LOW  
**Impact**: Nook room may behave differently due to missing parameter

- **Issue**: Missing `dynamic: false` parameter for Nook room
- **Fix**: Added check to set `dynamic: false` for Nook room in service calls
- **Location**: `homeautomation-go/internal/plugins/lighting/manager.go:405-407`

## Test Updates

- ✅ Updated lighting tests to expect `scene.turn_on` service calls instead of `hue.hue_activate_scene`
- ✅ Updated music tests to expect "day" music during morning phase without wake-up events
- ✅ Fixed test scenario to ensure only OFF conditions are true when testing turn_off behavior
- ✅ All tests passing: 11/11 integration tests + all unit tests
- ✅ No race conditions detected

## Testing

```bash
# All tests pass
go test ./...  # ✅ All passed

# No race conditions
go test -race ./...  # ✅ Clean

# Integration tests
go test ./test/integration/...  # ✅ 11/11 passing
```

## Files Changed

- `homeautomation-go/internal/plugins/lighting/manager.go` - All lighting fixes
- `homeautomation-go/internal/plugins/lighting/manager_test.go` - Updated test expectations
- `homeautomation-go/internal/plugins/music/manager.go` - Morning music logic fix
- `homeautomation-go/internal/plugins/music/manager_test.go` - Updated test expectations

## Verification

The implementation now matches Node-RED behavior for:
- ✅ ON/OFF precedence (ON wins when both conditions are true)
- ✅ Scene activation service calls (uses `scene.turn_on` with proper entity IDs)
- ✅ Morning music triggering (only on wake-up events, not entire morning phase)
- ✅ Room evaluation efficiency (only evaluates relevant rooms)
- ✅ Special parameters (dynamic: false for Nook room)

## Next Steps

After this PR is merged, the Go implementation will be ready for parallel testing with Node-RED to verify end-to-end behavior matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)