### PR TITLE
fix(energy): Fix flaky TestIndicatorLightsUnknownEnergyLevel test

### DIFF
--- a/homeautomation-go/internal/plugins/energy/manager_test.go
+++ b/homeautomation-go/internal/plugins/energy/manager_test.go
@@ -1053,6 +1053,9 @@ func TestIndicatorLightsUnknownEnergyLevel(t *testing.T) {
 	assert.NoError(t, err)
 	defer manager.Stop()
 
+	// Wait for async goroutines (e.g., runFreeEnergyChecker) to complete initial work
+	time.Sleep(50 * time.Millisecond)
+
 	// Clear any service calls from startup
 	mockClient.ClearServiceCalls()
 


### PR DESCRIPTION
## Summary
- Add 50ms sleep after `Start()` to allow `runFreeEnergyChecker()` goroutine to complete its initial work before clearing service calls
- This fixes a race condition where `checkFreeEnergy()` could trigger `updateIndicatorLights()` after `ClearServiceCalls()` when running during the free energy window (21:00-07:00 UTC)

## Root Cause
The test had a race condition:
1. `Start()` returns and launches `runFreeEnergyChecker()` as a goroutine
2. Test immediately calls `mockClient.ClearServiceCalls()`
3. Meanwhile, the goroutine is running and calling `checkFreeEnergy()` which updates state and triggers `updateIndicatorLights()`
4. When the test runs during the free energy window (21:00-07:00 UTC), this triggers a `light.turn_on` call AFTER `ClearServiceCalls()`, causing the assertion to fail

## Test plan
- [x] `go test -race -count=5 -run TestIndicatorLightsUnknownEnergyLevel ./internal/plugins/energy/` passes
- [x] Full test suite passes with race detector

Fixes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)