### PR TITLE
test(energy): Replace time.Sleep with WaitForStartup in integration tests

### DIFF
--- a/homeautomation-go/test/integration/scenario_energy_test.go
+++ b/homeautomation-go/test/integration/scenario_energy_test.go
@@ -43,8 +43,8 @@ func setupEnergyScenarioTest(t *testing.T) (*MockHAServer, *energy.Manager, *sta
 	err = energyMgr.Start()
 	require.NoError(t, err, "Failed to start energy manager")
 
-	// Give the plugin time to initialize
-	time.Sleep(200 * time.Millisecond)
+	// Wait for startup goroutines to complete initial work
+	energyMgr.WaitForStartup()
 
 	cleanup := func() {
 		energyMgr.Stop()
@@ -185,8 +185,8 @@ func TestScenario_GridAvailability_RecalculatesFreeEnergy(t *testing.T) {
 	require.NoError(t, err, "Failed to start energy manager")
 	defer energyMgr.Stop()
 
-	// Give the plugin time to initialize
-	time.Sleep(300 * time.Millisecond)
+	// Wait for startup goroutines to complete initial work
+	energyMgr.WaitForStartup()
 
 	// GIVEN: Grid is available, outside free energy time window (12:00 noon)
 	t.Log("GIVEN: Grid is available, outside free energy time window (12:00 noon)")
@@ -260,8 +260,8 @@ func TestScenario_OverallEnergyLevel_ReflectsWorstState(t *testing.T) {
 	require.NoError(t, err, "Failed to start energy manager")
 	defer energyMgr.Stop()
 
-	// Give the plugin time to initialize
-	time.Sleep(300 * time.Millisecond)
+	// Wait for startup goroutines to complete initial work
+	energyMgr.WaitForStartup()
 
 	// GIVEN: Battery at green (85%), solar at green (2kW, 15kWh)
 	t.Log("GIVEN: Battery green, solar green (at noon, outside free energy window)")
@@ -342,7 +342,8 @@ func TestScenario_FreeEnergyTimeWindow_OverridesEnergyLevel(t *testing.T) {
 	require.NoError(t, err)
 	defer energyMgr.Stop()
 
-	time.Sleep(200 * time.Millisecond)
+	// Wait for startup goroutines to complete initial work
+	energyMgr.WaitForStartup()
 
 	// GIVEN: Battery at red (15%), grid available, in free energy time window
 	t.Log("GIVEN: Battery red, grid available, in free energy time window")


### PR DESCRIPTION
## Summary

- Follows PR #236 which added `WaitForStartup()` to the energy plugin
- Replaces 4 instances of `time.Sleep()` after `energyMgr.Start()` with deterministic `energyMgr.WaitForStartup()` calls
- Makes test startup synchronization explicit rather than relying on arbitrary timing

## Context

PR #236 added `WaitForStartup()` to the energy plugin's Manager struct for unit tests. This PR extends that pattern to the integration tests in `scenario_energy_test.go`.

## What This PR Does NOT Address

The remaining `time.Sleep()` calls in integration tests fall into two categories:

1. **Event propagation sleeps** - Waiting for WebSocket events to propagate from `server.SetState()` calls to the plugin handlers. These would require additional infrastructure (e.g., condition variables or polling with timeout) to address deterministically.

2. **Duration-based tests** - Tests that intentionally run for a specified duration (e.g., stress tests, 48-hour simulations).

These are out of scope for this PR and could be addressed in future work.

## Test plan

- [x] All energy integration tests pass
- [x] All integration tests pass
- [x] Pre-push validation passes (tests + race detector + 70% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)