### PR TITLE
fix: Ensure shadow state callback fires on startup

### DIFF
--- a/homeautomation-go/internal/state/helpers.go
+++ b/homeautomation-go/internal/state/helpers.go
@@ -65,6 +65,9 @@ func (h *DerivedStateHelper) Start() error {
 	h.updateIsEveryoneAsleep()
 	h.syncGuestAsleepIfNoGuests() // Initialize auto-sync
 
+	// Ensure shadow state is populated even if no values changed during init
+	h.notifyCallback()
+
 	h.logger.Info("Derived state helper started")
 	return nil
 }

--- a/homeautomation-go/internal/state/helpers_test.go
+++ b/homeautomation-go/internal/state/helpers_test.go
@@ -201,3 +201,51 @@ func TestDerivedStateHelper_AutoGuestSleepNoGuests(t *testing.T) {
 	isGuestAsleep, _ := manager.GetBool("isGuestAsleep")
 	assert.False(t, isGuestAsleep, "Guest should NOT auto-sleep when no guests present")
 }
+
+func TestDerivedStateHelper_CallbackFiresOnStartup(t *testing.T) {
+	// This test verifies that the callback fires on startup even when
+	// derived values already match current state (issue #155)
+	logger, _ := zap.NewDevelopment()
+	mockClient := ha.NewMockClient()
+	manager := NewManager(mockClient, logger, false)
+
+	// Pre-populate states with values that match what derived computation produces
+	// This simulates the startup scenario where HA sync already has correct values
+	manager.SetBool("isNickHome", true)
+	manager.SetBool("isCarolineHome", false)
+	manager.SetBool("isAnyOwnerHome", true) // Already matches: isNickHome || isCarolineHome
+	manager.SetBool("isAnyoneHome", true)   // Already matches derived value
+	manager.SetBool("isMasterAsleep", false)
+	manager.SetBool("isGuestAsleep", false)
+	manager.SetBool("isAnyoneAsleep", false)   // Already matches derived value
+	manager.SetBool("isEveryoneAsleep", false) // Already matches derived value
+
+	// Track callback invocations
+	callbackCount := 0
+	var lastAnyOwnerHome, lastAnyoneHome, lastAnyoneAsleep, lastEveryoneAsleep bool
+
+	helper := NewDerivedStateHelper(manager, logger)
+	helper.SetUpdateCallback(func(anyOwnerHome, anyoneHome, anyoneAsleep, everyoneAsleep bool) {
+		callbackCount++
+		lastAnyOwnerHome = anyOwnerHome
+		lastAnyoneHome = anyoneHome
+		lastAnyoneAsleep = anyoneAsleep
+		lastEveryoneAsleep = everyoneAsleep
+	})
+
+	err := helper.Start()
+	assert.NoError(t, err)
+	defer helper.Stop()
+
+	// Give startup time to complete
+	time.Sleep(100 * time.Millisecond)
+
+	// Callback should have fired at least once during startup
+	assert.GreaterOrEqual(t, callbackCount, 1, "Callback should fire on startup even if values match")
+
+	// Verify callback received correct values
+	assert.True(t, lastAnyOwnerHome, "Callback should receive correct isAnyOwnerHome value")
+	assert.True(t, lastAnyoneHome, "Callback should receive correct isAnyoneHome value")
+	assert.False(t, lastAnyoneAsleep, "Callback should receive correct isAnyoneAsleep value")
+	assert.False(t, lastEveryoneAsleep, "Callback should receive correct isEveryoneAsleep value")
+}


### PR DESCRIPTION
## Summary

- Add unconditional `notifyCallback()` call at the end of `Start()` method in `DerivedStateHelper`
- Ensures shadow state outputs are populated even when derived values match current state during initialization
- Add test to verify callback fires on startup with pre-populated matching values

## Problem

Shadow state outputs remain at zero values (`false`) on startup when computed derived values match current state. The `/api/shadow/statetracking` endpoint shows inputs correctly but outputs incorrectly.

The `update*` methods in `helpers.go` return early when computed values match current values:
```go
if currentValue == isAnyOwnerHome {
    return  // callback never fires
}
```

On startup, since state syncs from Home Assistant and computed values match, the callback never executes, leaving shadow outputs uninitialized.

## Solution

Add an unconditional `notifyCallback()` call after all derived state initialization in `Start()`, ensuring shadow state is populated regardless of whether values changed.

## Test plan

- [x] New test `TestDerivedStateHelper_CallbackFiresOnStartup` verifies callback fires with matching values
- [x] All existing tests pass
- [x] Pre-push validation passes (build, tests, race detector, coverage)

Fixes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)