### PR TITLE
feat: Add occupancy-based lighting and speaker control

### DIFF
--- a/homeautomation-go/internal/plugins/lighting/occupancy_scenario_test.go
+++ b/homeautomation-go/internal/plugins/lighting/occupancy_scenario_test.go
@@ -1,0 +1,403 @@
+package lighting
+
+// =============================================================================
+// OCCUPANCY-BASED LIGHTING SCENARIO TESTS
+// =============================================================================
+//
+// PURPOSE:
+// These tests validate that the Lighting Manager responds correctly to room
+// occupancy changes. When a room becomes occupied, its lights should turn on
+// with the appropriate scene. When a room becomes unoccupied, its lights
+// should turn off.
+//
+// CURRENT STATUS: PASSING
+// The Lighting Manager now subscribes to occupancy variables and responds
+// to state changes by activating scenes or turning off lights.
+//
+// NODE-RED REFERENCE:
+// - Flow: Lighting Control (16cd74edb3f2c03d)
+// - URL: https://node-red.featherback-mermaid.ts.net/#flow/16cd74edb3f2c03d
+// - The Node-RED flow subscribes to occupancy state changes and triggers
+//   scene activations or light turn-offs based on room configuration.
+//
+// CONFIGURATION REFERENCE:
+// - File: configs/hue_config.yaml
+// - Relevant room configs:
+//   - N Office: on_if_true: isNickOfficeOccupied, off_if_false: isNickOfficeOccupied
+//   - Kitchen: on_if_true: isKitchenOccupied, off_if_false: isAnyoneHomeAndAwake
+//
+// IMPLEMENTATION:
+// The Lighting Manager (internal/plugins/lighting/manager.go) implements:
+//
+// 1. collectConditionVariables(): Parses all unique variables from room configs
+//    - Extracts variables from OnIfTrue, OnIfFalse, OffIfTrue, OffIfFalse fields
+//    - Example: "isNickOfficeOccupied", "isKitchenOccupied", "isAnyoneHomeAndAwake"
+//
+// 2. Subscribe to state changes for these variables in Start()
+//    - Calls stateManager.Subscribe() for each condition variable
+//    - The subscription callback triggers room re-evaluation
+//
+// 3. handleOccupancyChange(): When a subscribed variable changes
+//    - Identifies which rooms use that variable in their conditions
+//    - For each affected room, evaluates the on/off conditions
+//    - If on_if_true matches: activates the appropriate scene (scene.turn_on)
+//    - If off_if_false matches: turns off lights (light.turn_off)
+//
+// 4. Scene naming convention:
+//    - Scene entity_id format: scene.{snake_case(hue_group + " " + dayPhase)}
+//    - Example: scene.n_office_day, scene.kitchen_evening
+//
+// =============================================================================
+
+import (
+	"testing"
+
+	"homeautomation/internal/ha"
+	"homeautomation/internal/state"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// createOccupancyTestConfig creates a configuration matching the actual hue_config.yaml
+// with Nick Office and Kitchen rooms that respond to occupancy.
+//
+// This mirrors the real configuration where:
+// - N Office turns on when isNickOfficeOccupied becomes true
+// - N Office turns off when isNickOfficeOccupied becomes false
+// - Kitchen turns on when isKitchenOccupied becomes true
+// - Kitchen turns off when isAnyoneHomeAndAwake becomes false (different trigger!)
+func createOccupancyTestConfig() *HueConfig {
+	transition2 := 2
+	transition5 := 5
+
+	return &HueConfig{
+		Rooms: []RoomConfig{
+			{
+				HueGroup:          "N Office",
+				HASSAreaID:        "n_office",
+				OnIfTrue:          "isNickOfficeOccupied",
+				OnIfFalse:         nil,
+				OffIfTrue:         nil,
+				OffIfFalse:        "isNickOfficeOccupied",
+				TransitionSeconds: &transition2,
+			},
+			{
+				HueGroup:          "Kitchen",
+				HASSAreaID:        "kitchen",
+				OnIfTrue:          "isKitchenOccupied",
+				OnIfFalse:         nil,
+				OffIfTrue:         nil,
+				OffIfFalse:        "isAnyoneHomeAndAwake",
+				TransitionSeconds: &transition5,
+			},
+		},
+	}
+}
+
+// =============================================================================
+// TEST: Nick Office Occupied -> Lights Turn On
+// =============================================================================
+//
+// SCENARIO:
+// Nick enters his office (occupancy sensor triggers isNickOfficeOccupied = true)
+//
+// EXPECTED BEHAVIOR:
+// The Lighting Manager should activate the office scene based on current dayPhase.
+// - Service call: scene.turn_on
+// - Entity: scene.n_office_day (when dayPhase = "day")
+// - Data: { entity_id: "scene.n_office_day", area_id: "n_office", transition: 2 }
+//
+// NODE-RED BEHAVIOR:
+// In Node-RED, the "Nick Office Occupied" node watches for state changes and
+// triggers the "Determine what action" function, which then activates the scene.
+func TestScenario_NickOfficeOccupied_TurnsOnLights(t *testing.T) {
+	logger := zap.NewNop()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	config := createOccupancyTestConfig()
+
+	manager := NewManager(mockClient, stateManager, config, logger, false)
+
+	// Initialize required state variables
+	// dayPhase determines which scene to activate (e.g., "day" -> scene.n_office_day)
+	_ = stateManager.SetString("dayPhase", "day")
+	_ = stateManager.SetString("sunevent", "day")
+	_ = stateManager.SetBool("isAnyoneHome", true)
+	_ = stateManager.SetBool("isTVPlaying", false)
+	_ = stateManager.SetBool("isEveryoneAsleep", false)
+	_ = stateManager.SetBool("isMasterAsleep", false)
+	_ = stateManager.SetBool("isHaveGuests", false)
+	_ = stateManager.SetBool("isNickOfficeOccupied", false) // Office starts unoccupied
+	_ = stateManager.SetBool("isKitchenOccupied", false)
+	_ = stateManager.SetBool("isAnyoneHomeAndAwake", true)
+
+	// Start manager - this is where subscriptions should be set up
+	err := manager.Start()
+	assert.NoError(t, err)
+	defer manager.Stop()
+
+	// Clear any initial service calls from manager startup
+	mockClient.ClearServiceCalls()
+
+	// ==========================================================
+	// ACTION: Nick enters his office (occupancy sensor triggers)
+	// ==========================================================
+	err = stateManager.SetBool("isNickOfficeOccupied", true)
+	assert.NoError(t, err)
+
+	// ==========================================================
+	// VERIFICATION: Office lights should turn on with "day" scene
+	// ==========================================================
+	calls := mockClient.GetServiceCalls()
+
+	// Look for scene.turn_on call for the office
+	foundSceneActivation := false
+	for _, call := range calls {
+		if call.Domain == "scene" && call.Service == "turn_on" {
+			entityID, ok := call.Data["entity_id"].(string)
+			if ok && entityID == "scene.n_office_day" {
+				foundSceneActivation = true
+				// Verify area_id is included for targeting
+				assert.Equal(t, "n_office", call.Data["area_id"],
+					"Scene activation should include area_id")
+				// Verify transition time from config
+				assert.Equal(t, 2, call.Data["transition"],
+					"Scene activation should use configured transition time")
+			}
+		}
+	}
+
+	assert.True(t, foundSceneActivation,
+		"Expected scene.turn_on for scene.n_office_day when Nick Office becomes occupied. "+
+			"Calls received: %+v", calls)
+}
+
+// =============================================================================
+// TEST: Nick Office Unoccupied -> Lights Turn Off
+// =============================================================================
+//
+// SCENARIO:
+// Nick leaves his office (occupancy sensor clears, isNickOfficeOccupied = false)
+//
+// EXPECTED BEHAVIOR:
+// The Lighting Manager should turn off the office lights.
+// - Service call: light.turn_off
+// - Target: area_id: "n_office"
+// - Data: { area_id: "n_office", transition: 2 }
+//
+// CONFIG REFERENCE:
+// The room config has: off_if_false: "isNickOfficeOccupied"
+// This means: when isNickOfficeOccupied becomes FALSE, turn off lights.
+func TestScenario_NickOfficeUnoccupied_TurnsOffLights(t *testing.T) {
+	logger := zap.NewNop()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	config := createOccupancyTestConfig()
+
+	manager := NewManager(mockClient, stateManager, config, logger, false)
+
+	// Initialize required state variables - office is currently OCCUPIED
+	_ = stateManager.SetString("dayPhase", "day")
+	_ = stateManager.SetString("sunevent", "day")
+	_ = stateManager.SetBool("isAnyoneHome", true)
+	_ = stateManager.SetBool("isTVPlaying", false)
+	_ = stateManager.SetBool("isEveryoneAsleep", false)
+	_ = stateManager.SetBool("isMasterAsleep", false)
+	_ = stateManager.SetBool("isHaveGuests", false)
+	_ = stateManager.SetBool("isNickOfficeOccupied", true) // Office starts occupied
+	_ = stateManager.SetBool("isKitchenOccupied", false)
+	_ = stateManager.SetBool("isAnyoneHomeAndAwake", true)
+
+	// Start manager
+	err := manager.Start()
+	assert.NoError(t, err)
+	defer manager.Stop()
+
+	// Clear any initial service calls
+	mockClient.ClearServiceCalls()
+
+	// ==========================================================
+	// ACTION: Nick leaves his office (occupancy sensor clears)
+	// ==========================================================
+	err = stateManager.SetBool("isNickOfficeOccupied", false)
+	assert.NoError(t, err)
+
+	// ==========================================================
+	// VERIFICATION: Office lights should turn off
+	// ==========================================================
+	calls := mockClient.GetServiceCalls()
+
+	// Look for light.turn_off call for the office area
+	foundLightOff := false
+	for _, call := range calls {
+		if call.Domain == "light" && call.Service == "turn_off" {
+			areaID, ok := call.Data["area_id"].(string)
+			if ok && areaID == "n_office" {
+				foundLightOff = true
+				// Verify transition time from config
+				assert.Equal(t, 2, call.Data["transition"],
+					"Light turn_off should use configured transition time")
+			}
+		}
+	}
+
+	assert.True(t, foundLightOff,
+		"Expected light.turn_off for n_office when Nick Office becomes unoccupied. "+
+			"Calls received: %+v", calls)
+}
+
+// =============================================================================
+// TEST: Kitchen Occupied -> Lights Turn On
+// =============================================================================
+//
+// SCENARIO:
+// Someone enters the kitchen (occupancy sensor triggers isKitchenOccupied = true)
+//
+// EXPECTED BEHAVIOR:
+// The Lighting Manager should activate the kitchen scene based on current dayPhase.
+// - Service call: scene.turn_on
+// - Entity: scene.kitchen_evening (when dayPhase = "evening")
+// - Data: { entity_id: "scene.kitchen_evening", area_id: "kitchen", transition: 5 }
+//
+// NOTE: Kitchen has DIFFERENT off condition!
+// - on_if_true: isKitchenOccupied (turns on when someone enters)
+// - off_if_false: isAnyoneHomeAndAwake (turns off when everyone leaves/sleeps)
+// This is different from the office which uses the same variable for both.
+func TestScenario_KitchenOccupied_TurnsOnLights(t *testing.T) {
+	logger := zap.NewNop()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	config := createOccupancyTestConfig()
+
+	manager := NewManager(mockClient, stateManager, config, logger, false)
+
+	// Initialize required state variables
+	// Using "evening" dayPhase to verify correct scene selection
+	_ = stateManager.SetString("dayPhase", "evening")
+	_ = stateManager.SetString("sunevent", "sunset")
+	_ = stateManager.SetBool("isAnyoneHome", true)
+	_ = stateManager.SetBool("isTVPlaying", false)
+	_ = stateManager.SetBool("isEveryoneAsleep", false)
+	_ = stateManager.SetBool("isMasterAsleep", false)
+	_ = stateManager.SetBool("isHaveGuests", false)
+	_ = stateManager.SetBool("isNickOfficeOccupied", false)
+	_ = stateManager.SetBool("isKitchenOccupied", false) // Kitchen starts unoccupied
+	_ = stateManager.SetBool("isAnyoneHomeAndAwake", true)
+
+	// Start manager
+	err := manager.Start()
+	assert.NoError(t, err)
+	defer manager.Stop()
+
+	// Clear any initial service calls
+	mockClient.ClearServiceCalls()
+
+	// ==========================================================
+	// ACTION: Someone enters the kitchen (occupancy sensor triggers)
+	// ==========================================================
+	err = stateManager.SetBool("isKitchenOccupied", true)
+	assert.NoError(t, err)
+
+	// ==========================================================
+	// VERIFICATION: Kitchen lights should turn on with "evening" scene
+	// ==========================================================
+	calls := mockClient.GetServiceCalls()
+
+	// Look for scene.turn_on call for the kitchen
+	foundSceneActivation := false
+	for _, call := range calls {
+		if call.Domain == "scene" && call.Service == "turn_on" {
+			entityID, ok := call.Data["entity_id"].(string)
+			if ok && entityID == "scene.kitchen_evening" {
+				foundSceneActivation = true
+				// Verify area_id
+				assert.Equal(t, "kitchen", call.Data["area_id"],
+					"Scene activation should include area_id")
+				// Verify transition time from config (kitchen uses 5 seconds)
+				assert.Equal(t, 5, call.Data["transition"],
+					"Scene activation should use configured transition time")
+			}
+		}
+	}
+
+	assert.True(t, foundSceneActivation,
+		"Expected scene.turn_on for scene.kitchen_evening when Kitchen becomes occupied. "+
+			"Calls received: %+v", calls)
+}
+
+// =============================================================================
+// TEST: Occupancy Change Only Affects Relevant Room
+// =============================================================================
+//
+// SCENARIO:
+// Nick enters his office (isNickOfficeOccupied = true)
+//
+// EXPECTED BEHAVIOR:
+// ONLY the office lights should be affected. The kitchen lights should NOT
+// change, even though it's also configured for occupancy-based control.
+//
+// WHY THIS TEST MATTERS:
+// This validates that the implementation correctly maps variables to rooms.
+// When isNickOfficeOccupied changes, only rooms that reference that variable
+// in their on/off conditions should be affected.
+func TestScenario_OccupancyChangeOnlyAffectsRelevantRoom(t *testing.T) {
+	logger := zap.NewNop()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	config := createOccupancyTestConfig()
+
+	manager := NewManager(mockClient, stateManager, config, logger, false)
+
+	// Initialize required state variables
+	_ = stateManager.SetString("dayPhase", "day")
+	_ = stateManager.SetString("sunevent", "day")
+	_ = stateManager.SetBool("isAnyoneHome", true)
+	_ = stateManager.SetBool("isTVPlaying", false)
+	_ = stateManager.SetBool("isEveryoneAsleep", false)
+	_ = stateManager.SetBool("isMasterAsleep", false)
+	_ = stateManager.SetBool("isHaveGuests", false)
+	_ = stateManager.SetBool("isNickOfficeOccupied", false)
+	_ = stateManager.SetBool("isKitchenOccupied", false)
+	_ = stateManager.SetBool("isAnyoneHomeAndAwake", true)
+
+	// Start manager
+	err := manager.Start()
+	assert.NoError(t, err)
+	defer manager.Stop()
+
+	// Clear any initial service calls
+	mockClient.ClearServiceCalls()
+
+	// ==========================================================
+	// ACTION: Nick enters his office
+	// ==========================================================
+	err = stateManager.SetBool("isNickOfficeOccupied", true)
+	assert.NoError(t, err)
+
+	// ==========================================================
+	// VERIFICATION: Only office should be affected, NOT kitchen
+	// ==========================================================
+	calls := mockClient.GetServiceCalls()
+
+	for _, call := range calls {
+		if call.Domain == "scene" && call.Service == "turn_on" {
+			entityID, ok := call.Data["entity_id"].(string)
+			if ok {
+				// Should NOT see any kitchen scene activation
+				assert.NotEqual(t, "scene.kitchen_day", entityID,
+					"Kitchen lights should NOT be affected by Nick Office occupancy change. "+
+						"The implementation must correctly map variables to rooms.")
+			}
+		}
+		if call.Domain == "light" && call.Service == "turn_off" {
+			areaID, ok := call.Data["area_id"].(string)
+			if ok {
+				// Should NOT see kitchen turn off
+				assert.NotEqual(t, "kitchen", areaID,
+					"Kitchen lights should NOT be turned off by Nick Office occupancy change. "+
+						"The implementation must correctly map variables to rooms.")
+			}
+		}
+	}
+}

--- a/homeautomation-go/internal/plugins/music/occupancy_scenario_test.go
+++ b/homeautomation-go/internal/plugins/music/occupancy_scenario_test.go
@@ -1,0 +1,404 @@
+package music
+
+// =============================================================================
+// OCCUPANCY-BASED SPEAKER MUTE SCENARIO TESTS
+// =============================================================================
+//
+// PURPOSE:
+// These tests validate that the Music Manager correctly handles speaker mute
+// conditions based on room occupancy. Specifically, the Office speaker should
+// be muted when Nick's office is unoccupied, and unmuted when he enters.
+//
+// CURRENT STATUS: PASSING
+// The Music Manager now subscribes to mute condition variables and responds
+// to state changes by unmuting/muting speakers during active playback.
+//
+// NODE-RED REFERENCE:
+// - Flow: Music (90f5fe8cb80ae6a7)
+// - URL: https://node-red.featherback-mermaid.ts.net/#flow/90f5fe8cb80ae6a7
+// - The Node-RED flow subscribes to occupancy changes and re-evaluates
+//   speaker participation during active playback.
+//
+// CONFIGURATION REFERENCE:
+// - File: configs/music_config.yaml
+// - Relevant speaker config (appears in multiple music modes):
+//   - player_name: "Office"
+//     base_volume: 6-8 (varies by mode)
+//     leave_muted_if:
+//       - variable: isNickOfficeOccupied
+//         value: false
+//
+// HOW leave_muted_if WORKS:
+// - If ALL conditions in leave_muted_if match current state, speaker stays MUTED
+// - If ANY condition does NOT match, speaker is UNMUTED
+// - Empty leave_muted_if means speaker is always unmuted (e.g., Kitchen)
+//
+// EXAMPLE:
+// - Office speaker has: leave_muted_if: isNickOfficeOccupied = false
+// - When isNickOfficeOccupied = false: condition MATCHES → speaker MUTED
+// - When isNickOfficeOccupied = true: condition does NOT match → speaker UNMUTED
+//
+// IMPLEMENTATION:
+// The Music Manager (internal/plugins/music/manager.go) implements:
+//
+// 1. collectMuteConditionVariables(): Collects all variables from leave_muted_if
+//    conditions across all music modes
+//
+// 2. Subscribe to state changes for these variables in Start()
+//    - Calls stateManager.Subscribe() for each mute condition variable
+//    - The subscription callback triggers re-evaluation of speaker states
+//
+// 3. handleMuteConditionChange(): When a subscribed variable changes during playback
+//    - Checks if music is currently playing
+//    - Re-evaluates shouldUnmuteSpeaker() for affected participants
+//    - Calls unmuteSpeaker() or muteSpeaker() as appropriate
+//
+// =============================================================================
+
+import (
+	"testing"
+	"time"
+
+	"homeautomation/internal/ha"
+	"homeautomation/internal/state"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// createOccupancyMusicConfig creates a configuration matching the actual music_config.yaml
+// where the Office speaker has leave_muted_if: isNickOfficeOccupied = false.
+//
+// This mirrors the real configuration where:
+// - Kitchen speaker has NO mute conditions (always plays)
+// - Office speaker is MUTED when office is unoccupied (isNickOfficeOccupied = false)
+// - Office speaker is UNMUTED when office is occupied (isNickOfficeOccupied = true)
+func createOccupancyMusicConfig() *MusicConfig {
+	return &MusicConfig{
+		Music: map[string]MusicMode{
+			"day": {
+				Participants: []Participant{
+					{
+						PlayerName:   "Kitchen",
+						BaseVolume:   9,
+						LeaveMutedIf: []MuteCondition{}, // No conditions = always unmuted
+					},
+					{
+						PlayerName: "Office",
+						BaseVolume: 6,
+						LeaveMutedIf: []MuteCondition{
+							{
+								Variable: "isNickOfficeOccupied",
+								Value:    false, // Mute when office is NOT occupied
+							},
+						},
+					},
+				},
+				PlaybackOptions: []PlaybackOption{
+					{
+						URI:              "spotify:playlist:test123",
+						MediaType:        "playlist",
+						VolumeMultiplier: 1.0,
+					},
+				},
+			},
+			"morning": {
+				Participants: []Participant{
+					{
+						PlayerName:   "Kitchen",
+						BaseVolume:   9,
+						LeaveMutedIf: []MuteCondition{},
+					},
+					{
+						PlayerName: "Office",
+						BaseVolume: 8, // Different volume in morning mode
+						LeaveMutedIf: []MuteCondition{
+							{
+								Variable: "isNickOfficeOccupied",
+								Value:    false,
+							},
+						},
+					},
+				},
+				PlaybackOptions: []PlaybackOption{
+					{
+						URI:              "spotify:playlist:morning123",
+						MediaType:        "playlist",
+						VolumeMultiplier: 1.0,
+					},
+				},
+			},
+		},
+	}
+}
+
+// =============================================================================
+// TEST: shouldUnmuteSpeaker() Logic - Office Occupied
+// =============================================================================
+//
+// WHAT THIS TEST VALIDATES:
+// The core mute condition evaluation logic in shouldUnmuteSpeaker() works correctly.
+// This is a UNIT TEST of the decision logic.
+//
+// SCENARIO:
+// 1. Start with isNickOfficeOccupied = false → Office should be MUTED
+// 2. Change to isNickOfficeOccupied = true → Office should be UNMUTED
+func TestScenario_OfficeSpeaker_UnmutedWhenOccupied(t *testing.T) {
+	logger := zap.NewNop()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	config := createOccupancyMusicConfig()
+
+	// Use fixed time provider for deterministic testing
+	fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC) // Monday 10am
+	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
+
+	// Initialize required state variables
+	_ = stateManager.SetString("dayPhase", "day")
+	_ = stateManager.SetString("musicPlaybackType", "")
+	_ = stateManager.SetBool("isAnyoneHome", true)
+	_ = stateManager.SetBool("isAnyoneAsleep", false)
+	_ = stateManager.SetBool("isMasterAsleep", false)
+	_ = stateManager.SetBool("isEveryoneAsleep", false)
+	_ = stateManager.SetBool("isNickOfficeOccupied", false) // Office NOT occupied initially
+	_ = stateManager.SetBool("isTVPlaying", false)
+
+	// Start manager to initialize subscriptions
+	err := manager.Start()
+	assert.NoError(t, err)
+	defer manager.Stop()
+
+	// Allow initial processing
+	time.Sleep(100 * time.Millisecond)
+
+	// Clear initial service calls
+	mockClient.ClearServiceCalls()
+
+	// Create participant with mute conditions from config
+	participant := ParticipantWithVolume{
+		PlayerName:   "Office",
+		BaseVolume:   6,
+		Volume:       6,
+		LeaveMutedIf: config.Music["day"].Participants[1].LeaveMutedIf,
+	}
+
+	// ==========================================================
+	// VERIFICATION 1: Office should be MUTED when unoccupied
+	// ==========================================================
+	// Mute condition: isNickOfficeOccupied = false
+	// Current state: isNickOfficeOccupied = false
+	// Condition MATCHES → speaker stays MUTED
+	shouldUnmute := manager.shouldUnmuteSpeaker(participant)
+	assert.False(t, shouldUnmute,
+		"Office speaker should stay MUTED when isNickOfficeOccupied = false. "+
+			"The mute condition (value: false) matches current state (false).")
+
+	// ==========================================================
+	// ACTION: Nick enters the office
+	// ==========================================================
+	_ = stateManager.SetBool("isNickOfficeOccupied", true)
+
+	// ==========================================================
+	// VERIFICATION 2: Office should be UNMUTED when occupied
+	// ==========================================================
+	// Mute condition: isNickOfficeOccupied = false
+	// Current state: isNickOfficeOccupied = true
+	// Condition does NOT match → speaker is UNMUTED
+	shouldUnmute = manager.shouldUnmuteSpeaker(participant)
+	assert.True(t, shouldUnmute,
+		"Office speaker should be UNMUTED when isNickOfficeOccupied = true. "+
+			"The mute condition (value: false) does NOT match current state (true).")
+}
+
+// =============================================================================
+// TEST: shouldUnmuteSpeaker() Logic - Office Unoccupied
+// =============================================================================
+//
+// WHAT THIS TEST VALIDATES:
+// The inverse of the above test - confirms speaker is correctly muted when
+// Nick leaves his office.
+//
+// SCENARIO:
+// 1. Start with isNickOfficeOccupied = true → Office should be UNMUTED
+// 2. Change to isNickOfficeOccupied = false → Office should be MUTED
+func TestScenario_OfficeSpeaker_MutedWhenUnoccupied(t *testing.T) {
+	logger := zap.NewNop()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	config := createOccupancyMusicConfig()
+
+	// Use fixed time provider
+	fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
+
+	// Initialize - office IS occupied
+	_ = stateManager.SetString("dayPhase", "day")
+	_ = stateManager.SetBool("isAnyoneHome", true)
+	_ = stateManager.SetBool("isAnyoneAsleep", false)
+	_ = stateManager.SetBool("isNickOfficeOccupied", true) // Office IS occupied initially
+
+	// Create participant with mute conditions
+	participant := ParticipantWithVolume{
+		PlayerName:   "Office",
+		BaseVolume:   6,
+		Volume:       6,
+		LeaveMutedIf: config.Music["day"].Participants[1].LeaveMutedIf,
+	}
+
+	// ==========================================================
+	// VERIFICATION 1: Office should be UNMUTED when occupied
+	// ==========================================================
+	shouldUnmute := manager.shouldUnmuteSpeaker(participant)
+	assert.True(t, shouldUnmute,
+		"Office speaker should be UNMUTED when isNickOfficeOccupied = true")
+
+	// ==========================================================
+	// ACTION: Nick leaves the office
+	// ==========================================================
+	_ = stateManager.SetBool("isNickOfficeOccupied", false)
+
+	// ==========================================================
+	// VERIFICATION 2: Office should be MUTED when unoccupied
+	// ==========================================================
+	shouldUnmute = manager.shouldUnmuteSpeaker(participant)
+	assert.False(t, shouldUnmute,
+		"Office speaker should be MUTED when isNickOfficeOccupied = false")
+}
+
+// =============================================================================
+// TEST: Real-Time Speaker Unmute During Active Playback
+// =============================================================================
+//
+// WHAT THIS TEST VALIDATES:
+// When music is actively playing and Nick enters his office, the Music Manager
+// should AUTOMATICALLY unmute the Office speaker by setting its volume.
+//
+// THIS IS THE KEY INTEGRATION TEST that validates the subscription mechanism.
+//
+// SCENARIO:
+// 1. Music starts playing in "day" mode
+// 2. Office speaker is initially MUTED (isNickOfficeOccupied = false)
+// 3. Nick enters his office (isNickOfficeOccupied = true)
+// 4. Music Manager should detect the change and unmute the Office speaker
+//
+// EXPECTED BEHAVIOR:
+// - Service call: media_player.volume_set
+// - Entity: media_player.office
+// - Data: { entity_id: "media_player.office", volume_level: 0.06 } (6% = base_volume 6)
+func TestScenario_OfficeSpeaker_UnmuteOnOccupancyChangeDuringPlayback(t *testing.T) {
+	logger := zap.NewNop()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	config := createOccupancyMusicConfig()
+
+	// Use fixed time provider
+	fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
+
+	// Initialize required state variables - music will start playing
+	_ = stateManager.SetString("dayPhase", "day")
+	_ = stateManager.SetString("musicPlaybackType", "")
+	_ = stateManager.SetBool("isAnyoneHome", true)
+	_ = stateManager.SetBool("isAnyoneAsleep", false)
+	_ = stateManager.SetBool("isMasterAsleep", false)
+	_ = stateManager.SetBool("isEveryoneAsleep", false)
+	_ = stateManager.SetBool("isNickOfficeOccupied", false) // Office NOT occupied
+	_ = stateManager.SetBool("isTVPlaying", false)
+
+	// Start manager - music should start playing (Kitchen speaker only)
+	err := manager.Start()
+	assert.NoError(t, err)
+	defer manager.Stop()
+
+	// Allow some processing time for initial music start
+	time.Sleep(200 * time.Millisecond)
+
+	// Clear service calls from initial music start
+	mockClient.ClearServiceCalls()
+
+	// ==========================================================
+	// ACTION: Nick enters his office during active playback
+	// ==========================================================
+	// This should trigger the Music Manager to:
+	// 1. Detect the isNickOfficeOccupied state change
+	// 2. Re-evaluate speaker mute conditions
+	// 3. Unmute the Office speaker by setting its volume
+	err = stateManager.SetBool("isNickOfficeOccupied", true)
+	assert.NoError(t, err)
+
+	// Allow processing time for the callback to execute
+	time.Sleep(200 * time.Millisecond)
+
+	// ==========================================================
+	// VERIFICATION: Office speaker should be unmuted (volume set)
+	// ==========================================================
+	calls := mockClient.GetServiceCalls()
+
+	// Look for a volume_set call for the office speaker
+	foundOfficeVolumeSet := false
+	for _, call := range calls {
+		if call.Domain == "media_player" && call.Service == "volume_set" {
+			entityID, ok := call.Data["entity_id"].(string)
+			if ok && entityID == "media_player.office" {
+				volumeLevel, hasVolume := call.Data["volume_level"]
+				if hasVolume {
+					// Should be non-zero volume (unmuting)
+					// Base volume is 6, so expected volume_level is 0.06 (6%)
+					if vol, ok := volumeLevel.(float64); ok && vol > 0 {
+						foundOfficeVolumeSet = true
+					}
+				}
+			}
+		}
+	}
+
+	assert.True(t, foundOfficeVolumeSet,
+		"Expected media_player.volume_set for Office speaker when Nick Office becomes "+
+			"occupied during playback. Calls received: %+v", calls)
+}
+
+// =============================================================================
+// TEST: Kitchen Speaker Always Unmuted
+// =============================================================================
+//
+// WHAT THIS TEST VALIDATES:
+// Speakers with NO mute conditions (empty leave_muted_if) should always be
+// unmuted during playback, regardless of any state changes.
+//
+// SCENARIO:
+// Kitchen speaker has no mute conditions, so shouldUnmuteSpeaker() should
+// always return true. An empty leave_muted_if array means the speaker always
+// participates.
+func TestScenario_KitchenSpeaker_AlwaysUnmuted(t *testing.T) {
+	logger := zap.NewNop()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	config := createOccupancyMusicConfig()
+
+	fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
+
+	// Kitchen speaker has no mute conditions - empty array
+	participant := ParticipantWithVolume{
+		PlayerName:   "Kitchen",
+		BaseVolume:   9,
+		Volume:       9,
+		LeaveMutedIf: []MuteCondition{}, // Empty = no conditions = always unmuted
+	}
+
+	// ==========================================================
+	// VERIFICATION: Kitchen should always be unmuted
+	// ==========================================================
+	shouldUnmute := manager.shouldUnmuteSpeaker(participant)
+	assert.True(t, shouldUnmute,
+		"Kitchen speaker with no mute conditions (empty leave_muted_if) should "+
+			"always be unmuted. Empty conditions means the speaker always participates.")
+}


### PR DESCRIPTION
## Summary
- Implement dynamic subscription to occupancy/condition variables in the Lighting and Music managers
- Lighting Manager now responds to room occupancy changes (turns on scenes when rooms become occupied, turns off when unoccupied)
- Music Manager now responds to speaker mute condition changes during active playback (unmutes speakers when occupancy conditions change)

## Changes

### Lighting Manager
- Added `collectConditionVariables()` to gather unique variables from room on/off conditions
- Subscribe to occupancy variables (e.g., `isNickOfficeOccupied`, `isKitchenOccupied`, `isAnyoneHomeAndAwake`)
- Added `handleOccupancyChange()` handler to trigger room re-evaluation when occupancy changes

### Music Manager
- Added `collectMuteConditionVariables()` to gather variables from speaker `leave_muted_if` conditions
- Subscribe to mute condition variables during playback
- Added `handleMuteConditionChange()` to re-evaluate speaker mute state on changes
- Added `unmuteSpeaker()` and `muteSpeaker()` helper methods

## Test plan
- [x] All existing unit tests pass
- [x] All existing integration tests pass
- [x] New occupancy scenario tests pass for Lighting Manager
- [x] New occupancy scenario tests pass for Music Manager
- [x] Pre-push validation passes (build, race detector, coverage ≥70%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)