### PR TITLE
refactor(plugins): Add 'all' package for simpler downstream imports

### DIFF
--- a/homeautomation-go/cmd/main.go
+++ b/homeautomation-go/cmd/main.go
@@ -3,14 +3,19 @@
 // This main.go serves as the plugin registration entry point.
 // The actual application logic lives in cmd/app/run.go.
 //
-// Downstream forks can create their own main.go that imports additional
-// plugins via blank imports while reusing the core app.Run() function:
+// Downstream forks can create their own main.go that imports the "all" package
+// to get all public plugins, then add private overrides:
 //
 //	package main
 //
 //	import (
 //		"homeautomation/cmd/app"
-//		_ "github.com/example/my-private-plugin"  // Additional plugins
+//
+//		// Import all public plugins
+//		_ "homeautomation/internal/plugins/all"
+//
+//		// Import private overrides (higher priority wins)
+//		_ "github.com/your-org/your-private-security-plugin"
 //	)
 //
 //	func main() {
@@ -21,17 +26,8 @@ package main
 import (
 	"homeautomation/cmd/app"
 
-	// Import plugin packages to trigger init() registrations
-	_ "homeautomation/internal/plugins/dayphase"
-	_ "homeautomation/internal/plugins/energy"
-	_ "homeautomation/internal/plugins/lighting"
-	_ "homeautomation/internal/plugins/loadshedding"
-	_ "homeautomation/internal/plugins/music"
-	_ "homeautomation/internal/plugins/security"
-	_ "homeautomation/internal/plugins/sexmode"
-	_ "homeautomation/internal/plugins/sleephygiene"
-	_ "homeautomation/internal/plugins/statetracking"
-	_ "homeautomation/internal/plugins/tv"
+	// Import all plugins via the convenience package
+	_ "homeautomation/internal/plugins/all"
 )
 
 func main() {

--- a/homeautomation-go/internal/plugins/all/all.go
+++ b/homeautomation-go/internal/plugins/all/all.go
@@ -1,0 +1,33 @@
+// Package all imports all public plugins for convenience.
+// Downstream forks can import this package to get all plugins,
+// then add their own overrides separately.
+//
+// Usage in downstream main.go:
+//
+//	import (
+//	    "homeautomation/cmd/app"
+//
+//	    // Import all public plugins
+//	    _ "homeautomation/internal/plugins/all"
+//
+//	    // Import private overrides (these take priority)
+//	    _ "github.com/your-org/your-private-security-plugin"
+//	)
+//
+//	func main() {
+//	    app.Run()
+//	}
+package all
+
+import (
+	_ "homeautomation/internal/plugins/dayphase"
+	_ "homeautomation/internal/plugins/energy"
+	_ "homeautomation/internal/plugins/lighting"
+	_ "homeautomation/internal/plugins/loadshedding"
+	_ "homeautomation/internal/plugins/music"
+	_ "homeautomation/internal/plugins/security"
+	_ "homeautomation/internal/plugins/sexmode"
+	_ "homeautomation/internal/plugins/sleephygiene"
+	_ "homeautomation/internal/plugins/statetracking"
+	_ "homeautomation/internal/plugins/tv"
+)


### PR DESCRIPTION
## Summary
- Adds `internal/plugins/all` package that imports all public plugins
- Simplifies downstream forks: they only need to list private overrides, not all plugins
- Updates `cmd/main.go` to use the new package

Builds on #239 which introduced the reusable `app.Run()` pattern for downstream forks.

## Motivation
The private `home-automation-plus-security` repo was missing most plugins because it only imported the security override. Downstream forks shouldn't need to explicitly list every public plugin.

## Usage
Downstream `main.go` now only needs:
```go
import (
    "homeautomation/cmd/app"
    _ "homeautomation/internal/plugins/all"           // All public plugins
    _ "github.com/your-org/your-private-plugin"       // Overrides only
)
```

When new plugins are added to the public repo, they're automatically included via the `all` package.

## Test plan
- [x] Build passes
- [x] All tests pass with race detector
- [x] Coverage ≥70%

🤖 Generated with [Claude Code](https://claude.com/claude-code)