### PR TITLE
fix: Add callback pattern to fix shadow state outputs never updated

### DIFF
--- a/homeautomation-go/internal/plugins/dayphase/manager.go
+++ b/homeautomation-go/internal/plugins/dayphase/manager.go
@@ -210,6 +210,9 @@ func (m *Manager) updateSunEventAndDayPhase() error {
 		m.shadowTracker.UpdateDayPhase(dayPhaseStr)
 	}
 
+	// Always update next transition (time changes even when phase doesn't)
+	m.updateNextTransition(dayPhase)
+
 	return nil
 }
 
@@ -248,4 +251,80 @@ func (m *Manager) updateShadowInputs() {
 	}
 
 	m.shadowTracker.UpdateCurrentInputs(inputs)
+}
+
+// updateNextTransition calculates and updates the next phase transition in shadow state
+func (m *Manager) updateNextTransition(currentPhase dayphaselib.DayPhase) {
+	now := time.Now()
+	sunTimes := m.calculator.GetSunTimes()
+
+	var nextTime time.Time
+	var nextPhase string
+
+	// Determine next transition based on current phase
+	// Transition order: night → morning → day → sunset → dusk → winddown → night
+	switch currentPhase {
+	case dayphaselib.DayPhaseNight:
+		// Next: morning at dawn
+		if t, ok := sunTimes["dawn"]; ok && t.After(now) {
+			nextTime = t
+			nextPhase = string(dayphaselib.DayPhaseMorning)
+		} else {
+			// Dawn is tomorrow, use approximate time
+			tomorrow := now.AddDate(0, 0, 1)
+			nextTime = time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 6, 0, 0, 0, now.Location())
+			nextPhase = string(dayphaselib.DayPhaseMorning)
+		}
+
+	case dayphaselib.DayPhaseMorning:
+		// Next: day at goldenHourEnd
+		if t, ok := sunTimes["goldenHourEnd"]; ok && t.After(now) {
+			nextTime = t
+			nextPhase = string(dayphaselib.DayPhaseDay)
+		}
+
+	case dayphaselib.DayPhaseDay:
+		// Next: sunset at goldenHour
+		if t, ok := sunTimes["goldenHour"]; ok && t.After(now) {
+			nextTime = t
+			nextPhase = string(dayphaselib.DayPhaseSunset)
+		}
+
+	case dayphaselib.DayPhaseSunset:
+		// Next: dusk at dusk
+		if t, ok := sunTimes["dusk"]; ok && t.After(now) {
+			nextTime = t
+			nextPhase = string(dayphaselib.DayPhaseDusk)
+		}
+
+	case dayphaselib.DayPhaseDusk:
+		// Next: winddown (or night) at astronomical night
+		if t, ok := sunTimes["night"]; ok && t.After(now) {
+			nextTime = t
+			nextPhase = string(dayphaselib.DayPhaseWinddown)
+		}
+
+	case dayphaselib.DayPhaseWinddown:
+		// Next: night at scheduled night time
+		schedule, err := m.configLoader.GetTodaysSchedule()
+		if err == nil && schedule != nil && schedule.Night.After(now) {
+			nextTime = schedule.Night
+			nextPhase = string(dayphaselib.DayPhaseNight)
+		} else {
+			// Default to 23:00 if no schedule
+			nightTime := time.Date(now.Year(), now.Month(), now.Day(), 23, 0, 0, 0, now.Location())
+			if nightTime.After(now) {
+				nextTime = nightTime
+				nextPhase = string(dayphaselib.DayPhaseNight)
+			}
+		}
+	}
+
+	// Only update if we calculated a valid next transition
+	if !nextTime.IsZero() && nextPhase != "" {
+		m.shadowTracker.UpdateNextTransition(nextTime, nextPhase)
+		m.logger.Debug("Updated next transition",
+			zap.Time("next_time", nextTime),
+			zap.String("next_phase", nextPhase))
+	}
 }

--- a/homeautomation-go/internal/plugins/dayphase/manager_test.go
+++ b/homeautomation-go/internal/plugins/dayphase/manager_test.go
@@ -262,3 +262,94 @@ func TestManagerReset(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, dayPhase)
 }
+
+func TestManager_ShadowState_NextTransitionUpdated(t *testing.T) {
+	// Test that shadow state outputs.NextTransitionTime and NextTransitionPhase are populated
+	// This test catches the bug where UpdateNextTransition() was never called
+	logger, _ := zap.NewDevelopment()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	configLoader := config.NewLoader("../../../configs", logger)
+	calculator := dayphaselib.NewCalculator(32.85486, -97.50515, logger)
+
+	manager := NewManager(mockClient, stateManager, configLoader, calculator, logger, false)
+
+	// Initialize state
+	err := stateManager.SyncFromHA()
+	assert.NoError(t, err)
+
+	// Update sun event and day phase (which should also update next transition)
+	err = manager.updateSunEventAndDayPhase()
+	assert.NoError(t, err)
+
+	// Get shadow state
+	shadowState := manager.GetShadowState()
+
+	// Verify shadow state outputs are populated (not zero values)
+	// NextTransitionTime should be set
+	assert.False(t, shadowState.Outputs.NextTransitionTime.IsZero(),
+		"Expected NextTransitionTime to be set, got zero time")
+
+	// NextTransitionPhase should be a valid phase
+	validPhases := []string{"morning", "day", "sunset", "dusk", "winddown", "night"}
+	found := false
+	for _, phase := range validPhases {
+		if shadowState.Outputs.NextTransitionPhase == phase {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found,
+		"Expected NextTransitionPhase to be a valid phase, got: %s", shadowState.Outputs.NextTransitionPhase)
+
+	// NextTransitionTime should be in the future (or within a reasonable range)
+	now := time.Now()
+	assert.True(t, shadowState.Outputs.NextTransitionTime.After(now.Add(-1*time.Hour)),
+		"Expected NextTransitionTime to be recent or in the future")
+}
+
+func TestManager_ShadowState_SunEventAndDayPhaseUpdated(t *testing.T) {
+	// Test that shadow state outputs for sun event and day phase are populated
+	logger, _ := zap.NewDevelopment()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	configLoader := config.NewLoader("../../../configs", logger)
+	calculator := dayphaselib.NewCalculator(32.85486, -97.50515, logger)
+
+	manager := NewManager(mockClient, stateManager, configLoader, calculator, logger, false)
+
+	// Initialize state
+	err := stateManager.SyncFromHA()
+	assert.NoError(t, err)
+
+	// Update sun event and day phase
+	err = manager.updateSunEventAndDayPhase()
+	assert.NoError(t, err)
+
+	// Get shadow state
+	shadowState := manager.GetShadowState()
+
+	// Verify SunEvent is set
+	validSunEvents := []string{"morning", "day", "sunset", "dusk", "night"}
+	foundSunEvent := false
+	for _, event := range validSunEvents {
+		if shadowState.Outputs.SunEvent == event {
+			foundSunEvent = true
+			break
+		}
+	}
+	assert.True(t, foundSunEvent,
+		"Expected SunEvent to be a valid value, got: %s", shadowState.Outputs.SunEvent)
+
+	// Verify DayPhase is set
+	validDayPhases := []string{"morning", "day", "sunset", "dusk", "winddown", "night"}
+	foundDayPhase := false
+	for _, phase := range validDayPhases {
+		if shadowState.Outputs.DayPhase == phase {
+			foundDayPhase = true
+			break
+		}
+	}
+	assert.True(t, foundDayPhase,
+		"Expected DayPhase to be a valid value, got: %s", shadowState.Outputs.DayPhase)
+}

--- a/homeautomation-go/internal/plugins/statetracking/manager.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager.go
@@ -133,6 +133,12 @@ func (m *Manager) Start() error {
 
 	// Create and start the derived state helper
 	m.helper = state.NewDerivedStateHelper(m.stateManager, m.logger)
+
+	// Wire up callback to update shadow state when derived states are computed
+	m.helper.SetUpdateCallback(func(anyOwnerHome, anyoneHome, anyoneAsleep, everyoneAsleep bool) {
+		m.shadowTracker.UpdateDerivedStates(anyOwnerHome, anyoneHome, anyoneAsleep, everyoneAsleep)
+	})
+
 	if err := m.helper.Start(); err != nil {
 		return fmt.Errorf("failed to start derived state helper: %w", err)
 	}

--- a/homeautomation-go/internal/plugins/statetracking/manager_test.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager_test.go
@@ -1079,3 +1079,110 @@ func TestStateTrackingManager_NoAnnouncement_OnStateChangeFromUnknown(t *testing
 		}
 	}
 }
+
+func TestStateTrackingManager_ShadowState_DerivedStatesUpdated(t *testing.T) {
+	// Test that shadow state outputs.derivedStates is populated after plugin operations
+	// This test catches the bug where UpdateDerivedStates() was never called
+	mockHA := ha.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	// Setup: Nick is home
+	if err := stateMgr.SetBool("isNickHome", true); err != nil {
+		t.Fatalf("Failed to set isNickHome: %v", err)
+	}
+	if err := stateMgr.SetBool("isCarolineHome", false); err != nil {
+		t.Fatalf("Failed to set isCarolineHome: %v", err)
+	}
+	if err := stateMgr.SetBool("isMasterAsleep", false); err != nil {
+		t.Fatalf("Failed to set isMasterAsleep: %v", err)
+	}
+	if err := stateMgr.SetBool("isGuestAsleep", false); err != nil {
+		t.Fatalf("Failed to set isGuestAsleep: %v", err)
+	}
+	if err := stateMgr.SetBool("isHaveGuests", true); err != nil {
+		t.Fatalf("Failed to set isHaveGuests: %v", err)
+	}
+
+	// Create and start manager
+	manager := NewManager(mockHA, stateMgr, logger, false, nil)
+	if err := manager.Start(); err != nil {
+		t.Fatalf("Failed to start manager: %v", err)
+	}
+	defer manager.Stop()
+
+	// Get shadow state
+	shadowState := manager.GetShadowState()
+
+	// Verify shadow state outputs are populated (not zero values)
+	if !shadowState.Outputs.DerivedStates.IsAnyOwnerHome {
+		t.Error("Expected shadow state IsAnyOwnerHome=true (Nick is home), got false")
+	}
+	if !shadowState.Outputs.DerivedStates.IsAnyoneHome {
+		t.Error("Expected shadow state IsAnyoneHome=true (Nick is home), got false")
+	}
+	if shadowState.Outputs.DerivedStates.IsAnyoneAsleep {
+		t.Error("Expected shadow state IsAnyoneAsleep=false (nobody asleep), got true")
+	}
+	if shadowState.Outputs.DerivedStates.IsEveryoneAsleep {
+		t.Error("Expected shadow state IsEveryoneAsleep=false (nobody asleep), got true")
+	}
+
+	// Verify LastComputation is set (not zero time)
+	if shadowState.Outputs.LastComputation.IsZero() {
+		t.Error("Expected shadow state LastComputation to be set, got zero time")
+	}
+}
+
+func TestStateTrackingManager_ShadowState_DerivedStatesUpdateOnChange(t *testing.T) {
+	// Test that shadow state updates when derived states change
+	mockHA := ha.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	// Setup: Everyone away
+	if err := stateMgr.SetBool("isNickHome", false); err != nil {
+		t.Fatalf("Failed to set isNickHome: %v", err)
+	}
+	if err := stateMgr.SetBool("isCarolineHome", false); err != nil {
+		t.Fatalf("Failed to set isCarolineHome: %v", err)
+	}
+
+	// Create and start manager
+	manager := NewManager(mockHA, stateMgr, logger, false, nil)
+	if err := manager.Start(); err != nil {
+		t.Fatalf("Failed to start manager: %v", err)
+	}
+	defer manager.Stop()
+
+	// Verify initial shadow state
+	shadowState := manager.GetShadowState()
+	if shadowState.Outputs.DerivedStates.IsAnyOwnerHome {
+		t.Error("Expected initial IsAnyOwnerHome=false")
+	}
+
+	// Get initial computation time
+	initialCompTime := shadowState.Outputs.LastComputation
+
+	// Wait a bit to ensure time difference
+	time.Sleep(10 * time.Millisecond)
+
+	// Nick arrives home
+	if err := stateMgr.SetBool("isNickHome", true); err != nil {
+		t.Fatalf("Failed to update isNickHome: %v", err)
+	}
+
+	// Verify shadow state was updated
+	shadowState = manager.GetShadowState()
+	if !shadowState.Outputs.DerivedStates.IsAnyOwnerHome {
+		t.Error("Expected shadow state IsAnyOwnerHome=true after Nick arrives")
+	}
+	if !shadowState.Outputs.DerivedStates.IsAnyoneHome {
+		t.Error("Expected shadow state IsAnyoneHome=true after Nick arrives")
+	}
+
+	// Verify LastComputation was updated
+	if !shadowState.Outputs.LastComputation.After(initialCompTime) {
+		t.Error("Expected LastComputation to be updated after state change")
+	}
+}

--- a/homeautomation-go/internal/state/helpers.go
+++ b/homeautomation-go/internal/state/helpers.go
@@ -7,11 +7,16 @@ import (
 // Helper functions for derived state computation
 // These implement the logic from Node-RED's State Tracking tab
 
+// DerivedStatesCallback is called when derived states are computed.
+// Parameters: isAnyOwnerHome, isAnyoneHome, isAnyoneAsleep, isEveryoneAsleep
+type DerivedStatesCallback func(anyOwnerHome, anyoneHome, anyoneAsleep, everyoneAsleep bool)
+
 // DerivedStateHelper manages automatic computation of derived states
 type DerivedStateHelper struct {
-	manager *Manager
-	logger  *zap.Logger
-	subs    []Subscription
+	manager  *Manager
+	logger   *zap.Logger
+	subs     []Subscription
+	onUpdate DerivedStatesCallback
 }
 
 // NewDerivedStateHelper creates a new helper for managing derived states
@@ -21,6 +26,12 @@ func NewDerivedStateHelper(manager *Manager, logger *zap.Logger) *DerivedStateHe
 		logger:  logger,
 		subs:    make([]Subscription, 0),
 	}
+}
+
+// SetUpdateCallback sets a callback that is invoked whenever derived states are computed.
+// The callback receives the current values of all four derived states.
+func (h *DerivedStateHelper) SetUpdateCallback(cb DerivedStatesCallback) {
+	h.onUpdate = cb
 }
 
 // Start begins monitoring and updating derived states
@@ -65,6 +76,22 @@ func (h *DerivedStateHelper) Stop() {
 		sub.Unsubscribe()
 	}
 	h.subs = nil
+}
+
+// notifyCallback invokes the update callback with current derived state values.
+// This should be called after any derived state is updated.
+func (h *DerivedStateHelper) notifyCallback() {
+	if h.onUpdate == nil {
+		return
+	}
+
+	// Gather current values of all derived states
+	isAnyOwnerHome, _ := h.manager.GetBool("isAnyOwnerHome")
+	isAnyoneHome, _ := h.manager.GetBool("isAnyoneHome")
+	isAnyoneAsleep, _ := h.manager.GetBool("isAnyoneAsleep")
+	isEveryoneAsleep, _ := h.manager.GetBool("isEveryoneAsleep")
+
+	h.onUpdate(isAnyOwnerHome, isAnyoneHome, isAnyoneAsleep, isEveryoneAsleep)
 }
 
 // setupPresenceTracking subscribes to presence changes and updates isAnyOwnerHome and isAnyoneHome
@@ -187,6 +214,9 @@ func (h *DerivedStateHelper) updateIsAnyOwnerHome() {
 		zap.Bool("isNickHome", isNickHome),
 		zap.Bool("isCarolineHome", isCarolineHome),
 		zap.Bool("isAnyOwnerHome", isAnyOwnerHome))
+
+	// Notify callback with updated derived states
+	h.notifyCallback()
 }
 
 // updateIsAnyoneHome computes: isAnyoneHome = isAnyOwnerHome OR isToriHere
@@ -218,6 +248,9 @@ func (h *DerivedStateHelper) updateIsAnyoneHome() {
 		zap.Bool("isAnyOwnerHome", isAnyOwnerHome),
 		zap.Bool("isToriHere", isToriHere),
 		zap.Bool("isAnyoneHome", isAnyoneHome))
+
+	// Notify callback with updated derived states
+	h.notifyCallback()
 }
 
 // updateIsAnyoneAsleep computes: isAnyoneAsleep = isMasterAsleep OR isGuestAsleep
@@ -249,6 +282,9 @@ func (h *DerivedStateHelper) updateIsAnyoneAsleep() {
 		zap.Bool("isMasterAsleep", isMasterAsleep),
 		zap.Bool("isGuestAsleep", isGuestAsleep),
 		zap.Bool("isAnyoneAsleep", isAnyoneAsleep))
+
+	// Notify callback with updated derived states
+	h.notifyCallback()
 }
 
 // updateIsEveryoneAsleep computes: isEveryoneAsleep = isMasterAsleep AND isGuestAsleep
@@ -280,6 +316,9 @@ func (h *DerivedStateHelper) updateIsEveryoneAsleep() {
 		zap.Bool("isMasterAsleep", isMasterAsleep),
 		zap.Bool("isGuestAsleep", isGuestAsleep),
 		zap.Bool("isEveryoneAsleep", isEveryoneAsleep))
+
+	// Notify callback with updated derived states
+	h.notifyCallback()
 }
 
 // checkAutoGuestSleep checks if guest should be automatically marked as asleep


### PR DESCRIPTION
## Summary

Implements **Option A (Callback/Observer Pattern)** from issue #151 to fix shadow state outputs never being updated.

- Add callback hooks to `DerivedStateHelper` that notify when derived states are computed
- Wire `StateTrackingManager` to update shadow state via the callback
- Add next transition tracking to `DayPhase` plugin

## Bugs Fixed

| Method | Tracker | Status |
|--------|---------|--------|
| `UpdateDerivedStates()` | StateTrackingTracker | ✅ Fixed (via callback) |
| `UpdateNextTransition()` | DayPhaseTracker | ✅ Fixed (new logic added) |

Note: `UpdateSensorReadings()` in EnergyTracker was reviewed but found to be a batch convenience method - the individual `Update*()` methods are already being called correctly.

## Changes

### `internal/state/helpers.go`
- Added `DerivedStatesCallback` type for callback function signature
- Added `SetUpdateCallback()` method to register a callback
- Added `notifyCallback()` helper that gathers current values and invokes callback
- All update methods now call `notifyCallback()` after state changes

### `internal/plugins/statetracking/manager.go`
- Wired callback in `Start()` to call `shadowTracker.UpdateDerivedStates()`

### `internal/plugins/dayphase/manager.go`
- Added `updateNextTransition()` method to calculate next phase transition
- Calls `UpdateNextTransition()` on shadow tracker after each phase calculation

### Tests Added
- `TestStateTrackingManager_ShadowState_DerivedStatesUpdated`
- `TestStateTrackingManager_ShadowState_DerivedStatesUpdateOnChange`
- `TestManager_ShadowState_NextTransitionUpdated`
- `TestManager_ShadowState_SunEventAndDayPhaseUpdated`

## Test plan
- [x] All existing tests pass
- [x] New shadow state population tests pass
- [x] Pre-push validation passes (race detector + coverage)
- [ ] Verify `/api/shadow/statetracking` shows populated derivedStates
- [ ] Verify `/api/shadow/dayphase` shows populated nextTransition

Closes #150
Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)