### PR TITLE
Fix TV plugin not being started

### DIFF
--- a/homeautomation-go/cmd/main.go
+++ b/homeautomation-go/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"homeautomation/internal/plugins/security"
 	"homeautomation/internal/plugins/sleephygiene"
 	"homeautomation/internal/plugins/statetracking"
+	"homeautomation/internal/plugins/tv"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
 
@@ -250,6 +251,14 @@ func main() {
 	shadowTracker.RegisterPluginProvider("loadshedding", func() shadowstate.PluginShadowState {
 		return loadSheddingManager.GetShadowState()
 	})
+
+	// Start TV Manager
+	tvManager := tv.NewManager(client, stateManager, logger, readOnly)
+	if err := tvManager.Start(); err != nil {
+		logger.Fatal("Failed to start TV Manager", zap.Error(err))
+	}
+	defer tvManager.Stop()
+	logger.Info("TV Manager started successfully")
 
 	// Register Phase 6 read-heavy plugin shadow state providers
 	shadowTracker.RegisterPluginProvider("energy", func() shadowstate.PluginShadowState {


### PR DESCRIPTION
## Summary
- Added missing import for `homeautomation/internal/plugins/tv`
- Added TV Manager startup code to `cmd/main.go`
- The TV plugin was fully implemented but never actually started

The TV Manager monitors:
- Apple TV playback state (`media_player.big_beautiful_oled`)
- Sync box power state (`switch.sync_box_power`)
- HDMI input selection (`select.sync_box_hdmi_input`)

And updates state variables:
- `isAppleTVPlaying`
- `isTVon`
- `isTVPlaying`

## Test plan
- [x] All tests pass with race detector
- [x] Code coverage meets minimum 70% requirement
- [x] Pre-push validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)