### PR TITLE
Fix Sleep Hygiene behavior - correct light flashing and add wake cancellation

### DIFF
--- a/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
@@ -211,10 +211,10 @@ func TestWake_AllConditionsMet(t *testing.T) {
 
 	// Should have:
 	// - 2 calls for master bedroom lights (initial + transition)
-	// - 2 calls for common area lights flash
 	// - 1 call for TTS cuddle announcement
-	if len(calls) < 5 {
-		t.Errorf("Expected at least 5 service calls, got %d", len(calls))
+	// Note: Flash lights removed from wake sequence (moved to bedtime triggers)
+	if len(calls) < 3 {
+		t.Errorf("Expected at least 3 service calls, got %d", len(calls))
 	}
 
 	// Check that light service was called for master bedroom


### PR DESCRIPTION
## Summary
Fixes #69

This PR addresses two critical logic errors in the Sleep Hygiene implementation identified in issue #69:

### 1. Removed Light Flashing from Wake Sequence ❌➡️✅
**Problem:** Light flashing was incorrectly triggered during the wake-up phase, which would be jarring for someone waking up.

**Solution:**
- Removed `flashCommonAreaLights()` call from `handleWake()`
- Light flashing now only occurs during bedtime reminders:
  - `stop_screens` trigger (reminder to stop using screens)
  - `go_to_bed` trigger (reminder to go to bed)
- Updated `handleGoToBed()` to implement light flashing with proper conditions

### 2. Added Wake Cancellation Logic ✅
**Problem:** Bathroom light control was missing, and there was no way to handle manual wake cancellation.

**Solution:** Implemented bedroom light monitoring to detect when users manually cancel the wake sequence:
- Added `turnOffBathroomLights()` function to turn off `light.primary_bathroom_main_lights`
- Added `handleBedroomLightsOff()` to check if wake cancellation should occur
- Added `handleBedroomLightsChange()` callback for HA state changes
- Subscribed to `light.primary_suite` state changes in Home Assistant
- When bedroom lights turn off during wake sequence (`musicPlaybackType == "wakeup"`):
  - Music playback reverts to "sleep" mode
  - Bathroom lights are turned off

## Technical Changes

### New Functions
- `turnOffBathroomLights()` - Turns off primary bathroom lights
- `handleBedroomLightsOff(state string)` - Checks if wake should be cancelled based on bedroom light state
- `handleBedroomLightsChange(entityID string, oldState, newState *ha.State)` - Callback for HA bedroom light state changes

### Modified Functions
- `handleWake()` - Removed `flashCommonAreaLights()` call
- `handleGoToBed()` - Added light flashing functionality with proper conditions
- `Start()` - Added subscription to bedroom lights state changes
- `Stop()` - Added cleanup for HA subscriptions

### New Fields
- `haSubscriptions []ha.Subscription` - Tracks HA-specific subscriptions separately from state subscriptions

## Test Updates
- Updated `TestWake_AllConditionsMet` to expect 3 service calls instead of 5 (removed flash lights)
- All 39 sleep hygiene tests passing ✅
- All integration tests passing with race detector ✅

## Test plan
- [x] All unit tests pass
- [x] All integration tests pass with race detector
- [x] Code formatted with gofmt
- [x] Pre-commit hooks pass
- [ ] Manual testing in production environment (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)