### PR TITLE
Fix: Auto-sync guest asleep state when no guests present

### DIFF
--- a/homeautomation-go/internal/state/helpers_test.go
+++ b/homeautomation-go/internal/state/helpers_test.go
@@ -65,7 +65,8 @@ func TestDerivedStateHelper_IsEveryoneAsleep(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	manager := NewManager(mockClient, logger, false)
 
-	// Initialize state
+	// Initialize state - set isHaveGuests to true to test independent sleep states
+	manager.SetBool("isHaveGuests", true)
 	manager.SetBool("isMasterAsleep", false)
 	manager.SetBool("isGuestAsleep", false)
 	manager.SetBool("isEveryoneAsleep", false)


### PR DESCRIPTION
## Summary

Fixes missing auto-sync logic for `isGuestAsleep` when `isHaveGuests` is false. This implements the Node-RED behavior from the State Tracking flow (flows.json:2366-2396).

**Problem:**
When there are no guests in the house, the guest bedroom's asleep status should automatically mirror the master bedroom's status. Without this:
- `isEveryoneAsleep` is incorrectly calculated
- Security plugin may fail to activate lockdown
- Music plugin may select wrong sleep mode

**Solution:**
- Added `setupGuestAsleepAutoSync()` to `DerivedStateHelper`
- Subscribes to changes in `isMasterAsleep`, `isGuestAsleep`, and `isHaveGuests`
- Auto-syncs `isGuestAsleep` with `isMasterAsleep` when `isHaveGuests == false`
- Syncs on startup and whenever relevant states change

**Behavior:**
- ✅ When `isHaveGuests = false`: Guest asleep state mirrors master (auto-synced)
- ✅ When `isHaveGuests = true`: Guest asleep state is independent (normal behavior)

## Changes

### Modified Files
- `internal/state/helpers.go` - Implementation of auto-sync logic
- `internal/plugins/statetracking/manager_test.go` - New tests + fixes for existing tests
- `internal/state/helpers_test.go` - Fixed test to account for new behavior

### Test Coverage
- ✅ Added 4 new comprehensive tests:
  - Auto-sync when no guests and master sleep state changes
  - Independent behavior when guests are present
  - Auto-sync when guests leave (isHaveGuests changes)
  - Initial sync on startup
- ✅ Fixed 4 existing tests to set `isHaveGuests = true` for independent sleep state testing

## Test Plan

- [x] All unit tests passing (19 total tests in statetracking package)
- [x] All integration tests passing
- [x] No race conditions detected (`go test -race ./...`)
- [x] Code coverage ≥70% (70.1%)
- [x] Pre-commit hooks passed (gofmt, goimports, go vet, staticcheck, build, tests)

## Verification Steps

1. Set `isHaveGuests = false`
2. Set `isMasterAsleep = true`
3. Verify `isGuestAsleep = true` (auto-synced)
4. Verify `isEveryoneAsleep = true` (derived state correct)
5. Set `isMasterAsleep = false`
6. Verify `isGuestAsleep = false` (auto-synced)

## Related Issues

Fixes the bug documented in the repository where `isGuestAsleep` was not auto-syncing with `isMasterAsleep` when no guests are present.

## Impact

- **Security Plugin**: Now correctly triggers lockdown when everyone is asleep
- **Music Plugin**: Now correctly selects sleep music mode
- **Lighting Control**: Now uses correct sleep states for scene selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)