### PR TITLE
fix(logging): Output logs to stdout instead of stderr

### DIFF
--- a/homeautomation-go/cmd/main.go
+++ b/homeautomation-go/cmd/main.go
@@ -35,8 +35,11 @@ import (
 )
 
 func main() {
-	// Initialize logger
-	logger, err := zap.NewProduction()
+	// Initialize logger with stdout output (better for docker logs)
+	config := zap.NewProductionConfig()
+	config.OutputPaths = []string{"stdout"}
+	config.ErrorOutputPaths = []string{"stdout"}
+	logger, err := config.Build()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create logger: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary
- Configure zap logger to write to stdout instead of the default stderr
- Improves compatibility with `docker logs` which captures stdout by default

## Test plan
- [x] Code compiles successfully
- [x] All tests pass with race detector
- [x] Pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)