### PR TITLE
fix(dayphase): Add timezone debugging to diagnose schedule parsing issue

### DIFF
--- a/homeautomation-go/internal/dayphase/calculator.go
+++ b/homeautomation-go/internal/dayphase/calculator.go
@@ -173,6 +173,12 @@ func (c *Calculator) CalculateDayPhase(schedule *config.ParsedSchedule) DayPhase
 	// If schedule overrides are available, use them to delay transitions
 	// This prevents lights from getting too dim too early
 	if schedule != nil {
+		c.logger.Debug("Schedule comparison",
+			zap.Time("now", now),
+			zap.Time("schedule_dusk", schedule.Dusk),
+			zap.Time("schedule_night", schedule.Night),
+			zap.Bool("before_dusk", now.Before(schedule.Dusk)),
+			zap.Bool("before_night", now.Before(schedule.Night)))
 		// Early morning (before 6am) is always night, regardless of schedule
 		// This prevents returning sunset phase at 3am when schedule.Dusk is "20:00"
 		// (which would be "in the future" relative to 3am today)

--- a/homeautomation-go/internal/plugins/dayphase/manager.go
+++ b/homeautomation-go/internal/plugins/dayphase/manager.go
@@ -253,8 +253,16 @@ func (m *Manager) updateShadowInputs() {
 	if err == nil && schedule != nil {
 		inputs["scheduleWake"] = schedule.Wake.Format(time.RFC3339)
 		inputs["scheduleBeginWake"] = schedule.BeginWake.Format(time.RFC3339)
+		inputs["scheduleDusk"] = schedule.Dusk.Format(time.RFC3339)
 		inputs["scheduleWinddown"] = schedule.Winddown.Format(time.RFC3339)
 		inputs["scheduleNight"] = schedule.Night.Format(time.RFC3339)
+	}
+
+	// Add timezone info for debugging
+	if m.timezone != nil {
+		inputs["configuredTimezone"] = m.timezone.String()
+	} else {
+		inputs["configuredTimezone"] = "nil (using time.Local)"
 	}
 
 	m.shadowTracker.UpdateCurrentInputs(inputs)


### PR DESCRIPTION
## Summary
- Add `scheduleDusk` to shadow state inputs (was missing, making debugging impossible)
- Add `configuredTimezone` to shadow state to show what timezone the dayphase manager is using
- Add debug logging in `CalculateDayPhase` showing schedule comparison values

## Problem
Living Room lights showing "Night" scene at 6:52 PM despite `schedule_config.yaml` specifying dusk at 20:00. Investigation revealed schedule times in shadow state appear to be parsed with UTC instead of America/Chicago:

| Field | Expected (Monday 23:00 CST) | Actual in Shadow State |
|-------|--------------------------|------------------------|
| scheduleNight | `2025-12-30T05:00:00Z` | `2025-12-30T23:00:00Z` |

The 18-hour difference indicates times are being parsed as UTC instead of CST.

## Test plan
- [ ] Deploy and check `/api/shadow/dayphase` for new `scheduleDusk` and `configuredTimezone` fields
- [ ] If `configuredTimezone` shows "America/Chicago" but times are wrong, bug is in `GetTodaysScheduleInTimezone`
- [ ] If `configuredTimezone` shows "UTC" or "Local", bug is in how timezone is passed from private repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)