### PR TITLE
feat: Add trigger field to shadow state AtLastAction inputs

### DIFF
--- a/homeautomation-go/internal/plugins/lighting/manager_test.go
+++ b/homeautomation-go/internal/plugins/lighting/manager_test.go
@@ -238,7 +238,7 @@ func TestActivateSceneReadOnly(t *testing.T) {
 	dayPhase := "Morning"
 
 	// Should not call service in read-only mode
-	manager.activateScene(room, dayPhase)
+	manager.activateScene(room, dayPhase, "test_trigger")
 
 	// Verify no service calls were made
 	calls := mockClient.GetServiceCalls()
@@ -255,7 +255,7 @@ func TestActivateScene(t *testing.T) {
 	room := &config.Rooms[0]
 	dayPhase := "Morning"
 
-	manager.activateScene(room, dayPhase)
+	manager.activateScene(room, dayPhase, "test_trigger")
 
 	// Verify service call was made
 	calls := mockClient.GetServiceCalls()
@@ -279,7 +279,7 @@ func TestTurnOffRoomReadOnly(t *testing.T) {
 	room := &config.Rooms[0]
 
 	// Should not call service in read-only mode
-	manager.turnOffRoom(room)
+	manager.turnOffRoom(room, "test_trigger")
 
 	// Verify no service calls were made
 	calls := mockClient.GetServiceCalls()
@@ -295,7 +295,7 @@ func TestTurnOffRoom(t *testing.T) {
 
 	room := &config.Rooms[0]
 
-	manager.turnOffRoom(room)
+	manager.turnOffRoom(room, "test_trigger")
 
 	// Verify service call was made
 	calls := mockClient.GetServiceCalls()

--- a/homeautomation-go/internal/plugins/loadshedding/manager_shadow_test.go
+++ b/homeautomation-go/internal/plugins/loadshedding/manager_shadow_test.go
@@ -57,7 +57,7 @@ func TestLoadSheddingShadowState_RecordEnableAction(t *testing.T) {
 
 	// Record an enable action
 	reason := "Energy state is red (low battery) - restricting HVAC"
-	manager.recordAction(true, "enable", reason, true, tempLowRestricted, tempHighRestricted)
+	manager.recordAction(true, "enable", reason, true, tempLowRestricted, tempHighRestricted, "test_trigger")
 
 	// Verify shadow state was updated
 	shadowState := manager.GetShadowState()
@@ -114,11 +114,11 @@ func TestLoadSheddingShadowState_RecordDisableAction(t *testing.T) {
 	manager := NewManager(mockClient, stateManager, zap.NewNop(), true)
 
 	// First enable load shedding
-	manager.recordAction(true, "enable", "Test enable", true, tempLowRestricted, tempHighRestricted)
+	manager.recordAction(true, "enable", "Test enable", true, tempLowRestricted, tempHighRestricted, "test_trigger")
 
 	// Then disable it
 	reason := "Energy state is green (battery restored) - returning to normal HVAC"
-	manager.recordAction(false, "disable", reason, false, 0, 0)
+	manager.recordAction(false, "disable", reason, false, 0, 0, "test_trigger")
 
 	// Verify shadow state was updated
 	shadowState := manager.GetShadowState()
@@ -205,7 +205,7 @@ func TestLoadSheddingShadowState_ConcurrentAccess(t *testing.T) {
 	// Writer goroutine - updates shadow state
 	go func() {
 		for i := 0; i < 100; i++ {
-			manager.recordAction(i%2 == 0, "test_action", "Concurrent test", true, 65.0, 80.0)
+			manager.recordAction(i%2 == 0, "test_action", "Concurrent test", true, 65.0, 80.0, "concurrent_test")
 			time.Sleep(1 * time.Millisecond)
 		}
 		done <- true
@@ -263,7 +263,7 @@ func TestLoadSheddingShadowState_InputSnapshot(t *testing.T) {
 	manager := NewManager(mockClient, stateManager, zap.NewNop(), true)
 
 	// Record action with red energy level
-	manager.recordAction(true, "enable", "Low battery", true, tempLowRestricted, tempHighRestricted)
+	manager.recordAction(true, "enable", "Low battery", true, tempLowRestricted, tempHighRestricted, "test_trigger")
 
 	// Verify at-last-action inputs captured red
 	shadowState := manager.GetShadowState()
@@ -299,7 +299,7 @@ func TestLoadSheddingShadowState_MultipleActions(t *testing.T) {
 	if err := stateManager.SetString("currentEnergyLevel", "red"); err != nil {
 		t.Fatalf("Failed to set energy level: %v", err)
 	}
-	manager.recordAction(true, "enable", "Battery low", true, tempLowRestricted, tempHighRestricted)
+	manager.recordAction(true, "enable", "Battery low", true, tempLowRestricted, tempHighRestricted, "test_trigger")
 
 	// Verify enabled
 	shadowState := manager.GetShadowState()
@@ -315,7 +315,7 @@ func TestLoadSheddingShadowState_MultipleActions(t *testing.T) {
 	if err := stateManager.SetString("currentEnergyLevel", "green"); err != nil {
 		t.Fatalf("Failed to change energy level: %v", err)
 	}
-	manager.recordAction(false, "disable", "Battery restored", false, 0, 0)
+	manager.recordAction(false, "disable", "Battery restored", false, 0, 0, "test_trigger")
 
 	// Verify disabled
 	shadowState = manager.GetShadowState()

--- a/homeautomation-go/internal/plugins/music/manager_shadow_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_shadow_test.go
@@ -50,7 +50,7 @@ func TestMusicShadowState_RecordAction(t *testing.T) {
 	manager := NewManager(nil, stateManager, mockConfig, zap.NewNop(), true, timeProvider)
 
 	// Record an action
-	manager.updateShadowState("start_playback", "Test playback started")
+	manager.updateShadowState("start_playback", "Test playback started", "test_trigger")
 
 	// Verify shadow state was updated
 	shadowState := manager.GetShadowState()
@@ -157,7 +157,7 @@ func TestMusicShadowState_GetShadowState(t *testing.T) {
 	manager := NewManager(nil, stateManager, mockConfig, zap.NewNop(), true, nil)
 
 	// Record some state
-	manager.updateShadowState("test_action", "Test reason")
+	manager.updateShadowState("test_action", "Test reason", "test_trigger")
 
 	// Get shadow state
 	shadowState := manager.GetShadowState()
@@ -208,7 +208,7 @@ func TestMusicShadowState_ConcurrentAccess(t *testing.T) {
 	// Writer goroutine - updates shadow state
 	go func() {
 		for i := 0; i < 100; i++ {
-			manager.updateShadowState("test_action", "Concurrent test")
+			manager.updateShadowState("test_action", "Concurrent test", "concurrent_test")
 			time.Sleep(1 * time.Millisecond)
 		}
 		done <- true

--- a/homeautomation-go/internal/plugins/music/manager_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_test.go
@@ -777,7 +777,7 @@ func TestOrchestratePlayback(t *testing.T) {
 	manager := NewManager(mockClient, stateManager, config, logger, true, nil)
 
 	// Test orchestration
-	err := manager.orchestratePlayback("day")
+	err := manager.orchestratePlayback("day", "test_trigger")
 	if err != nil {
 		t.Fatalf("orchestratePlayback() failed: %v", err)
 	}
@@ -800,7 +800,7 @@ func TestOrchestratePlayback(t *testing.T) {
 	}
 
 	// Test with unknown music type
-	err = manager.orchestratePlayback("unknown")
+	err = manager.orchestratePlayback("unknown", "test_trigger")
 	if err == nil {
 		t.Error("orchestratePlayback() with unknown type should return error")
 	}
@@ -1106,7 +1106,7 @@ func TestCurrentlyPlayingMusicUri_SetOnPlayback(t *testing.T) {
 	manager := NewManager(mockClient, stateManager, config, logger, true, nil)
 
 	// Orchestrate playback
-	err := manager.orchestratePlayback("day")
+	err := manager.orchestratePlayback("day", "test_trigger")
 	if err != nil {
 		t.Fatalf("orchestratePlayback() failed: %v", err)
 	}
@@ -1214,7 +1214,7 @@ func TestCurrentlyPlayingMusicUri_UpdateOnModeChange(t *testing.T) {
 	manager := NewManager(mockClient, stateManager, config, logger, true, timeProvider)
 
 	// Start with day music
-	err := manager.orchestratePlayback("day")
+	err := manager.orchestratePlayback("day", "test_trigger")
 	if err != nil {
 		t.Fatalf("orchestratePlayback(day) failed: %v", err)
 	}
@@ -1233,7 +1233,7 @@ func TestCurrentlyPlayingMusicUri_UpdateOnModeChange(t *testing.T) {
 	manager.timeProvider = timeProvider
 
 	// Switch to evening music
-	err = manager.orchestratePlayback("evening")
+	err = manager.orchestratePlayback("evening", "test_trigger")
 	if err != nil {
 		t.Fatalf("orchestratePlayback(evening) failed: %v", err)
 	}

--- a/homeautomation-go/internal/plugins/sleephygiene/manager.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager.go
@@ -330,7 +330,7 @@ func (m *Manager) handleBeginWake() {
 	}
 
 	// Record action in shadow state
-	m.recordAction("begin_wake", fmt.Sprintf("Starting fade out for %d bedroom speakers", len(bedroomSpeakers)))
+	m.recordAction("begin_wake", fmt.Sprintf("Starting fade out for %d bedroom speakers", len(bedroomSpeakers)), "eight_sleep_alarm")
 	m.shadowTracker.UpdateWakeSequenceStatus("begin_wake")
 
 	if !m.readOnly {
@@ -604,7 +604,7 @@ func (m *Manager) handleWake() {
 	m.logger.Info("Conditions met for wake, executing wake sequence")
 
 	// Record action in shadow state
-	m.recordAction("wake", "Executing wake sequence: turning on lights and checking for cuddle announcement")
+	m.recordAction("wake", "Executing wake sequence: turning on lights and checking for cuddle announcement", "wake_timer")
 	m.shadowTracker.UpdateWakeSequenceStatus("wake_in_progress")
 
 	if !m.readOnly {
@@ -642,7 +642,7 @@ func (m *Manager) handleStopScreens() {
 	m.logger.Info("Conditions met for stop_screens, flashing lights")
 
 	// Record action in shadow state
-	m.recordAction("stop_screens", "Flashing common area lights as screen stop reminder")
+	m.recordAction("stop_screens", "Flashing common area lights as screen stop reminder", "stop_screens_timer")
 	m.shadowTracker.RecordStopScreensReminder()
 
 	if !m.readOnly {
@@ -673,7 +673,7 @@ func (m *Manager) handleGoToBed() {
 	m.logger.Info("Conditions met for go_to_bed, flashing lights")
 
 	// Record action in shadow state
-	m.recordAction("go_to_bed", "Flashing common area lights as bedtime reminder")
+	m.recordAction("go_to_bed", "Flashing common area lights as bedtime reminder", "go_to_bed_timer")
 	m.shadowTracker.RecordGoToBedReminder()
 
 	if !m.readOnly {
@@ -797,7 +797,7 @@ func (m *Manager) handleBedroomLightsOff(state string) {
 		m.logger.Info("Bedroom lights turned off during wake sequence - cancelling wake and reverting to sleep music")
 
 		// Record cancel wake action in shadow state
-		m.recordAction("cancel_wake", "Bedroom lights turned off during wake sequence, reverting to sleep music")
+		m.recordAction("cancel_wake", "Bedroom lights turned off during wake sequence, reverting to sleep music", "bedroom_lights_off")
 		m.shadowTracker.UpdateWakeSequenceStatus("inactive")
 		m.shadowTracker.ClearFadeOutProgress()
 
@@ -867,10 +867,17 @@ func (m *Manager) updateShadowInputs() {
 	m.shadowTracker.UpdateCurrentInputs(inputs)
 }
 
+// updateShadowInputsWithTrigger updates the shadow state current inputs including trigger
+func (m *Manager) updateShadowInputsWithTrigger(trigger string) {
+	inputs := m.captureCurrentInputs()
+	inputs["trigger"] = trigger
+	m.shadowTracker.UpdateCurrentInputs(inputs)
+}
+
 // recordAction records an action in shadow state
-func (m *Manager) recordAction(actionType string, reason string) {
-	// Update current inputs
-	m.updateShadowInputs()
+func (m *Manager) recordAction(actionType string, reason string, trigger string) {
+	// Update current inputs including trigger
+	m.updateShadowInputsWithTrigger(trigger)
 
 	// Snapshot inputs for this action
 	m.shadowTracker.SnapshotInputsForAction()

--- a/homeautomation-go/internal/plugins/sleephygiene/manager_shadow_test.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager_shadow_test.go
@@ -57,7 +57,7 @@ func TestSleepHygieneShadowState_RecordAction(t *testing.T) {
 	stateManager.SetString("musicPlaybackType", "sleep")
 
 	// Record an action
-	manager.recordAction("begin_wake", "Starting wake sequence")
+	manager.recordAction("begin_wake", "Starting wake sequence", "test_trigger")
 
 	// Get shadow state
 	shadowState := manager.GetShadowState()
@@ -446,7 +446,7 @@ func TestSleepHygieneShadowState_BedroomLightsNoCancel(t *testing.T) {
 	stateManager.SetString("musicPlaybackType", "sleep")
 
 	// Record an initial action
-	manager.recordAction("test_action", "test reason")
+	manager.recordAction("test_action", "test reason", "test_trigger")
 
 	// Simulate bedroom lights turning off (should not cancel wake)
 	manager.handleBedroomLightsOff("off")


### PR DESCRIPTION
## Summary

- Add a `trigger` field to shadow state `AtLastAction` inputs that tracks what caused an action
- This helps with debugging by distinguishing between actions triggered by state variable changes vs reset commands
- All 5 plugins with Reset functionality now include trigger information in their shadow state

## Plugins Updated

| Plugin | Trigger Values |
|--------|---------------|
| **Lighting** | `dayPhase`, `sunevent`, `isAnyoneHome`, `reset` |
| **LoadShedding** | `currentEnergyLevel`, `reset` |
| **Security** | `isEveryoneAsleep`, `isAnyoneHome`, `doorbell`, `vehicle_arriving`, `didOwnerJustReturnHome`, `lockdown_timer`, `reset` |
| **Music** | `musicPlaybackType`, `reset` |
| **SleepHygiene** | `eight_sleep_alarm`, `wake_timer`, `stop_screens_timer`, `go_to_bed_timer`, `bedroom_lights_off` |

## Test plan

- [x] All existing tests pass with race detector
- [x] Test coverage ≥70% maintained
- [x] Updated test files to include trigger parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)