### PR TITLE
Energy Manager does not support local timezone specification

### DIFF
--- a/homeautomation-go/.env.example
+++ b/homeautomation-go/.env.example
@@ -5,3 +5,9 @@ READ_ONLY=false
 # Optional: Override config directory path
 # Default: Auto-detects ./configs (container) or ../configs (local dev)
 # CONFIG_DIR=./configs
+
+# Optional: Timezone for time-based automations (e.g., free energy windows)
+# Default: UTC
+# Examples: America/New_York, America/Chicago, America/Los_Angeles, Europe/London
+# See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+# TIMEZONE=America/New_York

--- a/homeautomation-go/README.md
+++ b/homeautomation-go/README.md
@@ -83,6 +83,7 @@ The system manages 28 state variables across 3 types (27 synced with HA + 1 loca
    HA_URL=wss://your-homeassistant/api/websocket
    HA_TOKEN=your_long_lived_access_token
    READ_ONLY=true
+   TIMEZONE=America/New_York
    ```
 
    **Configuration Options:**
@@ -93,6 +94,11 @@ The system manages 28 state variables across 3 types (27 synced with HA + 1 loca
    - `READ_ONLY`: Set to `true` for read-only mode (recommended for parallel testing)
      - `true`: Only reads and monitors state, makes NO changes to Home Assistant
      - `false`: Can read and write state changes
+   - `TIMEZONE` (Optional): Timezone for time-based automations (e.g., free energy windows)
+     - Default: `UTC`
+     - Examples: `America/New_York`, `America/Chicago`, `America/Los_Angeles`, `Europe/London`
+     - See [IANA Time Zone Database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for all valid values
+     - This ensures automations trigger at the correct local time, not UTC
 
    **Read-Only Mode** is perfect for:
    - Running alongside your existing Node-RED setup


### PR DESCRIPTION
The energy manager was using UTC timezone for free energy window calculations, causing automations to trigger at incorrect times for users in non-UTC timezones.

Changes:
- Add TIMEZONE environment variable configuration (.env.example)
- Load timezone in main.go with default to UTC if not specified
- Update energy.Manager to accept and store timezone
- Modify isFreeEnergyTime to use configured timezone instead of system timezone
- Update all NewManager calls in tests to include timezone parameter
- Add comprehensive timezone handling tests
- Document TIMEZONE configuration in README.md

This ensures free energy windows and other time-based automations respect the user's local timezone rather than defaulting to UTC.

Fixes issue where free energy availability was being set at wrong times.