### PR TITLE
fix(tv): Activate Hue Sync Box light sync when TV is playing

### DIFF
--- a/homeautomation-go/internal/plugins/tv/manager.go
+++ b/homeautomation-go/internal/plugins/tv/manager.go
@@ -33,6 +33,9 @@ const (
 	SyncBoxSoftwarePowerEntity = "switch.sync_box_power"
 	SyncBoxPhysicalPowerEntity = "switch.hue_sync_box_power"
 	SyncBoxHDMIInputEntity     = "select.sync_box_hdmi_input"
+
+	// Entity ID for sync box light sync control
+	SyncBoxLightSyncEntity = "switch.sync_box_light_sync"
 )
 
 // Manager handles TV monitoring and manipulation
@@ -423,6 +426,40 @@ func (m *Manager) calculateTVPlaying(hdmiInput string) {
 
 	// Update shadow state
 	m.shadowTracker.UpdateTVPlaying(isTVPlaying)
+
+	// Control sync box light sync based on TV playing state
+	m.controlSyncBoxLightSync(isTVPlaying)
+}
+
+// controlSyncBoxLightSync turns the sync box light sync on or off based on TV playing state
+func (m *Manager) controlSyncBoxLightSync(isTVPlaying bool) {
+	if m.readOnly {
+		m.logger.Debug("Skipping sync box light sync control in read-only mode",
+			zap.Bool("would_sync", isTVPlaying))
+		return
+	}
+
+	action := "turn_off"
+	if isTVPlaying {
+		action = "turn_on"
+	}
+
+	m.logger.Info("Controlling sync box light sync",
+		zap.String("action", action),
+		zap.String("entity_id", SyncBoxLightSyncEntity))
+
+	err := m.haClient.CallService("switch", action, map[string]interface{}{
+		"entity_id": SyncBoxLightSyncEntity,
+	})
+	if err != nil {
+		m.logger.Error("Failed to control sync box light sync",
+			zap.String("action", action),
+			zap.Error(err))
+		return
+	}
+
+	m.logger.Debug("Sync box light sync controlled successfully",
+		zap.String("action", action))
 }
 
 // checkAndRecoverSyncBox checks if sync box recovery is needed and performs power cycle


### PR DESCRIPTION
## Summary
- Adds missing functionality to control `switch.sync_box_light_sync` when TV playback state changes
- Turns on light sync when `isTVPlaying` becomes true
- Turns off light sync when `isTVPlaying` becomes false
- Matches the Node-RED behavior which was not migrated to Go

## Background
The TV plugin was tracking `isTVPlaying` state and handling sync box recovery, but never actually activated the light sync feature. The Node-RED flow at line 19567-19591 listens for "Is TV Playing?" state changes and calls `switch.turn_on`/`switch.turn_off` on `switch.sync_box_light_sync` accordingly.

## Test plan
- [ ] Verify in logs that "Controlling sync box light sync" appears when TV starts/stops playing
- [ ] Confirm lights sync to video when Apple TV plays content
- [ ] Verify sync stops when playback stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)