### PR TITLE
feat: Make API endpoint paths clickable links on sitemap

### DIFF
--- a/homeautomation-go/internal/api/server.go
+++ b/homeautomation-go/internal/api/server.go
@@ -470,6 +470,8 @@ func (s *Server) handleSitemap(w http.ResponseWriter, r *http.Request) {
         .endpoint { background: #2d2d2d; padding: 15px; margin: 10px 0; border-left: 3px solid #007acc; }
         .method { color: #4ec9b0; font-weight: bold; }
         .path { color: #ce9178; }
+        a.path { color: #ce9178; text-decoration: none; }
+        a.path:hover { text-decoration: underline; }
         .description { color: #9cdcfe; margin-top: 5px; }
         a { color: #569cd6; text-decoration: none; }
         a:hover { text-decoration: underline; }
@@ -482,10 +484,10 @@ func (s *Server) handleSitemap(w http.ResponseWriter, r *http.Request) {
 `)
 		for _, ep := range endpoints {
 			fmt.Fprintf(w, `    <div class="endpoint">
-        <div><span class="method">%s</span> <span class="path">%s</span></div>
+        <div><span class="method">%s</span> <a href="%s" class="path">%s</a></div>
         <div class="description">%s</div>
     </div>
-`, ep.Method, ep.Path, ep.Description)
+`, ep.Method, ep.Path, ep.Path, ep.Description)
 		}
 		fmt.Fprintf(w, `    <h2>Examples</h2>
     <div class="endpoint">


### PR DESCRIPTION
## Summary
- The "Available Endpoints" section on the API sitemap (`/`) now displays each endpoint path as a clickable link
- Clicking a path navigates directly to that resource (e.g., clicking `/api/shadow/lighting` opens that endpoint)
- This matches the behavior already present in the "Examples" section at the bottom of the page
- Added CSS to maintain the rust/orange color for path links with underline on hover

## Test plan
- [x] All existing tests pass
- [x] Verified HTML output shows `<a href="..." class="path">` elements for each endpoint
- [ ] Deploy and verify links are clickable in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)