### PR TITLE
Add test coverage check to pre-commit hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,11 +125,24 @@ clean-go:
 	rm -f homeautomation-go/homeautomation
 	rm -f homeautomation-go/coverage.out
 
+#check-coverage: @ Check that test coverage meets minimum requirement (≥70%)
+check-coverage:
+	@echo "📊 Checking test coverage..."
+	@cd homeautomation-go && \
+	  go test ./... -coverprofile=coverage.out -covermode=atomic > /dev/null 2>&1 && \
+	  coverage=$$(go tool cover -func=coverage.out | grep total | awk '{print $$3}' | sed 's/%//') && \
+	  echo "Total coverage: $${coverage}%" && \
+	  if [ "$$(echo "$$coverage < 70" | bc -l)" = "1" ]; then \
+	    echo "❌ ERROR: Test coverage $${coverage}% is below required 70%"; \
+	    exit 1; \
+	  fi && \
+	  echo "✅ Test coverage $${coverage}% meets requirement"
+
 #pre-commit: @ Run all pre-commit checks (style, format, lint, build, tests)
 pre-commit:
 	@echo "🔍 Running pre-commit checks..."
 	@echo ""
-	@echo "📝 Step 1/7: Checking gofmt formatting..."
+	@echo "📝 Step 1/8: Checking gofmt formatting..."
 	@cd homeautomation-go && \
 	  unformatted=$$(gofmt -l .) && \
 	  if [ -n "$$unformatted" ]; then \
@@ -141,7 +154,7 @@ pre-commit:
 	  fi
 	@echo "✅ gofmt formatting check passed"
 	@echo ""
-	@echo "📦 Step 2/7: Checking goimports formatting..."
+	@echo "📦 Step 2/8: Checking goimports formatting..."
 	@cd homeautomation-go && \
 	  if ! command -v goimports >/dev/null 2>&1; then \
 	    echo "⚠️  goimports not installed. Installing..."; \
@@ -158,11 +171,11 @@ pre-commit:
 	  fi
 	@echo "✅ goimports formatting check passed"
 	@echo ""
-	@echo "🔎 Step 3/7: Running go vet static analysis..."
+	@echo "🔎 Step 3/8: Running go vet static analysis..."
 	@cd homeautomation-go && go vet ./...
 	@echo "✅ go vet passed"
 	@echo ""
-	@echo "🔬 Step 4/7: Running staticcheck linting..."
+	@echo "🔬 Step 4/8: Running staticcheck linting..."
 	@cd homeautomation-go && \
 	  if ! command -v staticcheck >/dev/null 2>&1; then \
 	    echo "⚠️  staticcheck not installed. Installing..."; \
@@ -172,17 +185,28 @@ pre-commit:
 	  $$STATICCHECK ./...
 	@echo "✅ staticcheck passed"
 	@echo ""
-	@echo "🔨 Step 5/7: Building all packages..."
+	@echo "🔨 Step 5/8: Building all packages..."
 	@cd homeautomation-go && go build ./...
 	@echo "✅ Build successful"
 	@echo ""
-	@echo "🧪 Step 6/7: Running all tests..."
+	@echo "🧪 Step 6/8: Running all tests..."
 	@cd homeautomation-go && go test ./...
 	@echo "✅ All tests passed"
 	@echo ""
-	@echo "🏁 Step 7/7: Running tests with race detector..."
+	@echo "🏁 Step 7/8: Running tests with race detector..."
 	@cd homeautomation-go && go test -race ./...
 	@echo "✅ Race detector passed (including integration tests)"
+	@echo ""
+	@echo "📊 Step 8/8: Checking test coverage (≥70%)..."
+	@cd homeautomation-go && \
+	  go test ./... -coverprofile=coverage.out -covermode=atomic > /dev/null 2>&1 && \
+	  coverage=$$(go tool cover -func=coverage.out | grep total | awk '{print $$3}' | sed 's/%//') && \
+	  echo "Total coverage: $${coverage}%" && \
+	  if [ "$$(echo "$$coverage < 70" | bc -l)" = "1" ]; then \
+	    echo "❌ ERROR: Test coverage $${coverage}% is below required 70%"; \
+	    exit 1; \
+	  fi && \
+	  echo "✅ Test coverage $${coverage}% meets requirement"
 	@echo ""
 	@echo "════════════════════════════════════════════════════════════════════"
 	@echo "🎉 All pre-commit checks passed! Your code is ready to commit."


### PR DESCRIPTION
Convert the CI pipeline coverage check (≥70%) to a make command and add it to the pre-commit checks.

Changes:
- Add new `make check-coverage` target that checks test coverage ≥70%
- Add coverage check as step 8/8 in `make pre-commit`
- Update step numbering from 7 to 8 steps
- Create .git/hooks/pre-commit that runs `make pre-commit`

The pre-commit hook now enforces the same coverage requirement as CI, preventing commits with insufficient test coverage.