### PR TITLE
feat(api): Add in-memory log buffer for timeline visualization

### DIFF
--- a/homeautomation-go/cmd/main.go
+++ b/homeautomation-go/cmd/main.go
@@ -12,6 +12,7 @@ import (
 	"homeautomation/internal/api"
 	"homeautomation/internal/devserver"
 	"homeautomation/internal/ha"
+	"homeautomation/internal/logbuffer"
 	"homeautomation/internal/plugins/reset"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
@@ -36,16 +37,29 @@ import (
 )
 
 func main() {
+	// Create in-memory log buffer for timeline visualization
+	// This stores the last 10,000 log events for the /api/timeline/events endpoint
+	logBuffer := logbuffer.NewBuffer(logbuffer.DefaultBufferSize)
+
 	// Initialize logger with stdout output (better for docker logs)
+	// and ring buffer capture for timeline visualization
 	config := zap.NewProductionConfig()
 	config.OutputPaths = []string{"stdout"}
 	config.ErrorOutputPaths = []string{"stdout"}
 	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
-	logger, err := config.Build()
+
+	// Build the production logger core for stdout
+	stdoutCore, err := buildStdoutCore(config)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create logger: %v\n", err)
 		os.Exit(1)
 	}
+
+	// Create buffer core for timeline visualization (capture INFO and above)
+	bufferCore := logbuffer.NewBufferCore(logBuffer, zapcore.InfoLevel)
+
+	// Combine both cores using zap.NewTee
+	logger := zap.New(zapcore.NewTee(stdoutCore, bufferCore))
 	defer logger.Sync()
 
 	// Load environment variables from .env file if present
@@ -184,7 +198,7 @@ func main() {
 	logger.Info("Subscription Registry created for automatic input tracking")
 
 	// Start HTTP API server
-	apiServer := api.NewServer(stateManager, shadowTracker, logger, httpPort, timezone)
+	apiServer := api.NewServer(stateManager, shadowTracker, logBuffer, logger, httpPort, timezone)
 	if err := apiServer.Start(); err != nil {
 		logger.Fatal("Failed to start HTTP API server", zap.Error(err))
 	}
@@ -347,4 +361,17 @@ func subscribeToChanges(manager *state.Manager, logger *zap.Logger) {
 
 	logger.Info("Subscribed to all state change notifications",
 		zap.Int("variable_count", len(state.AllVariables)))
+}
+
+// buildStdoutCore creates a zap core that writes to stdout with the given config.
+func buildStdoutCore(config zap.Config) (zapcore.Core, error) {
+	encoder := zapcore.NewJSONEncoder(config.EncoderConfig)
+
+	// Create stdout sink
+	stdoutSink, _, err := zap.Open("stdout")
+	if err != nil {
+		return nil, fmt.Errorf("failed to open stdout: %w", err)
+	}
+
+	return zapcore.NewCore(encoder, stdoutSink, config.Level), nil
 }

--- a/homeautomation-go/internal/api/server.go
+++ b/homeautomation-go/internal/api/server.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
+	"homeautomation/internal/logbuffer"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
 
@@ -24,16 +26,18 @@ var timelineHTML string
 type Server struct {
 	stateManager  *state.Manager
 	shadowTracker *shadowstate.Tracker
+	logBuffer     *logbuffer.Buffer
 	logger        *zap.Logger
 	server        *http.Server
 	timezone      *time.Location
 }
 
 // NewServer creates a new API server
-func NewServer(stateManager *state.Manager, shadowTracker *shadowstate.Tracker, logger *zap.Logger, port int, timezone *time.Location) *Server {
+func NewServer(stateManager *state.Manager, shadowTracker *shadowstate.Tracker, logBuffer *logbuffer.Buffer, logger *zap.Logger, port int, timezone *time.Location) *Server {
 	s := &Server{
 		stateManager:  stateManager,
 		shadowTracker: shadowTracker,
+		logBuffer:     logBuffer,
 		logger:        logger,
 		timezone:      timezone,
 	}
@@ -55,6 +59,7 @@ func NewServer(stateManager *state.Manager, shadowTracker *shadowstate.Tracker, 
 	mux.HandleFunc("/health", s.handleHealth)
 	mux.HandleFunc("/dashboard", s.handleDashboard)
 	mux.HandleFunc("/timeline", s.handleTimeline)
+	mux.HandleFunc("/api/timeline/events", s.handleTimelineEvents)
 
 	s.server = &http.Server{
 		Addr:         fmt.Sprintf(":%d", port),
@@ -446,6 +451,11 @@ func (s *Server) handleSitemap(w http.ResponseWriter, r *http.Request) {
 			Path:        "/timeline",
 			Method:      "GET",
 			Description: "State Timeline - visualize state changes over time for debugging",
+		},
+		{
+			Path:        "/api/timeline/events",
+			Method:      "GET",
+			Description: "Get recent log events from in-memory buffer - query params: since (ISO8601), limit (int, default 1000)",
 		},
 	}
 
@@ -920,4 +930,66 @@ func (s *Server) handleTimeline(w http.ResponseWriter, r *http.Request) {
 
 	s.logger.Debug("Timeline request served",
 		zap.String("remote_addr", r.RemoteAddr))
+}
+
+// TimelineEventsResponse represents the JSON response for the timeline events endpoint
+type TimelineEventsResponse struct {
+	Events   []logbuffer.Event `json:"events"`
+	Count    int               `json:"count"`
+	Capacity int               `json:"capacity"`
+	Overflow bool              `json:"overflow"`
+}
+
+// handleTimelineEvents returns recent log events from the in-memory ring buffer
+// Query parameters:
+//   - since: ISO8601 timestamp to filter events after (optional)
+//   - limit: maximum number of events to return (optional, default 1000)
+func (s *Server) handleTimelineEvents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Parse query parameters
+	var since time.Time
+	if sinceStr := r.URL.Query().Get("since"); sinceStr != "" {
+		parsed, err := time.Parse(time.RFC3339, sinceStr)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid 'since' parameter: %v", err), http.StatusBadRequest)
+			return
+		}
+		since = parsed
+	}
+
+	limit := 1000 // default limit
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		parsed, err := strconv.Atoi(limitStr)
+		if err != nil || parsed < 0 {
+			http.Error(w, "Invalid 'limit' parameter: must be a positive integer", http.StatusBadRequest)
+			return
+		}
+		if parsed > 0 {
+			limit = parsed
+		}
+	}
+
+	// Get events from buffer
+	events := s.logBuffer.GetEvents(since, limit)
+
+	response := TimelineEventsResponse{
+		Events:   events,
+		Count:    s.logBuffer.Count(),
+		Capacity: s.logBuffer.Capacity(),
+		Overflow: s.logBuffer.HasOverflowed(),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		s.logger.Error("Failed to encode timeline events response", zap.Error(err))
+	}
+
+	s.logger.Debug("Timeline events request served",
+		zap.String("remote_addr", r.RemoteAddr),
+		zap.Int("events_returned", len(events)),
+		zap.Int("limit", limit))
 }

--- a/homeautomation-go/internal/api/server_test.go
+++ b/homeautomation-go/internal/api/server_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"homeautomation/internal/ha"
+	"homeautomation/internal/logbuffer"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
 
@@ -33,7 +34,7 @@ func TestHandleGetState(t *testing.T) {
 
 	// Create API server
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logger, 8080, time.UTC)
+	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/state", nil)
@@ -108,7 +109,7 @@ func TestHandleGetStateMethodNotAllowed(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logger, 8080, time.UTC)
+	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Test POST method (should be rejected)
 	req := httptest.NewRequest(http.MethodPost, "/api/state", nil)
@@ -126,7 +127,7 @@ func TestHandleHealth(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logger, 8080, time.UTC)
+	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
@@ -152,7 +153,7 @@ func TestHandleSitemap(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logger, 8080, time.UTC)
+	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
@@ -203,7 +204,7 @@ func TestHandleSitemapHTML(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logger, 8080, time.UTC)
+	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Accept", "text/html")
@@ -256,7 +257,7 @@ func TestHandleSitemapMethodNotAllowed(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logger, 8080, time.UTC)
+	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Test POST method (should be rejected)
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -274,7 +275,7 @@ func TestHandleSitemapNonRootPath(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logger, 8080, time.UTC)
+	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Test non-root path (should return 404 without sitemap)
 	req := httptest.NewRequest(http.MethodGet, "/nonexistent", nil)
@@ -328,7 +329,7 @@ func TestHandleGetStatesByPlugin(t *testing.T) {
 
 	// Create API server
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logger, 8080, time.UTC)
+	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/states", nil)
@@ -460,7 +461,7 @@ func TestHandleGetStatesByPluginMethodNotAllowed(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logger, 8080, time.UTC)
+	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Test POST method (should be rejected)
 	req := httptest.NewRequest(http.MethodPost, "/api/states", nil)
@@ -479,7 +480,7 @@ func TestHandleGetStatesByPluginEmptyState(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logger, 8080, time.UTC)
+	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/states", nil)
 	w := httptest.NewRecorder()
@@ -581,7 +582,7 @@ func TestHandleGetLightingShadowState(t *testing.T) {
 	shadowTracker.RegisterPlugin("lighting", lightingState)
 
 	// Create API server
-	server := NewServer(stateManager, shadowTracker, logger, 8080, time.UTC)
+	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/shadow/lighting", nil)
@@ -630,7 +631,7 @@ func TestHandleGetLightingShadowState_NotFound(t *testing.T) {
 	shadowTracker := shadowstate.NewTracker()
 
 	// Create API server
-	server := NewServer(stateManager, shadowTracker, logger, 8080, time.UTC)
+	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/shadow/lighting", nil)
@@ -667,7 +668,7 @@ func TestHandleGetSecurityShadowState(t *testing.T) {
 	shadowTracker.RegisterPlugin("security", securityState)
 
 	// Create API server
-	server := NewServer(stateManager, shadowTracker, logger, 8080, time.UTC)
+	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/shadow/security", nil)
@@ -724,7 +725,7 @@ func TestHandleGetSecurityShadowState_NotFound(t *testing.T) {
 	shadowTracker := shadowstate.NewTracker()
 
 	// Create API server
-	server := NewServer(stateManager, shadowTracker, logger, 8080, time.UTC)
+	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/shadow/security", nil)
@@ -762,7 +763,7 @@ func TestHandleGetAllShadowStates(t *testing.T) {
 	shadowTracker.RegisterPlugin("security", securityState)
 
 	// Create API server
-	server := NewServer(stateManager, shadowTracker, logger, 8080, time.UTC)
+	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/shadow", nil)
@@ -821,7 +822,7 @@ func TestAddLocalTimestamps(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logger, 8080, estLocation)
+	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, estLocation)
 
 	// Test cases
 	tests := []struct {
@@ -932,7 +933,7 @@ func TestAddLocalTimestamps(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.name == "nil timezone returns original" {
 				// Test with nil timezone
-				nilTzServer := NewServer(stateManager, shadowTracker, logger, 8080, nil)
+				nilTzServer := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, nil)
 				result := nilTzServer.addLocalTimestamps(tc.input)
 				m := result.(map[string]interface{})
 				if _, ok := m["tsLocal"]; ok {
@@ -963,7 +964,7 @@ func TestHandleDashboard(t *testing.T) {
 	shadowTracker.RegisterPlugin("lighting", lightingState)
 
 	// Create API server
-	server := NewServer(stateManager, shadowTracker, logger, 8080, time.UTC)
+	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
@@ -1014,7 +1015,7 @@ func TestHandleDashboardMethodNotAllowed(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logger, 8080, time.UTC)
+	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Test POST method (should be rejected)
 	req := httptest.NewRequest(http.MethodPost, "/dashboard", nil)
@@ -1039,7 +1040,7 @@ func TestWriteJSONWithLocalTimestamps(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logger, 8080, estLocation)
+	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, estLocation)
 
 	// Create a test struct with a timestamp
 	type TestData struct {
@@ -1079,4 +1080,124 @@ func TestWriteJSONWithLocalTimestamps(t *testing.T) {
 	if result["name"] != "test" {
 		t.Errorf("Expected name to be 'test', got %v", result["name"])
 	}
+}
+
+func TestHandleTimelineEvents(t *testing.T) {
+	// Create logger and dependencies
+	logger, _ := zap.NewDevelopment()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	shadowTracker := shadowstate.NewTracker()
+
+	// Create buffer with test events
+	buffer := logbuffer.NewBuffer(100)
+	baseTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 5; i++ {
+		buffer.Add(logbuffer.Event{
+			Timestamp: baseTime.Add(time.Duration(i) * time.Minute),
+			Level:     "info",
+			Message:   "State changed",
+			Fields: map[string]interface{}{
+				"key": "dayPhase",
+				"old": "day",
+				"new": "evening",
+			},
+		})
+	}
+
+	server := NewServer(stateManager, shadowTracker, buffer, logger, 8080, time.UTC)
+
+	t.Run("basic request", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/timeline/events", nil)
+		w := httptest.NewRecorder()
+		server.handleTimelineEvents(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("Expected status 200, got %d", w.Code)
+		}
+
+		var response TimelineEventsResponse
+		if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+			t.Fatalf("Failed to decode response: %v", err)
+		}
+
+		if len(response.Events) != 5 {
+			t.Errorf("Expected 5 events, got %d", len(response.Events))
+		}
+		if response.Count != 5 {
+			t.Errorf("Expected count 5, got %d", response.Count)
+		}
+		if response.Capacity != 100 {
+			t.Errorf("Expected capacity 100, got %d", response.Capacity)
+		}
+	})
+
+	t.Run("with limit", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/timeline/events?limit=2", nil)
+		w := httptest.NewRecorder()
+		server.handleTimelineEvents(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("Expected status 200, got %d", w.Code)
+		}
+
+		var response TimelineEventsResponse
+		if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+			t.Fatalf("Failed to decode response: %v", err)
+		}
+
+		if len(response.Events) != 2 {
+			t.Errorf("Expected 2 events, got %d", len(response.Events))
+		}
+	})
+
+	t.Run("with since", func(t *testing.T) {
+		since := baseTime.Add(2 * time.Minute).Format(time.RFC3339)
+		req := httptest.NewRequest(http.MethodGet, "/api/timeline/events?since="+since, nil)
+		w := httptest.NewRecorder()
+		server.handleTimelineEvents(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("Expected status 200, got %d", w.Code)
+		}
+
+		var response TimelineEventsResponse
+		if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+			t.Fatalf("Failed to decode response: %v", err)
+		}
+
+		if len(response.Events) != 3 {
+			t.Errorf("Expected 3 events (minutes 2,3,4), got %d", len(response.Events))
+		}
+	})
+
+	t.Run("invalid since", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/timeline/events?since=invalid", nil)
+		w := httptest.NewRecorder()
+		server.handleTimelineEvents(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("Expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid limit", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/timeline/events?limit=abc", nil)
+		w := httptest.NewRecorder()
+		server.handleTimelineEvents(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("Expected status 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("method not allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/timeline/events", nil)
+		w := httptest.NewRecorder()
+		server.handleTimelineEvents(w, req)
+
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("Expected status 405, got %d", w.Code)
+		}
+	})
 }

--- a/homeautomation-go/internal/api/templates/timeline.html
+++ b/homeautomation-go/internal/api/templates/timeline.html
@@ -463,6 +463,7 @@
         </div>
         <div class="button-row">
             <button class="btn-primary" onclick="parseAndRender()">Visualize Timeline</button>
+            <button class="btn-primary" onclick="fetchRecentLogs()">Fetch Recent Logs</button>
             <button class="btn-secondary" onclick="loadSampleData()">Load Sample Data</button>
             <button class="btn-secondary" onclick="clearAll()">Clear</button>
         </div>
@@ -1031,6 +1032,61 @@
                     <p>Paste log lines above or upload a log file, then click <strong>Visualize Timeline</strong></p>
                 </div>
             `;
+        }
+
+        async function fetchRecentLogs() {
+            const btn = event.target;
+            const originalText = btn.textContent;
+            btn.textContent = 'Fetching...';
+            btn.disabled = true;
+
+            try {
+                const response = await fetch('/api/timeline/events?limit=5000');
+                if (!response.ok) {
+                    throw new Error(`HTTP error: ${response.status}`);
+                }
+
+                const data = await response.json();
+
+                if (!data.events || data.events.length === 0) {
+                    alert('No log events found in the buffer. The application may have just started or no state changes have occurred yet.');
+                    return;
+                }
+
+                // Convert API response events to the format expected by parseLogLines
+                // The API returns: {ts, level, msg, fields: {key, old, new, ...}}
+                // parseLogLines expects: {ts, level, msg, key, old, new, ...}
+                const logLines = data.events.map(event => {
+                    const line = {
+                        level: event.level,
+                        ts: event.ts,
+                        msg: event.msg
+                    };
+                    // Merge fields into the line object
+                    if (event.fields) {
+                        Object.assign(line, event.fields);
+                    }
+                    return JSON.stringify(line);
+                }).join('\n');
+
+                // Put the converted logs in the textarea
+                document.getElementById('logInput').value = logLines;
+                document.getElementById('fileName').textContent = `Fetched ${data.events.length} events from server`;
+
+                // Show buffer info
+                const overflow = data.overflow ? ' (buffer has overflowed - oldest events lost)' : '';
+                console.log(`Fetched ${data.events.length} events (buffer: ${data.count}/${data.capacity})${overflow}`);
+
+                // Automatically render the timeline
+                parseAndRender();
+
+            } catch (err) {
+                console.error('Failed to fetch logs:', err);
+                alert(`Failed to fetch logs from server: ${err.message}\n\nMake sure the application is running and accessible.`);
+            } finally {
+                btn.textContent = originalText;
+                btn.disabled = false;
+            }
         }
     </script>
 </body>

--- a/homeautomation-go/internal/logbuffer/buffer.go
+++ b/homeautomation-go/internal/logbuffer/buffer.go
@@ -1,0 +1,123 @@
+// Package logbuffer provides an in-memory ring buffer for storing recent log events.
+// This enables the timeline visualization to access recent logs directly without
+// requiring copy/paste or file upload.
+package logbuffer
+
+import (
+	"sync"
+	"time"
+)
+
+// DefaultBufferSize is the default number of events to store in the ring buffer.
+const DefaultBufferSize = 10000
+
+// Event represents a single log event that can be displayed on the timeline.
+type Event struct {
+	Timestamp time.Time              `json:"ts"`
+	Level     string                 `json:"level"`
+	Message   string                 `json:"msg"`
+	Fields    map[string]interface{} `json:"fields,omitempty"`
+}
+
+// Buffer is a thread-safe ring buffer for storing log events.
+type Buffer struct {
+	mu       sync.RWMutex
+	events   []Event
+	size     int
+	head     int // next write position
+	count    int // number of events currently stored
+	overflow bool
+}
+
+// NewBuffer creates a new ring buffer with the specified capacity.
+func NewBuffer(size int) *Buffer {
+	if size <= 0 {
+		size = DefaultBufferSize
+	}
+	return &Buffer{
+		events: make([]Event, size),
+		size:   size,
+	}
+}
+
+// Add adds an event to the buffer. If the buffer is full, the oldest event is overwritten.
+func (b *Buffer) Add(event Event) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.events[b.head] = event
+	b.head = (b.head + 1) % b.size
+	if b.count < b.size {
+		b.count++
+	} else {
+		b.overflow = true
+	}
+}
+
+// GetEvents returns all events since the specified timestamp, up to the limit.
+// Events are returned in chronological order (oldest first).
+// If since is zero, all events are considered.
+// If limit is 0, all matching events are returned.
+func (b *Buffer) GetEvents(since time.Time, limit int) []Event {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	if b.count == 0 {
+		return []Event{}
+	}
+
+	// Calculate the start position (oldest event)
+	start := 0
+	if b.count == b.size {
+		start = b.head // oldest event is at head when buffer is full
+	}
+
+	// Collect events in chronological order
+	result := make([]Event, 0, b.count)
+	for i := 0; i < b.count; i++ {
+		idx := (start + i) % b.size
+		event := b.events[idx]
+
+		// Filter by timestamp
+		if !since.IsZero() && event.Timestamp.Before(since) {
+			continue
+		}
+
+		result = append(result, event)
+
+		// Check limit
+		if limit > 0 && len(result) >= limit {
+			break
+		}
+	}
+
+	return result
+}
+
+// Count returns the number of events currently in the buffer.
+func (b *Buffer) Count() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.count
+}
+
+// Capacity returns the maximum capacity of the buffer.
+func (b *Buffer) Capacity() int {
+	return b.size
+}
+
+// HasOverflowed returns true if any events have been dropped due to buffer overflow.
+func (b *Buffer) HasOverflowed() bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.overflow
+}
+
+// Clear removes all events from the buffer.
+func (b *Buffer) Clear() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.head = 0
+	b.count = 0
+	b.overflow = false
+}

--- a/homeautomation-go/internal/logbuffer/buffer_test.go
+++ b/homeautomation-go/internal/logbuffer/buffer_test.go
@@ -1,0 +1,219 @@
+package logbuffer
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewBuffer(t *testing.T) {
+	tests := []struct {
+		name         string
+		size         int
+		wantCapacity int
+	}{
+		{"default size", 0, DefaultBufferSize},
+		{"negative size", -1, DefaultBufferSize},
+		{"custom size", 100, 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBuffer(tt.size)
+			if b.Capacity() != tt.wantCapacity {
+				t.Errorf("Capacity() = %d, want %d", b.Capacity(), tt.wantCapacity)
+			}
+			if b.Count() != 0 {
+				t.Errorf("Count() = %d, want 0", b.Count())
+			}
+		})
+	}
+}
+
+func TestBuffer_Add(t *testing.T) {
+	b := NewBuffer(3)
+
+	// Add first event
+	e1 := Event{Timestamp: time.Now(), Level: "info", Message: "first"}
+	b.Add(e1)
+	if b.Count() != 1 {
+		t.Errorf("Count() = %d, want 1", b.Count())
+	}
+
+	// Add second event
+	e2 := Event{Timestamp: time.Now(), Level: "info", Message: "second"}
+	b.Add(e2)
+	if b.Count() != 2 {
+		t.Errorf("Count() = %d, want 2", b.Count())
+	}
+
+	// Add third event
+	e3 := Event{Timestamp: time.Now(), Level: "info", Message: "third"}
+	b.Add(e3)
+	if b.Count() != 3 {
+		t.Errorf("Count() = %d, want 3", b.Count())
+	}
+
+	// Add fourth event (should trigger overflow)
+	e4 := Event{Timestamp: time.Now(), Level: "info", Message: "fourth"}
+	b.Add(e4)
+	if b.Count() != 3 {
+		t.Errorf("Count() = %d, want 3 (overflow)", b.Count())
+	}
+	if !b.HasOverflowed() {
+		t.Error("HasOverflowed() = false, want true")
+	}
+}
+
+func TestBuffer_GetEvents(t *testing.T) {
+	b := NewBuffer(5)
+
+	baseTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// Add events with different timestamps
+	for i := 0; i < 5; i++ {
+		b.Add(Event{
+			Timestamp: baseTime.Add(time.Duration(i) * time.Minute),
+			Level:     "info",
+			Message:   "event",
+			Fields:    map[string]interface{}{"index": i},
+		})
+	}
+
+	t.Run("all events", func(t *testing.T) {
+		events := b.GetEvents(time.Time{}, 0)
+		if len(events) != 5 {
+			t.Errorf("len(events) = %d, want 5", len(events))
+		}
+		// Verify chronological order
+		for i := 0; i < len(events); i++ {
+			if events[i].Fields["index"] != i {
+				t.Errorf("events[%d].Fields[\"index\"] = %v, want %d", i, events[i].Fields["index"], i)
+			}
+		}
+	})
+
+	t.Run("events since timestamp", func(t *testing.T) {
+		since := baseTime.Add(2 * time.Minute)
+		events := b.GetEvents(since, 0)
+		if len(events) != 3 {
+			t.Errorf("len(events) = %d, want 3", len(events))
+		}
+		// First event should be at minute 2
+		if events[0].Fields["index"] != 2 {
+			t.Errorf("events[0].Fields[\"index\"] = %v, want 2", events[0].Fields["index"])
+		}
+	})
+
+	t.Run("limited events", func(t *testing.T) {
+		events := b.GetEvents(time.Time{}, 2)
+		if len(events) != 2 {
+			t.Errorf("len(events) = %d, want 2", len(events))
+		}
+	})
+
+	t.Run("since and limit combined", func(t *testing.T) {
+		since := baseTime.Add(1 * time.Minute)
+		events := b.GetEvents(since, 2)
+		if len(events) != 2 {
+			t.Errorf("len(events) = %d, want 2", len(events))
+		}
+		if events[0].Fields["index"] != 1 {
+			t.Errorf("events[0].Fields[\"index\"] = %v, want 1", events[0].Fields["index"])
+		}
+	})
+}
+
+func TestBuffer_GetEvents_WithOverflow(t *testing.T) {
+	b := NewBuffer(3)
+
+	baseTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// Add 5 events to a buffer of size 3 (first 2 will be overwritten)
+	for i := 0; i < 5; i++ {
+		b.Add(Event{
+			Timestamp: baseTime.Add(time.Duration(i) * time.Minute),
+			Level:     "info",
+			Message:   "event",
+			Fields:    map[string]interface{}{"index": i},
+		})
+	}
+
+	events := b.GetEvents(time.Time{}, 0)
+	if len(events) != 3 {
+		t.Errorf("len(events) = %d, want 3", len(events))
+	}
+
+	// Should have events 2, 3, 4 (oldest 0, 1 were overwritten)
+	expectedIndices := []int{2, 3, 4}
+	for i, expected := range expectedIndices {
+		if events[i].Fields["index"] != expected {
+			t.Errorf("events[%d].Fields[\"index\"] = %v, want %d", i, events[i].Fields["index"], expected)
+		}
+	}
+}
+
+func TestBuffer_Clear(t *testing.T) {
+	b := NewBuffer(5)
+
+	// Add some events
+	for i := 0; i < 3; i++ {
+		b.Add(Event{Timestamp: time.Now(), Level: "info", Message: "event"})
+	}
+
+	b.Clear()
+
+	if b.Count() != 0 {
+		t.Errorf("Count() = %d, want 0", b.Count())
+	}
+	if b.HasOverflowed() {
+		t.Error("HasOverflowed() = true, want false after clear")
+	}
+
+	events := b.GetEvents(time.Time{}, 0)
+	if len(events) != 0 {
+		t.Errorf("len(events) = %d, want 0", len(events))
+	}
+}
+
+func TestBuffer_EmptyBuffer(t *testing.T) {
+	b := NewBuffer(5)
+
+	events := b.GetEvents(time.Time{}, 0)
+	if len(events) != 0 {
+		t.Errorf("len(events) = %d, want 0", len(events))
+	}
+}
+
+func TestBuffer_Concurrent(t *testing.T) {
+	b := NewBuffer(100)
+
+	// Test concurrent writes and reads
+	done := make(chan bool)
+
+	// Writer goroutine
+	go func() {
+		for i := 0; i < 50; i++ {
+			b.Add(Event{
+				Timestamp: time.Now(),
+				Level:     "info",
+				Message:   "concurrent write",
+			})
+		}
+		done <- true
+	}()
+
+	// Reader goroutine
+	go func() {
+		for i := 0; i < 50; i++ {
+			_ = b.GetEvents(time.Time{}, 0)
+			_ = b.Count()
+			_ = b.HasOverflowed()
+		}
+		done <- true
+	}()
+
+	<-done
+	<-done
+
+	// If we get here without a race detector panic, the test passes
+}

--- a/homeautomation-go/internal/logbuffer/zapcore.go
+++ b/homeautomation-go/internal/logbuffer/zapcore.go
@@ -1,0 +1,129 @@
+package logbuffer
+
+import (
+	"time"
+
+	"go.uber.org/zap/zapcore"
+)
+
+// BufferCore is a zap core that writes log entries to a Buffer.
+type BufferCore struct {
+	buffer  *Buffer
+	level   zapcore.LevelEnabler
+	encoder zapcore.Encoder
+	fields  []zapcore.Field
+}
+
+// NewBufferCore creates a new BufferCore that writes to the given buffer.
+// It captures log entries at or above the specified level.
+func NewBufferCore(buffer *Buffer, level zapcore.LevelEnabler) *BufferCore {
+	return &BufferCore{
+		buffer: buffer,
+		level:  level,
+		encoder: zapcore.NewJSONEncoder(zapcore.EncoderConfig{
+			MessageKey:     "msg",
+			LevelKey:       "level",
+			TimeKey:        "ts",
+			EncodeLevel:    zapcore.LowercaseLevelEncoder,
+			EncodeTime:     zapcore.ISO8601TimeEncoder,
+			EncodeDuration: zapcore.SecondsDurationEncoder,
+		}),
+	}
+}
+
+// Enabled implements zapcore.Core.
+func (c *BufferCore) Enabled(level zapcore.Level) bool {
+	return c.level.Enabled(level)
+}
+
+// With implements zapcore.Core.
+func (c *BufferCore) With(fields []zapcore.Field) zapcore.Core {
+	clone := &BufferCore{
+		buffer:  c.buffer,
+		level:   c.level,
+		encoder: c.encoder.Clone(),
+		fields:  make([]zapcore.Field, len(c.fields)+len(fields)),
+	}
+	copy(clone.fields, c.fields)
+	copy(clone.fields[len(c.fields):], fields)
+	return clone
+}
+
+// Check implements zapcore.Core.
+func (c *BufferCore) Check(entry zapcore.Entry, checked *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(entry.Level) {
+		return checked.AddCore(entry, c)
+	}
+	return checked
+}
+
+// Write implements zapcore.Core.
+func (c *BufferCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	// Combine context fields and entry fields
+	allFields := make([]zapcore.Field, 0, len(c.fields)+len(fields))
+	allFields = append(allFields, c.fields...)
+	allFields = append(allFields, fields...)
+
+	// Convert fields to map
+	fieldMap := make(map[string]interface{}, len(allFields))
+	for _, f := range allFields {
+		fieldMap[f.Key] = fieldToInterface(f)
+	}
+
+	event := Event{
+		Timestamp: entry.Time,
+		Level:     entry.Level.String(),
+		Message:   entry.Message,
+		Fields:    fieldMap,
+	}
+
+	c.buffer.Add(event)
+	return nil
+}
+
+// Sync implements zapcore.Core.
+func (c *BufferCore) Sync() error {
+	return nil
+}
+
+// fieldToInterface converts a zapcore.Field to its interface{} value.
+func fieldToInterface(f zapcore.Field) interface{} {
+	switch f.Type {
+	case zapcore.BoolType:
+		return f.Integer == 1
+	case zapcore.Int64Type, zapcore.Int32Type, zapcore.Int16Type, zapcore.Int8Type:
+		return f.Integer
+	case zapcore.Uint64Type, zapcore.Uint32Type, zapcore.Uint16Type, zapcore.Uint8Type:
+		return uint64(f.Integer)
+	case zapcore.Float64Type:
+		return float64(f.Integer)
+	case zapcore.Float32Type:
+		return float32(f.Integer)
+	case zapcore.StringType:
+		return f.String
+	case zapcore.StringerType:
+		if f.Interface != nil {
+			return f.Interface
+		}
+		return nil
+	case zapcore.DurationType:
+		return time.Duration(f.Integer).String()
+	case zapcore.TimeType:
+		if f.Interface != nil {
+			return f.Interface.(time.Time).Format(time.RFC3339)
+		}
+		return time.Unix(0, f.Integer).Format(time.RFC3339)
+	case zapcore.ReflectType:
+		return f.Interface
+	default:
+		if f.Interface != nil {
+			return f.Interface
+		}
+		return f.String
+	}
+}
+
+// GetBuffer returns the underlying buffer.
+func (c *BufferCore) GetBuffer() *Buffer {
+	return c.buffer
+}

--- a/homeautomation-go/internal/logbuffer/zapcore_test.go
+++ b/homeautomation-go/internal/logbuffer/zapcore_test.go
@@ -1,0 +1,157 @@
+package logbuffer
+
+import (
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestBufferCore_Integration(t *testing.T) {
+	buffer := NewBuffer(100)
+	core := NewBufferCore(buffer, zapcore.InfoLevel)
+	logger := zap.New(core)
+
+	// Log some events
+	logger.Info("test message 1",
+		zap.String("key", "dayPhase"),
+		zap.String("old", "day"),
+		zap.String("new", "evening"))
+
+	logger.Info("test message 2",
+		zap.Bool("active", true),
+		zap.Int("count", 42))
+
+	// Debug should be filtered out
+	logger.Debug("debug message")
+
+	events := buffer.GetEvents(time.Time{}, 0)
+	if len(events) != 2 {
+		t.Errorf("len(events) = %d, want 2", len(events))
+	}
+
+	// Check first event
+	e1 := events[0]
+	if e1.Level != "info" {
+		t.Errorf("events[0].Level = %q, want %q", e1.Level, "info")
+	}
+	if e1.Message != "test message 1" {
+		t.Errorf("events[0].Message = %q, want %q", e1.Message, "test message 1")
+	}
+	if e1.Fields["key"] != "dayPhase" {
+		t.Errorf("events[0].Fields[\"key\"] = %v, want %q", e1.Fields["key"], "dayPhase")
+	}
+
+	// Check second event
+	e2 := events[1]
+	if e2.Fields["active"] != true {
+		t.Errorf("events[1].Fields[\"active\"] = %v, want true", e2.Fields["active"])
+	}
+	if e2.Fields["count"] != int64(42) {
+		t.Errorf("events[1].Fields[\"count\"] = %v, want 42", e2.Fields["count"])
+	}
+}
+
+func TestBufferCore_LevelFiltering(t *testing.T) {
+	tests := []struct {
+		name      string
+		coreLevel zapcore.Level
+		logLevel  zapcore.Level
+		logged    bool
+	}{
+		{"info core, info log", zapcore.InfoLevel, zapcore.InfoLevel, true},
+		{"info core, warn log", zapcore.InfoLevel, zapcore.WarnLevel, true},
+		{"info core, debug log", zapcore.InfoLevel, zapcore.DebugLevel, false},
+		{"warn core, info log", zapcore.WarnLevel, zapcore.InfoLevel, false},
+		{"warn core, warn log", zapcore.WarnLevel, zapcore.WarnLevel, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buffer := NewBuffer(10)
+			core := NewBufferCore(buffer, tt.coreLevel)
+			logger := zap.New(core)
+
+			switch tt.logLevel {
+			case zapcore.DebugLevel:
+				logger.Debug("test")
+			case zapcore.InfoLevel:
+				logger.Info("test")
+			case zapcore.WarnLevel:
+				logger.Warn("test")
+			case zapcore.ErrorLevel:
+				logger.Error("test")
+			}
+
+			events := buffer.GetEvents(time.Time{}, 0)
+			if tt.logged && len(events) != 1 {
+				t.Errorf("expected event to be logged, got %d events", len(events))
+			}
+			if !tt.logged && len(events) != 0 {
+				t.Errorf("expected event not to be logged, got %d events", len(events))
+			}
+		})
+	}
+}
+
+func TestBufferCore_With(t *testing.T) {
+	buffer := NewBuffer(10)
+	core := NewBufferCore(buffer, zapcore.InfoLevel)
+	logger := zap.New(core)
+
+	// Create a child logger with context fields
+	childLogger := logger.With(zap.String("plugin", "lighting"))
+	childLogger.Info("test message")
+
+	events := buffer.GetEvents(time.Time{}, 0)
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+
+	if events[0].Fields["plugin"] != "lighting" {
+		t.Errorf("events[0].Fields[\"plugin\"] = %v, want %q", events[0].Fields["plugin"], "lighting")
+	}
+}
+
+func TestBufferCore_GetBuffer(t *testing.T) {
+	buffer := NewBuffer(10)
+	core := NewBufferCore(buffer, zapcore.InfoLevel)
+
+	if core.GetBuffer() != buffer {
+		t.Error("GetBuffer() did not return the expected buffer")
+	}
+}
+
+func TestBufferCore_Sync(t *testing.T) {
+	buffer := NewBuffer(10)
+	core := NewBufferCore(buffer, zapcore.InfoLevel)
+
+	// Sync should be a no-op that returns nil
+	if err := core.Sync(); err != nil {
+		t.Errorf("Sync() returned error: %v", err)
+	}
+}
+
+func TestFieldToInterface(t *testing.T) {
+	tests := []struct {
+		name     string
+		field    zapcore.Field
+		expected interface{}
+	}{
+		{"string", zap.String("key", "value"), "value"},
+		{"int64", zap.Int64("key", 42), int64(42)},
+		{"bool true", zap.Bool("key", true), true},
+		{"bool false", zap.Bool("key", false), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := fieldToInterface(tt.field)
+			if result != tt.expected {
+				t.Errorf("fieldToInterface(%v) = %v (%T), want %v (%T)",
+					tt.field, result, result, tt.expected, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Implements issue #217 - Allow timeline to read application logs directly instead of requiring copy/paste
- Adds `logbuffer` package with thread-safe ring buffer storing last 10,000 log events
- Creates custom zap core to capture logs to buffer while preserving stdout output
- Adds `/api/timeline/events` endpoint with `since` and `limit` query parameters
- Adds "Fetch Recent Logs" button to timeline UI that fetches and auto-renders events

## Implementation Details
The **in-memory ring buffer approach** (Option A from the issue) was chosen because:
- No external dependencies (doesn't need Docker socket)
- Memory-bounded and predictable (~10MB max at 10k events)
- Works in all environments (local, Docker, etc.)
- Integrates cleanly with existing zap logging

### New Files
- `internal/logbuffer/buffer.go` - Thread-safe ring buffer implementation
- `internal/logbuffer/zapcore.go` - Custom zap core for dual-writing logs
- `internal/logbuffer/buffer_test.go` - Ring buffer tests (80.5% coverage)
- `internal/logbuffer/zapcore_test.go` - Zap core integration tests

### API Endpoint
```
GET /api/timeline/events?since=<ISO8601>&limit=<int>
```

Response:
```json
{
  "events": [...],
  "count": 123,
  "capacity": 10000,
  "overflow": false
}
```

## Test plan
- [x] Unit tests for ring buffer (buffer operations, thread safety)
- [x] Unit tests for zap core (log capture, level filtering)
- [x] API endpoint tests (basic, with limit, with since, error cases)
- [x] Pre-push validation passes (70.6% coverage)
- [ ] Manual test: Start app, make state changes, click "Fetch Recent Logs" in timeline UI

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)