### PR TITLE
Resolve issue #63 from home automation

### DIFF
--- a/homeautomation-go/internal/state/manager.go
+++ b/homeautomation-go/internal/state/manager.go
@@ -258,7 +258,9 @@ func (m *Manager) ensureWritable(variable StateVariable) error {
 	if variable.ReadOnly {
 		return fmt.Errorf("variable %s is read-only", variable.Key)
 	}
-	if m.readOnly && !variable.LocalOnly {
+	// Allow writes to computed outputs even in read-only mode
+	// These are values calculated by the Go code that need to be published to HA
+	if m.readOnly && !variable.LocalOnly && !variable.ComputedOutput {
 		return ErrReadOnlyMode
 	}
 	return nil

--- a/homeautomation-go/internal/state/variables.go
+++ b/homeautomation-go/internal/state/variables.go
@@ -12,12 +12,13 @@ const (
 
 // StateVariable defines metadata for a state variable
 type StateVariable struct {
-	Key       string      // Go variable name (e.g., "isNickHome")
-	EntityID  string      // HA entity ID (e.g., "input_boolean.nick_home")
-	Type      StateType   // bool, string, number, json
-	Default   interface{} // Default value
-	ReadOnly  bool        // Whether it's read-only from HA
-	LocalOnly bool        // If true, only exists in memory, not synced with HA
+	Key            string      // Go variable name (e.g., "isNickHome")
+	EntityID       string      // HA entity ID (e.g., "input_boolean.nick_home")
+	Type           StateType   // bool, string, number, json
+	Default        interface{} // Default value
+	ReadOnly       bool        // Whether it's read-only from HA
+	LocalOnly      bool        // If true, only exists in memory, not synced with HA
+	ComputedOutput bool        // If true, can be written even in read-only mode (for computed values)
 }
 
 // AllVariables contains all 31 state variables (29 synced with HA + 2 local-only)
@@ -54,9 +55,9 @@ var AllVariables = []StateVariable{
 	{Key: "sunevent", EntityID: "input_text.sun_event", Type: TypeString, Default: ""},
 	{Key: "musicPlaybackType", EntityID: "input_text.music_playback_type", Type: TypeString, Default: ""},
 	{Key: "currentlyPlayingMusicUri", EntityID: "input_text.currently_playing_music_uri", Type: TypeString, Default: ""},
-	{Key: "batteryEnergyLevel", EntityID: "input_text.battery_energy_level", Type: TypeString, Default: ""},
-	{Key: "currentEnergyLevel", EntityID: "input_text.current_energy_level", Type: TypeString, Default: ""},
-	{Key: "solarProductionEnergyLevel", EntityID: "input_text.solar_production_energy_level", Type: TypeString, Default: ""},
+	{Key: "batteryEnergyLevel", EntityID: "input_text.battery_energy_level", Type: TypeString, Default: "", ComputedOutput: true},
+	{Key: "currentEnergyLevel", EntityID: "input_text.current_energy_level", Type: TypeString, Default: "", ComputedOutput: true},
+	{Key: "solarProductionEnergyLevel", EntityID: "input_text.solar_production_energy_level", Type: TypeString, Default: "", ComputedOutput: true},
 
 	// Local-only variables (not synced with HA)
 	{Key: "didOwnerJustReturnHome", EntityID: "", Type: TypeBool, Default: false, LocalOnly: true},


### PR DESCRIPTION
Resolves #63

## Problem
The Energy Manager correctly calculated energy state values but failed to publish them to Home Assistant in read-only mode. This broke integration with dependent systems (Node-RED, dashboards, etc).

## Root Cause
- System runs in READ_ONLY mode for parallel testing alongside Node-RED
- State manager's `ensureWritable()` blocked ALL writes to HA-synced variables in read-only mode
- Energy levels (batteryEnergyLevel, solarProductionEnergyLevel, currentEnergyLevel) are COMPUTED OUTPUTS that need to be published to HA, not input values read from HA

## Solution
Added `ComputedOutput` flag to StateVariable struct:
- When true, allows writes even in read-only mode
- Applied to all three energy level variables
- Updated `ensureWritable()` to skip read-only check for computed outputs

## Changes
- internal/state/variables.go: Added ComputedOutput field, marked energy variables
- internal/state/manager.go: Updated ensureWritable() logic
- internal/state/manager_test.go: Added comprehensive tests for read-only mode behavior

## Testing
- All existing tests pass
- New tests verify:
  - Regular variables blocked in read-only mode (expected)
  - Computed outputs writable in read-only mode (NEW)
  - Local-only variables still work
  - All HA service calls made for computed outputs
- No race conditions detected