### PR TITLE
refactor: Add SubscriptionHelper to reduce m.updateShadowInputs() boilerplate

### DIFF
--- a/homeautomation-go/internal/plugins/energy/manager_test.go
+++ b/homeautomation-go/internal/plugins/energy/manager_test.go
@@ -445,16 +445,16 @@ func TestEnergyManager_Stop(t *testing.T) {
 	err := manager.Start()
 	assert.NoError(t, err)
 
-	// Verify subscriptions were created
-	assert.Equal(t, 3, len(manager.haSubscriptions), "Should have 3 HA subscriptions")
-	assert.Equal(t, 4, len(manager.stateSubscriptions), "Should have 4 state subscriptions")
+	// Verify subscriptions were created via subHelper
+	assert.Equal(t, 3, len(manager.subHelper.GetHASubscriptions()), "Should have 3 HA subscriptions")
+	assert.Equal(t, 4, len(manager.subHelper.GetStateSubscriptions()), "Should have 4 state subscriptions")
 
 	// Stop manager
 	manager.Stop()
 
 	// Verify subscriptions were cleaned up
-	assert.Nil(t, manager.haSubscriptions, "HA subscriptions should be nil after Stop")
-	assert.Nil(t, manager.stateSubscriptions, "State subscriptions should be nil after Stop")
+	assert.Equal(t, 0, len(manager.subHelper.GetHASubscriptions()), "HA subscriptions should be empty after Stop")
+	assert.Equal(t, 0, len(manager.subHelper.GetStateSubscriptions()), "State subscriptions should be empty after Stop")
 }
 
 func TestEnergyManager_ReadOnlyMode(t *testing.T) {

--- a/homeautomation-go/internal/shadowstate/subscription_helper.go
+++ b/homeautomation-go/internal/shadowstate/subscription_helper.go
@@ -1,0 +1,179 @@
+package shadowstate
+
+import (
+	"fmt"
+
+	"homeautomation/internal/ha"
+	"homeautomation/internal/state"
+
+	"go.uber.org/zap"
+)
+
+// ShadowInputUpdater is the interface that shadow trackers must implement
+// to receive automatic input updates from SubscriptionHelper.
+type ShadowInputUpdater interface {
+	UpdateCurrentInputs(inputs map[string]interface{})
+}
+
+// SubscriptionHelper wraps HA and state subscriptions to automatically
+// capture shadow state inputs before invoking handlers. This eliminates
+// the need for every handler to manually call updateShadowInputs().
+type SubscriptionHelper struct {
+	haClient      ha.HAClient
+	stateManager  *state.Manager
+	registry      *SubscriptionRegistry
+	inputHelper   *InputCaptureHelper
+	shadowTracker ShadowInputUpdater
+	pluginName    string
+	logger        *zap.Logger
+
+	// Track subscriptions for cleanup
+	haSubscriptions    []ha.Subscription
+	stateSubscriptions []state.Subscription
+}
+
+// NewSubscriptionHelper creates a new subscription helper for a plugin.
+// The shadowTracker receives automatic input updates before each handler runs.
+func NewSubscriptionHelper(
+	haClient ha.HAClient,
+	stateManager *state.Manager,
+	registry *SubscriptionRegistry,
+	shadowTracker ShadowInputUpdater,
+	pluginName string,
+	logger *zap.Logger,
+) *SubscriptionHelper {
+	h := &SubscriptionHelper{
+		haClient:           haClient,
+		stateManager:       stateManager,
+		registry:           registry,
+		shadowTracker:      shadowTracker,
+		pluginName:         pluginName,
+		logger:             logger,
+		haSubscriptions:    make([]ha.Subscription, 0),
+		stateSubscriptions: make([]state.Subscription, 0),
+	}
+
+	// Create input helper for automatic capture
+	if registry != nil {
+		h.inputHelper = NewInputCaptureHelper(registry, haClient, stateManager)
+	}
+
+	return h
+}
+
+// captureInputs captures all registered inputs and updates the shadow tracker.
+// This is called automatically before every handler.
+func (h *SubscriptionHelper) captureInputs() {
+	if h.inputHelper == nil || h.shadowTracker == nil {
+		return
+	}
+	inputs := h.inputHelper.CaptureInputs(h.pluginName)
+	h.shadowTracker.UpdateCurrentInputs(inputs)
+}
+
+// SubscribeToSensor subscribes to a Home Assistant sensor entity and parses its
+// state as a float64. Shadow state inputs are automatically captured before
+// the handler is called.
+func (h *SubscriptionHelper) SubscribeToSensor(entityID string, handler func(value float64)) error {
+	// Register the subscription for input capture
+	if h.registry != nil {
+		h.registry.RegisterHASubscription(h.pluginName, entityID)
+	}
+
+	sub, err := h.haClient.SubscribeStateChanges(entityID, func(entity string, oldState, newState *ha.State) {
+		if newState == nil {
+			return
+		}
+
+		// Capture shadow state inputs BEFORE calling the handler
+		h.captureInputs()
+
+		// Parse the state string as float64
+		var val float64
+		_, parseErr := fmt.Sscanf(newState.State, "%f", &val)
+		if parseErr != nil {
+			h.logger.Warn("Failed to parse sensor value as number",
+				zap.String("entity_id", entityID),
+				zap.String("value", newState.State))
+			return
+		}
+
+		handler(val)
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to subscribe to %s: %w", entityID, err)
+	}
+
+	h.haSubscriptions = append(h.haSubscriptions, sub)
+	return nil
+}
+
+// SubscribeToEntity subscribes to a Home Assistant entity with full state access.
+// Shadow state inputs are automatically captured before the handler is called.
+func (h *SubscriptionHelper) SubscribeToEntity(entityID string, handler func(entityID string, oldState, newState *ha.State)) error {
+	// Register the subscription for input capture
+	if h.registry != nil {
+		h.registry.RegisterHASubscription(h.pluginName, entityID)
+	}
+
+	sub, err := h.haClient.SubscribeStateChanges(entityID, func(entity string, oldState, newState *ha.State) {
+		// Capture shadow state inputs BEFORE calling the handler
+		h.captureInputs()
+
+		handler(entity, oldState, newState)
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to subscribe to %s: %w", entityID, err)
+	}
+
+	h.haSubscriptions = append(h.haSubscriptions, sub)
+	return nil
+}
+
+// SubscribeToState subscribes to a state variable change.
+// Shadow state inputs are automatically captured before the handler is called.
+func (h *SubscriptionHelper) SubscribeToState(key string, handler func(key string, oldValue, newValue interface{})) error {
+	// Register the subscription for input capture
+	if h.registry != nil {
+		h.registry.RegisterStateSubscription(h.pluginName, key)
+	}
+
+	sub, err := h.stateManager.Subscribe(key, func(k string, oldValue, newValue interface{}) {
+		// Capture shadow state inputs BEFORE calling the handler
+		h.captureInputs()
+
+		handler(k, oldValue, newValue)
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to subscribe to %s: %w", key, err)
+	}
+
+	h.stateSubscriptions = append(h.stateSubscriptions, sub)
+	return nil
+}
+
+// GetHASubscriptions returns all HA subscriptions (for manual cleanup if needed)
+func (h *SubscriptionHelper) GetHASubscriptions() []ha.Subscription {
+	return h.haSubscriptions
+}
+
+// GetStateSubscriptions returns all state subscriptions (for manual cleanup if needed)
+func (h *SubscriptionHelper) GetStateSubscriptions() []state.Subscription {
+	return h.stateSubscriptions
+}
+
+// UnsubscribeAll cleans up all subscriptions
+func (h *SubscriptionHelper) UnsubscribeAll() {
+	for _, sub := range h.haSubscriptions {
+		sub.Unsubscribe()
+	}
+	h.haSubscriptions = nil
+
+	for _, sub := range h.stateSubscriptions {
+		sub.Unsubscribe()
+	}
+	h.stateSubscriptions = nil
+}

--- a/homeautomation-go/internal/shadowstate/subscription_helper_test.go
+++ b/homeautomation-go/internal/shadowstate/subscription_helper_test.go
@@ -1,0 +1,269 @@
+package shadowstate
+
+import (
+	"testing"
+
+	"homeautomation/internal/ha"
+
+	"go.uber.org/zap"
+)
+
+// mockShadowTracker implements ShadowInputUpdater for testing
+type mockShadowTracker struct {
+	inputs      map[string]interface{}
+	updateCount int
+}
+
+func newMockShadowTracker() *mockShadowTracker {
+	return &mockShadowTracker{
+		inputs: make(map[string]interface{}),
+	}
+}
+
+func (m *mockShadowTracker) UpdateCurrentInputs(inputs map[string]interface{}) {
+	m.inputs = inputs
+	m.updateCount++
+}
+
+// mockHAClient implements ha.HAClient for testing
+type mockHAClient struct {
+	states      map[string]*ha.State
+	subscribers map[string][]ha.StateChangeHandler
+}
+
+func newMockHAClient() *mockHAClient {
+	return &mockHAClient{
+		states:      make(map[string]*ha.State),
+		subscribers: make(map[string][]ha.StateChangeHandler),
+	}
+}
+
+func (m *mockHAClient) Connect() error                     { return nil }
+func (m *mockHAClient) Disconnect() error                  { return nil }
+func (m *mockHAClient) IsConnected() bool                  { return true }
+func (m *mockHAClient) GetAllStates() ([]*ha.State, error) { return nil, nil }
+func (m *mockHAClient) CallService(domain, service string, data map[string]interface{}) error {
+	return nil
+}
+func (m *mockHAClient) SetInputBoolean(name string, value bool) error   { return nil }
+func (m *mockHAClient) SetInputNumber(name string, value float64) error { return nil }
+func (m *mockHAClient) SetInputText(name string, value string) error    { return nil }
+
+func (m *mockHAClient) GetState(entityID string) (*ha.State, error) {
+	if s, ok := m.states[entityID]; ok {
+		return s, nil
+	}
+	return &ha.State{EntityID: entityID, State: "unknown"}, nil
+}
+
+func (m *mockHAClient) SubscribeStateChanges(entityID string, handler ha.StateChangeHandler) (ha.Subscription, error) {
+	m.subscribers[entityID] = append(m.subscribers[entityID], handler)
+	return &mockSubscription{entityID: entityID, client: m}, nil
+}
+
+// simulateStateChange simulates a state change for testing
+func (m *mockHAClient) simulateStateChange(entityID string, oldState, newState *ha.State) {
+	for _, handler := range m.subscribers[entityID] {
+		handler(entityID, oldState, newState)
+	}
+}
+
+type mockSubscription struct {
+	entityID string
+	client   *mockHAClient
+}
+
+func (s *mockSubscription) Unsubscribe() error {
+	s.client.subscribers[s.entityID] = nil
+	return nil
+}
+
+func TestSubscriptionHelper_SubscribeToSensor(t *testing.T) {
+	logger := zap.NewNop()
+	haClient := newMockHAClient()
+	registry := NewSubscriptionRegistry()
+	tracker := newMockShadowTracker()
+
+	helper := NewSubscriptionHelper(haClient, nil, registry, tracker, "test", logger)
+
+	// Track if handler was called
+	handlerCalled := false
+	var receivedValue float64
+
+	err := helper.SubscribeToSensor("sensor.test", func(value float64) {
+		handlerCalled = true
+		receivedValue = value
+	})
+
+	if err != nil {
+		t.Fatalf("SubscribeToSensor failed: %v", err)
+	}
+
+	// Verify registration
+	subs := registry.GetHASubscriptions("test")
+	if len(subs) != 1 || subs[0] != "sensor.test" {
+		t.Errorf("Expected sensor.test to be registered, got %v", subs)
+	}
+
+	// Simulate state change
+	haClient.simulateStateChange("sensor.test", nil, &ha.State{
+		EntityID: "sensor.test",
+		State:    "42.5",
+	})
+
+	if !handlerCalled {
+		t.Error("Handler was not called")
+	}
+
+	if receivedValue != 42.5 {
+		t.Errorf("Expected value 42.5, got %v", receivedValue)
+	}
+
+	// Shadow tracker should have been updated
+	if tracker.updateCount == 0 {
+		t.Error("Shadow tracker was not updated")
+	}
+}
+
+func TestSubscriptionHelper_SubscribeToEntity(t *testing.T) {
+	logger := zap.NewNop()
+	haClient := newMockHAClient()
+	registry := NewSubscriptionRegistry()
+	tracker := newMockShadowTracker()
+
+	helper := NewSubscriptionHelper(haClient, nil, registry, tracker, "test", logger)
+
+	// Track if handler was called
+	handlerCalled := false
+	var receivedState *ha.State
+
+	err := helper.SubscribeToEntity("sensor.test", func(entityID string, oldState, newState *ha.State) {
+		handlerCalled = true
+		receivedState = newState
+	})
+
+	if err != nil {
+		t.Fatalf("SubscribeToEntity failed: %v", err)
+	}
+
+	// Simulate state change
+	newState := &ha.State{EntityID: "sensor.test", State: "on"}
+	haClient.simulateStateChange("sensor.test", nil, newState)
+
+	if !handlerCalled {
+		t.Error("Handler was not called")
+	}
+
+	if receivedState.State != "on" {
+		t.Errorf("Expected state 'on', got %v", receivedState.State)
+	}
+
+	// Shadow tracker should have been updated
+	if tracker.updateCount == 0 {
+		t.Error("Shadow tracker was not updated")
+	}
+}
+
+func TestSubscriptionHelper_UnsubscribeAll(t *testing.T) {
+	logger := zap.NewNop()
+	haClient := newMockHAClient()
+	registry := NewSubscriptionRegistry()
+	tracker := newMockShadowTracker()
+
+	helper := NewSubscriptionHelper(haClient, nil, registry, tracker, "test", logger)
+
+	// Subscribe to multiple entities
+	_ = helper.SubscribeToSensor("sensor.test1", func(value float64) {})
+	_ = helper.SubscribeToSensor("sensor.test2", func(value float64) {})
+
+	if len(helper.GetHASubscriptions()) != 2 {
+		t.Errorf("Expected 2 subscriptions, got %d", len(helper.GetHASubscriptions()))
+	}
+
+	// Unsubscribe all
+	helper.UnsubscribeAll()
+
+	if len(helper.GetHASubscriptions()) != 0 {
+		t.Errorf("Expected 0 subscriptions after unsubscribe, got %d", len(helper.GetHASubscriptions()))
+	}
+}
+
+func TestSubscriptionHelper_CapturesInputsBeforeHandler(t *testing.T) {
+	logger := zap.NewNop()
+	haClient := newMockHAClient()
+	registry := NewSubscriptionRegistry()
+	tracker := newMockShadowTracker()
+
+	// Pre-populate some state in the HA client for capture
+	haClient.states["sensor.other"] = &ha.State{EntityID: "sensor.other", State: "100"}
+
+	helper := NewSubscriptionHelper(haClient, nil, registry, tracker, "test", logger)
+
+	// Register another entity so it gets captured
+	registry.RegisterHASubscription("test", "sensor.other")
+
+	var capturedInputsAtHandlerTime map[string]interface{}
+
+	err := helper.SubscribeToSensor("sensor.trigger", func(value float64) {
+		// Capture what the tracker saw when handler was called
+		capturedInputsAtHandlerTime = make(map[string]interface{})
+		for k, v := range tracker.inputs {
+			capturedInputsAtHandlerTime[k] = v
+		}
+	})
+
+	if err != nil {
+		t.Fatalf("SubscribeToSensor failed: %v", err)
+	}
+
+	// Simulate state change
+	haClient.simulateStateChange("sensor.trigger", nil, &ha.State{
+		EntityID: "sensor.trigger",
+		State:    "50",
+	})
+
+	// Verify that inputs were captured (should include sensor.other and sensor.trigger)
+	if capturedInputsAtHandlerTime == nil {
+		t.Fatal("Inputs were not captured before handler")
+	}
+
+	// sensor.other should have been captured since it was registered
+	if _, ok := capturedInputsAtHandlerTime["sensor.other"]; !ok {
+		t.Error("Expected sensor.other to be in captured inputs")
+	}
+}
+
+func TestSubscriptionHelper_NilRegistry(t *testing.T) {
+	logger := zap.NewNop()
+	haClient := newMockHAClient()
+	tracker := newMockShadowTracker()
+
+	// Create helper with nil registry
+	helper := NewSubscriptionHelper(haClient, nil, nil, tracker, "test", logger)
+
+	// Should still work, just without input capture
+	handlerCalled := false
+
+	err := helper.SubscribeToSensor("sensor.test", func(value float64) {
+		handlerCalled = true
+	})
+
+	if err != nil {
+		t.Fatalf("SubscribeToSensor failed: %v", err)
+	}
+
+	// Simulate state change
+	haClient.simulateStateChange("sensor.test", nil, &ha.State{
+		EntityID: "sensor.test",
+		State:    "42.5",
+	})
+
+	if !handlerCalled {
+		t.Error("Handler was not called")
+	}
+
+	// Shadow tracker should not have been updated (no inputHelper)
+	if tracker.updateCount != 0 {
+		t.Errorf("Shadow tracker should not have been updated without registry, got %d updates", tracker.updateCount)
+	}
+}


### PR DESCRIPTION
## Summary

This PR addresses the repetition of `m.updateShadowInputs()` calls that appear at the start of every handler in PR #141.

**The Problem:** Every handler in PR #141 needs to manually call `m.updateShadowInputs()` at the start to capture shadow state inputs. This leads to:
- Repetitive boilerplate code
- Risk of forgetting the call in new handlers
- Inconsistent patterns across plugins

**The Solution:** Introduces `SubscriptionHelper` that wraps subscription creation and automatically captures shadow inputs before invoking handlers.

### Changes

- **New `SubscriptionHelper`** in `internal/shadowstate/subscription_helper.go`:
  - `SubscribeToSensor(entityID, handler)` - subscribes to HA sensors, parses float values
  - `SubscribeToEntity(entityID, handler)` - subscribes to HA entities with full state
  - `SubscribeToState(key, handler)` - subscribes to state variables
  - All methods automatically capture shadow inputs before calling the handler
  - Automatically registers subscriptions with the registry
  - `UnsubscribeAll()` for cleanup

- **Refactored energy plugin** as proof of concept:
  - Removed ~100 lines of boilerplate
  - No more manual `m.updateShadowInputs()` calls
  - Simplified Start() and Stop() methods
  - All tests pass

### Before/After

**Before (every handler):**
```go
func (m *Manager) handleBatteryChange(percentage float64) {
    // Capture shadow state inputs at the start of every handler
    m.updateShadowInputs()
    
    // actual handler logic...
}
```

**After (automatic):**
```go
func (m *Manager) handleBatteryChange(percentage float64) {
    // Shadow inputs already captured by SubscriptionHelper!
    
    // actual handler logic...
}
```

**Before (Start method):**
```go
batteryEntity := "sensor.span_panel_span_storage_battery_percentage_2"
if err := m.subscribeToSensor(batteryEntity, m.handleBatteryChange); err != nil {
    return fmt.Errorf("failed to subscribe to battery sensor: %w", err)
}
if m.registry != nil {
    m.registry.RegisterHASubscription(m.pluginName, batteryEntity)
}
```

**After:**
```go
if err := m.subHelper.SubscribeToSensor("sensor.span_panel_span_storage_battery_percentage_2", m.handleBatteryChange); err != nil {
    return fmt.Errorf("failed to subscribe to battery sensor: %w", err)
}
```

## Test plan

- [x] All existing tests pass
- [x] New tests for SubscriptionHelper
- [x] Race detector passes
- [x] Coverage meets requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)