### PR TITLE
fix: Prevent WebSocket id_reuse errors from concurrent message sends

### DIFF
--- a/homeautomation-go/internal/ha/client.go
+++ b/homeautomation-go/internal/ha/client.go
@@ -36,11 +36,13 @@ type subscriberEntry struct {
 // Lock ordering (to prevent deadlocks, always acquire in this order):
 //  1. connMu - connection state
 //  2. ctxMu - context for cancellation
-//  3. writeMu - websocket writes
+//  3. writeMu - websocket writes (also protects msgID to ensure ordered sends)
 //  4. pendingMu - pending response channels
 //  5. subsMu - subscribers
-//  6. msgIDMu - message ID counter
-//  7. nextSubIDMu - subscription ID counter
+//  6. nextSubIDMu - subscription ID counter
+//
+// Note: msgIDMu has been eliminated; msgID is now protected by writeMu to ensure
+// message IDs are allocated and sent atomically, preventing out-of-order sends.
 type Client struct {
 	url         string
 	token       string
@@ -48,8 +50,7 @@ type Client struct {
 	conn        *websocket.Conn
 	connected   bool
 	connMu      sync.RWMutex
-	msgID       int
-	msgIDMu     sync.Mutex
+	msgID       int // Protected by writeMu (not separate mutex) to ensure atomic ID+send
 	pending     map[int]chan Message
 	pendingMu   sync.Mutex
 	subscribers map[string][]subscriberEntry
@@ -60,7 +61,7 @@ type Client struct {
 	cancel      context.CancelFunc
 	ctxMu       sync.RWMutex // Protects ctx and cancel
 	reconnect   bool
-	writeMu     sync.Mutex // Protects websocket writes
+	writeMu     sync.Mutex // Protects websocket writes AND msgID counter
 }
 
 func (c *Client) clearSubscribers() {
@@ -113,9 +114,10 @@ func (c *Client) Connect() error {
 
 	// Reset message ID counter for new connection
 	// Each WebSocket session expects message IDs to start from 1
-	c.msgIDMu.Lock()
+	// Protected by writeMu for consistency, though not strictly needed during Connect
+	c.writeMu.Lock()
 	c.msgID = 0
-	c.msgIDMu.Unlock()
+	c.writeMu.Unlock()
 
 	// Connect to WebSocket
 	conn, _, err := websocket.DefaultDialer.Dial(c.url, nil)
@@ -233,15 +235,17 @@ func (c *Client) IsConnected() bool {
 	return c.connected
 }
 
-// nextMsgID returns the next message ID
+// nextMsgID returns the next message ID.
+// IMPORTANT: Caller must hold writeMu to ensure atomic ID allocation + send.
 func (c *Client) nextMsgID() int {
-	c.msgIDMu.Lock()
-	defer c.msgIDMu.Unlock()
 	c.msgID++
 	return c.msgID
 }
 
-// sendMessage sends a message and waits for response
+// sendMessage sends a message and waits for response.
+// The message ID is assigned atomically with the send to prevent out-of-order delivery.
+// This fixes the race condition where goroutines could get sequential IDs but send them
+// out of order, causing Home Assistant to return "id_reuse" errors.
 func (c *Client) sendMessage(msg interface{}) (*Message, error) {
 	// Capture connection reference while holding the lock to prevent race with Disconnect().
 	// Invariant: connected == true implies conn != nil (enforced by Connect/Disconnect).
@@ -258,37 +262,48 @@ func (c *Client) sendMessage(msg interface{}) (*Message, error) {
 	ctx := c.ctx
 	c.ctxMu.RUnlock()
 
-	// Get message ID
-	var msgID int
+	// Create response channel (created before locking writeMu to minimize lock hold time)
+	respChan := make(chan Message, 1)
+
+	// CRITICAL: Hold writeMu from ID generation through send to ensure messages are
+	// sent in ID order. This prevents the race where:
+	//   1. Goroutine A gets ID 100
+	//   2. Goroutine B gets ID 101
+	//   3. Goroutine B sends ID 101 first
+	//   4. Goroutine A sends ID 100 -> HA returns "id_reuse" error
+	c.writeMu.Lock()
+
+	// Generate message ID while holding writeMu
+	msgID := c.nextMsgID()
+
+	// Assign ID to the message
 	switch m := msg.(type) {
 	case *CallServiceRequest:
-		msgID = m.ID
+		m.ID = msgID
 	case *GetStatesRequest:
-		msgID = m.ID
+		m.ID = msgID
 	case *SubscribeEventsRequest:
-		msgID = m.ID
+		m.ID = msgID
 	default:
+		c.writeMu.Unlock()
 		return nil, fmt.Errorf("unsupported message type")
 	}
 
-	// Create response channel
-	respChan := make(chan Message, 1)
+	// Register response channel before sending (still holding writeMu)
 	c.pendingMu.Lock()
 	c.pending[msgID] = respChan
 	c.pendingMu.Unlock()
 
-	// Clean up after timeout
+	// Send message while still holding writeMu
+	err := conn.WriteJSON(msg)
+	c.writeMu.Unlock()
+
+	// Clean up on exit
 	defer func() {
 		c.pendingMu.Lock()
 		delete(c.pending, msgID)
 		c.pendingMu.Unlock()
 	}()
-
-	// Send message (protected by writeMu to prevent concurrent writes)
-	// Use the captured conn reference to avoid race with Disconnect setting c.conn = nil
-	c.writeMu.Lock()
-	err := conn.WriteJSON(msg)
-	c.writeMu.Unlock()
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to send message: %w", err)
@@ -442,9 +457,7 @@ func (c *Client) attemptReconnect() {
 
 // subscribeToStateChanges subscribes to all state_changed events
 func (c *Client) subscribeToStateChanges() error {
-	msgID := c.nextMsgID()
 	req := &SubscribeEventsRequest{
-		ID:        msgID,
 		Type:      "subscribe_events",
 		EventType: "state_changed",
 	}
@@ -471,9 +484,7 @@ func (c *Client) GetState(entityID string) (*State, error) {
 
 // GetAllStates retrieves all entity states
 func (c *Client) GetAllStates() ([]*State, error) {
-	msgID := c.nextMsgID()
 	req := &GetStatesRequest{
-		ID:   msgID,
 		Type: "get_states",
 	}
 
@@ -492,9 +503,7 @@ func (c *Client) GetAllStates() ([]*State, error) {
 
 // CallService calls a Home Assistant service
 func (c *Client) CallService(domain, service string, data map[string]interface{}) error {
-	msgID := c.nextMsgID()
 	req := &CallServiceRequest{
-		ID:          msgID,
 		Type:        "call_service",
 		Domain:      domain,
 		Service:     service,

--- a/homeautomation-go/internal/ha/client_test.go
+++ b/homeautomation-go/internal/ha/client_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -583,5 +585,125 @@ func TestClient_HandleEventBackpressuresHandlers(t *testing.T) {
 		assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("handlers did not complete in time")
+	}
+}
+
+// TestClient_ConcurrentCallService verifies that concurrent CallService calls
+// result in messages with monotonically increasing IDs being sent in order.
+// This is a regression test for the "id_reuse" race condition where:
+//  1. Goroutine A gets ID 100
+//  2. Goroutine B gets ID 101
+//  3. Goroutine B sends ID 101 first
+//  4. Goroutine A sends ID 100 -> Home Assistant returns "id_reuse" error
+//
+// The fix ensures ID generation and send are atomic (protected by same mutex).
+func TestClient_ConcurrentCallService(t *testing.T) {
+	logger := zap.NewNop()
+	token := "test_token"
+
+	const numConcurrentCalls = 50
+
+	// Track received message IDs in order
+	var receivedIDsMu sync.Mutex
+	receivedIDs := make([]int, 0, numConcurrentCalls)
+	allReceived := make(chan struct{})
+
+	server := mockHAServer(t, func(conn *websocket.Conn) {
+		standardAuthFlow(t, conn, token)
+
+		// Handle subscribe_events
+		var subMsg SubscribeEventsRequest
+		conn.ReadJSON(&subMsg)
+		success := true
+		conn.WriteJSON(Message{
+			ID:      subMsg.ID,
+			Type:    "result",
+			Success: &success,
+		})
+
+		// Handle all service calls - track the order of received IDs
+		for i := 0; i < numConcurrentCalls; i++ {
+			var serviceReq CallServiceRequest
+			if err := conn.ReadJSON(&serviceReq); err != nil {
+				return
+			}
+
+			receivedIDsMu.Lock()
+			receivedIDs = append(receivedIDs, serviceReq.ID)
+			count := len(receivedIDs)
+			receivedIDsMu.Unlock()
+
+			// Send success response
+			conn.WriteJSON(Message{
+				ID:      serviceReq.ID,
+				Type:    "result",
+				Success: &success,
+			})
+
+			if count == numConcurrentCalls {
+				close(allReceived)
+			}
+		}
+
+		// Keep connection alive for responses
+		time.Sleep(100 * time.Millisecond)
+	})
+	defer server.Close()
+
+	url := "ws" + strings.TrimPrefix(server.URL, "http")
+	client := NewClient(url, token, logger)
+
+	err := client.Connect()
+	require.NoError(t, err)
+	defer client.Disconnect()
+
+	// Launch many concurrent CallService calls
+	var wg sync.WaitGroup
+	wg.Add(numConcurrentCalls)
+
+	for i := 0; i < numConcurrentCalls; i++ {
+		go func(n int) {
+			defer wg.Done()
+			err := client.CallService("test", "service", map[string]interface{}{
+				"call_number": n,
+			})
+			// Ignore errors - some may timeout if test is slow
+			_ = err
+		}(i)
+	}
+
+	// Wait for all calls to be received by server
+	select {
+	case <-allReceived:
+		// Good - all messages received
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for all messages to be received")
+	}
+
+	wg.Wait()
+
+	// Verify IDs were received in strictly increasing order
+	// This is the key assertion: if there was a race, IDs would be out of order
+	receivedIDsMu.Lock()
+	idsCopy := make([]int, len(receivedIDs))
+	copy(idsCopy, receivedIDs)
+	receivedIDsMu.Unlock()
+
+	assert.Len(t, idsCopy, numConcurrentCalls, "Should have received all messages")
+
+	// Check that IDs are strictly increasing
+	sortedIDs := make([]int, len(idsCopy))
+	copy(sortedIDs, idsCopy)
+	sort.Ints(sortedIDs)
+
+	assert.Equal(t, sortedIDs, idsCopy,
+		"Message IDs should be received in strictly increasing order. "+
+			"If this fails, there's a race condition between ID generation and send. "+
+			"Received order: %v, Expected (sorted): %v", idsCopy, sortedIDs)
+
+	// Also verify IDs are consecutive (no gaps)
+	for i := 1; i < len(idsCopy); i++ {
+		assert.Equal(t, idsCopy[i-1]+1, idsCopy[i],
+			"Message IDs should be consecutive. Got %d then %d", idsCopy[i-1], idsCopy[i])
 	}
 }


### PR DESCRIPTION
## Summary
- Fixes the race condition where concurrent goroutines could get sequential message IDs but send them out of order, causing Home Assistant to return "id_reuse" errors
- Ensures message ID generation and send are atomic by moving ID allocation inside the `writeMu` lock scope
- Eliminates the separate `msgIDMu` mutex since `writeMu` now protects `msgID`
- Adds regression test verifying concurrent `CallService` calls result in monotonically increasing IDs

## Root Cause
The race occurred during music fade-in when multiple speakers were controlled in parallel:
1. Goroutine A calls `nextMsgID()` → gets ID 100
2. Goroutine B calls `nextMsgID()` → gets ID 101
3. Goroutine B acquires `writeMu` first and sends ID 101
4. Goroutine A acquires `writeMu` and sends ID 100
5. Home Assistant receives 101, then 100 → **"id_reuse" error**

## Test plan
- [x] New `TestClient_ConcurrentCallService` test verifies IDs are sent in order
- [x] All existing tests pass with race detector
- [x] Coverage meets minimum 70% threshold

Fixes #163
Fixes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)