### PR TITLE
fix: Ensure shadow state inputs are captured on plugin startup

### DIFF
--- a/homeautomation-go/internal/plugins/energy/manager.go
+++ b/homeautomation-go/internal/plugins/energy/manager.go
@@ -102,8 +102,23 @@ func (m *Manager) Start() error {
 	// Start free energy check timer (check every minute)
 	go m.runFreeEnergyChecker()
 
+	// Capture initial shadow state inputs after all subscriptions are registered
+	m.captureInitialInputs()
+
 	m.logger.Info("Energy State Manager started successfully")
 	return nil
+}
+
+// captureInitialInputs captures the current input values at startup.
+// This ensures shadow state shows inputs immediately, not just after first event.
+func (m *Manager) captureInitialInputs() {
+	if m.subHelper == nil {
+		return
+	}
+	// The SubscriptionHelper automatically captures inputs before each handler,
+	// but we need to capture them once on startup so the shadow state isn't empty
+	// until the first event fires.
+	m.subHelper.CaptureInitialInputs()
 }
 
 // Stop stops the Energy State Manager and cleans up subscriptions

--- a/homeautomation-go/internal/plugins/lighting/manager.go
+++ b/homeautomation-go/internal/plugins/lighting/manager.go
@@ -56,9 +56,6 @@ func NewManager(haClient ha.HAClient, stateManager *state.Manager, config *HueCo
 func (m *Manager) Start() error {
 	m.logger.Info("Starting Lighting Control Manager")
 
-	// Initialize shadow state with current input values
-	m.updateShadowInputs()
-
 	// Subscribe to day phase changes
 	sub, err := m.stateManager.Subscribe("dayPhase", m.handleDayPhaseChange)
 	if err != nil {
@@ -147,6 +144,9 @@ func (m *Manager) Start() error {
 		m.logger.Debug("Subscribed to condition variable",
 			zap.String("variable", varNameCopy))
 	}
+
+	// Initialize shadow state with current input values (after all subscriptions registered)
+	m.updateShadowInputs()
 
 	m.logger.Info("Lighting Control Manager started successfully")
 	return nil

--- a/homeautomation-go/internal/plugins/statetracking/manager.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager.go
@@ -128,6 +128,9 @@ func (m *Manager) Start() error {
 		m.registry.RegisterStateSubscription(m.pluginName, "didOwnerJustReturnHome")
 	}
 
+	// Initialize shadow state with current input values (after registrations)
+	m.updateShadowInputs()
+
 	// Create and start the derived state helper
 	m.helper = state.NewDerivedStateHelper(m.stateManager, m.logger)
 	if err := m.helper.Start(); err != nil {

--- a/homeautomation-go/internal/shadowstate/subscription_helper.go
+++ b/homeautomation-go/internal/shadowstate/subscription_helper.go
@@ -71,6 +71,13 @@ func (h *SubscriptionHelper) captureInputs() {
 	h.shadowTracker.UpdateCurrentInputs(inputs)
 }
 
+// CaptureInitialInputs captures all registered inputs at startup.
+// Call this after all subscriptions are registered to populate shadow state
+// before any events fire. This prevents empty inputs.current in shadow state.
+func (h *SubscriptionHelper) CaptureInitialInputs() {
+	h.captureInputs()
+}
+
 // SubscribeToSensor subscribes to a Home Assistant sensor entity and parses its
 // state as a float64. Shadow state inputs are automatically captured before
 // the handler is called.


### PR DESCRIPTION
## Summary

Fixes shadow state `inputs.current` being empty for energy, lighting, and statetracking plugins. This is a follow-up to PR #141 which introduced the subscription registry infrastructure but didn't properly initialize inputs at startup.

### Root Cause

Three plugins had different issues preventing initial input capture:

| Plugin | Issue | Fix |
|--------|-------|-----|
| **Energy** | Uses `SubscriptionHelper` which only captures inputs when events fire | Added `CaptureInitialInputs()` call after subscriptions registered |
| **StateTracking** | Had `updateShadowInputs()` method but never called it in `Start()` | Added call after subscription registrations |
| **Lighting** | Called `updateShadowInputs()` BEFORE subscriptions were registered | Moved call to after all subscriptions registered |

### Changes

- **`internal/shadowstate/subscription_helper.go`**: Added `CaptureInitialInputs()` method for plugins using `SubscriptionHelper` pattern
- **`internal/plugins/energy/manager.go`**: Call `CaptureInitialInputs()` after subscriptions in `Start()`
- **`internal/plugins/statetracking/manager.go`**: Call `updateShadowInputs()` after registrations in `Start()`
- **`internal/plugins/lighting/manager.go`**: Moved `updateShadowInputs()` to after all subscriptions registered

### Expected Results

After this fix, `/api/shadow` should show populated `inputs.current` for:
- ✅ energy (was `{}`)
- ✅ lighting (was `{}`)
- ✅ statetracking (was `{}`)

Joins the already-working plugins:
- ✅ security
- ✅ loadshedding
- ✅ dayphase

## Test plan

- [x] All unit tests pass
- [x] All integration tests pass  
- [x] Race detector finds no issues
- [x] Coverage ≥70%
- [ ] Deploy and verify `/api/shadow` shows populated inputs for all plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)