### PR TITLE
fix: Initialize computed state to fix isAnyoneHomeAndAwake bug

### DIFF
--- a/homeautomation-go/cmd/main.go
+++ b/homeautomation-go/cmd/main.go
@@ -133,6 +133,11 @@ func main() {
 		logger.Fatal("Failed to sync state from HA", zap.Error(err))
 	}
 
+	// Setup computed state variables
+	if err := stateManager.SetupComputedState(); err != nil {
+		logger.Fatal("Failed to setup computed state", zap.Error(err))
+	}
+
 	// Start HTTP API server
 	apiServer := api.NewServer(stateManager, logger, httpPort)
 	if err := apiServer.Start(); err != nil {
@@ -249,7 +254,7 @@ func displayState(manager *state.Manager, logger *zap.Logger) {
 	logger.Info("--- Boolean Variables ---")
 	boolVars := []string{
 		"isNickHome", "isCarolineHome", "isToriHere",
-		"isAnyOwnerHome", "isAnyoneHome",
+		"isAnyOwnerHome", "isAnyoneHome", "isAnyoneHomeAndAwake",
 		"isMasterAsleep", "isGuestAsleep", "isAnyoneAsleep", "isEveryoneAsleep",
 		"isGuestBedroomDoorOpen", "isHaveGuests",
 		"isAppleTVPlaying", "isTVPlaying", "isTVon",


### PR DESCRIPTION
## Summary

- Fixed critical bug where `isAnyoneHomeAndAwake` was always `false` regardless of actual state
- Added missing `SetupComputedState()` initialization call in `cmd/main.go`
- Added variable to `displayState()` for visibility in logs

## Root Cause

The `SetupComputedState()` method was never called during application initialization, causing:
- `isAnyoneHomeAndAwake` to remain at default value (`false`)
- No subscriptions to dependency changes (`isAnyoneHome`, `isAnyoneAsleep`)
- No synchronization with Home Assistant

## Changes

**File: `homeautomation-go/cmd/main.go`**

1. **Line 136-139**: Added `SetupComputedState()` call after `SyncFromHA()`
   ```go
   // Setup computed state variables
   if err := stateManager.SetupComputedState(); err != nil {
       logger.Fatal("Failed to setup computed state", zap.Error(err))
   }
   ```

2. **Line 257**: Added `isAnyoneHomeAndAwake` to `displayState()` boolean variables list

## Testing

✅ All unit tests passing  
✅ All integration tests passing (11/11)  
✅ Race detector clean  
✅ Code compiles successfully  

## Example Bug State

**Before fix:**
```json
{
  "isAnyoneHome": true,
  "isAnyoneAsleep": false,
  "isAnyoneHomeAndAwake": false  ❌ WRONG
}
```

**After fix:**
```json
{
  "isAnyoneHome": true,
  "isAnyoneAsleep": false,
  "isAnyoneHomeAndAwake": true  ✅ CORRECT (true && !false = true)
}
```

## Impact

- Computed state now initializes correctly on startup
- Variable updates automatically when dependencies change
- Proper synchronization with Home Assistant
- Any plugins depending on this variable will now receive correct values

🤖 Generated with [Claude Code](https://claude.com/claude-code)