### PR TITLE
fix: Use suncalc library for accurate sun event calculations

### DIFF
--- a/homeautomation-go/go.mod
+++ b/homeautomation-go/go.mod
@@ -5,7 +5,7 @@ go 1.23
 require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/joho/godotenv v1.5.1
-	github.com/nathan-osman/go-sunrise v1.1.0
+	github.com/sixdouglas/suncalc v0.0.0-20250114185126-291b1938b70c
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.26.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/homeautomation-go/go.sum
+++ b/homeautomation-go/go.sum
@@ -4,10 +4,10 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
-github.com/nathan-osman/go-sunrise v1.1.0 h1:ZqZmtmtzs8Os/DGQYi0YMHpuUqR/iRoJK+wDO0wTCw8=
-github.com/nathan-osman/go-sunrise v1.1.0/go.mod h1:RcWqhT+5ShCZDev79GuWLayetpJp78RSjSWxiDowmlM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sixdouglas/suncalc v0.0.0-20250114185126-291b1938b70c h1:Lyrtmwq1VO3vK30KXmA4S4u816l/HqyT11d75WR0UiU=
+github.com/sixdouglas/suncalc v0.0.0-20250114185126-291b1938b70c/go.mod h1:IxOCrQX3pAL52wPiWuamnWxGcuyWANPyQfwcRb0iDqc=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=


### PR DESCRIPTION
## Summary
- Switch from `go-sunrise` to `sixdouglas/suncalc` library for sun position calculations
- This uses the same algorithm as Node-RED's suncalc library, ensuring identical day phase calculations
- Fixes discrepancy where Go was reporting "night" when Node-RED reported "dusk"

## Problem
The Go implementation was using approximate time offsets for twilight periods (e.g., "dusk = sunset + 30 minutes") instead of actual astronomical calculations based on solar angles. This caused the Go implementation to transition to "night" much earlier than Node-RED.

## Solution
The `sixdouglas/suncalc` library is a Go port of the same JavaScript suncalc library that Node-RED uses. It calculates sun positions using proper solar angles:

| Event | Sun Angle | Description |
|-------|-----------|-------------|
| dawn/dusk | -6° | Civil twilight |
| nauticalDawn/nauticalDusk | -12° | Nautical twilight |
| nightEnd/night | -18° | Astronomical twilight |
| goldenHourEnd/goldenHour | +6° | Golden hour |

## Test plan
- [x] All existing dayphase tests pass
- [x] All unit tests pass with race detector
- [x] Coverage remains above 70%
- [x] Verified test output shows correct sun event calculation matching Node-RED

🤖 Generated with [Claude Code](https://claude.com/claude-code)