### PR TITLE
Add Front Room speaker and rename Dining Room to Sitting Room

### DIFF
--- a/configs/music_config.yaml
+++ b/configs/music_config.yaml
@@ -20,11 +20,14 @@ music:
         leave_muted_if:
           - variable: isMasterAsleep
             value: true
-      - player_name: "Dining Room"
+      - player_name: "Sitting Room"
         base_volume: 8
         leave_muted_if:
           - variable: isTVPlaying
             value: true
+      - player_name: "Front Room"
+        base_volume: 8
+        leave_muted_if: []
       - player_name: "Office"
         base_volume: 8
         leave_muted_if:
@@ -67,11 +70,14 @@ music:
         leave_muted_if:
           - variable: isMasterAsleep
             value: true
-      - player_name: "Dining Room"
+      - player_name: "Sitting Room"
         base_volume: 9
         leave_muted_if:
           - variable: isTVPlaying
             value: true
+      - player_name: "Front Room"
+        base_volume: 9
+        leave_muted_if: []
       - player_name: "Office"
         base_volume: 6
         leave_muted_if:
@@ -127,11 +133,14 @@ music:
         leave_muted_if:
           - variable: isMasterAsleep
             value: true
-      - player_name: "Dining Room"
+      - player_name: "Sitting Room"
         base_volume: 8
         leave_muted_if:
           - variable: isTVPlaying
             value: true
+      - player_name: "Front Room"
+        base_volume: 8
+        leave_muted_if: []
       - player_name: "Office"
         base_volume: 8
         leave_muted_if:
@@ -183,11 +192,14 @@ music:
         leave_muted_if:
           - variable: isMasterAsleep
             value: true
-      - player_name: "Dining Room"
+      - player_name: "Sitting Room"
         base_volume: 7
         leave_muted_if:
           - variable: isTVPlaying
             value: true
+      - player_name: "Front Room"
+        base_volume: 7
+        leave_muted_if: []
       - player_name: "Office"
         base_volume: 8
         leave_muted_if:
@@ -211,11 +223,14 @@ music:
       - player_name: "Bedroom"
         base_volume: 16
         leave_muted_if: []
-      - player_name: "Dining Room"
+      - player_name: "Sitting Room"
         base_volume: 9
         leave_muted_if:
           - variable: isTVPlaying
             value: true
+      - player_name: "Front Room"
+        base_volume: 9
+        leave_muted_if: []
       - player_name: "Kitchen"
         base_volume: 16
         leave_muted_if: []


### PR DESCRIPTION
## Summary
- Add new "Front Room" speaker to all music phases (morning, day, evening, winddown, sleep)
- Rename "Dining Room" speaker to "Sitting Room" across all phases
- Front Room configured with no muting conditions, Sitting Room maintains isTVPlaying mute condition

## Test plan
- [ ] Verify Front Room speaker appears in Home Assistant
- [ ] Confirm music playback includes Front Room in all day phases
- [ ] Verify Sitting Room correctly mutes when TV is playing

🤖 Generated with [Claude Code](https://claude.com/claude-code)