### PR TITLE
fix: Change missing .env log from warn to info

### DIFF
--- a/homeautomation-go/cmd/main.go
+++ b/homeautomation-go/cmd/main.go
@@ -36,9 +36,9 @@ func main() {
 	}
 	defer logger.Sync()
 
-	// Load environment variables
+	// Load environment variables from .env file if present
 	if err := godotenv.Load(); err != nil {
-		logger.Warn("No .env file found, using environment variables")
+		logger.Info("No .env file found, using environment variables")
 	}
 
 	haURL := os.Getenv("HA_URL")


### PR DESCRIPTION
## Summary
- Changes the log level from `Warn` to `Info` when no `.env` file is found
- Not having a `.env` file is a valid deployment pattern (Docker, Kubernetes, systemd all set environment variables directly)
- Updated comment to clarify `.env` file is optional

## Test plan
- [x] Pre-push validation passed
- [ ] Verify log output shows `"level":"info"` instead of `"level":"warn"` when running without a `.env` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)