### PR TITLE
feat: Add front of house person presence trigger for lighting

### DIFF
--- a/configs/hue_config.yaml
+++ b/configs/hue_config.yaml
@@ -29,11 +29,13 @@ rooms:
     on_if_true:
       - isHaveGuests
       - didOwnerJustReturnHome
+      - isFrontOfHousePersonPresent
     on_if_false: ~
     off_if_true: isEveryoneAsleep
     off_if_false:
       - isHaveGuests
       - didOwnerJustReturnHome
+      - isFrontOfHousePersonPresent
     increase_brightness_if_true: ~
     transition_seconds: 120
   - hue_group: Decorative Outdoor Lights

--- a/homeautomation-go/internal/state/variables.go
+++ b/homeautomation-go/internal/state/variables.go
@@ -21,9 +21,9 @@ type StateVariable struct {
 	ComputedOutput bool        // If true, can be written even in read-only mode (for computed values)
 }
 
-// AllVariables contains all 37 state variables (35 synced with HA + 2 local-only)
+// AllVariables contains all 38 state variables (36 synced with HA + 2 local-only)
 var AllVariables = []StateVariable{
-	// Booleans (25)
+	// Booleans (26)
 	{Key: "isNickHome", EntityID: "input_boolean.nick_home", Type: TypeBool, Default: false},
 	{Key: "isCarolineHome", EntityID: "input_boolean.caroline_home", Type: TypeBool, Default: false},
 	{Key: "isToriHere", EntityID: "input_boolean.tori_here", Type: TypeBool, Default: false},
@@ -50,6 +50,7 @@ var AllVariables = []StateVariable{
 	{Key: "isCarolineNearHome", EntityID: "input_boolean.caroline_near_home", Type: TypeBool, Default: false},
 	{Key: "isLockdown", EntityID: "input_boolean.lockdown", Type: TypeBool, Default: false},
 	{Key: "reset", EntityID: "input_boolean.reset", Type: TypeBool, Default: false},
+	{Key: "isFrontOfHousePersonPresent", EntityID: "input_boolean.front_of_house_person_present", Type: TypeBool, Default: false},
 
 	// Numbers (3)
 	{Key: "alarmTime", EntityID: "input_number.alarm_time", Type: TypeNumber, Default: 0.0},


### PR DESCRIPTION
## Summary
- Add `isFrontOfHousePersonPresent` state variable mapped to `input_boolean.front_of_house_person_present`
- Configure it as `on_if_true` trigger for the "Front of House" hue group (lights turn on when person detected)
- Configure it as `off_if_false` trigger (lights turn off when no person present, unless other conditions keep them on)

## Test plan
- [x] Verify `input_boolean.front_of_house_person_present` exists in Home Assistant
- [ ] Test that Front of House lights turn on when the boolean becomes true
- [ ] Test that lights turn off when the boolean becomes false (and no guests/owner-just-returned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)