### PR TITLE
fix(config): Use injectable clock in GetTodaysScheduleInTimezone

### DIFF
--- a/homeautomation-go/internal/config/loader.go
+++ b/homeautomation-go/internal/config/loader.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"homeautomation/internal/clock"
+
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 )
@@ -64,6 +66,7 @@ type Loader struct {
 	scheduleConfig *ScheduleConfig
 	stopChan       chan struct{}
 	timezone       *time.Location
+	clock          clock.Clock
 }
 
 // NewLoader creates a new configuration loader
@@ -73,6 +76,15 @@ func NewLoader(configDir string, logger *zap.Logger) *Loader {
 		logger:    logger,
 		stopChan:  make(chan struct{}),
 		timezone:  time.Local,
+		clock:     clock.NewRealClock(),
+	}
+}
+
+// SetClock sets the clock implementation for schedule parsing.
+// This is primarily used for testing with a mock clock.
+func (l *Loader) SetClock(clk clock.Clock) {
+	if clk != nil {
+		l.clock = clk
 	}
 }
 
@@ -197,8 +209,8 @@ func (l *Loader) GetTodaysScheduleInTimezone(timezone *time.Location) (*ParsedSc
 		return nil, fmt.Errorf("schedule config not loaded")
 	}
 
-	// Get current time in the specified timezone
-	now := time.Now().In(timezone)
+	// Get current time in the specified timezone using the injectable clock
+	now := l.clock.Now().In(timezone)
 	weekday := int(now.Weekday())
 
 	if weekday >= len(l.scheduleConfig.Schedule) {

--- a/homeautomation-go/test/integration/scenario_48hr_simulation_test.go
+++ b/homeautomation-go/test/integration/scenario_48hr_simulation_test.go
@@ -51,16 +51,17 @@ func setupDayPhaseSimulation(t *testing.T, timezone *time.Location, startTime ti
 	// Create logger
 	logger, _ := zap.NewDevelopment()
 
+	// Create mock clock starting at the specified time
+	mockClock := clock.NewMockClock(startTime)
+
 	// Create config loader - tests run from test/integration/ directory,
 	// so configs is at ../../../configs (up to homeautomation-go, up to home-automation-two, into configs)
 	configPath := "../../../configs"
 	configLoader := config.NewLoader(configPath, logger)
+	configLoader.SetClock(mockClock) // Inject mock clock BEFORE loading schedule
 	err := configLoader.LoadScheduleConfig()
 	require.NoError(t, err, "Failed to load schedule config from %s", configPath)
 	configLoader.SetTimezone(timezone)
-
-	// Create mock clock starting at the specified time
-	mockClock := clock.NewMockClock(startTime)
 
 	// Create dayphase calculator with coordinates (Austin, TX area)
 	calculator := dayphase.NewCalculator(32.85486, -97.50515, logger)


### PR DESCRIPTION
## Summary

- Add `clock.Clock` field to `Loader` struct to support clock injection
- Add `SetClock()` method for injecting mock clock in tests
- Update `GetTodaysScheduleInTimezone()` to use `l.clock.Now()` instead of `time.Now()`
- Inject mock clock into config loader in 48-hour simulation tests

This fixes the schedule date mismatch bug where `GetTodaysScheduleInTimezone()` was using real time (`time.Now()`) while tests used simulated time. The mismatch caused dusk and winddown phases to be skipped in tests because schedule times (December 2025) were always in the future compared to simulated time (January 2025).

## Test plan

- [x] Run `make pre-push` - all tests pass
- [x] Verify 48-hour simulation tests now show winddown phase transitions at expected times
- [x] Verify config loader tests continue to pass

Fixes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)