### PR TITLE
Add missing isAnyoneHomeAndAwake state variable

### DIFF
--- a/homeautomation-go/internal/state/variables.go
+++ b/homeautomation-go/internal/state/variables.go
@@ -20,14 +20,15 @@ type StateVariable struct {
 	LocalOnly bool        // If true, only exists in memory, not synced with HA
 }
 
-// AllVariables contains all 30 state variables (28 synced with HA + 2 local-only)
+// AllVariables contains all 31 state variables (29 synced with HA + 2 local-only)
 var AllVariables = []StateVariable{
-	// Booleans (18)
+	// Booleans (19)
 	{Key: "isNickHome", EntityID: "input_boolean.nick_home", Type: TypeBool, Default: false},
 	{Key: "isCarolineHome", EntityID: "input_boolean.caroline_home", Type: TypeBool, Default: false},
 	{Key: "isToriHere", EntityID: "input_boolean.tori_here", Type: TypeBool, Default: false},
 	{Key: "isAnyOwnerHome", EntityID: "input_boolean.any_owner_home", Type: TypeBool, Default: false},
 	{Key: "isAnyoneHome", EntityID: "input_boolean.anyone_home", Type: TypeBool, Default: false},
+	{Key: "isAnyoneHomeAndAwake", EntityID: "input_boolean.anyone_home_and_awake", Type: TypeBool, Default: false},
 	{Key: "isMasterAsleep", EntityID: "input_boolean.master_asleep", Type: TypeBool, Default: false},
 	{Key: "isGuestAsleep", EntityID: "input_boolean.guest_asleep", Type: TypeBool, Default: false},
 	{Key: "isAnyoneAsleep", EntityID: "input_boolean.anyone_asleep", Type: TypeBool, Default: false},


### PR DESCRIPTION
## Summary

- Added the missing `isAnyoneHomeAndAwake` boolean state variable to the Go implementation
- This variable exists in Node-RED (flows.json) but was missing from `homeautomation-go/internal/state/variables.go`
- Fixes lighting condition evaluation errors: `"variable isAnyoneHomeAndAwake not found"`

## Changes

- **Added variable**: `isAnyoneHomeAndAwake` mapped to `input_boolean.anyone_home_and_awake`
- **Updated counts**: 30→31 total variables, 18→19 boolean variables, 28→29 synced variables
- **File modified**: `homeautomation-go/internal/state/variables.go`

## Context

The lighting manager (`hue_config.yaml`) references this variable in multiple rules:
- `on_if_true: isAnyoneHomeAndAwake` (lines 5, 21)
- `off_if_false: isAnyoneHomeAndAwake` (lines 60, 68)

Without this variable, lighting conditions fail to evaluate, causing runtime errors.

## Test Plan

- [x] All unit tests pass (`go test ./...`)
- [x] Race detector passes (`go test -race ./...`)
- [x] Integration tests pass
- [x] Pre-commit hook passed (formatting, linting, build)
- [x] Variable matches Node-RED implementation (flows.json:1416)

## References

- Node-RED implementation: flows.json line 1416
- Config usage: configs/hue_config.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)