### PR TITLE
feat: Add plugin system with priority-based override mechanism

### DIFF
--- a/docs/architecture/PLUGIN_SYSTEM.md
+++ b/docs/architecture/PLUGIN_SYSTEM.md
@@ -1,0 +1,1050 @@
+# Plugin System Architecture
+
+This document describes the plugin architecture for the Golang home automation system, including plugin interfaces, lifecycle management, and the override mechanism for private plugins.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Plugin Architecture](#plugin-architecture)
+3. [Core Plugin Interfaces](#core-plugin-interfaces)
+4. [Plugin Lifecycle](#plugin-lifecycle)
+5. [Existing Plugins](#existing-plugins)
+6. [Creating New Plugins](#creating-new-plugins)
+7. [Private Plugin Override System](#private-plugin-override-system)
+8. [Testing Plugins](#testing-plugins)
+9. [Best Practices](#best-practices)
+
+---
+
+## Overview
+
+The home automation system uses a **plugin-based monolith** architecture where each automation domain is implemented as a separate plugin. Plugins are compiled into a single binary but maintain clear separation of concerns through well-defined interfaces.
+
+### Key Principles
+
+1. **Loose Coupling** - Plugins interact through the State Manager and HA Client, not directly with each other
+2. **State-Driven** - Plugins subscribe to state changes and react accordingly
+3. **Idempotent Operations** - Plugins can be reset without side effects
+4. **Shadow State Tracking** - Plugins record their decision-making for observability
+5. **Read-Only Mode Support** - All plugins must respect the READ_ONLY flag
+
+### Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Main Application (cmd/main.go)                │
+│                                                                  │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────────────┐   │
+│  │   HA Client  │  │State Manager │  │  Shadow State Tracker│   │
+│  │  (internal/  │  │  (internal/  │  │    (internal/        │   │
+│  │   ha/)       │  │   state/)    │  │    shadowstate/)     │   │
+│  └──────┬───────┘  └──────┬───────┘  └──────────┬───────────┘   │
+│         │                 │                      │               │
+│         │                 │                      │               │
+│  ┌──────▼─────────────────▼──────────────────────▼───────────┐  │
+│  │                    Plugin Layer                            │  │
+│  │                                                            │  │
+│  │  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────────┐  │  │
+│  │  │  Energy  │ │ Lighting │ │  Music   │ │ State        │  │  │
+│  │  │  Plugin  │ │  Plugin  │ │  Plugin  │ │ Tracking     │  │  │
+│  │  └──────────┘ └──────────┘ └──────────┘ └──────────────┘  │  │
+│  │                                                            │  │
+│  │  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────────┐  │  │
+│  │  │ Security │ │   TV     │ │  Sleep   │ │ Load         │  │  │
+│  │  │  Plugin  │ │  Plugin  │ │ Hygiene  │ │ Shedding     │  │  │
+│  │  └──────────┘ └──────────┘ └──────────┘ └──────────────┘  │  │
+│  │                                                            │  │
+│  │  ┌──────────┐ ┌──────────────────────────────────────┐    │  │
+│  │  │ Day Phase│ │     Reset Coordinator                │    │  │
+│  │  │  Plugin  │ │     (orchestrates plugin resets)     │    │  │
+│  │  └──────────┘ └──────────────────────────────────────┘    │  │
+│  └────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Plugin Architecture
+
+### Directory Structure
+
+Each plugin lives in its own package under `internal/plugins/`:
+
+```
+homeautomation-go/
+├── internal/
+│   └── plugins/
+│       ├── energy/              # Energy State plugin
+│       │   ├── manager.go       # Main plugin implementation
+│       │   ├── config.go        # Configuration loading
+│       │   └── manager_test.go  # Unit tests
+│       ├── lighting/            # Lighting Control plugin
+│       │   ├── manager.go
+│       │   ├── config.go
+│       │   ├── config_test.go
+│       │   └── manager_test.go
+│       ├── music/               # Music Management plugin
+│       │   ├── manager.go
+│       │   ├── config.go
+│       │   └── manager_test.go
+│       ├── security/            # Security plugin
+│       │   ├── manager.go
+│       │   └── manager_test.go
+│       ├── tv/                  # TV Monitoring plugin
+│       │   ├── manager.go
+│       │   └── manager_test.go
+│       ├── sleephygiene/        # Sleep Hygiene plugin
+│       │   ├── manager.go
+│       │   └── manager_test.go
+│       ├── loadshedding/        # Load Shedding plugin
+│       │   ├── manager.go
+│       │   └── manager_test.go
+│       ├── statetracking/       # State Tracking plugin
+│       │   ├── manager.go
+│       │   └── manager_test.go
+│       ├── dayphase/            # Day Phase plugin
+│       │   ├── manager.go
+│       │   └── manager_test.go
+│       └── reset/               # Reset Coordinator
+│           ├── coordinator.go
+│           └── coordinator_test.go
+```
+
+### Plugin Dependencies
+
+Plugins receive their dependencies through constructor injection:
+
+```go
+type Manager struct {
+    haClient      ha.HAClient        // For calling Home Assistant services
+    stateManager  *state.Manager     // For reading/writing state variables
+    config        *Config            // Plugin-specific configuration (optional)
+    logger        *zap.Logger        // Structured logging
+    readOnly      bool               // Whether to skip HA writes
+
+    // Subscription tracking for cleanup
+    haSubscriptions    []ha.Subscription
+    stateSubscriptions []state.Subscription
+
+    // Shadow state tracking (optional)
+    shadowTracker *shadowstate.Tracker
+}
+```
+
+---
+
+## Core Plugin Interfaces
+
+### Plugin Interface
+
+While there is no explicit `Plugin` interface defined, all plugins follow this implicit contract:
+
+```go
+// Implicit Plugin interface
+type Plugin interface {
+    // Start begins the plugin's operation
+    // - Sets up subscriptions to state changes
+    // - Starts any background goroutines
+    // - Returns error if initialization fails
+    Start() error
+
+    // Stop gracefully shuts down the plugin
+    // - Unsubscribes from all state changes
+    // - Stops any background goroutines
+    // - Releases resources
+    Stop()
+}
+```
+
+### Resettable Interface
+
+Plugins that support the system-wide reset mechanism implement the `Resettable` interface:
+
+```go
+// Defined in internal/plugins/reset/coordinator.go
+type Resettable interface {
+    // Reset re-evaluates all conditions and recalculates state
+    // - Clears any rate limiters or timers
+    // - Re-applies current state conditions
+    // - Returns error if reset fails
+    Reset() error
+}
+```
+
+### ShadowStateProvider Interface
+
+Plugins that track their decision-making for observability implement shadow state:
+
+```go
+// Implicit ShadowStateProvider interface
+type ShadowStateProvider interface {
+    // GetShadowState returns the current shadow state for the plugin
+    GetShadowState() shadowstate.PluginShadowState
+}
+```
+
+---
+
+## Plugin Lifecycle
+
+### Startup Sequence
+
+Plugins are started in a specific order in `cmd/main.go`:
+
+```
+1. State Tracking Plugin (first - computes derived states used by others)
+2. Day Phase Plugin (provides dayPhase and sunevent state)
+3. Energy Plugin (provides energy level states)
+4. Music Plugin
+5. Lighting Plugin
+6. Security Plugin
+7. Sleep Hygiene Plugin
+8. Load Shedding Plugin
+9. TV Plugin
+10. Reset Coordinator (last - needs all plugins registered)
+```
+
+**Important:** The State Tracking plugin must start first because other plugins depend on computed states like `isAnyoneHome` and `isAnyoneAsleep`.
+
+### Startup Example
+
+```go
+// In cmd/main.go
+func main() {
+    // ... initialization ...
+
+    // Start plugins in order
+    stateTrackingManager := statetracking.NewManager(client, stateManager, logger, readOnly)
+    if err := stateTrackingManager.Start(); err != nil {
+        logger.Fatal("Failed to start State Tracking Manager", zap.Error(err))
+    }
+    defer stateTrackingManager.Stop()
+
+    // Register shadow state provider
+    shadowTracker.RegisterPluginProvider("statetracking", func() shadowstate.PluginShadowState {
+        return stateTrackingManager.GetShadowState()
+    })
+
+    // ... more plugins ...
+}
+```
+
+### Shutdown Sequence
+
+Plugins are stopped in reverse order using Go's `defer` mechanism:
+
+```go
+// Deferred calls execute in LIFO order
+defer resetCoordinator.Stop()      // Stops last (registered last)
+defer tvManager.Stop()
+defer loadSheddingManager.Stop()
+defer sleepHygieneManager.Stop()
+defer securityManager.Stop()
+defer lightingManager.Stop()
+defer musicManager.Stop()
+defer energyManager.Stop()
+defer dayPhaseManager.Stop()
+defer stateTrackingManager.Stop()  // Stops first (registered first)
+```
+
+---
+
+## Existing Plugins
+
+### State Tracking Plugin (`statetracking`)
+
+**Purpose:** Computes derived state variables from individual presence and sleep states.
+
+**State Variables Managed:**
+- `isAnyOwnerHome` - Computed from `isNickHome || isCarolineHome`
+- `isAnyoneHome` - Computed from presence states
+- `isAnyoneAsleep` - Computed from `isMasterAsleep || isGuestAsleep`
+- `isEveryoneAsleep` - Computed from sleep states
+- `isAnyoneHomeAndAwake` - Computed from `isAnyoneHome && !isAnyoneAsleep`
+
+**Events Subscribed:**
+- `isNickHome`, `isCarolineHome`, `isToriHere`
+- `isMasterAsleep`, `isGuestAsleep`
+- `isHaveGuests`
+
+### Day Phase Plugin (`dayphase`)
+
+**Purpose:** Calculates and updates the current day phase based on time and sun events.
+
+**State Variables Managed:**
+- `dayPhase` - Current phase: morning, day, sunset, dusk, winddown, night
+- `sunevent` - Current sun event: sunrise, sunset, dusk, night
+
+**Configuration:** Uses `schedule_config.yaml` for day phase transition times.
+
+### Energy Plugin (`energy`)
+
+**Purpose:** Tracks energy availability from battery, solar, and grid sources.
+
+**State Variables Managed:**
+- `batteryEnergyLevel` - Battery charge level category
+- `solarProductionEnergyLevel` - Solar production category
+- `currentEnergyLevel` - Combined energy availability
+- `isFreeEnergyAvailable` - Whether grid is providing free energy
+
+**HA Entities Subscribed:**
+- `sensor.span_panel_span_storage_battery_percentage_2`
+- `sensor.energy_next_hour`
+- `sensor.energy_production_today_remaining`
+
+**Configuration:** Uses `energy_config.yaml` for thresholds and free energy time windows.
+
+### Music Plugin (`music`)
+
+**Purpose:** Manages Sonos music playback based on presence, sleep, and time of day.
+
+**State Variables Managed:**
+- `musicPlaybackType` - Current music mode (morning, day, evening, winddown, sleep, etc.)
+- `currentlyPlayingMusicUri` - Currently playing track/playlist
+
+**Events Subscribed:**
+- `dayPhase`, `isAnyoneHome`, `isAnyoneAsleep`
+- `isMasterAsleep`, `isGuestAsleep`, `isToriHere`
+
+**Configuration:** Uses `music_config.yaml` for playlists and speaker groups.
+
+### Lighting Plugin (`lighting`)
+
+**Purpose:** Activates lighting scenes based on day phase and occupancy.
+
+**State Variables Subscribed:**
+- `dayPhase`, `sunevent`
+- `isAnyoneHome`, `isAnyoneAsleep`, `isAnyoneHomeAndAwake`
+- `isTVPlaying`
+
+**Configuration:** Uses `hue_config.yaml` for room-to-scene mappings and conditional logic.
+
+### Security Plugin (`security`)
+
+**Purpose:** Handles lockdown, doorbell notifications, and garage automation.
+
+**Features:**
+- Auto-lockdown when everyone asleep or no one home
+- Doorbell TTS notifications with rate limiting
+- Garage door auto-open on owner return
+- Vehicle arrival notifications
+
+**State Variables Subscribed:**
+- `isEveryoneAsleep`, `isAnyoneHome`
+- `isExpectingSomeone`, `didOwnerJustReturnHome`
+
+### TV Plugin (`tv`)
+
+**Purpose:** Monitors TV and Apple TV state to update state variables.
+
+**State Variables Managed:**
+- `isAppleTVPlaying` - Whether Apple TV is actively playing
+- `isTVon` - Whether TV/sync box is powered on
+- `isTVPlaying` - Whether content is actively playing
+
+**HA Entities Subscribed:**
+- `media_player.big_beautiful_oled`
+- `switch.sync_box_power`
+- `select.sync_box_hdmi_input`
+
+### Sleep Hygiene Plugin (`sleephygiene`)
+
+**Purpose:** Manages wake-up sequences and sleep-related automations.
+
+**Features:**
+- Time-based wake-up triggers from `alarmTime`
+- Fade-out sleep music sequence
+- Wake-up light activation
+- Stop screens reminder
+
+**State Variables Subscribed:**
+- `isMasterAsleep`, `alarmTime`
+- `musicPlaybackType`
+
+### Load Shedding Plugin (`loadshedding`)
+
+**Purpose:** Adjusts thermostat settings based on energy availability.
+
+**State Variables Subscribed:**
+- `currentEnergyLevel`
+
+**Actions:**
+- Sets thermostat to hold mode during low energy
+- Widens temperature range to reduce consumption
+- Restores normal settings when energy is abundant
+
+### Reset Coordinator (`reset`)
+
+**Purpose:** Orchestrates system-wide resets when the `reset` state variable is triggered.
+
+**Features:**
+- Watches `reset` boolean state variable
+- Calls `Reset()` on all registered plugins
+- Auto-clears the reset flag after execution
+
+---
+
+## Creating New Plugins
+
+### Step 1: Create Package Structure
+
+```bash
+mkdir -p internal/plugins/myplugin
+touch internal/plugins/myplugin/manager.go
+touch internal/plugins/myplugin/manager_test.go
+```
+
+### Step 2: Implement Manager
+
+```go
+package myplugin
+
+import (
+    "fmt"
+
+    "homeautomation/internal/ha"
+    "homeautomation/internal/shadowstate"
+    "homeautomation/internal/state"
+
+    "go.uber.org/zap"
+)
+
+type Manager struct {
+    haClient      ha.HAClient
+    stateManager  *state.Manager
+    logger        *zap.Logger
+    readOnly      bool
+
+    // Subscriptions for cleanup
+    haSubscriptions    []ha.Subscription
+    stateSubscriptions []state.Subscription
+
+    // Shadow state tracking
+    shadowTracker *shadowstate.MyPluginTracker
+}
+
+func NewManager(haClient ha.HAClient, stateManager *state.Manager, logger *zap.Logger, readOnly bool) *Manager {
+    return &Manager{
+        haClient:           haClient,
+        stateManager:       stateManager,
+        logger:             logger.Named("myplugin"),
+        readOnly:           readOnly,
+        haSubscriptions:    make([]ha.Subscription, 0),
+        stateSubscriptions: make([]state.Subscription, 0),
+        shadowTracker:      shadowstate.NewMyPluginTracker(),
+    }
+}
+
+func (m *Manager) Start() error {
+    m.logger.Info("Starting MyPlugin Manager")
+
+    // Subscribe to relevant state changes
+    sub, err := m.stateManager.Subscribe("someStateVar", m.handleStateChange)
+    if err != nil {
+        return fmt.Errorf("failed to subscribe to someStateVar: %w", err)
+    }
+    m.stateSubscriptions = append(m.stateSubscriptions, sub)
+
+    // Subscribe to HA entity changes
+    haSub, err := m.haClient.SubscribeStateChanges("sensor.my_sensor", m.handleSensorChange)
+    if err != nil {
+        return fmt.Errorf("failed to subscribe to sensor: %w", err)
+    }
+    m.haSubscriptions = append(m.haSubscriptions, haSub)
+
+    m.logger.Info("MyPlugin Manager started successfully")
+    return nil
+}
+
+func (m *Manager) Stop() {
+    m.logger.Info("Stopping MyPlugin Manager")
+
+    // Unsubscribe from HA entities
+    for _, sub := range m.haSubscriptions {
+        sub.Unsubscribe()
+    }
+    m.haSubscriptions = nil
+
+    // Unsubscribe from state changes
+    for _, sub := range m.stateSubscriptions {
+        sub.Unsubscribe()
+    }
+    m.stateSubscriptions = nil
+
+    m.logger.Info("MyPlugin Manager stopped")
+}
+
+func (m *Manager) Reset() error {
+    m.logger.Info("Resetting MyPlugin - re-evaluating state")
+
+    // Re-evaluate conditions and reapply state
+    // Clear any rate limiters or cached values
+
+    m.logger.Info("Successfully reset MyPlugin")
+    return nil
+}
+
+func (m *Manager) GetShadowState() *shadowstate.MyPluginShadowState {
+    return m.shadowTracker.GetState()
+}
+
+// State change handlers
+func (m *Manager) handleStateChange(key string, oldValue, newValue interface{}) {
+    // Update shadow state with current inputs
+    m.shadowTracker.UpdateCurrentInputs(...)
+
+    // Process the state change
+    value, ok := newValue.(bool)
+    if !ok {
+        m.logger.Error("Invalid type for state", zap.Any("value", newValue))
+        return
+    }
+
+    // Perform action
+    m.performAction(value)
+}
+
+func (m *Manager) handleSensorChange(entity string, oldState, newState *ha.State) {
+    // Process HA entity state change
+    m.logger.Info("Sensor changed",
+        zap.String("entity", entity),
+        zap.String("old", oldState.State),
+        zap.String("new", newState.State))
+}
+
+func (m *Manager) performAction(value bool) {
+    // Record action in shadow state
+    m.shadowTracker.RecordAction(...)
+
+    if m.readOnly {
+        m.logger.Info("READ-ONLY: Would perform action", zap.Bool("value", value))
+        return
+    }
+
+    if err := m.haClient.CallService("domain", "service", map[string]interface{}{
+        "entity_id": "my.entity",
+    }); err != nil {
+        m.logger.Error("Failed to call service", zap.Error(err))
+    }
+}
+```
+
+### Step 3: Register in main.go
+
+```go
+// In cmd/main.go
+
+import "homeautomation/internal/plugins/myplugin"
+
+func main() {
+    // ... existing initialization ...
+
+    // Start MyPlugin Manager
+    myPluginManager := myplugin.NewManager(client, stateManager, logger, readOnly)
+    if err := myPluginManager.Start(); err != nil {
+        logger.Fatal("Failed to start MyPlugin Manager", zap.Error(err))
+    }
+    defer myPluginManager.Stop()
+    logger.Info("MyPlugin Manager started successfully")
+
+    // Register shadow state provider
+    shadowTracker.RegisterPluginProvider("myplugin", func() shadowstate.PluginShadowState {
+        return myPluginManager.GetShadowState()
+    })
+
+    // Add to Reset Coordinator
+    resetCoordinator := reset.NewCoordinator(stateManager, logger, readOnly, []reset.PluginWithName{
+        // ... existing plugins ...
+        {Name: "MyPlugin", Plugin: myPluginManager},
+    })
+}
+```
+
+---
+
+## Private Plugin Override System
+
+For security-sensitive plugins that should not be open-source, the system supports a compile-time override mechanism.
+
+### Overview
+
+- **Public repo** contains a reference/sample implementation
+- **Private repo** contains actual security logic
+- Private plugin **overrides** the public one when imported
+
+### Implementation Steps
+
+#### Step 1: Create Public Plugin API (`pkg/plugin/`)
+
+Create a `pkg/` directory (not `internal/`) for external package imports:
+
+```go
+// pkg/plugin/interfaces.go
+package plugin
+
+type Plugin interface {
+    Name() string
+    Start() error
+    Stop()
+}
+
+type Resettable interface {
+    Reset() error
+}
+
+type ShadowStateProvider interface {
+    GetShadowState() ShadowState
+}
+
+type Factory func(ctx *Context) (Plugin, error)
+```
+
+```go
+// pkg/plugin/context.go
+package plugin
+
+type Context struct {
+    HAClient     HAClient      // Interface wrapping ha.HAClient
+    StateManager StateManager  // Interface wrapping state.Manager
+    Logger       *zap.Logger
+    ReadOnly     bool
+    ConfigDir    string
+}
+```
+
+#### Step 2: Create Plugin Registry
+
+```go
+// pkg/plugin/registry.go
+package plugin
+
+const (
+    PriorityDefault  = 0
+    PriorityOverride = 100
+)
+
+type PluginInfo struct {
+    Name        string
+    Description string
+    Priority    int
+    Factory     Factory
+}
+
+type Registry struct {
+    mu      sync.RWMutex
+    plugins map[string]PluginInfo
+    order   []string
+}
+
+func (r *Registry) Register(info PluginInfo) error {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+
+    if existing, exists := r.plugins[info.Name]; exists {
+        log.Printf("Plugin %s being overridden (priority %d -> %d)",
+            info.Name, existing.Priority, info.Priority)
+    }
+
+    // Higher priority wins
+    if existing, exists := r.plugins[info.Name]; !exists || info.Priority >= existing.Priority {
+        r.plugins[info.Name] = info
+        if !exists {
+            r.order = append(r.order, info.Name)
+        }
+    }
+    return nil
+}
+```
+
+#### Step 3: Public Plugin Registration
+
+```go
+// internal/plugins/security/register.go
+package security
+
+import "github.com/NickBorgers/node-red/homeautomation-go/pkg/plugin"
+
+func init() {
+    plugin.Register(plugin.PluginInfo{
+        Name:        "security",
+        Description: "Reference security plugin",
+        Priority:    plugin.PriorityDefault,  // Can be overridden
+        Factory:     createPlugin,
+    })
+}
+```
+
+#### Step 4: Private Override
+
+Create a private repository (e.g., `github.com/NickBorgers/homeautomation-security`):
+
+```go
+// In private repo: register.go
+package security
+
+import "github.com/NickBorgers/node-red/homeautomation-go/pkg/plugin"
+
+func init() {
+    plugin.Register(plugin.PluginInfo{
+        Name:        "security",
+        Description: "Private security plugin",
+        Priority:    plugin.PriorityOverride,  // Overrides public
+        Factory:     New,
+    })
+}
+```
+
+#### Step 5: Usage in main.go
+
+```go
+import (
+    // Public plugin (reference implementation)
+    _ "github.com/NickBorgers/node-red/homeautomation-go/internal/plugins/security"
+
+    // Private override (uncomment for private builds)
+    // _ "github.com/NickBorgers/homeautomation-security"
+)
+```
+
+### How Override Works
+
+**Public build:**
+```
+Plugin "security" registered (priority 0)
+Starting plugin: security (Reference security plugin)
+```
+
+**Private build:**
+```
+Plugin "security" registered (priority 0)
+Plugin "security" being overridden (priority 0 -> 100)
+Starting plugin: security (Private security plugin)
+```
+
+---
+
+## Testing Plugins
+
+### Unit Test Structure
+
+```go
+// manager_test.go
+package myplugin
+
+import (
+    "testing"
+
+    "homeautomation/internal/ha"
+    "homeautomation/internal/state"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "go.uber.org/zap/zaptest"
+)
+
+func TestManager_Start(t *testing.T) {
+    logger := zaptest.NewLogger(t)
+    mockClient := ha.NewMockClient()
+    stateManager := state.NewManager(mockClient, logger, true)
+
+    manager := NewManager(mockClient, stateManager, logger, true)
+
+    err := manager.Start()
+    require.NoError(t, err)
+    defer manager.Stop()
+
+    // Verify subscriptions were created
+    assert.Greater(t, len(manager.stateSubscriptions), 0)
+}
+
+func TestManager_HandleStateChange(t *testing.T) {
+    tests := []struct {
+        name     string
+        input    interface{}
+        expected string
+    }{
+        {"when true", true, "action_performed"},
+        {"when false", false, "no_action"},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            // Setup
+            logger := zaptest.NewLogger(t)
+            mockClient := ha.NewMockClient()
+            stateManager := state.NewManager(mockClient, logger, true)
+            manager := NewManager(mockClient, stateManager, logger, true)
+
+            // Execute
+            manager.handleStateChange("key", nil, tt.input)
+
+            // Assert
+            shadowState := manager.GetShadowState()
+            assert.Equal(t, tt.expected, shadowState.LastAction)
+        })
+    }
+}
+
+func TestManager_Reset(t *testing.T) {
+    logger := zaptest.NewLogger(t)
+    mockClient := ha.NewMockClient()
+    stateManager := state.NewManager(mockClient, logger, true)
+
+    manager := NewManager(mockClient, stateManager, logger, true)
+    manager.Start()
+    defer manager.Stop()
+
+    err := manager.Reset()
+    assert.NoError(t, err)
+}
+```
+
+### Testing with Mock HA Client
+
+The `ha.NewMockClient()` provides a mock implementation for testing:
+
+```go
+mockClient := ha.NewMockClient()
+
+// Set expected states
+mockClient.SetState("sensor.my_sensor", &ha.State{
+    State: "42",
+    Attributes: map[string]interface{}{
+        "unit": "kW",
+    },
+})
+
+// Verify service calls
+assert.Eventually(t, func() bool {
+    calls := mockClient.GetServiceCalls()
+    return len(calls) > 0 && calls[0].Service == "expected_service"
+}, time.Second, 10*time.Millisecond)
+```
+
+### Running Tests
+
+```bash
+# Run all plugin tests
+cd homeautomation-go
+go test ./internal/plugins/... -v
+
+# Run with race detector
+go test ./internal/plugins/... -race
+
+# Run specific plugin tests
+go test ./internal/plugins/energy/... -v
+
+# Generate coverage report
+go test ./internal/plugins/... -coverprofile=coverage.out
+go tool cover -html=coverage.out
+```
+
+---
+
+## Best Practices
+
+### 1. Always Respect Read-Only Mode
+
+```go
+func (m *Manager) performAction() {
+    if m.readOnly {
+        m.logger.Info("READ-ONLY: Would perform action")
+        return
+    }
+
+    // Actual action
+    m.haClient.CallService(...)
+}
+```
+
+### 2. Clean Up Subscriptions
+
+```go
+func (m *Manager) Stop() {
+    for _, sub := range m.haSubscriptions {
+        sub.Unsubscribe()
+    }
+    m.haSubscriptions = nil
+
+    for _, sub := range m.stateSubscriptions {
+        sub.Unsubscribe()
+    }
+    m.stateSubscriptions = nil
+}
+```
+
+### 3. Track Shadow State for Observability
+
+```go
+func (m *Manager) handleChange(...) {
+    // 1. Update current inputs
+    m.shadowTracker.UpdateCurrentInputs(inputs)
+
+    // 2. Snapshot inputs before action
+    m.shadowTracker.SnapshotInputsForAction()
+
+    // 3. Record the action taken
+    m.shadowTracker.RecordAction(action, reason)
+
+    // 4. Perform actual action
+    if !m.readOnly {
+        m.performAction()
+    }
+}
+```
+
+### 4. Use Named Loggers
+
+```go
+func NewManager(...) *Manager {
+    return &Manager{
+        logger: logger.Named("myplugin"),  // Creates "myplugin" prefix
+    }
+}
+```
+
+### 5. Handle Errors Gracefully
+
+```go
+func (m *Manager) handleStateChange(key string, old, new interface{}) {
+    value, ok := new.(bool)
+    if !ok {
+        m.logger.Error("Invalid type for state",
+            zap.String("key", key),
+            zap.Any("value", new))
+        return  // Don't crash, just log and skip
+    }
+
+    // Continue processing...
+}
+```
+
+### 6. Implement Reset Properly
+
+```go
+func (m *Manager) Reset() error {
+    m.logger.Info("Resetting MyPlugin")
+
+    // Clear rate limiters
+    m.mu.Lock()
+    m.lastNotification = time.Time{}
+    m.mu.Unlock()
+
+    // Re-evaluate current conditions
+    currentState, err := m.stateManager.GetBool("relevantState")
+    if err != nil {
+        return fmt.Errorf("failed to get state: %w", err)
+    }
+
+    if currentState {
+        m.performAction()
+    }
+
+    m.logger.Info("Successfully reset MyPlugin")
+    return nil
+}
+```
+
+### 7. Use Constants for Magic Values
+
+```go
+const (
+    NotificationRateLimit = 20 * time.Second
+    RetryDelay            = 5 * time.Second
+    MaxRetries            = 3
+)
+```
+
+### 8. Document State Dependencies
+
+Include a comment block documenting which state variables the plugin reads and writes:
+
+```go
+// Manager handles energy state calculations.
+//
+// State Variables Read:
+//   - isGridAvailable (bool)
+//   - batteryEnergyLevel (string)
+//   - solarProductionEnergyLevel (string)
+//
+// State Variables Written:
+//   - currentEnergyLevel (string)
+//   - isFreeEnergyAvailable (bool)
+//
+// HA Entities Subscribed:
+//   - sensor.span_panel_span_storage_battery_percentage_2
+//   - sensor.energy_next_hour
+//   - sensor.energy_production_today_remaining
+type Manager struct {
+    // ...
+}
+```
+
+---
+
+## Implementation Status
+
+The plugin system has been fully implemented with the following components:
+
+### Public Package (`pkg/`)
+
+| File | Description |
+|------|-------------|
+| `pkg/plugin/interfaces.go` | Core Plugin, Resettable, ShadowStateProvider interfaces |
+| `pkg/plugin/context.go` | Context struct for plugin initialization |
+| `pkg/plugin/registry.go` | Global registry with priority-based override |
+| `pkg/plugin/registry_test.go` | Comprehensive tests (98.4% coverage) |
+| `pkg/ha/interfaces.go` | Public HA client interface |
+| `pkg/ha/adapter.go` | Adapter wrapping internal ha.Client |
+| `pkg/state/interfaces.go` | Public state manager interface |
+| `pkg/state/adapter.go` | Adapter wrapping internal state.Manager |
+
+### Reference Security Plugin
+
+| File | Description |
+|------|-------------|
+| `internal/plugins/security/register.go` | Plugin registration with `init()` |
+| `internal/plugins/security/manager.go` | Reference implementation |
+
+### Private Security Plugin (Separate Repo)
+
+Located at `../homeautomation-security/`:
+
+| File | Description |
+|------|-------------|
+| `go.mod` | Module definition with replace directive |
+| `security.go` | Private implementation with override priority |
+| `README.md` | Usage and development guide |
+
+**Private Features:**
+- Garage auto-close after 5-minute timeout
+
+### Usage Example
+
+To use the private security plugin:
+
+```go
+// In go.mod, add:
+require github.com/NickBorgersOnLowSecurityNode/homeautomation-security v0.0.0
+
+// In main.go, import:
+import (
+    _ "homeautomation/internal/plugins/security"  // Reference (auto-registers)
+    _ "github.com/NickBorgersOnLowSecurityNode/homeautomation-security"  // Override
+)
+```
+
+---
+
+## Related Documentation
+
+- **[IMPLEMENTATION_PLAN.md](./IMPLEMENTATION_PLAN.md)** - Overall project architecture and status
+- **[VISUAL_ARCHITECTURE.md](./VISUAL_ARCHITECTURE.md)** - System diagrams and flow charts
+- **[GOLANG_DESIGN.md](./GOLANG_DESIGN.md)** - Detailed plugin descriptions and Node-RED mappings
+- **[../development/CONCURRENCY_LESSONS.md](../development/CONCURRENCY_LESSONS.md)** - Concurrency patterns
+- **[../../homeautomation-go/README.md](../../homeautomation-go/README.md)** - User guide
+
+---
+
+**Last Updated:** 2025-11-29
+**Go Version:** 1.23

--- a/homeautomation-go/internal/plugins/security/register.go
+++ b/homeautomation-go/internal/plugins/security/register.go
@@ -1,0 +1,69 @@
+package security
+
+import (
+	"fmt"
+
+	pkgha "homeautomation/pkg/ha"
+	"homeautomation/pkg/plugin"
+	pkgstate "homeautomation/pkg/state"
+)
+
+func init() {
+	plugin.Register(plugin.PluginInfo{
+		Name:        "security",
+		Description: "Reference security plugin - handles lockdown, doorbell, garage automation",
+		Priority:    plugin.PriorityDefault,
+		Order:       60, // After state tracking (10), day phase (20), energy (30), music (40), lighting (50)
+		Factory:     createPlugin,
+	})
+}
+
+// createPlugin creates a new security plugin instance from the plugin context.
+func createPlugin(ctx *plugin.Context) (plugin.Plugin, error) {
+	// Unwrap the interfaces to get the internal types
+	haClient := pkgha.UnwrapClient(ctx.HAClient)
+	if haClient == nil {
+		return nil, fmt.Errorf("security plugin requires internal ha.HAClient")
+	}
+
+	stateManager := pkgstate.UnwrapManager(ctx.StateManager)
+	if stateManager == nil {
+		return nil, fmt.Errorf("security plugin requires internal state.Manager")
+	}
+
+	manager := NewManager(haClient, stateManager, ctx.Logger, ctx.ReadOnly)
+	return &pluginAdapter{manager: manager}, nil
+}
+
+// pluginAdapter wraps the Manager to implement the plugin.Plugin interface.
+type pluginAdapter struct {
+	manager *Manager
+}
+
+func (p *pluginAdapter) Name() string {
+	return "security"
+}
+
+func (p *pluginAdapter) Start() error {
+	return p.manager.Start()
+}
+
+func (p *pluginAdapter) Stop() {
+	p.manager.Stop()
+}
+
+// Implement plugin.Resettable
+func (p *pluginAdapter) Reset() error {
+	return p.manager.Reset()
+}
+
+// Implement plugin.ShadowStateProvider
+func (p *pluginAdapter) GetShadowState() interface{} {
+	return p.manager.GetShadowState()
+}
+
+// GetManager returns the underlying Manager instance.
+// This allows access to the full Manager API when needed (e.g., for shadow state registration).
+func (p *pluginAdapter) GetManager() *Manager {
+	return p.manager
+}

--- a/homeautomation-go/pkg/ha/adapter.go
+++ b/homeautomation-go/pkg/ha/adapter.go
@@ -1,0 +1,93 @@
+package ha
+
+import (
+	"homeautomation/internal/ha"
+)
+
+// internalToState converts internal ha.State to pkg ha.State
+func internalToState(s *ha.State) *State {
+	if s == nil {
+		return nil
+	}
+	return &State{
+		EntityID:    s.EntityID,
+		State:       s.State,
+		Attributes:  s.Attributes,
+		LastChanged: s.LastChanged,
+		LastUpdated: s.LastUpdated,
+	}
+}
+
+// ClientAdapter wraps internal ha.HAClient to implement pkg ha.Client
+type ClientAdapter struct {
+	internal ha.HAClient
+}
+
+// WrapClient wraps an internal ha.HAClient to implement the pkg ha.Client interface
+func WrapClient(c ha.HAClient) Client {
+	return &ClientAdapter{internal: c}
+}
+
+// UnwrapClient returns the underlying internal client if available
+func UnwrapClient(c Client) ha.HAClient {
+	if adapter, ok := c.(*ClientAdapter); ok {
+		return adapter.internal
+	}
+	return nil
+}
+
+func (a *ClientAdapter) Connect() error {
+	return a.internal.Connect()
+}
+
+func (a *ClientAdapter) Disconnect() error {
+	return a.internal.Disconnect()
+}
+
+func (a *ClientAdapter) IsConnected() bool {
+	return a.internal.IsConnected()
+}
+
+func (a *ClientAdapter) GetState(entityID string) (*State, error) {
+	s, err := a.internal.GetState(entityID)
+	if err != nil {
+		return nil, err
+	}
+	return internalToState(s), nil
+}
+
+func (a *ClientAdapter) GetAllStates() ([]*State, error) {
+	states, err := a.internal.GetAllStates()
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*State, len(states))
+	for i, s := range states {
+		result[i] = internalToState(s)
+	}
+	return result, nil
+}
+
+func (a *ClientAdapter) CallService(domain, service string, data map[string]interface{}) error {
+	return a.internal.CallService(domain, service, data)
+}
+
+func (a *ClientAdapter) SubscribeStateChanges(entityID string, handler StateChangeHandler) (Subscription, error) {
+	// Create a wrapper handler that converts internal states to pkg states
+	internalHandler := func(entity string, oldState, newState *ha.State) {
+		handler(entity, internalToState(oldState), internalToState(newState))
+	}
+	return a.internal.SubscribeStateChanges(entityID, internalHandler)
+}
+
+func (a *ClientAdapter) SetInputBoolean(name string, value bool) error {
+	return a.internal.SetInputBoolean(name, value)
+}
+
+func (a *ClientAdapter) SetInputNumber(name string, value float64) error {
+	return a.internal.SetInputNumber(name, value)
+}
+
+func (a *ClientAdapter) SetInputText(name string, value string) error {
+	return a.internal.SetInputText(name, value)
+}

--- a/homeautomation-go/pkg/ha/interfaces.go
+++ b/homeautomation-go/pkg/ha/interfaces.go
@@ -1,0 +1,43 @@
+// Package ha provides the public interface definitions for Home Assistant
+// client integration. These interfaces can be imported by external packages
+// (including private plugin implementations).
+//
+// The actual implementation is in internal/ha, which is wrapped by these
+// public interfaces for external consumption.
+package ha
+
+import (
+	"time"
+)
+
+// State represents an entity state from Home Assistant.
+type State struct {
+	EntityID    string                 `json:"entity_id"`
+	State       string                 `json:"state"`
+	Attributes  map[string]interface{} `json:"attributes"`
+	LastChanged time.Time              `json:"last_changed"`
+	LastUpdated time.Time              `json:"last_updated"`
+}
+
+// StateChangeHandler is called when a state change event is received.
+type StateChangeHandler func(entityID string, oldState, newState *State)
+
+// Subscription represents an active event subscription.
+type Subscription interface {
+	Unsubscribe() error
+}
+
+// Client defines the interface for Home Assistant WebSocket client.
+// This interface matches internal/ha.HAClient and can be used by external packages.
+type Client interface {
+	Connect() error
+	Disconnect() error
+	IsConnected() bool
+	GetState(entityID string) (*State, error)
+	GetAllStates() ([]*State, error)
+	CallService(domain, service string, data map[string]interface{}) error
+	SubscribeStateChanges(entityID string, handler StateChangeHandler) (Subscription, error)
+	SetInputBoolean(name string, value bool) error
+	SetInputNumber(name string, value float64) error
+	SetInputText(name string, value string) error
+}

--- a/homeautomation-go/pkg/plugin/context.go
+++ b/homeautomation-go/pkg/plugin/context.go
@@ -1,0 +1,64 @@
+package plugin
+
+import (
+	"time"
+
+	pkgha "homeautomation/pkg/ha"
+	pkgstate "homeautomation/pkg/state"
+
+	"go.uber.org/zap"
+)
+
+// Context provides dependencies to plugins during initialization.
+// It wraps the core services needed by all plugins in a single struct
+// for cleaner constructor signatures.
+//
+// Note: HAClient and StateManager use interface types from pkg/ha and pkg/state
+// respectively, which allows external packages to work with these types.
+// The actual implementations from internal/ha and internal/state satisfy
+// these interfaces.
+type Context struct {
+	// HAClient provides access to Home Assistant for service calls
+	// and entity state subscriptions.
+	HAClient pkgha.Client
+
+	// StateManager provides access to the state variable system
+	// for reading and writing state, and subscribing to changes.
+	StateManager pkgstate.Manager
+
+	// Logger is a structured logger for the plugin to use.
+	// Plugins should use logger.Named("pluginname") for namespacing.
+	Logger *zap.Logger
+
+	// ReadOnly indicates whether the application is in read-only mode.
+	// When true, plugins should log what they would do but not make
+	// actual changes to Home Assistant entities.
+	ReadOnly bool
+
+	// ConfigDir is the path to the configuration directory.
+	// Plugins that need configuration files can find them here.
+	ConfigDir string
+
+	// Timezone is the configured timezone for time-based calculations.
+	// Plugins that deal with time windows or schedules should use this.
+	Timezone *time.Location
+}
+
+// NewContext creates a new plugin context with all required dependencies.
+func NewContext(
+	haClient pkgha.Client,
+	stateManager pkgstate.Manager,
+	logger *zap.Logger,
+	readOnly bool,
+	configDir string,
+	timezone *time.Location,
+) *Context {
+	return &Context{
+		HAClient:     haClient,
+		StateManager: stateManager,
+		Logger:       logger,
+		ReadOnly:     readOnly,
+		ConfigDir:    configDir,
+		Timezone:     timezone,
+	}
+}

--- a/homeautomation-go/pkg/plugin/interfaces.go
+++ b/homeautomation-go/pkg/plugin/interfaces.go
@@ -1,0 +1,53 @@
+// Package plugin provides the plugin system interfaces and registry for the
+// home automation system. Plugins can register themselves with the global
+// registry using init() functions, allowing for compile-time plugin selection
+// and override mechanisms for private implementations.
+package plugin
+
+import "homeautomation/internal/shadowstate"
+
+// Plugin is the core interface that all plugins must implement.
+// Plugins are responsible for automation logic in a specific domain
+// (e.g., security, lighting, music).
+type Plugin interface {
+	// Name returns the unique identifier for this plugin.
+	// This name is used for registration and logging.
+	Name() string
+
+	// Start begins the plugin's operation.
+	// - Sets up subscriptions to state changes
+	// - Starts any background goroutines
+	// - Returns error if initialization fails
+	Start() error
+
+	// Stop gracefully shuts down the plugin.
+	// - Unsubscribes from all state changes
+	// - Stops any background goroutines
+	// - Releases resources
+	Stop()
+}
+
+// Resettable is an optional interface for plugins that support the system-wide
+// reset mechanism. When the reset state variable is triggered, the Reset
+// Coordinator calls Reset() on all plugins implementing this interface.
+type Resettable interface {
+	// Reset re-evaluates all conditions and recalculates state.
+	// - Clears any rate limiters or timers
+	// - Re-applies current state conditions
+	// - Returns error if reset fails
+	Reset() error
+}
+
+// ShadowStateProvider is an optional interface for plugins that track their
+// decision-making for observability. Shadow state captures the inputs that
+// led to each action, enabling debugging and verification.
+type ShadowStateProvider interface {
+	// GetShadowState returns the current shadow state for the plugin.
+	// The returned state captures recent decisions and their triggering inputs.
+	GetShadowState() shadowstate.PluginShadowState
+}
+
+// Factory is a function that creates a new plugin instance given a context.
+// Factories are registered with the global registry and called during
+// application startup to instantiate plugins.
+type Factory func(ctx *Context) (Plugin, error)

--- a/homeautomation-go/pkg/plugin/registry.go
+++ b/homeautomation-go/pkg/plugin/registry.go
@@ -1,0 +1,214 @@
+package plugin
+
+import (
+	"fmt"
+	"log"
+	"sort"
+	"sync"
+)
+
+// Priority constants for plugin registration.
+// Higher priority values override lower priority plugins with the same name.
+const (
+	// PriorityDefault is the default priority for plugins.
+	// Public/reference implementations should use this priority.
+	PriorityDefault = 0
+
+	// PriorityOverride is used by private implementations to override
+	// public plugins. Private plugins should use this priority to ensure
+	// they take precedence over the default implementation.
+	PriorityOverride = 100
+)
+
+// PluginInfo contains metadata about a registered plugin.
+type PluginInfo struct {
+	// Name is the unique identifier for the plugin.
+	// Plugins with the same name will override based on priority.
+	Name string
+
+	// Description is a human-readable description of the plugin.
+	Description string
+
+	// Priority determines which plugin wins when multiple plugins
+	// register with the same name. Higher priority wins.
+	Priority int
+
+	// Factory creates new instances of the plugin.
+	Factory Factory
+
+	// Order specifies the startup order. Lower values start first.
+	// Plugins that depend on others should have higher order values.
+	// Default is 50. State tracking should be 10, reset coordinator should be 90.
+	Order int
+}
+
+// Registry manages plugin registration and instantiation.
+// It supports priority-based override, allowing private implementations
+// to replace public ones at compile time through import ordering.
+type Registry struct {
+	mu      sync.RWMutex
+	plugins map[string]PluginInfo
+	order   []string
+}
+
+// NewRegistry creates a new plugin registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		plugins: make(map[string]PluginInfo),
+		order:   make([]string, 0),
+	}
+}
+
+// Register adds a plugin to the registry.
+// If a plugin with the same name already exists, the one with higher
+// priority wins. If priorities are equal, the later registration wins.
+func (r *Registry) Register(info PluginInfo) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if info.Name == "" {
+		return fmt.Errorf("plugin name cannot be empty")
+	}
+
+	if info.Factory == nil {
+		return fmt.Errorf("plugin %s: factory cannot be nil", info.Name)
+	}
+
+	// Set default order if not specified
+	if info.Order == 0 {
+		info.Order = 50
+	}
+
+	existing, exists := r.plugins[info.Name]
+	if exists {
+		if info.Priority < existing.Priority {
+			log.Printf("Plugin %q registration skipped (priority %d < existing %d)",
+				info.Name, info.Priority, existing.Priority)
+			return nil
+		}
+
+		if info.Priority >= existing.Priority {
+			log.Printf("Plugin %q being overridden (priority %d -> %d)",
+				info.Name, existing.Priority, info.Priority)
+		}
+	}
+
+	r.plugins[info.Name] = info
+
+	if !exists {
+		r.order = append(r.order, info.Name)
+	}
+
+	log.Printf("Plugin %q registered (priority %d, order %d): %s",
+		info.Name, info.Priority, info.Order, info.Description)
+
+	return nil
+}
+
+// Get returns the plugin info for a given name, or nil if not found.
+func (r *Registry) Get(name string) *PluginInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	info, ok := r.plugins[name]
+	if !ok {
+		return nil
+	}
+	return &info
+}
+
+// List returns all registered plugins sorted by their startup order.
+func (r *Registry) List() []PluginInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]PluginInfo, 0, len(r.plugins))
+	for _, name := range r.order {
+		result = append(result, r.plugins[name])
+	}
+
+	// Sort by order (lower first), then by name for stability
+	sort.SliceStable(result, func(i, j int) bool {
+		if result[i].Order != result[j].Order {
+			return result[i].Order < result[j].Order
+		}
+		return result[i].Name < result[j].Name
+	})
+
+	return result
+}
+
+// CreateAll instantiates all registered plugins using the provided context.
+// Plugins are created in order (by Order field), so dependencies should
+// have lower Order values.
+func (r *Registry) CreateAll(ctx *Context) ([]Plugin, error) {
+	plugins := r.List()
+	result := make([]Plugin, 0, len(plugins))
+
+	for _, info := range plugins {
+		plugin, err := info.Factory(ctx)
+		if err != nil {
+			// Clean up already-created plugins on error
+			for i := len(result) - 1; i >= 0; i-- {
+				result[i].Stop()
+			}
+			return nil, fmt.Errorf("failed to create plugin %s: %w", info.Name, err)
+		}
+		result = append(result, plugin)
+	}
+
+	return result, nil
+}
+
+// Names returns the names of all registered plugins.
+func (r *Registry) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]string, len(r.order))
+	copy(result, r.order)
+	return result
+}
+
+// Clear removes all registered plugins. Useful for testing.
+func (r *Registry) Clear() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.plugins = make(map[string]PluginInfo)
+	r.order = make([]string, 0)
+}
+
+// Global registry instance
+var globalRegistry = NewRegistry()
+
+// Register adds a plugin to the global registry.
+// This is typically called from init() functions in plugin packages.
+func Register(info PluginInfo) error {
+	return globalRegistry.Register(info)
+}
+
+// Get returns plugin info from the global registry.
+func Get(name string) *PluginInfo {
+	return globalRegistry.Get(name)
+}
+
+// List returns all plugins from the global registry.
+func List() []PluginInfo {
+	return globalRegistry.List()
+}
+
+// CreateAll creates all plugins from the global registry.
+func CreateAll(ctx *Context) ([]Plugin, error) {
+	return globalRegistry.CreateAll(ctx)
+}
+
+// Names returns all plugin names from the global registry.
+func Names() []string {
+	return globalRegistry.Names()
+}
+
+// ClearGlobal clears the global registry. Useful for testing.
+func ClearGlobal() {
+	globalRegistry.Clear()
+}

--- a/homeautomation-go/pkg/plugin/registry_test.go
+++ b/homeautomation-go/pkg/plugin/registry_test.go
@@ -1,0 +1,328 @@
+package plugin
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockPlugin implements the Plugin interface for testing
+type mockPlugin struct {
+	name    string
+	started bool
+	stopped bool
+}
+
+func (m *mockPlugin) Name() string { return m.name }
+func (m *mockPlugin) Start() error { m.started = true; return nil }
+func (m *mockPlugin) Stop()        { m.stopped = true }
+
+func TestRegistry_Register(t *testing.T) {
+	tests := []struct {
+		name        string
+		info        PluginInfo
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "valid registration",
+			info: PluginInfo{
+				Name:        "test-plugin",
+				Description: "A test plugin",
+				Priority:    PriorityDefault,
+				Factory:     func(ctx *Context) (Plugin, error) { return &mockPlugin{name: "test"}, nil },
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty name",
+			info: PluginInfo{
+				Name:    "",
+				Factory: func(ctx *Context) (Plugin, error) { return nil, nil },
+			},
+			wantErr:     true,
+			errContains: "name cannot be empty",
+		},
+		{
+			name: "nil factory",
+			info: PluginInfo{
+				Name:    "test-plugin",
+				Factory: nil,
+			},
+			wantErr:     true,
+			errContains: "factory cannot be nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := NewRegistry()
+			err := registry.Register(tt.info)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRegistry_PriorityOverride(t *testing.T) {
+	registry := NewRegistry()
+
+	// Register default priority plugin
+	defaultFactory := func(ctx *Context) (Plugin, error) {
+		return &mockPlugin{name: "default"}, nil
+	}
+	err := registry.Register(PluginInfo{
+		Name:        "security",
+		Description: "Default security plugin",
+		Priority:    PriorityDefault,
+		Factory:     defaultFactory,
+	})
+	require.NoError(t, err)
+
+	// Verify default is registered
+	info := registry.Get("security")
+	require.NotNil(t, info)
+	assert.Equal(t, PriorityDefault, info.Priority)
+	assert.Equal(t, "Default security plugin", info.Description)
+
+	// Register override priority plugin
+	overrideFactory := func(ctx *Context) (Plugin, error) {
+		return &mockPlugin{name: "override"}, nil
+	}
+	err = registry.Register(PluginInfo{
+		Name:        "security",
+		Description: "Private security plugin",
+		Priority:    PriorityOverride,
+		Factory:     overrideFactory,
+	})
+	require.NoError(t, err)
+
+	// Verify override took precedence
+	info = registry.Get("security")
+	require.NotNil(t, info)
+	assert.Equal(t, PriorityOverride, info.Priority)
+	assert.Equal(t, "Private security plugin", info.Description)
+
+	// Verify we can create the override plugin
+	plugin, err := info.Factory(nil)
+	require.NoError(t, err)
+	assert.Equal(t, "override", plugin.Name())
+}
+
+func TestRegistry_LowerPrioritySkipped(t *testing.T) {
+	registry := NewRegistry()
+
+	// Register high priority first
+	err := registry.Register(PluginInfo{
+		Name:        "security",
+		Description: "High priority",
+		Priority:    PriorityOverride,
+		Factory:     func(ctx *Context) (Plugin, error) { return &mockPlugin{name: "high"}, nil },
+	})
+	require.NoError(t, err)
+
+	// Try to register lower priority - should be skipped
+	err = registry.Register(PluginInfo{
+		Name:        "security",
+		Description: "Low priority",
+		Priority:    PriorityDefault,
+		Factory:     func(ctx *Context) (Plugin, error) { return &mockPlugin{name: "low"}, nil },
+	})
+	require.NoError(t, err) // No error, just skipped
+
+	// Verify high priority is still there
+	info := registry.Get("security")
+	require.NotNil(t, info)
+	assert.Equal(t, "High priority", info.Description)
+}
+
+func TestRegistry_List(t *testing.T) {
+	registry := NewRegistry()
+
+	// Register plugins with different orders
+	registry.Register(PluginInfo{
+		Name:    "reset",
+		Order:   90,
+		Factory: func(ctx *Context) (Plugin, error) { return &mockPlugin{name: "reset"}, nil },
+	})
+	registry.Register(PluginInfo{
+		Name:    "statetracking",
+		Order:   10,
+		Factory: func(ctx *Context) (Plugin, error) { return &mockPlugin{name: "statetracking"}, nil },
+	})
+	registry.Register(PluginInfo{
+		Name:    "security",
+		Order:   50,
+		Factory: func(ctx *Context) (Plugin, error) { return &mockPlugin{name: "security"}, nil },
+	})
+	registry.Register(PluginInfo{
+		Name:    "lighting",
+		Order:   50,
+		Factory: func(ctx *Context) (Plugin, error) { return &mockPlugin{name: "lighting"}, nil },
+	})
+
+	// List should be ordered by Order, then by name
+	list := registry.List()
+	require.Len(t, list, 4)
+
+	assert.Equal(t, "statetracking", list[0].Name) // Order 10
+	assert.Equal(t, "lighting", list[1].Name)      // Order 50, "l" < "s"
+	assert.Equal(t, "security", list[2].Name)      // Order 50, "s"
+	assert.Equal(t, "reset", list[3].Name)         // Order 90
+}
+
+func TestRegistry_CreateAll(t *testing.T) {
+	registry := NewRegistry()
+
+	created := make([]string, 0)
+
+	registry.Register(PluginInfo{
+		Name:  "first",
+		Order: 10,
+		Factory: func(ctx *Context) (Plugin, error) {
+			created = append(created, "first")
+			return &mockPlugin{name: "first"}, nil
+		},
+	})
+	registry.Register(PluginInfo{
+		Name:  "second",
+		Order: 20,
+		Factory: func(ctx *Context) (Plugin, error) {
+			created = append(created, "second")
+			return &mockPlugin{name: "second"}, nil
+		},
+	})
+
+	plugins, err := registry.CreateAll(nil)
+	require.NoError(t, err)
+	require.Len(t, plugins, 2)
+
+	// Verify creation order
+	assert.Equal(t, []string{"first", "second"}, created)
+	assert.Equal(t, "first", plugins[0].Name())
+	assert.Equal(t, "second", plugins[1].Name())
+}
+
+func TestRegistry_CreateAll_ErrorCleanup(t *testing.T) {
+	registry := NewRegistry()
+
+	plugin1 := &mockPlugin{name: "first"}
+	registry.Register(PluginInfo{
+		Name:  "first",
+		Order: 10,
+		Factory: func(ctx *Context) (Plugin, error) {
+			return plugin1, nil
+		},
+	})
+	registry.Register(PluginInfo{
+		Name:  "second",
+		Order: 20,
+		Factory: func(ctx *Context) (Plugin, error) {
+			return nil, errors.New("creation failed")
+		},
+	})
+
+	plugins, err := registry.CreateAll(nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create plugin second")
+	assert.Nil(t, plugins)
+
+	// Verify cleanup happened - first plugin should be stopped
+	assert.True(t, plugin1.stopped, "first plugin should have been stopped on cleanup")
+}
+
+func TestRegistry_Get_NotFound(t *testing.T) {
+	registry := NewRegistry()
+	info := registry.Get("nonexistent")
+	assert.Nil(t, info)
+}
+
+func TestRegistry_Names(t *testing.T) {
+	registry := NewRegistry()
+
+	registry.Register(PluginInfo{
+		Name:    "alpha",
+		Factory: func(ctx *Context) (Plugin, error) { return &mockPlugin{}, nil },
+	})
+	registry.Register(PluginInfo{
+		Name:    "beta",
+		Factory: func(ctx *Context) (Plugin, error) { return &mockPlugin{}, nil },
+	})
+
+	names := registry.Names()
+	assert.Len(t, names, 2)
+	assert.Contains(t, names, "alpha")
+	assert.Contains(t, names, "beta")
+}
+
+func TestRegistry_Clear(t *testing.T) {
+	registry := NewRegistry()
+
+	registry.Register(PluginInfo{
+		Name:    "test",
+		Factory: func(ctx *Context) (Plugin, error) { return &mockPlugin{}, nil },
+	})
+
+	assert.Len(t, registry.Names(), 1)
+
+	registry.Clear()
+
+	assert.Len(t, registry.Names(), 0)
+	assert.Nil(t, registry.Get("test"))
+}
+
+func TestRegistry_DefaultOrder(t *testing.T) {
+	registry := NewRegistry()
+
+	// Register without specifying Order
+	err := registry.Register(PluginInfo{
+		Name:    "test",
+		Factory: func(ctx *Context) (Plugin, error) { return &mockPlugin{}, nil },
+	})
+	require.NoError(t, err)
+
+	info := registry.Get("test")
+	require.NotNil(t, info)
+	assert.Equal(t, 50, info.Order, "default order should be 50")
+}
+
+func TestGlobalRegistry(t *testing.T) {
+	// Clear global registry for clean test
+	ClearGlobal()
+	defer ClearGlobal()
+
+	err := Register(PluginInfo{
+		Name:        "global-test",
+		Description: "Testing global registry",
+		Factory:     func(ctx *Context) (Plugin, error) { return &mockPlugin{name: "global"}, nil },
+	})
+	require.NoError(t, err)
+
+	// Test Get
+	info := Get("global-test")
+	require.NotNil(t, info)
+	assert.Equal(t, "Testing global registry", info.Description)
+
+	// Test List
+	list := List()
+	assert.Len(t, list, 1)
+
+	// Test Names
+	names := Names()
+	assert.Contains(t, names, "global-test")
+
+	// Test CreateAll
+	plugins, err := CreateAll(nil)
+	require.NoError(t, err)
+	require.Len(t, plugins, 1)
+	assert.Equal(t, "global", plugins[0].Name())
+}

--- a/homeautomation-go/pkg/state/adapter.go
+++ b/homeautomation-go/pkg/state/adapter.go
@@ -1,0 +1,75 @@
+package state
+
+import (
+	"homeautomation/internal/state"
+)
+
+// ManagerAdapter wraps internal state.Manager to implement pkg state.Manager
+type ManagerAdapter struct {
+	internal *state.Manager
+}
+
+// WrapManager wraps an internal state.Manager to implement the pkg state.Manager interface
+func WrapManager(m *state.Manager) Manager {
+	return &ManagerAdapter{internal: m}
+}
+
+// UnwrapManager returns the underlying internal manager if available
+func UnwrapManager(m Manager) *state.Manager {
+	if adapter, ok := m.(*ManagerAdapter); ok {
+		return adapter.internal
+	}
+	return nil
+}
+
+func (a *ManagerAdapter) SyncFromHA() error {
+	return a.internal.SyncFromHA()
+}
+
+func (a *ManagerAdapter) GetBool(key string) (bool, error) {
+	return a.internal.GetBool(key)
+}
+
+func (a *ManagerAdapter) SetBool(key string, value bool) error {
+	return a.internal.SetBool(key, value)
+}
+
+func (a *ManagerAdapter) CompareAndSwapBool(key string, old, new bool) (bool, error) {
+	return a.internal.CompareAndSwapBool(key, old, new)
+}
+
+func (a *ManagerAdapter) GetString(key string) (string, error) {
+	return a.internal.GetString(key)
+}
+
+func (a *ManagerAdapter) SetString(key string, value string) error {
+	return a.internal.SetString(key, value)
+}
+
+func (a *ManagerAdapter) GetNumber(key string) (float64, error) {
+	return a.internal.GetNumber(key)
+}
+
+func (a *ManagerAdapter) SetNumber(key string, value float64) error {
+	return a.internal.SetNumber(key, value)
+}
+
+func (a *ManagerAdapter) GetJSON(key string, target interface{}) error {
+	return a.internal.GetJSON(key, target)
+}
+
+func (a *ManagerAdapter) SetJSON(key string, value interface{}) error {
+	return a.internal.SetJSON(key, value)
+}
+
+func (a *ManagerAdapter) Subscribe(key string, handler StateChangeHandler) (Subscription, error) {
+	// Create wrapper handler that converts between handler types
+	internalHandler := func(k string, oldValue, newValue interface{}) {
+		handler(k, oldValue, newValue)
+	}
+	return a.internal.Subscribe(key, internalHandler)
+}
+
+func (a *ManagerAdapter) GetAllValues() map[string]interface{} {
+	return a.internal.GetAllValues()
+}

--- a/homeautomation-go/pkg/state/interfaces.go
+++ b/homeautomation-go/pkg/state/interfaces.go
@@ -1,0 +1,45 @@
+// Package state provides the public interface definitions for state management.
+// These interfaces can be imported by external packages (including private
+// plugin implementations).
+//
+// The actual implementation is in internal/state, which is wrapped by these
+// public interfaces for external consumption.
+package state
+
+// StateChangeHandler is called when a state variable changes.
+type StateChangeHandler func(key string, oldValue, newValue interface{})
+
+// Subscription represents an active state change subscription.
+type Subscription interface {
+	Unsubscribe()
+}
+
+// Manager defines the interface for state management.
+// This interface matches the public methods of internal/state.Manager.
+type Manager interface {
+	// Sync methods
+	SyncFromHA() error
+
+	// Boolean operations
+	GetBool(key string) (bool, error)
+	SetBool(key string, value bool) error
+	CompareAndSwapBool(key string, old, new bool) (bool, error)
+
+	// String operations
+	GetString(key string) (string, error)
+	SetString(key string, value string) error
+
+	// Number operations
+	GetNumber(key string) (float64, error)
+	SetNumber(key string, value float64) error
+
+	// JSON operations
+	GetJSON(key string, target interface{}) error
+	SetJSON(key string, value interface{}) error
+
+	// Subscription
+	Subscribe(key string, handler StateChangeHandler) (Subscription, error)
+
+	// Query
+	GetAllValues() map[string]interface{}
+}


### PR DESCRIPTION
## Summary

- Implement a plugin registry system that allows external packages to override internal plugins at compile time
- This enables private security implementations to replace the reference plugin without modifying the main codebase
- The registry supports priority-based override where higher priority plugins win

## Changes

### Public Package (`pkg/`)
- `pkg/plugin/interfaces.go` - Core Plugin, Resettable, ShadowStateProvider interfaces
- `pkg/plugin/context.go` - Context struct for plugin initialization  
- `pkg/plugin/registry.go` - Global registry with priority-based override
- `pkg/plugin/registry_test.go` - Comprehensive tests (98.4% coverage)
- `pkg/ha/interfaces.go` - Public HA client interface
- `pkg/ha/adapter.go` - Adapter wrapping internal ha.Client
- `pkg/state/interfaces.go` - Public state manager interface
- `pkg/state/adapter.go` - Adapter wrapping internal state.Manager

### Reference Security Plugin
- `internal/plugins/security/register.go` - Plugin registration with `init()` using PriorityDefault

### Documentation
- `docs/architecture/PLUGIN_SYSTEM.md` - Complete design and implementation guide

## How Override Works

1. Public plugin registers with `PriorityDefault` (0)
2. Private plugin (in separate repo) registers with `PriorityOverride` (100)
3. Higher priority plugin wins and is used

```
Plugin "security" registered (priority 0)
Plugin "security" being overridden (priority 0 -> 100)
Starting plugin: security (Private security plugin)
```

## Test plan

- [x] All existing tests pass
- [x] Plugin registry tests pass (98.4% coverage)
- [x] Pre-push hook validation passes (71.3% total coverage)
- [x] Private security repo compiles against pkg interfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)