### PR TITLE
fix: Add error checking to private repo trigger workflow

### DIFF
--- a/.github/workflows/trigger-private-rebuild.yml
+++ b/.github/workflows/trigger-private-rebuild.yml
@@ -17,11 +17,22 @@ jobs:
     steps:
       - name: Trigger private repository build
         run: |
-          curl -X POST \
+          HTTP_STATUS=$(curl -s -o response.json -w "%{http_code}" -X POST \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ secrets.PRIVATE_REPO_TRIGGER_TOKEN }}" \
             https://api.github.com/repos/NickBorgers/home-automation-plus-security/dispatches \
-            -d '{"event_type":"public-repo-updated","client_payload":{"ref":"${{ github.ref }}","sha":"${{ github.sha }}"}}'
+            -d '{"event_type":"public-repo-updated","client_payload":{"ref":"${{ github.ref }}","sha":"${{ github.sha }}"}}')
+
+          echo "HTTP Status: $HTTP_STATUS"
+
+          if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+            echo "✅ Successfully triggered rebuild"
+          else
+            echo "❌ Failed to trigger rebuild"
+            echo "Response:"
+            cat response.json
+            exit 1
+          fi
 
       - name: Log trigger
         run: |


### PR DESCRIPTION
## Summary
- The workflow was silently succeeding even when the GitHub API returned errors (e.g., 403 forbidden)
- Now properly checks HTTP status code and fails the job if the dispatch request fails
- Prints the error response for easier debugging

## Test plan
- [x] Workflow file syntax is valid
- [ ] Next push to main will properly fail if PAT permissions are incorrect

🤖 Generated with [Claude Code](https://claude.com/claude-code)