### PR TITLE
fix: Use HTTP_PORT env var in Docker healthcheck

### DIFF
--- a/homeautomation-go/Dockerfile
+++ b/homeautomation-go/Dockerfile
@@ -47,9 +47,13 @@ RUN chown -R homeautomation:homeautomation /app
 # Switch to non-root user
 USER homeautomation
 
-# The application doesn't expose ports by default (it's a WebSocket client)
-# But we could add health check or metrics endpoints in the future
-# EXPOSE 8080
+# Expose the HTTP port (default 8080, configurable via HTTP_PORT env var)
+EXPOSE 8080
+
+# Health check using the HTTP_PORT env var (defaults to 8080)
+# Uses /health endpoint which returns {"status":"ok"}
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:${HTTP_PORT:-8080}/health || exit 1
 
 # Run the application
 CMD ["./homeautomation"]


### PR DESCRIPTION
## Summary
- Fixed Docker healthcheck using wrong port (hardcoded 8080 instead of respecting HTTP_PORT env var)
- Changed healthcheck endpoint from `/api/state` to `/health`
- Added `EXPOSE 8080` for documentation

## Problem
The container was reporting as `unhealthy` because:
1. The healthcheck was hardcoded to port 8080
2. The deployment uses `HTTP_PORT=8081` via `.env` file
3. wget was getting 404 because nothing was listening on 8080

## Solution
Updated the HEALTHCHECK instruction to use `${HTTP_PORT:-8080}`, which respects the environment variable with a sensible default.

## Test plan
- [ ] Merge and let CI build new image
- [ ] Redeploy container with new image
- [ ] Verify `docker inspect home-automation` shows `"Status": "healthy"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)