### PR TITLE
fix(sexmode): Use correct Eight Sleep climate entities for bed cooling

### DIFF
--- a/homeautomation-go/internal/plugins/sexmode/manager.go
+++ b/homeautomation-go/internal/plugins/sexmode/manager.go
@@ -14,14 +14,14 @@ import (
 
 // EightSleep climate control constants
 const (
-	// EightSleepMinTemp is the minimum temperature setting for Eight Sleep
-	EightSleepMinTemp = -10 // Coldest setting
+	// EightSleepMinTemp is the minimum temperature setting for Eight Sleep (-100 to 100 range)
+	EightSleepMinTemp = -100 // Coldest setting
 
 	// EightSleepNickEntity is Nick's Eight Sleep climate entity
-	EightSleepNickEntity = "number.nick_s_eight_sleep_side_sleep_stage"
+	EightSleepNickEntity = "climate.nick_s_eight_sleep_side_climate"
 
 	// EightSleepCarolineEntity is Caroline's Eight Sleep climate entity
-	EightSleepCarolineEntity = "number.caroline_s_eight_sleep_side_sleep_stage"
+	EightSleepCarolineEntity = "climate.caroline_s_eight_sleep_side_climate"
 )
 
 // Manager handles sex mode coordination across music, lighting, and climate
@@ -337,10 +337,10 @@ func (m *Manager) setEightSleepToColdest() {
 		return
 	}
 
-	// Set Nick's side
-	err := m.haClient.CallService("number", "set_value", map[string]interface{}{
-		"entity_id": EightSleepNickEntity,
-		"value":     EightSleepMinTemp,
+	// Set Nick's side using climate.set_temperature
+	err := m.haClient.CallService("climate", "set_temperature", map[string]interface{}{
+		"entity_id":   EightSleepNickEntity,
+		"temperature": EightSleepMinTemp,
 	})
 	if err != nil {
 		m.logger.Error("Failed to set Nick's Eight Sleep to coldest", zap.Error(err))
@@ -348,10 +348,10 @@ func (m *Manager) setEightSleepToColdest() {
 		m.logger.Info("Nick's Eight Sleep set to coldest")
 	}
 
-	// Set Caroline's side
-	err = m.haClient.CallService("number", "set_value", map[string]interface{}{
-		"entity_id": EightSleepCarolineEntity,
-		"value":     EightSleepMinTemp,
+	// Set Caroline's side using climate.set_temperature
+	err = m.haClient.CallService("climate", "set_temperature", map[string]interface{}{
+		"entity_id":   EightSleepCarolineEntity,
+		"temperature": EightSleepMinTemp,
 	})
 	if err != nil {
 		m.logger.Error("Failed to set Caroline's Eight Sleep to coldest", zap.Error(err))

--- a/homeautomation-go/internal/plugins/sexmode/manager_test.go
+++ b/homeautomation-go/internal/plugins/sexmode/manager_test.go
@@ -138,20 +138,20 @@ func TestSexModeManager_ActivationSetsEightSleep(t *testing.T) {
 	carolineFound := false
 
 	for _, call := range calls {
-		if call.Domain == "number" && call.Service == "set_value" {
+		if call.Domain == "climate" && call.Service == "set_temperature" {
 			entityID, ok := call.Data["entity_id"].(string)
 			if !ok {
 				continue
 			}
-			value, valueOk := call.Data["value"].(int)
-			if !valueOk {
+			temp, tempOk := call.Data["temperature"].(int)
+			if !tempOk {
 				continue
 			}
 
-			if entityID == EightSleepNickEntity && value == EightSleepMinTemp {
+			if entityID == EightSleepNickEntity && temp == EightSleepMinTemp {
 				nickFound = true
 			}
-			if entityID == EightSleepCarolineEntity && value == EightSleepMinTemp {
+			if entityID == EightSleepCarolineEntity && temp == EightSleepMinTemp {
 				carolineFound = true
 			}
 		}

--- a/homeautomation-go/test/integration/scenario_sexmode_test.go
+++ b/homeautomation-go/test/integration/scenario_sexmode_test.go
@@ -114,7 +114,7 @@ func TestScenario_SexModeActivation_ActivatesNightScene(t *testing.T) {
 }
 
 // TestScenario_SexModeActivation_SetsEightSleepToColdest tests that activating sex mode
-// sets both Eight Sleep beds to the coldest setting (-10)
+// sets both Eight Sleep beds to the coldest setting (-100)
 func TestScenario_SexModeActivation_SetsEightSleepToColdest(t *testing.T) {
 	server, _, _, cleanup := setupSexModeScenarioTest(t)
 	defer cleanup()
@@ -128,24 +128,24 @@ func TestScenario_SexModeActivation_SetsEightSleepToColdest(t *testing.T) {
 	server.SetState("input_boolean.sex", "on", nil)
 	time.Sleep(500 * time.Millisecond)
 
-	t.Log("THEN: Both Eight Sleep sides should be set to coldest (-10)")
+	t.Log("THEN: Both Eight Sleep sides should be set to coldest (-100)")
 
 	calls := server.GetServiceCalls()
 
 	// Find Nick's Eight Sleep call
-	nickCall := FindServiceCallWithEntityID(calls, "number", "set_value", sexmode.EightSleepNickEntity)
+	nickCall := FindServiceCallWithEntityID(calls, "climate", "set_temperature", sexmode.EightSleepNickEntity)
 	assert.NotNil(t, nickCall, "Nick's Eight Sleep should be set")
 	if nickCall != nil {
-		value := getNumericValue(nickCall.ServiceData["value"])
+		value := getNumericValue(nickCall.ServiceData["temperature"])
 		assert.Equal(t, sexmode.EightSleepMinTemp, value, "Nick's Eight Sleep should be set to coldest")
 		t.Logf("✓ Nick's Eight Sleep set to %d", value)
 	}
 
 	// Find Caroline's Eight Sleep call
-	carolineCall := FindServiceCallWithEntityID(calls, "number", "set_value", sexmode.EightSleepCarolineEntity)
+	carolineCall := FindServiceCallWithEntityID(calls, "climate", "set_temperature", sexmode.EightSleepCarolineEntity)
 	assert.NotNil(t, carolineCall, "Caroline's Eight Sleep should be set")
 	if carolineCall != nil {
-		value := getNumericValue(carolineCall.ServiceData["value"])
+		value := getNumericValue(carolineCall.ServiceData["temperature"])
 		assert.Equal(t, sexmode.EightSleepMinTemp, value, "Caroline's Eight Sleep should be set to coldest")
 		t.Logf("✓ Caroline's Eight Sleep set to %d", value)
 	}
@@ -185,7 +185,7 @@ func TestScenario_SexModeActivation_FullCoordination(t *testing.T) {
 
 	// 3. Climate
 	calls := server.GetServiceCalls()
-	eightSleepCalls := FilterServiceCalls(calls, "number", "set_value")
+	eightSleepCalls := FilterServiceCalls(calls, "climate", "set_temperature")
 	assert.Equal(t, 2, len(eightSleepCalls), "Both Eight Sleep beds should be adjusted")
 	t.Log("  ✓ Climate: Eight Sleep beds set to coldest")
 


### PR DESCRIPTION
## Summary
- Fixed Eight Sleep bed cooling not activating when sex mode is toggled
- Changed entity IDs from `number.*_sleep_stage` to `climate.*_climate`
- Changed service from `number.set_value` to `climate.set_temperature`
- Changed temperature from -10 to -100 (Eight Sleep uses -100 to +100 range)

## Test plan
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Pre-push validation passes (70.5% coverage)
- [ ] Manual test: Toggle sex mode and verify Eight Sleep beds cool down

🤖 Generated with [Claude Code](https://claude.com/claude-code)