### PR TITLE
Add 6 missing state variables for lighting and security

### DIFF
--- a/docs/migration/migration_mapping.md
+++ b/docs/migration/migration_mapping.md
@@ -4,11 +4,11 @@ This document maps Node Red global state variables to their Home Assistant entit
 
 ## Migration Summary
 
-- **Total Node Red state variables**: 58
+- **Total Node Red state variables**: 64
 - **Variables in disabled flows (SKIP)**: 25
-- **Active variables to migrate**: 33
+- **Active variables to migrate**: 39
 - **Already exist in Home Assistant**: 10
-- **Need to create**: 23
+- **Need to create**: 29
 
 ---
 
@@ -31,7 +31,7 @@ These entities already exist in Home Assistant and will be synchronized with Nod
 
 ---
 
-## 🆕 NEED TO CREATE - Boolean Variables (13)
+## 🆕 NEED TO CREATE - Boolean Variables (19)
 
 | Node Red Variable | Home Assistant Entity | Description | Action |
 |------------------|----------------------|-------------|--------|
@@ -48,6 +48,12 @@ These entities already exist in Home Assistant and will be synchronized with Nod
 | isMasterAsleep | input_boolean.master_asleep | Master bedroom sleep status | Create & sync |
 | isTVPlaying | input_boolean.tv_playing | TV playback status | Create & sync |
 | isTVon | input_boolean.tv_on | TV power status | Create & sync |
+| isNickOfficeOccupied | input_boolean.nick_office_occupied | Nick's office occupancy sensor | Create & sync |
+| isKitchenOccupied | input_boolean.kitchen_occupied | Kitchen occupancy sensor | Create & sync |
+| isPrimaryBedroomDoorOpen | input_boolean.primary_bedroom_door_open | Primary bedroom door state | Create & sync |
+| isNickNearHome | input_boolean.nick_near_home | Nick proximity geofence trigger | Create & sync |
+| isCarolineNearHome | input_boolean.caroline_near_home | Caroline proximity geofence trigger | Create & sync |
+| isLockdown | input_boolean.lockdown | Security lockdown momentary trigger | Create & sync |
 
 ---
 
@@ -113,6 +119,40 @@ These variables are only referenced in disabled Node Red flows and will NOT be m
 
 ---
 
+## ⚠️ Special Variable Behaviors
+
+### isLockdown - Momentary Security Trigger
+
+**Behavior**: Acts as a momentary "pulse" trigger for security actions
+
+- **Trigger**: Automatically activated when `isEveryoneAsleep` becomes `true`
+- **Auto-Reset**: Stays `true` for **5 seconds**, then automatically resets to `false`
+- **Purpose**: Triggers security measures (garage door close, door locks, etc.) when everyone goes to sleep
+- **Implementation**: Node-RED uses a 5-second delay before auto-resetting
+- **Flow**: Security flow (`7097dab4eb91af0f`)
+
+### isNickNearHome / isCarolineNearHome - Proximity Geofence
+
+**Behavior**: Geofence triggers that activate home presence
+
+- **Trigger**: Set by Home Assistant proximity/geofence sensors
+- **Effect**: When `true`, these variables set `isNickHome` / `isCarolineHome` to `true`
+- **Important**: Automations (announcements, lights, music) trigger on `isHome`, **NOT** `isNearHome`
+- **Purpose**: Provides advance warning before someone arrives home, allowing preparation time
+- **Implementation**: `isNearHome` is input-only, `isHome` is the computed output used by automations
+- **Flow**: State Tracking flow (`d7a3510d.e93d98`)
+
+### Room Occupancy Sensors
+
+**Behavior**: Direct sensor inputs for room presence
+
+- **isNickOfficeOccupied**: Used by lighting plugin to control N Office lights (2-second transition)
+- **isKitchenOccupied**: Used by lighting plugin to control Kitchen lights (5-second transition)
+- **Purpose**: Enable instant lighting control based on room occupancy
+- **Configuration**: See `configs/hue_config.yaml` for room-specific lighting rules
+
+---
+
 ## Implementation Notes
 
 ### Entity Creation
@@ -122,6 +162,6 @@ These variables are only referenced in disabled Node Red flows and will NOT be m
 - input_text: Text entities for strings and JSON-serialized objects
 
 ### Synchronization Strategy
-1. **On Node Red startup**: Read all 33 variables from Home Assistant → initialize Node Red state
+1. **On Node Red startup**: Read all 39 variables from Home Assistant → initialize Node Red state
 2. **On Node Red variable change**: Write value to corresponding Home Assistant entity
 3. **During migration**: Both systems share state via Home Assistant entities

--- a/homeautomation-go/internal/state/variables.go
+++ b/homeautomation-go/internal/state/variables.go
@@ -21,9 +21,9 @@ type StateVariable struct {
 	ComputedOutput bool        // If true, can be written even in read-only mode (for computed values)
 }
 
-// AllVariables contains all 31 state variables (29 synced with HA + 2 local-only)
+// AllVariables contains all 37 state variables (35 synced with HA + 2 local-only)
 var AllVariables = []StateVariable{
-	// Booleans (19)
+	// Booleans (25)
 	{Key: "isNickHome", EntityID: "input_boolean.nick_home", Type: TypeBool, Default: false},
 	{Key: "isCarolineHome", EntityID: "input_boolean.caroline_home", Type: TypeBool, Default: false},
 	{Key: "isToriHere", EntityID: "input_boolean.tori_here", Type: TypeBool, Default: false},
@@ -43,6 +43,12 @@ var AllVariables = []StateVariable{
 	{Key: "isFreeEnergyAvailable", EntityID: "input_boolean.free_energy_available", Type: TypeBool, Default: false},
 	{Key: "isGridAvailable", EntityID: "input_boolean.grid_available", Type: TypeBool, Default: true},
 	{Key: "isExpectingSomeone", EntityID: "input_boolean.expecting_someone", Type: TypeBool, Default: false},
+	{Key: "isNickOfficeOccupied", EntityID: "input_boolean.nick_office_occupied", Type: TypeBool, Default: false},
+	{Key: "isKitchenOccupied", EntityID: "input_boolean.kitchen_occupied", Type: TypeBool, Default: false},
+	{Key: "isPrimaryBedroomDoorOpen", EntityID: "input_boolean.primary_bedroom_door_open", Type: TypeBool, Default: false},
+	{Key: "isNickNearHome", EntityID: "input_boolean.nick_near_home", Type: TypeBool, Default: false},
+	{Key: "isCarolineNearHome", EntityID: "input_boolean.caroline_near_home", Type: TypeBool, Default: false},
+	{Key: "isLockdown", EntityID: "input_boolean.lockdown", Type: TypeBool, Default: false},
 	{Key: "reset", EntityID: "input_boolean.reset", Type: TypeBool, Default: false},
 
 	// Numbers (3)


### PR DESCRIPTION
## Summary

Adds 6 state variables that were being used by plugins but not defined in the Go implementation. These variables exist in Home Assistant and Node-RED but were missed during the initial migration mapping.

## Variables Added

### Room Occupancy Sensors
- **isNickOfficeOccupied** → `input_boolean.nick_office_occupied`
  - Used by lighting plugin to control N Office lights (2-second transition)
- **isKitchenOccupied** → `input_boolean.kitchen_occupied`
  - Used by lighting plugin to control Kitchen lights (5-second transition)

### Presence & Proximity
- **isPrimaryBedroomDoorOpen** → `input_boolean.primary_bedroom_door_open`
  - Already subscribed to by state tracking plugin for wake detection
- **isNickNearHome** → `input_boolean.nick_near_home`
  - Proximity geofence trigger (not yet implemented in Go)
- **isCarolineNearHome** → `input_boolean.caroline_near_home`
  - Proximity geofence trigger (not yet implemented in Go)

### Security
- **isLockdown** → `input_boolean.lockdown`
  - Momentary security trigger (logic already fully implemented)
  - Auto-activates when everyone asleep or no one home
  - Auto-resets after 5 seconds

## Problem Solved

The lighting plugin was throwing errors:
```
Failed to evaluate condition: variable isNickOfficeOccupied not found
Failed to evaluate condition: variable isKitchenOccupied not found
```

These variables were referenced in `configs/hue_config.yaml` but not defined in `internal/state/variables.go`.

## Changes Made

### `homeautomation-go/internal/state/variables.go`
- Added 6 boolean variables (19 → 25 booleans)
- Updated total variable count (31 → 37 variables)

### `docs/migration/migration_mapping.md`
- Updated migration summary (33 → 39 active variables)
- Added special behavior documentation for:
  - **isLockdown**: Momentary 5-second pulse trigger
  - **isNickNearHome/isCarolineNearHome**: Geofence behavior (announcements on `isHome`, not `isNearHome`)
  - **Room occupancy sensors**: Usage in lighting configurations

## Implementation Status

| Variable | Logic Status | Notes |
|----------|--------------|-------|
| isLockdown | ✅ Fully implemented | Security plugin has complete auto-activate + auto-reset logic |
| isNickOfficeOccupied | ✅ Already in use | Lighting config references it |
| isKitchenOccupied | ✅ Already in use | Lighting config references it |
| isPrimaryBedroomDoorOpen | ✅ Already in use | State tracking subscribes to it |
| isNickNearHome | ⚠️ Variable only | Near home → home transition not yet implemented |
| isCarolineNearHome | ⚠️ Variable only | Near home → home transition not yet implemented |

## Test Results

```
✅ All 16 test suites pass
✅ Integration tests pass (117.353s)
✅ No race conditions detected
✅ Pre-commit and pre-push hooks pass
```

## Next Steps

1. Create these entities in Home Assistant (if they don't exist):
   - `input_boolean.nick_office_occupied`
   - `input_boolean.kitchen_occupied`
   - `input_boolean.primary_bedroom_door_open`
   - `input_boolean.nick_near_home`
   - `input_boolean.caroline_near_home`
   - `input_boolean.lockdown`

2. Restart the Go application to use the new variables

3. Lighting plugin errors will be resolved

4. (Future) Implement near home → home transition logic if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)