### PR TITLE
fix(logging): Use human-readable timestamps in production logs

### DIFF
--- a/homeautomation-go/cmd/main.go
+++ b/homeautomation-go/cmd/main.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/joho/godotenv"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func main() {
@@ -39,6 +40,7 @@ func main() {
 	config := zap.NewProductionConfig()
 	config.OutputPaths = []string{"stdout"}
 	config.ErrorOutputPaths = []string{"stdout"}
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	logger, err := config.Build()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create logger: %v\n", err)


### PR DESCRIPTION
## Summary
- Configure zap logger to use ISO8601 timestamps instead of Unix epoch timestamps
- Improves readability when viewing logs via `docker logs`

## Test plan
- [x] Code compiles successfully
- [x] All unit tests pass
- [x] All integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)