### PR TITLE
fix: Record shadow state in read-only mode for lighting and loadshedding plugins

### DIFF
--- a/homeautomation-go/internal/plugins/lighting/manager.go
+++ b/homeautomation-go/internal/plugins/lighting/manager.go
@@ -489,6 +489,10 @@ func (m *Manager) activateScene(room *RoomConfig, dayPhase string) {
 			zap.String("area_id", room.HASSAreaID),
 			zap.String("scene", dayPhase),
 			zap.String("entity_id", sceneEntityID))
+		// Record shadow state even in read-only mode for consistency with music plugin
+		m.recordAction(room.HueGroup, "activate_scene",
+			fmt.Sprintf("Would activate scene '%s'", dayPhase),
+			dayPhase, false)
 		return
 	}
 
@@ -543,6 +547,8 @@ func (m *Manager) turnOffRoom(room *RoomConfig) {
 		m.logger.Info("READ-ONLY: Would turn off room",
 			zap.String("room", room.HueGroup),
 			zap.String("area_id", room.HASSAreaID))
+		// Record shadow state even in read-only mode for consistency with music plugin
+		m.recordAction(room.HueGroup, "turn_off", "Would turn off room", "", true)
 		return
 	}
 

--- a/homeautomation-go/internal/plugins/loadshedding/manager.go
+++ b/homeautomation-go/internal/plugins/loadshedding/manager.go
@@ -185,6 +185,9 @@ func (m *Manager) enableLoadShedding(energyLevel string) {
 	if m.readOnly {
 		m.logger.Info("READ-ONLY: Would enable thermostat hold mode",
 			zap.Strings("entities", []string{thermostatHoldHouse, thermostatHoldSuite}))
+		// Record shadow state even in read-only mode for consistency
+		reason := fmt.Sprintf("Energy state is %s (low battery) - would restrict HVAC", energyLevel)
+		m.recordAction(true, "enable", reason, true, tempLowRestricted, tempHighRestricted)
 		return
 	}
 
@@ -276,6 +279,9 @@ func (m *Manager) disableLoadShedding(energyLevel string) {
 	if m.readOnly {
 		m.logger.Info("READ-ONLY: Would disable thermostat hold mode (restore schedule)",
 			zap.Strings("entities", []string{thermostatHoldHouse, thermostatHoldSuite}))
+		// Record shadow state even in read-only mode for consistency
+		reason := fmt.Sprintf("Energy state is %s (battery restored) - would return to normal HVAC", energyLevel)
+		m.recordAction(false, "disable", reason, false, 0, 0)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Fix lighting plugin to record shadow state in `activateScene()` and `turnOffRoom()` when in read-only mode
- Fix loadshedding plugin to record shadow state in `enableLoadShedding()` and `disableLoadShedding()` when in read-only mode

The music plugin correctly records shadow state (what actions would be taken) even in read-only mode, but lighting and loadshedding plugins were returning early without recording. This creates inconsistency in the `/api/shadow` endpoint where `/api/shadow/music` shows what music WOULD be playing, but `/api/shadow/lighting` and `/api/shadow/loadshedding` showed nothing.

## Test plan
- [x] All existing unit tests pass
- [x] All tests pass with race detector
- [x] Coverage remains above 70%
- [ ] Manual verification: Start in read-only mode, trigger lighting/loadshedding changes, check `/api/shadow/lighting` and `/api/shadow/loadshedding` endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)