### PR TITLE
feat(api): Add state timeline visualization for debugging

### DIFF
--- a/homeautomation-go/internal/api/server.go
+++ b/homeautomation-go/internal/api/server.go
@@ -17,6 +17,9 @@ import (
 //go:embed templates/dashboard.html
 var dashboardHTML string
 
+//go:embed templates/timeline.html
+var timelineHTML string
+
 // Server provides HTTP API endpoints for the home automation system
 type Server struct {
 	stateManager  *state.Manager
@@ -51,6 +54,7 @@ func NewServer(stateManager *state.Manager, shadowTracker *shadowstate.Tracker, 
 	mux.HandleFunc("/api/shadow/tv", s.handleGetTVShadowState)
 	mux.HandleFunc("/health", s.handleHealth)
 	mux.HandleFunc("/dashboard", s.handleDashboard)
+	mux.HandleFunc("/timeline", s.handleTimeline)
 
 	s.server = &http.Server{
 		Addr:         fmt.Sprintf(":%d", port),
@@ -437,6 +441,11 @@ func (s *Server) handleSitemap(w http.ResponseWriter, r *http.Request) {
 			Path:        "/dashboard",
 			Method:      "GET",
 			Description: "Shadow State Dashboard - web UI to visualize plugin states",
+		},
+		{
+			Path:        "/timeline",
+			Method:      "GET",
+			Description: "State Timeline - visualize state changes over time for debugging",
 		},
 	}
 
@@ -896,5 +905,19 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, dashboardHTML)
 
 	s.logger.Debug("Dashboard request served",
+		zap.String("remote_addr", r.RemoteAddr))
+}
+
+// handleTimeline serves a web UI for visualizing state changes over time
+func (s *Server) handleTimeline(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, timelineHTML)
+
+	s.logger.Debug("Timeline request served",
 		zap.String("remote_addr", r.RemoteAddr))
 }

--- a/homeautomation-go/internal/api/templates/timeline.html
+++ b/homeautomation-go/internal/api/templates/timeline.html
@@ -1,0 +1,1037 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>State Timeline</title>
+    <style>
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: #1a1a2e;
+            color: #eee;
+            min-height: 100vh;
+            padding: 20px;
+        }
+
+        .header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 15px;
+            margin-bottom: 20px;
+            padding-bottom: 15px;
+            border-bottom: 1px solid #0f3460;
+        }
+
+        .header h1 {
+            font-size: 1.5rem;
+            font-weight: 600;
+            color: #eee;
+        }
+
+        .header-links {
+            display: flex;
+            gap: 15px;
+        }
+
+        .header-links a {
+            color: #569cd6;
+            text-decoration: none;
+            font-size: 0.875rem;
+        }
+
+        .header-links a:hover {
+            text-decoration: underline;
+        }
+
+        .input-section {
+            background: #16213e;
+            border: 1px solid #0f3460;
+            border-radius: 8px;
+            padding: 20px;
+            margin-bottom: 20px;
+        }
+
+        .input-section h2 {
+            font-size: 1rem;
+            font-weight: 600;
+            margin-bottom: 15px;
+            color: #9cdcfe;
+        }
+
+        .input-row {
+            display: flex;
+            gap: 15px;
+            flex-wrap: wrap;
+            align-items: flex-start;
+        }
+
+        .input-group {
+            flex: 1;
+            min-width: 300px;
+        }
+
+        .input-group label {
+            display: block;
+            font-size: 0.875rem;
+            color: #888;
+            margin-bottom: 8px;
+        }
+
+        textarea {
+            width: 100%;
+            height: 120px;
+            background: #1a1a2e;
+            border: 1px solid #0f3460;
+            border-radius: 4px;
+            color: #eee;
+            font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Mono', monospace;
+            font-size: 0.8rem;
+            padding: 10px;
+            resize: vertical;
+        }
+
+        textarea:focus {
+            outline: none;
+            border-color: #569cd6;
+        }
+
+        .file-input-wrapper {
+            position: relative;
+        }
+
+        input[type="file"] {
+            display: none;
+        }
+
+        .file-label {
+            display: inline-block;
+            padding: 10px 20px;
+            background: #0f3460;
+            border: 1px solid #569cd6;
+            border-radius: 4px;
+            color: #569cd6;
+            cursor: pointer;
+            font-size: 0.875rem;
+            transition: background 0.2s;
+        }
+
+        .file-label:hover {
+            background: #16213e;
+        }
+
+        .file-name {
+            margin-left: 10px;
+            color: #888;
+            font-size: 0.875rem;
+        }
+
+        .button-row {
+            display: flex;
+            gap: 10px;
+            margin-top: 15px;
+        }
+
+        button {
+            padding: 10px 20px;
+            border: none;
+            border-radius: 4px;
+            font-size: 0.875rem;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+
+        .btn-primary {
+            background: #4ade80;
+            color: #1a1a2e;
+            font-weight: 600;
+        }
+
+        .btn-primary:hover {
+            background: #22c55e;
+        }
+
+        .btn-secondary {
+            background: #0f3460;
+            color: #eee;
+        }
+
+        .btn-secondary:hover {
+            background: #16213e;
+        }
+
+        .stats {
+            display: flex;
+            gap: 20px;
+            margin-top: 15px;
+            font-size: 0.8rem;
+            color: #888;
+        }
+
+        .stat {
+            display: flex;
+            align-items: center;
+            gap: 5px;
+        }
+
+        .stat-value {
+            color: #4ade80;
+            font-weight: 600;
+        }
+
+        .filter-section {
+            background: #16213e;
+            border: 1px solid #0f3460;
+            border-radius: 8px;
+            padding: 15px 20px;
+            margin-bottom: 20px;
+        }
+
+        .filter-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 10px;
+        }
+
+        .filter-header h3 {
+            font-size: 0.875rem;
+            font-weight: 600;
+            color: #9cdcfe;
+        }
+
+        .filter-actions {
+            display: flex;
+            gap: 10px;
+        }
+
+        .filter-actions button {
+            padding: 4px 10px;
+            font-size: 0.75rem;
+        }
+
+        .filter-grid {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .filter-item {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 10px;
+            background: #1a1a2e;
+            border-radius: 4px;
+            font-size: 0.8rem;
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .filter-item input {
+            cursor: pointer;
+        }
+
+        .filter-item.category-state {
+            border-left: 3px solid #569cd6;
+        }
+
+        .filter-item.category-lighting {
+            border-left: 3px solid #fbbf24;
+        }
+
+        .filter-item.category-music {
+            border-left: 3px solid #a855f7;
+        }
+
+        .timeline-container {
+            background: #16213e;
+            border: 1px solid #0f3460;
+            border-radius: 8px;
+            overflow: hidden;
+            min-height: 400px;
+        }
+
+        .timeline-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 15px 20px;
+            border-bottom: 1px solid #0f3460;
+        }
+
+        .timeline-header h2 {
+            font-size: 1rem;
+            font-weight: 600;
+            color: #9cdcfe;
+        }
+
+        .zoom-controls {
+            display: flex;
+            gap: 5px;
+        }
+
+        .zoom-controls button {
+            width: 32px;
+            height: 32px;
+            padding: 0;
+            font-size: 1rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .timeline-scroll {
+            overflow-x: auto;
+            overflow-y: auto;
+            max-height: 600px;
+        }
+
+        .timeline-content {
+            padding: 20px;
+            min-width: 800px;
+        }
+
+        .no-data {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 60px 20px;
+            color: #888;
+            text-align: center;
+        }
+
+        .no-data-icon {
+            font-size: 3rem;
+            margin-bottom: 15px;
+            opacity: 0.5;
+        }
+
+        .no-data p {
+            margin-bottom: 10px;
+        }
+
+        .no-data code {
+            background: #1a1a2e;
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.8rem;
+        }
+
+        /* SVG Timeline Styles */
+        .timeline-svg {
+            display: block;
+        }
+
+        .swimlane-label {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-size: 12px;
+            fill: #9cdcfe;
+        }
+
+        .swimlane-bg {
+            fill: #1a1a2e;
+        }
+
+        .swimlane-bg:nth-child(even) {
+            fill: #16213e;
+        }
+
+        .time-axis-line {
+            stroke: #0f3460;
+            stroke-width: 1;
+        }
+
+        .time-label {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-size: 10px;
+            fill: #888;
+        }
+
+        .segment-true {
+            fill: #4ade80;
+        }
+
+        .segment-false {
+            fill: #f87171;
+        }
+
+        .segment-string {
+            fill: #569cd6;
+        }
+
+        .segment:hover {
+            opacity: 0.8;
+            cursor: pointer;
+        }
+
+        .tooltip {
+            position: fixed;
+            background: #1a1a2e;
+            border: 1px solid #0f3460;
+            border-radius: 6px;
+            padding: 10px 14px;
+            font-size: 0.8rem;
+            pointer-events: none;
+            z-index: 1000;
+            max-width: 350px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+        }
+
+        .tooltip-time {
+            color: #888;
+            font-size: 0.75rem;
+            margin-bottom: 6px;
+        }
+
+        .tooltip-variable {
+            color: #9cdcfe;
+            font-weight: 600;
+            margin-bottom: 4px;
+        }
+
+        .tooltip-value {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .tooltip-old {
+            color: #f87171;
+        }
+
+        .tooltip-arrow {
+            color: #888;
+        }
+
+        .tooltip-new {
+            color: #4ade80;
+        }
+
+        @media (max-width: 640px) {
+            body {
+                padding: 15px;
+            }
+
+            .header {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+
+            .input-row {
+                flex-direction: column;
+            }
+
+            .input-group {
+                min-width: 100%;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>State Timeline</h1>
+        <div class="header-links">
+            <a href="/dashboard">Shadow State Dashboard</a>
+            <a href="/">API Endpoints</a>
+        </div>
+    </div>
+
+    <div class="input-section">
+        <h2>Load Log Data</h2>
+        <div class="input-row">
+            <div class="input-group">
+                <label>Paste log lines (JSON format)</label>
+                <textarea id="logInput" placeholder='{"level":"info","ts":"2025-12-30T06:00:00.000Z","msg":"State changed","key":"dayPhase","old":"night","new":"morning"}'></textarea>
+            </div>
+            <div class="input-group">
+                <label>Or upload a log file</label>
+                <div class="file-input-wrapper">
+                    <input type="file" id="fileInput" accept=".log,.txt,.json">
+                    <label for="fileInput" class="file-label">Choose File</label>
+                    <span class="file-name" id="fileName"></span>
+                </div>
+            </div>
+        </div>
+        <div class="button-row">
+            <button class="btn-primary" onclick="parseAndRender()">Visualize Timeline</button>
+            <button class="btn-secondary" onclick="loadSampleData()">Load Sample Data</button>
+            <button class="btn-secondary" onclick="clearAll()">Clear</button>
+        </div>
+        <div class="stats" id="stats" style="display: none;">
+            <div class="stat">Events: <span class="stat-value" id="statEvents">0</span></div>
+            <div class="stat">Variables: <span class="stat-value" id="statVariables">0</span></div>
+            <div class="stat">Time range: <span class="stat-value" id="statTimeRange">-</span></div>
+        </div>
+    </div>
+
+    <div class="filter-section" id="filterSection" style="display: none;">
+        <div class="filter-header">
+            <h3>Filter Variables</h3>
+            <div class="filter-actions">
+                <button class="btn-secondary" onclick="selectAllFilters()">All</button>
+                <button class="btn-secondary" onclick="selectNoneFilters()">None</button>
+            </div>
+        </div>
+        <div class="filter-grid" id="filterGrid"></div>
+    </div>
+
+    <div class="timeline-container">
+        <div class="timeline-header">
+            <h2>Timeline</h2>
+            <div class="zoom-controls">
+                <button class="btn-secondary" onclick="zoomOut()" title="Zoom out">-</button>
+                <button class="btn-secondary" onclick="resetZoom()" title="Reset zoom">1:1</button>
+                <button class="btn-secondary" onclick="zoomIn()" title="Zoom in">+</button>
+            </div>
+        </div>
+        <div class="timeline-scroll" id="timelineScroll">
+            <div class="timeline-content" id="timelineContent">
+                <div class="no-data">
+                    <div class="no-data-icon">📊</div>
+                    <p>No timeline data to display</p>
+                    <p>Paste log lines above or upload a log file, then click <strong>Visualize Timeline</strong></p>
+                    <p style="margin-top: 10px; font-size: 0.8rem;">
+                        Logs should be in JSON format with <code>ts</code> and <code>msg</code> fields
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="tooltip" id="tooltip" style="display: none;"></div>
+
+    <script>
+        // State
+        let parsedEvents = [];
+        let timelineData = null;
+        let zoomLevel = 1;
+        let enabledVariables = new Set();
+
+        // Constants
+        const LABEL_WIDTH = 180;
+        const ROW_HEIGHT = 30;
+        const TIME_AXIS_HEIGHT = 40;
+        const PADDING = 20;
+        const MIN_SEGMENT_WIDTH = 2;
+
+        // Color palette for string values (using hash)
+        const STRING_COLORS = [
+            '#569cd6', '#4ec9b0', '#ce9178', '#dcdcaa', '#c586c0',
+            '#9cdcfe', '#b5cea8', '#d7ba7d', '#f48771', '#89d185'
+        ];
+
+        // Parse timestamp - handles both Unix (1767114102.364) and ISO (2025-12-30T06:00:00.000Z)
+        function parseTimestamp(ts) {
+            if (typeof ts === 'number') {
+                // Unix timestamp (seconds with optional fractional part)
+                return new Date(ts * 1000);
+            } else if (typeof ts === 'string') {
+                // ISO string
+                return new Date(ts);
+            }
+            return null;
+        }
+
+        // Parse log lines
+        function parseLogLines(text) {
+            const events = [];
+            const lines = text.trim().split('\n');
+
+            for (const line of lines) {
+                if (!line.trim()) continue;
+
+                try {
+                    const entry = JSON.parse(line);
+                    if (!entry.ts) continue;
+
+                    const timestamp = parseTimestamp(entry.ts);
+                    if (!timestamp || isNaN(timestamp.getTime())) continue;
+
+                    // State changes
+                    if (entry.msg === 'State changed' && entry.key) {
+                        events.push({
+                            timestamp,
+                            variable: entry.key,
+                            oldValue: entry.old,
+                            newValue: entry.new,
+                            type: 'state',
+                            raw: entry
+                        });
+                    }
+                    // Lighting: Activating scene
+                    else if (entry.msg === 'Activating scene' && entry.room) {
+                        events.push({
+                            timestamp,
+                            variable: `lighting:${entry.room}`,
+                            newValue: entry.scene || 'unknown',
+                            type: 'lighting',
+                            raw: entry
+                        });
+                    }
+                    // Lighting: Scene activated successfully
+                    else if (entry.msg === 'Scene activated successfully' && entry.room) {
+                        events.push({
+                            timestamp,
+                            variable: `lighting:${entry.room}`,
+                            newValue: entry.scene || 'active',
+                            type: 'lighting',
+                            raw: entry
+                        });
+                    }
+                    // Lighting: Turning off room
+                    else if ((entry.msg === 'Turning off room' || entry.msg === 'Room turned off successfully') && entry.room) {
+                        events.push({
+                            timestamp,
+                            variable: `lighting:${entry.room}`,
+                            newValue: 'off',
+                            type: 'lighting',
+                            raw: entry
+                        });
+                    }
+                    // Music: Orchestrating playback
+                    else if (entry.msg === 'Orchestrating playback' && entry.type) {
+                        events.push({
+                            timestamp,
+                            variable: 'music:playback',
+                            newValue: entry.type,
+                            type: 'music',
+                            raw: entry
+                        });
+                    }
+                } catch (e) {
+                    // Skip non-JSON lines
+                }
+            }
+
+            return events.sort((a, b) => a.timestamp - b.timestamp);
+        }
+
+        // Build timeline data structure
+        function buildTimelineData(events) {
+            if (events.length === 0) return null;
+
+            const variables = new Map(); // variable -> [{start, end, value}]
+            const variableTypes = new Map(); // variable -> 'state'|'lighting'|'music'
+
+            // Group events by variable
+            const eventsByVar = new Map();
+            for (const event of events) {
+                if (!eventsByVar.has(event.variable)) {
+                    eventsByVar.set(event.variable, []);
+                    variableTypes.set(event.variable, event.type);
+                }
+                eventsByVar.get(event.variable).push(event);
+            }
+
+            // Build segments for each variable
+            const timeStart = events[0].timestamp;
+            const timeEnd = events[events.length - 1].timestamp;
+
+            for (const [varName, varEvents] of eventsByVar) {
+                const segments = [];
+
+                for (let i = 0; i < varEvents.length; i++) {
+                    const event = varEvents[i];
+                    const nextEvent = varEvents[i + 1];
+
+                    // For state changes, we also capture the old value for the period before
+                    if (i === 0 && event.oldValue !== undefined) {
+                        segments.push({
+                            start: timeStart,
+                            end: event.timestamp,
+                            value: event.oldValue,
+                            event: null
+                        });
+                    }
+
+                    segments.push({
+                        start: event.timestamp,
+                        end: nextEvent ? nextEvent.timestamp : timeEnd,
+                        value: event.newValue,
+                        event: event
+                    });
+                }
+
+                variables.set(varName, segments);
+            }
+
+            return {
+                variables,
+                variableTypes,
+                timeStart,
+                timeEnd,
+                events
+            };
+        }
+
+        // Get color for a value
+        function getValueColor(value, valueType) {
+            if (value === true || value === 'true') return '#4ade80';
+            if (value === false || value === 'false') return '#f87171';
+            if (value === null || value === undefined || value === '') return '#555';
+            if (value === 'off') return '#555';
+
+            // Hash string to color
+            const str = String(value);
+            let hash = 0;
+            for (let i = 0; i < str.length; i++) {
+                hash = str.charCodeAt(i) + ((hash << 5) - hash);
+            }
+            return STRING_COLORS[Math.abs(hash) % STRING_COLORS.length];
+        }
+
+        // Format time for display
+        function formatTime(date) {
+            return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+        }
+
+        function formatDateTime(date) {
+            return date.toLocaleString([], {
+                month: 'short',
+                day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit'
+            });
+        }
+
+        // Render the SVG timeline
+        function renderTimeline() {
+            if (!timelineData) {
+                document.getElementById('timelineContent').innerHTML = `
+                    <div class="no-data">
+                        <div class="no-data-icon">📊</div>
+                        <p>No timeline data to display</p>
+                        <p>Paste log lines above or upload a log file, then click <strong>Visualize Timeline</strong></p>
+                    </div>
+                `;
+                return;
+            }
+
+            // Filter variables
+            const visibleVars = Array.from(timelineData.variables.keys())
+                .filter(v => enabledVariables.has(v))
+                .sort((a, b) => {
+                    // Sort: state vars first, then lighting, then music
+                    const typeA = timelineData.variableTypes.get(a);
+                    const typeB = timelineData.variableTypes.get(b);
+                    const order = { 'state': 0, 'lighting': 1, 'music': 2 };
+                    if (order[typeA] !== order[typeB]) return order[typeA] - order[typeB];
+                    return a.localeCompare(b);
+                });
+
+            if (visibleVars.length === 0) {
+                document.getElementById('timelineContent').innerHTML = `
+                    <div class="no-data">
+                        <div class="no-data-icon">🔍</div>
+                        <p>No variables selected</p>
+                        <p>Enable some variables in the filter above</p>
+                    </div>
+                `;
+                return;
+            }
+
+            const timeRange = timelineData.timeEnd - timelineData.timeStart;
+            const baseWidth = 800;
+            const timeWidth = Math.max(baseWidth, timeRange / 1000 / 60 * 10) * zoomLevel; // ~10px per minute base
+
+            const svgHeight = TIME_AXIS_HEIGHT + visibleVars.length * ROW_HEIGHT + PADDING;
+            const svgWidth = LABEL_WIDTH + timeWidth + PADDING * 2;
+
+            let svg = `<svg class="timeline-svg" width="${svgWidth}" height="${svgHeight}" xmlns="http://www.w3.org/2000/svg">`;
+
+            // Background
+            svg += `<rect width="${svgWidth}" height="${svgHeight}" fill="#16213e"/>`;
+
+            // Draw swimlane backgrounds
+            visibleVars.forEach((varName, idx) => {
+                const y = TIME_AXIS_HEIGHT + idx * ROW_HEIGHT;
+                const fill = idx % 2 === 0 ? '#1a1a2e' : '#16213e';
+                svg += `<rect x="0" y="${y}" width="${svgWidth}" height="${ROW_HEIGHT}" fill="${fill}"/>`;
+            });
+
+            // Draw time axis
+            const timeAxisY = TIME_AXIS_HEIGHT - 5;
+            svg += `<line x1="${LABEL_WIDTH}" y1="${timeAxisY}" x2="${LABEL_WIDTH + timeWidth}" y2="${timeAxisY}" stroke="#0f3460" stroke-width="1"/>`;
+
+            // Time labels
+            const numLabels = Math.min(20, Math.floor(timeWidth / 80));
+            for (let i = 0; i <= numLabels; i++) {
+                const x = LABEL_WIDTH + (timeWidth * i / numLabels);
+                const time = new Date(timelineData.timeStart.getTime() + (timeRange * i / numLabels));
+                svg += `<line x1="${x}" y1="${timeAxisY - 5}" x2="${x}" y2="${svgHeight}" stroke="#0f3460" stroke-width="1" stroke-dasharray="2,4"/>`;
+                svg += `<text x="${x}" y="${timeAxisY - 10}" class="time-label" text-anchor="middle">${formatTime(time)}</text>`;
+            }
+
+            // Draw swimlanes and segments
+            visibleVars.forEach((varName, idx) => {
+                const y = TIME_AXIS_HEIGHT + idx * ROW_HEIGHT;
+                const segments = timelineData.variables.get(varName);
+                const varType = timelineData.variableTypes.get(varName);
+
+                // Label
+                const labelColor = varType === 'lighting' ? '#fbbf24' : varType === 'music' ? '#a855f7' : '#9cdcfe';
+                const displayName = varName.length > 22 ? varName.substring(0, 20) + '...' : varName;
+                svg += `<text x="${LABEL_WIDTH - 10}" y="${y + ROW_HEIGHT / 2 + 4}" class="swimlane-label" text-anchor="end" fill="${labelColor}">${escapeHtml(displayName)}</text>`;
+
+                // Segments
+                for (const seg of segments) {
+                    const segStart = (seg.start - timelineData.timeStart) / timeRange;
+                    const segEnd = (seg.end - timelineData.timeStart) / timeRange;
+                    const x = LABEL_WIDTH + segStart * timeWidth;
+                    const width = Math.max(MIN_SEGMENT_WIDTH, (segEnd - segStart) * timeWidth);
+                    const color = getValueColor(seg.value, varType);
+
+                    const segData = JSON.stringify({
+                        variable: varName,
+                        value: seg.value,
+                        start: seg.start.toISOString(),
+                        end: seg.end.toISOString(),
+                        event: seg.event ? seg.event.raw : null
+                    }).replace(/"/g, '&quot;');
+
+                    svg += `<rect class="segment" x="${x}" y="${y + 4}" width="${width}" height="${ROW_HEIGHT - 8}" rx="3" fill="${color}" data-seg="${segData}" onmousemove="showTooltip(event)" onmouseout="hideTooltip()"/>`;
+
+                    // Label inside segment if wide enough
+                    if (width > 40) {
+                        const label = String(seg.value).length > 10 ? String(seg.value).substring(0, 8) + '...' : String(seg.value);
+                        const textColor = (color === '#4ade80' || color === '#fbbf24') ? '#1a1a2e' : '#fff';
+                        svg += `<text x="${x + width / 2}" y="${y + ROW_HEIGHT / 2 + 4}" fill="${textColor}" font-size="10" text-anchor="middle" pointer-events="none">${escapeHtml(label)}</text>`;
+                    }
+                }
+            });
+
+            svg += '</svg>';
+            document.getElementById('timelineContent').innerHTML = svg;
+        }
+
+        // Tooltip handling
+        function showTooltip(event) {
+            const rect = event.target;
+            const data = JSON.parse(rect.dataset.seg);
+            const tooltip = document.getElementById('tooltip');
+
+            const start = new Date(data.start);
+            const end = new Date(data.end);
+
+            let html = `<div class="tooltip-time">${formatDateTime(start)} - ${formatDateTime(end)}</div>`;
+            html += `<div class="tooltip-variable">${escapeHtml(data.variable)}</div>`;
+
+            if (data.event && data.event.old !== undefined) {
+                html += `<div class="tooltip-value">
+                    <span class="tooltip-old">${escapeHtml(String(data.event.old))}</span>
+                    <span class="tooltip-arrow">→</span>
+                    <span class="tooltip-new">${escapeHtml(String(data.event.new))}</span>
+                </div>`;
+            } else {
+                html += `<div class="tooltip-value">
+                    <span class="tooltip-new">${escapeHtml(String(data.value))}</span>
+                </div>`;
+            }
+
+            tooltip.innerHTML = html;
+            tooltip.style.display = 'block';
+            tooltip.style.left = (event.clientX + 15) + 'px';
+            tooltip.style.top = (event.clientY + 15) + 'px';
+        }
+
+        function hideTooltip() {
+            document.getElementById('tooltip').style.display = 'none';
+        }
+
+        // Escape HTML
+        function escapeHtml(str) {
+            if (typeof str !== 'string') return str;
+            const div = document.createElement('div');
+            div.textContent = str;
+            return div.innerHTML;
+        }
+
+        // Update filter checkboxes
+        function updateFilters() {
+            if (!timelineData) {
+                document.getElementById('filterSection').style.display = 'none';
+                return;
+            }
+
+            document.getElementById('filterSection').style.display = 'block';
+            const grid = document.getElementById('filterGrid');
+            grid.innerHTML = '';
+
+            const vars = Array.from(timelineData.variables.keys()).sort((a, b) => {
+                const typeA = timelineData.variableTypes.get(a);
+                const typeB = timelineData.variableTypes.get(b);
+                const order = { 'state': 0, 'lighting': 1, 'music': 2 };
+                if (order[typeA] !== order[typeB]) return order[typeA] - order[typeB];
+                return a.localeCompare(b);
+            });
+
+            for (const varName of vars) {
+                const varType = timelineData.variableTypes.get(varName);
+                const checked = enabledVariables.has(varName) ? 'checked' : '';
+                const categoryClass = `category-${varType}`;
+                grid.innerHTML += `
+                    <label class="filter-item ${categoryClass}">
+                        <input type="checkbox" ${checked} onchange="toggleVariable('${escapeHtml(varName)}')">
+                        ${escapeHtml(varName)}
+                    </label>
+                `;
+            }
+        }
+
+        function toggleVariable(varName) {
+            if (enabledVariables.has(varName)) {
+                enabledVariables.delete(varName);
+            } else {
+                enabledVariables.add(varName);
+            }
+            renderTimeline();
+        }
+
+        function selectAllFilters() {
+            if (!timelineData) return;
+            for (const varName of timelineData.variables.keys()) {
+                enabledVariables.add(varName);
+            }
+            updateFilters();
+            renderTimeline();
+        }
+
+        function selectNoneFilters() {
+            enabledVariables.clear();
+            updateFilters();
+            renderTimeline();
+        }
+
+        // Zoom controls
+        function zoomIn() {
+            zoomLevel = Math.min(zoomLevel * 1.5, 10);
+            renderTimeline();
+        }
+
+        function zoomOut() {
+            zoomLevel = Math.max(zoomLevel / 1.5, 0.5);
+            renderTimeline();
+        }
+
+        function resetZoom() {
+            zoomLevel = 1;
+            renderTimeline();
+        }
+
+        // Main parse and render function
+        function parseAndRender() {
+            const textarea = document.getElementById('logInput');
+            const text = textarea.value.trim();
+
+            if (!text) {
+                alert('Please paste log data or upload a file first');
+                return;
+            }
+
+            parsedEvents = parseLogLines(text);
+
+            if (parsedEvents.length === 0) {
+                alert('No valid events found in the log data. Make sure logs are in JSON format with "ts" timestamps.');
+                return;
+            }
+
+            timelineData = buildTimelineData(parsedEvents);
+
+            // Enable all variables by default
+            enabledVariables.clear();
+            for (const varName of timelineData.variables.keys()) {
+                enabledVariables.add(varName);
+            }
+
+            // Update stats
+            document.getElementById('stats').style.display = 'flex';
+            document.getElementById('statEvents').textContent = parsedEvents.length;
+            document.getElementById('statVariables').textContent = timelineData.variables.size;
+            document.getElementById('statTimeRange').textContent =
+                `${formatDateTime(timelineData.timeStart)} - ${formatDateTime(timelineData.timeEnd)}`;
+
+            updateFilters();
+            renderTimeline();
+        }
+
+        // File upload handling
+        document.getElementById('fileInput').addEventListener('change', function(e) {
+            const file = e.target.files[0];
+            if (!file) return;
+
+            document.getElementById('fileName').textContent = file.name;
+
+            const reader = new FileReader();
+            reader.onload = function(e) {
+                document.getElementById('logInput').value = e.target.result;
+            };
+            reader.readAsText(file);
+        });
+
+        // Load sample data
+        function loadSampleData() {
+            const sampleData = [
+                {"level":"info","ts":"2025-12-30T05:00:00.000Z","msg":"State changed","key":"dayPhase","old":"night","new":"night"},
+                {"level":"info","ts":"2025-12-30T06:00:00.000Z","msg":"State changed","key":"dayPhase","old":"night","new":"dawn"},
+                {"level":"info","ts":"2025-12-30T06:00:00.000Z","msg":"State changed","key":"isAnyoneAsleep","old":true,"new":true},
+                {"level":"info","ts":"2025-12-30T06:30:00.000Z","msg":"State changed","key":"dayPhase","old":"dawn","new":"morning"},
+                {"level":"info","ts":"2025-12-30T06:30:00.000Z","msg":"Activating scene","room":"Living Room","scene":"morning","entity_id":"scene.living_room_morning"},
+                {"level":"info","ts":"2025-12-30T06:30:00.000Z","msg":"Activating scene","room":"Kitchen","scene":"morning","entity_id":"scene.kitchen_morning"},
+                {"level":"info","ts":"2025-12-30T06:30:00.000Z","msg":"Orchestrating playback","type":"morning","trigger":"dayPhase"},
+                {"level":"info","ts":"2025-12-30T06:30:00.000Z","msg":"State changed","key":"musicPlaybackType","old":"","new":"morning"},
+                {"level":"info","ts":"2025-12-30T07:00:00.000Z","msg":"State changed","key":"isAnyoneAsleep","old":true,"new":false},
+                {"level":"info","ts":"2025-12-30T07:00:00.000Z","msg":"State changed","key":"isMasterAsleep","old":true,"new":false},
+                {"level":"info","ts":"2025-12-30T08:00:00.000Z","msg":"State changed","key":"isNickHome","old":true,"new":false},
+                {"level":"info","ts":"2025-12-30T08:00:00.000Z","msg":"State changed","key":"isAnyoneHome","old":true,"new":false},
+                {"level":"info","ts":"2025-12-30T08:00:00.000Z","msg":"Turning off room","room":"Living Room"},
+                {"level":"info","ts":"2025-12-30T08:00:00.000Z","msg":"Turning off room","room":"Kitchen"},
+                {"level":"info","ts":"2025-12-30T09:00:00.000Z","msg":"State changed","key":"dayPhase","old":"morning","new":"day"},
+                {"level":"info","ts":"2025-12-30T12:00:00.000Z","msg":"State changed","key":"isNickHome","old":false,"new":true},
+                {"level":"info","ts":"2025-12-30T12:00:00.000Z","msg":"State changed","key":"isAnyoneHome","old":false,"new":true},
+                {"level":"info","ts":"2025-12-30T12:00:00.000Z","msg":"Activating scene","room":"Living Room","scene":"day","entity_id":"scene.living_room_day"},
+                {"level":"info","ts":"2025-12-30T17:00:00.000Z","msg":"State changed","key":"dayPhase","old":"day","new":"evening"},
+                {"level":"info","ts":"2025-12-30T17:00:00.000Z","msg":"Activating scene","room":"Living Room","scene":"evening","entity_id":"scene.living_room_evening"},
+                {"level":"info","ts":"2025-12-30T17:00:00.000Z","msg":"Orchestrating playback","type":"evening","trigger":"dayPhase"},
+                {"level":"info","ts":"2025-12-30T17:00:00.000Z","msg":"State changed","key":"musicPlaybackType","old":"morning","new":"evening"},
+                {"level":"info","ts":"2025-12-30T20:00:00.000Z","msg":"State changed","key":"isTVPlaying","old":false,"new":true},
+                {"level":"info","ts":"2025-12-30T22:00:00.000Z","msg":"State changed","key":"isTVPlaying","old":true,"new":false},
+                {"level":"info","ts":"2025-12-30T22:00:00.000Z","msg":"State changed","key":"dayPhase","old":"evening","new":"late_evening"},
+                {"level":"info","ts":"2025-12-30T23:00:00.000Z","msg":"State changed","key":"isMasterAsleep","old":false,"new":true},
+                {"level":"info","ts":"2025-12-30T23:00:00.000Z","msg":"State changed","key":"isAnyoneAsleep","old":false,"new":true}
+            ];
+
+            document.getElementById('logInput').value = sampleData.map(e => JSON.stringify(e)).join('\n');
+            document.getElementById('fileName').textContent = 'sample-data.log';
+        }
+
+        // Clear all
+        function clearAll() {
+            document.getElementById('logInput').value = '';
+            document.getElementById('fileName').textContent = '';
+            document.getElementById('stats').style.display = 'none';
+            document.getElementById('filterSection').style.display = 'none';
+            parsedEvents = [];
+            timelineData = null;
+            enabledVariables.clear();
+            zoomLevel = 1;
+            document.getElementById('timelineContent').innerHTML = `
+                <div class="no-data">
+                    <div class="no-data-icon">📊</div>
+                    <p>No timeline data to display</p>
+                    <p>Paste log lines above or upload a log file, then click <strong>Visualize Timeline</strong></p>
+                </div>
+            `;
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `/timeline` endpoint that visualizes state changes over time from log files
- Helps debug issues like incorrect lighting or unexpected music playback by showing what changed and when

## Features
- Parse JSON logs (supports both Unix and ISO timestamps)
- Visualize state variable changes (`dayPhase`, `isAnyoneAsleep`, etc.)
- Per-room lighting actions (scene activations, room off)
- Music playback events
- Interactive SVG timeline with zoom, pan, filters
- Hover tooltips showing timestamp and old→new values

## Test plan
- [x] All existing tests pass
- [x] Verified `/timeline` endpoint serves the page
- [x] Verified sitemap includes new endpoint
- [ ] Manual test with production logs

## Screenshots
Access at http://localhost:8080/timeline after starting with `make dev-ui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)