### PR TITLE
fix: Correct media_player.join parameters for speaker grouping

### DIFF
--- a/homeautomation-go/internal/plugins/music/manager.go
+++ b/homeautomation-go/internal/plugins/music/manager.go
@@ -766,22 +766,27 @@ func (m *Manager) executePlayback(musicType string, option PlaybackOption, parti
 func (m *Manager) buildSpeakerGroup(participants []ParticipantWithVolume, leadEntityID string) error {
 	m.logger.Info("Building speaker group", zap.Int("count", len(participants)))
 
-	// Join all other speakers to the lead
+	// Build list of follower entity IDs
+	var groupMembers []string
 	for i, p := range participants {
 		if i == 0 {
 			// Skip lead player
 			continue
 		}
+		groupMembers = append(groupMembers, m.getSpeakerEntityID(p.PlayerName))
+	}
 
-		entityID := m.getSpeakerEntityID(p.PlayerName)
+	// Single call: lead speaker joins all followers to its group
+	if len(groupMembers) > 0 {
 		if err := m.callService("media_player", "join", map[string]interface{}{
-			"entity_id":     entityID,
-			"group_members": []string{leadEntityID},
+			"entity_id":     leadEntityID, // Coordinator
+			"group_members": groupMembers, // All followers
 		}); err != nil {
-			m.logger.Error("Failed to join speaker to group",
-				zap.String("speaker", p.PlayerName),
-				zap.Error(err))
+			return fmt.Errorf("failed to create speaker group: %w", err)
 		}
+		m.logger.Info("Speaker group created",
+			zap.String("lead", leadEntityID),
+			zap.Strings("members", groupMembers))
 	}
 
 	// Wait for group to stabilize

--- a/homeautomation-go/internal/plugins/music/manager_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_test.go
@@ -1035,6 +1035,9 @@ func TestBuildSpeakerGroup(t *testing.T) {
 	config := &MusicConfig{Music: map[string]MusicMode{}}
 	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
 
+	// Clear any previous calls
+	mockClient.ClearServiceCalls()
+
 	participants := []ParticipantWithVolume{
 		{PlayerName: "Kitchen", Volume: 9},
 		{PlayerName: "Living Room", Volume: 10},
@@ -1044,6 +1047,47 @@ func TestBuildSpeakerGroup(t *testing.T) {
 	err := manager.buildSpeakerGroup(participants, "media_player.kitchen")
 	if err != nil {
 		t.Errorf("buildSpeakerGroup() failed: %v", err)
+	}
+
+	// Verify the service call was made with correct parameters
+	calls := mockClient.GetServiceCalls()
+
+	// Should be exactly one call (single call with all followers)
+	joinCalls := 0
+	for _, call := range calls {
+		if call.Domain == "media_player" && call.Service == "join" {
+			joinCalls++
+
+			// Verify entity_id is the lead speaker (coordinator)
+			entityID, ok := call.Data["entity_id"].(string)
+			if !ok || entityID != "media_player.kitchen" {
+				t.Errorf("Expected entity_id to be lead speaker 'media_player.kitchen', got: %v", call.Data["entity_id"])
+			}
+
+			// Verify group_members contains all followers
+			groupMembers, ok := call.Data["group_members"].([]string)
+			if !ok {
+				t.Errorf("Expected group_members to be []string, got: %T", call.Data["group_members"])
+			} else {
+				if len(groupMembers) != 2 {
+					t.Errorf("Expected 2 group members, got %d", len(groupMembers))
+				}
+				// Check that Living Room and Bedroom are in group_members
+				expectedMembers := map[string]bool{
+					"media_player.living_room": true,
+					"media_player.bedroom":     true,
+				}
+				for _, member := range groupMembers {
+					if !expectedMembers[member] {
+						t.Errorf("Unexpected group member: %s", member)
+					}
+				}
+			}
+		}
+	}
+
+	if joinCalls != 1 {
+		t.Errorf("Expected exactly 1 media_player.join call, got %d", joinCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixed inverted `media_player.join` parameters in `buildSpeakerGroup` that caused music to only play on the lead speaker
- Changed from multiple service calls (one per follower) to a single call with all followers
- Added comprehensive test to verify correct parameters are passed

## Problem

The `buildSpeakerGroup` function was using inverted parameters for the `media_player.join` service call:

**Previous (incorrect):**
```go
// Called once per follower - WRONG
m.callService("media_player", "join", map[string]interface{}{
    "entity_id":     entityID,              // Follower speaker
    "group_members": []string{leadEntityID}, // Lead speaker
})
```

**Fixed:**
```go
// Single call with correct parameters
m.callService("media_player", "join", map[string]interface{}{
    "entity_id":     leadEntityID,  // Coordinator (lead speaker)
    "group_members": groupMembers,  // All followers
})
```

## Test plan

- [x] Updated `TestBuildSpeakerGroup` to verify:
  - Only one `media_player.join` call is made (instead of multiple)
  - `entity_id` is the lead speaker (coordinator)
  - `group_members` contains all follower speakers
- [x] All tests pass with race detector
- [x] Coverage meets minimum requirement (≥70%)

Fixes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)