### PR TITLE
refactor(pkg): Move shadow state types to pkg/ for external plugin support

### DIFF
--- a/homeautomation-go/internal/shadowstate/types.go
+++ b/homeautomation-go/internal/shadowstate/types.go
@@ -1,26 +1,27 @@
 package shadowstate
 
-import "time"
+import (
+	"time"
 
-// PluginShadowState is the interface that all plugin shadow states must implement
-type PluginShadowState interface {
-	GetCurrentInputs() map[string]interface{}
-	GetLastActionInputs() map[string]interface{}
-	GetOutputs() interface{}
-	GetMetadata() StateMetadata
-}
+	pkgshadow "homeautomation/pkg/shadowstate"
+)
 
-// InputSnapshot represents a snapshot of input values at a specific time
-type InputSnapshot struct {
-	Timestamp time.Time              `json:"timestamp"`
-	Values    map[string]interface{} `json:"values"`
-}
+// Re-export public types from pkg/shadowstate for internal use.
+// This allows internal code to continue importing from internal/shadowstate
+// while the actual interface types are defined in the public pkg/shadowstate.
+type (
+	// PluginShadowState is re-exported from pkg/shadowstate.
+	// See pkg/shadowstate.PluginShadowState for documentation.
+	PluginShadowState = pkgshadow.PluginShadowState
 
-// StateMetadata contains metadata about the shadow state
-type StateMetadata struct {
-	LastUpdated time.Time `json:"lastUpdated"`
-	PluginName  string    `json:"pluginName"`
-}
+	// StateMetadata is re-exported from pkg/shadowstate.
+	// See pkg/shadowstate.StateMetadata for documentation.
+	StateMetadata = pkgshadow.StateMetadata
+
+	// InputSnapshot is re-exported from pkg/shadowstate.
+	// See pkg/shadowstate.InputSnapshot for documentation.
+	InputSnapshot = pkgshadow.InputSnapshot
+)
 
 // ActionRecord represents a single action taken by a plugin
 type ActionRecord struct {

--- a/homeautomation-go/pkg/plugin/interfaces.go
+++ b/homeautomation-go/pkg/plugin/interfaces.go
@@ -4,7 +4,7 @@
 // and override mechanisms for private implementations.
 package plugin
 
-import "homeautomation/internal/shadowstate"
+import "homeautomation/pkg/shadowstate"
 
 // Plugin is the core interface that all plugins must implement.
 // Plugins are responsible for automation logic in a specific domain

--- a/homeautomation-go/pkg/shadowstate/types.go
+++ b/homeautomation-go/pkg/shadowstate/types.go
@@ -1,0 +1,55 @@
+// Package shadowstate provides public interface types for the shadow state system.
+// External plugins can import this package to implement the ShadowStateProvider
+// interface, enabling full integration with the shadow state observability system.
+//
+// Internal implementation details (trackers, registries) remain in the internal
+// package. This package only exposes the interface types needed by external plugins.
+package shadowstate
+
+import "time"
+
+// PluginShadowState is the interface that all plugin shadow states must implement.
+// Shadow state captures the inputs that led to each action, enabling debugging
+// and verification of plugin behavior.
+//
+// External plugins should implement this interface to participate in the
+// shadow state observability system. The shadow state will be exposed via
+// the /api/shadow endpoint.
+type PluginShadowState interface {
+	// GetCurrentInputs returns the current values of all inputs this plugin monitors.
+	// These are the "live" values that would be used if an action were taken now.
+	GetCurrentInputs() map[string]interface{}
+
+	// GetLastActionInputs returns the input values that were present when the
+	// plugin last took an action. This enables comparing what changed between
+	// the last action and the current state.
+	GetLastActionInputs() map[string]interface{}
+
+	// GetOutputs returns the plugin's output state. The concrete type varies
+	// by plugin and should be a struct that marshals to JSON.
+	GetOutputs() interface{}
+
+	// GetMetadata returns metadata about this shadow state, including
+	// the plugin name and when it was last updated.
+	GetMetadata() StateMetadata
+}
+
+// StateMetadata contains metadata about the shadow state.
+// This is included in every plugin's shadow state for observability.
+type StateMetadata struct {
+	// LastUpdated is when this shadow state was last modified.
+	LastUpdated time.Time `json:"lastUpdated"`
+
+	// PluginName identifies which plugin this shadow state belongs to.
+	PluginName string `json:"pluginName"`
+}
+
+// InputSnapshot represents a snapshot of input values at a specific time.
+// This can be used by plugins to track input history or for debugging.
+type InputSnapshot struct {
+	// Timestamp is when this snapshot was taken.
+	Timestamp time.Time `json:"timestamp"`
+
+	// Values contains the input values at the time of the snapshot.
+	Values map[string]interface{} `json:"values"`
+}


### PR DESCRIPTION
## Summary

- Create new `pkg/shadowstate` package with public interface types (`PluginShadowState`, `StateMetadata`, `InputSnapshot`)
- Update `internal/shadowstate/types.go` to re-export types from `pkg/shadowstate` for backwards compatibility
- Update `pkg/plugin/interfaces.go` to import from `pkg/shadowstate`

External plugins can now import `homeautomation/pkg/shadowstate` to implement full shadow state support without needing internal packages.

## Test plan

- [x] All existing tests pass (70.4% coverage)
- [x] Race detector shows no issues
- [x] Integration tests pass
- [x] Build succeeds

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)