### PR TITLE
Fix: Remove clock-based noon cutoff from day phase calculation

### DIFF
--- a/homeautomation-go/internal/dayphase/calculator.go
+++ b/homeautomation-go/internal/dayphase/calculator.go
@@ -135,10 +135,6 @@ func (c *Calculator) CalculateDayPhase(schedule *config.ParsedSchedule) DayPhase
 
 	switch sunEvent {
 	case SunEventMorning:
-		// Stay in morning until noon, then switch to day
-		if now.Hour() >= 12 {
-			return DayPhaseDay
-		}
 		return DayPhaseMorning
 
 	case SunEventDay:

--- a/homeautomation-go/internal/dayphase/calculator_test.go
+++ b/homeautomation-go/internal/dayphase/calculator_test.go
@@ -237,7 +237,6 @@ func TestCalculator_CalculateDayPhaseAllCases(t *testing.T) {
 			name: "morning period",
 			setupSunTimes: func(c *Calculator) {
 				// Set sun times so current time falls in morning sun event
-				// Note: If current hour >= 12, it will transition to day
 				c.dawn = now.Add(-2 * time.Hour)
 				c.sunrise = now.Add(-1 * time.Hour)
 				c.sunriseEnd = now.Add(1 * time.Hour) // Still in morning sun event
@@ -247,13 +246,7 @@ func TestCalculator_CalculateDayPhaseAllCases(t *testing.T) {
 				c.lastUpdate = now
 			},
 			schedule: schedule,
-			// If running after noon, morning sun event becomes day phase
-			expected: func() DayPhase {
-				if now.Hour() >= 12 {
-					return DayPhaseDay
-				}
-				return DayPhaseMorning
-			}(),
+			expected: DayPhaseMorning,
 		},
 		{
 			name: "day phase",
@@ -379,8 +372,7 @@ func TestCalculator_CalculateDayPhaseEdgeCases(t *testing.T) {
 
 	now := time.Now()
 
-	// Test morning sun event transitioning to day after noon
-	// We need to set up the test to run when hour >= 12
+	// Test day sun event - sun has already risen (sunriseEnd in past)
 	calc.dawn = now.Add(-8 * time.Hour)
 	calc.sunrise = now.Add(-7 * time.Hour)
 	calc.sunriseEnd = now.Add(-6 * time.Hour)
@@ -389,9 +381,8 @@ func TestCalculator_CalculateDayPhaseEdgeCases(t *testing.T) {
 	calc.dusk = now.Add(8 * time.Hour)
 	calc.lastUpdate = now
 
-	// If current hour >= 12 and sun is still up, it should be day
+	// Since sun times show we're in "day" period (after sunriseEnd), it should be day
 	phase := calc.CalculateDayPhase(nil)
-	// Since sun times show we're in "day" period, this should be DayPhaseDay
 	assert.Equal(t, DayPhaseDay, phase)
 }
 


### PR DESCRIPTION
## Summary

- Remove clock-based noon cutoff from day phase calculation
- Make day phase purely solar-based (follows sun event timing)
- Fix inconsistency where day phase could be "day" while sun event was still "morning"

## Problem

Previously, the day phase calculator had a special case that would transition from "morning" to "day" at 12:00 noon regardless of the sun event timing:

```go
case SunEventMorning:
    if now.Hour() >= 12 {
        return DayPhaseDay  // Clock-based override
    }
    return DayPhaseMorning
```

This caused observable inconsistencies in the logs where:
- `13:21:18` - Day phase changed to "day" (clock-based noon cutoff)
- `13:36:18` - Sun event changed to "day" (solar-based sunriseEnd)

The 15-minute gap was confusing and timezone-dependent.

## Solution

Removed the clock-based cutoff entirely. Now day phase transitions to "day" only when sun event naturally transitions to "day" (at sunriseEnd, 30 minutes after sunrise).

```go
case SunEventMorning:
    return DayPhaseMorning
```

## Changes

**Code:**
- `internal/dayphase/calculator.go:137-138` - Removed noon cutoff logic

**Tests:**
- `internal/dayphase/calculator_test.go` - Updated test expectations and comments
  - Simplified "morning period" test to always expect `DayPhaseMorning`
  - Updated edge case test comments for clarity

## Benefits

✅ **Consistent** - Day phase now always matches sun event timing  
✅ **Timezone-agnostic** - No clock-time dependencies  
✅ **Predictable** - Purely solar-based transitions  
✅ **Maintainable** - Simpler logic, fewer edge cases  

## Test Results

All tests passing:
- ✅ 11/11 dayphase tests pass
- ✅ No race conditions detected (`-race` flag)
- ✅ All 16 test packages pass (including integration tests)
- ✅ Total coverage: 71.2% (meets ≥70% requirement)

## Test plan

- [x] All unit tests pass
- [x] Integration tests pass
- [x] Race detector clean
- [x] Code coverage ≥70%
- [x] Pre-push hook validation passed
- [ ] Manual verification: Monitor logs after deployment to confirm day phase transitions match sun event timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)