### PR TITLE
fix(sleephygiene): Start sleep music at go_to_bed time

### DIFF
--- a/homeautomation-go/internal/plugins/sleephygiene/manager.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager.go
@@ -662,8 +662,8 @@ func (m *Manager) handleStopScreens() {
 
 // handleGoToBed handles the go_to_bed trigger (flash lights and start sleep music)
 // This matches Node-RED behavior which does two things:
-// 1. Flashes lights (conditional on anyone home + not everyone asleep)
-// 2. Sets musicPlaybackType to "sleep" (always, triggers music plugin to start sleep music)
+// 1. Sets musicPlaybackType to "sleep" (always, triggers music plugin to start sleep music)
+// 2. Flashes lights (conditional on anyone home + not everyone asleep)
 func (m *Manager) handleGoToBed() {
 	m.logger.Info("Handling go_to_bed trigger")
 
@@ -681,28 +681,37 @@ func (m *Manager) handleGoToBed() {
 
 	// Check conditions for flashing lights: anyone home and not everyone asleep
 	isAnyoneHome, err := m.stateManager.GetBool("isAnyoneHome")
-	if err != nil || !isAnyoneHome {
-		m.logger.Debug("Skipping go_to_bed light flash: no one home")
-		return
+	if err != nil {
+		isAnyoneHome = false
 	}
 
 	isEveryoneAsleep, err := m.stateManager.GetBool("isEveryoneAsleep")
-	if err != nil || isEveryoneAsleep {
-		m.logger.Debug("Skipping go_to_bed light flash: everyone is asleep")
-		return
+	if err != nil {
+		isEveryoneAsleep = false
 	}
 
-	// Conditions met - flash lights
-	m.logger.Info("Conditions met for go_to_bed, flashing lights")
+	shouldFlashLights := isAnyoneHome && !isEveryoneAsleep
 
-	// Record action in shadow state
-	m.recordAction("go_to_bed", "Flashing common area lights and starting sleep music", "go_to_bed_timer")
+	// Record action in shadow state - always record since music is always started
+	if shouldFlashLights {
+		m.recordAction("go_to_bed", "Starting sleep music and flashing common area lights", "go_to_bed_timer")
+	} else {
+		m.recordAction("go_to_bed", "Starting sleep music (no light flash: conditions not met)", "go_to_bed_timer")
+	}
 	m.shadowTracker.RecordGoToBedReminder()
 
-	if !m.readOnly {
-		m.flashCommonAreaLights()
+	// Flash lights only if conditions are met
+	if shouldFlashLights {
+		m.logger.Info("Conditions met for go_to_bed, flashing lights")
+		if !m.readOnly {
+			m.flashCommonAreaLights()
+		} else {
+			m.logger.Info("READ-ONLY: Would flash common area lights")
+		}
 	} else {
-		m.logger.Info("READ-ONLY: Would flash common area lights")
+		m.logger.Debug("Skipping go_to_bed light flash: conditions not met",
+			zap.Bool("isAnyoneHome", isAnyoneHome),
+			zap.Bool("isEveryoneAsleep", isEveryoneAsleep))
 	}
 }
 

--- a/homeautomation-go/internal/plugins/sleephygiene/manager_shadow_test.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager_shadow_test.go
@@ -460,39 +460,41 @@ func TestSleepHygieneShadowState_BedroomLightsNoCancel(t *testing.T) {
 }
 
 // TestSleepHygieneShadowState_HandleGoToBed tests go to bed handler with various conditions
+// Shadow state is ALWAYS recorded because sleep music is always started.
+// Lights are only flashed when someone is home and not everyone is asleep.
 func TestSleepHygieneShadowState_HandleGoToBed(t *testing.T) {
 	testCases := []struct {
 		name              string
 		isAnyoneHome      bool
 		isEveryoneAsleep  bool
-		shouldTrigger     bool
+		shouldFlashLights bool
 		setupStateManager func(*state.Manager)
 	}{
 		{
-			name:             "No one home - should not trigger",
-			isAnyoneHome:     false,
-			isEveryoneAsleep: false,
-			shouldTrigger:    false,
+			name:              "No one home - music starts, no lights",
+			isAnyoneHome:      false,
+			isEveryoneAsleep:  false,
+			shouldFlashLights: false,
 			setupStateManager: func(sm *state.Manager) {
 				sm.SetBool("isAnyoneHome", false)
 				sm.SetBool("isEveryoneAsleep", false)
 			},
 		},
 		{
-			name:             "Everyone asleep - should not trigger",
-			isAnyoneHome:     true,
-			isEveryoneAsleep: true,
-			shouldTrigger:    false,
+			name:              "Everyone asleep - music starts, no lights",
+			isAnyoneHome:      true,
+			isEveryoneAsleep:  true,
+			shouldFlashLights: false,
 			setupStateManager: func(sm *state.Manager) {
 				sm.SetBool("isAnyoneHome", true)
 				sm.SetBool("isEveryoneAsleep", true)
 			},
 		},
 		{
-			name:             "Someone home and awake - should trigger",
-			isAnyoneHome:     true,
-			isEveryoneAsleep: false,
-			shouldTrigger:    true,
+			name:              "Someone home and awake - music starts, lights flash",
+			isAnyoneHome:      true,
+			isEveryoneAsleep:  false,
+			shouldFlashLights: true,
 			setupStateManager: func(sm *state.Manager) {
 				sm.SetBool("isAnyoneHome", true)
 				sm.SetBool("isEveryoneAsleep", false)
@@ -516,18 +518,22 @@ func TestSleepHygieneShadowState_HandleGoToBed(t *testing.T) {
 
 			shadowState := manager.GetShadowState()
 
-			if tc.shouldTrigger {
-				// Verify reminder was recorded
-				if shadowState.Outputs.GoToBedReminder == nil {
-					t.Error("Expected GoToBedReminder to be set")
-				}
-				if shadowState.Outputs.LastActionType != "go_to_bed" {
-					t.Errorf("Expected LastActionType to be 'go_to_bed', got %s", shadowState.Outputs.LastActionType)
+			// Shadow state should ALWAYS be recorded (music is always started)
+			if shadowState.Outputs.GoToBedReminder == nil {
+				t.Error("Expected GoToBedReminder to be set (music always starts)")
+			}
+			if shadowState.Outputs.LastActionType != "go_to_bed" {
+				t.Errorf("Expected LastActionType to be 'go_to_bed', got %s", shadowState.Outputs.LastActionType)
+			}
+
+			// Verify action reason reflects whether lights were flashed
+			if tc.shouldFlashLights {
+				if shadowState.Outputs.LastActionReason != "Starting sleep music and flashing common area lights" {
+					t.Errorf("Expected action reason for lights+music, got '%s'", shadowState.Outputs.LastActionReason)
 				}
 			} else {
-				// Verify reminder was NOT recorded
-				if shadowState.Outputs.GoToBedReminder != nil {
-					t.Error("Expected GoToBedReminder to not be set")
+				if shadowState.Outputs.LastActionReason != "Starting sleep music (no light flash: conditions not met)" {
+					t.Errorf("Expected action reason for music only, got '%s'", shadowState.Outputs.LastActionReason)
 				}
 			}
 		})

--- a/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
@@ -481,6 +481,18 @@ func TestHandleGoToBed_SetsSleepMusicEvenWhenEveryoneAsleep(t *testing.T) {
 			}
 		}
 	}
+
+	// Verify shadow state was still recorded (bug fix: shadow state should be recorded even without lights)
+	shadowState := manager.GetShadowState()
+	if shadowState.Outputs.GoToBedReminder == nil {
+		t.Fatal("Expected GoToBedReminder to be recorded even when everyone is asleep")
+	}
+	if !shadowState.Outputs.GoToBedReminder.Triggered {
+		t.Error("Expected GoToBedReminder.Triggered to be true")
+	}
+	if shadowState.Outputs.LastActionType != "go_to_bed" {
+		t.Errorf("Expected LastActionType to be 'go_to_bed', got '%s'", shadowState.Outputs.LastActionType)
+	}
 }
 
 // TestHandleGoToBed_NoOneHome tests go_to_bed when no one is home
@@ -516,6 +528,18 @@ func TestHandleGoToBed_NoOneHome(t *testing.T) {
 				t.Error("Should not flash lights when no one is home")
 			}
 		}
+	}
+
+	// Verify shadow state was still recorded (bug fix: shadow state should be recorded even without lights)
+	shadowState := manager.GetShadowState()
+	if shadowState.Outputs.GoToBedReminder == nil {
+		t.Fatal("Expected GoToBedReminder to be recorded even when no one is home")
+	}
+	if !shadowState.Outputs.GoToBedReminder.Triggered {
+		t.Error("Expected GoToBedReminder.Triggered to be true")
+	}
+	if shadowState.Outputs.LastActionType != "go_to_bed" {
+		t.Errorf("Expected LastActionType to be 'go_to_bed', got '%s'", shadowState.Outputs.LastActionType)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixed missing Node-RED behavior: go_to_bed trigger now sets `musicPlaybackType` to "sleep"
- This triggers the music plugin to start sleep music at the configured go_to_bed time (e.g., 23:30)
- Light flashing behavior remains unchanged (conditional on anyone home + not everyone asleep)

## Problem
The go_to_bed schedule trigger was configured for 23:30, but sleep music wasn't starting. Investigation of Node-RED flows.json revealed that go_to_bed does **two things**:
1. Sets `musicPlaybackType = "sleep"` (triggers music plugin to start sleep sounds)
2. Flashes lights (if anyone home and not everyone asleep)

The Go implementation was only doing #2.

## Solution
Updated `handleGoToBed()` to:
1. **Always** set `musicPlaybackType` to "sleep" first (unconditionally)
2. Then check conditions for flashing lights (same as before)

## Test plan
- [x] Added `TestHandleGoToBed_SetsSleepMusicAndFlashesLights` - verifies both behaviors work
- [x] Added `TestHandleGoToBed_SetsSleepMusicEvenWhenEveryoneAsleep` - confirms music starts even if everyone is asleep
- [x] Added `TestHandleGoToBed_NoOneHome` - confirms music starts even if no one is home
- [x] Added `TestHandleGoToBed_ReadOnly` - verifies read-only mode doesn't make changes
- [x] All 70+ existing tests pass with race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)