### PR TITLE
fix(music): Slow down volume fade-in to match Node-RED behavior

### DIFF
--- a/homeautomation-go/internal/plugins/music/manager.go
+++ b/homeautomation-go/internal/plugins/music/manager.go
@@ -1265,12 +1265,13 @@ func (m *Manager) fadeInSpeaker(speakerName string, targetVolume int, startingMu
 		}
 
 		// Adaptive delay: slower at start, faster as volume increases
-		// At volume 0%: 200ms delay, at 50%: 100ms, at 100%: clamped to 100ms minimum
-		delayMs := (100 - currentVolume) * 2 // 2ms per percentage point remaining
-		if delayMs < 100 {
-			delayMs = 100 // Minimum 100ms between steps
+		// Matches Node-RED behavior: msg.delay = (100 - current_volume) * 250
+		// At volume 0%: 25s delay, at 50%: 12.5s, at 90%: 2.5s, at 99%: 250ms
+		delayMs := (100 - currentVolume) * 250 // 250ms per percentage point remaining
+		if delayMs < 250 {
+			delayMs = 250 // Minimum 250ms between steps
 		}
-		time.Sleep(time.Duration(delayMs) * time.Millisecond)
+		m.sleepFunc(time.Duration(delayMs) * time.Millisecond)
 	}
 
 	// Log completion with failure summary if any failures occurred

--- a/homeautomation-go/internal/plugins/music/manager_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_test.go
@@ -1502,6 +1502,8 @@ func TestFadeInSpeaker_SafeUnmuteSequence(t *testing.T) {
 
 	// NOT read-only so service calls actually go through
 	manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider)
+	// Skip sleep delays in tests (fade-in uses very slow timing to match Node-RED behavior)
+	manager.SetSleepFunc(func(d time.Duration) {})
 
 	// Set up musicPlaybackType so fade-in doesn't abort early
 	if err := stateManager.SetString("musicPlaybackType", "evening"); err != nil {
@@ -1594,6 +1596,8 @@ func TestFadeInSpeaker_VolumeNormalization(t *testing.T) {
 			fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)
 			timeProvider := FixedTimeProvider{FixedTime: fixedTime}
 			manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider)
+			// Skip sleep delays in tests (fade-in uses very slow timing to match Node-RED behavior)
+			manager.SetSleepFunc(func(d time.Duration) {})
 
 			// Set up musicPlaybackType so fade-in doesn't abort
 			if err := stateManager.SetString("musicPlaybackType", "evening"); err != nil {
@@ -1646,6 +1650,8 @@ func TestFadeInSpeaker_InitialVolumeSetFailure(t *testing.T) {
 	fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)
 	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
 	manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider)
+	// Skip sleep delays in tests (fade-in uses very slow timing to match Node-RED behavior)
+	manager.SetSleepFunc(func(d time.Duration) {})
 
 	// Set up musicPlaybackType
 	if err := stateManager.SetString("musicPlaybackType", "evening"); err != nil {
@@ -1683,6 +1689,8 @@ func TestFadeInSpeaker_UnmuteFailure(t *testing.T) {
 	fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)
 	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
 	manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider)
+	// Skip sleep delays in tests (fade-in uses very slow timing to match Node-RED behavior)
+	manager.SetSleepFunc(func(d time.Duration) {})
 
 	// Set up musicPlaybackType
 	if err := stateManager.SetString("musicPlaybackType", "evening"); err != nil {


### PR DESCRIPTION
## Summary
- Updated fade-in delay formula from `(100 - volume) * 2ms` to `(100 - volume) * 250ms` to match Node-RED behavior exactly
- The Go implementation was completing fade-ins 125x faster than Node-RED, making the volume increase feel abrupt
- Changed minimum delay from 100ms to 250ms to match the curve

## Timing comparison
| Volume | Old delay | New delay |
|--------|-----------|-----------|
| 0% | 200ms | 25s |
| 50% | 100ms | 12.5s |
| 90% | 100ms | 2.5s |
| 99% | 100ms | 250ms |

## Test plan
- [x] All existing fade-in tests pass
- [x] Updated tests to use injectable `sleepFunc` to skip delays in tests
- [x] Full pre-push validation passes (lint, tests, race detector, coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)