### PR TITLE
refactor(lighting): Replace fixed precedence with ordered conditions

### DIFF
--- a/configs/hue_config.yaml
+++ b/configs/hue_config.yaml
@@ -2,71 +2,144 @@
 rooms:
   - hue_group: Living Room
     hass_area_id: living_room_2
-    on_if_true: isAnyoneHomeAndAwake
-    on_if_false: isTVPlaying
-    off_if_true: isEveryoneAsleep
-    off_if_false: isAnyoneHome
+    conditions:
+      # Priority 1: No one home -> OFF
+      - action: off
+        variable: isAnyoneHome
+        value: false
+      # Priority 2: Everyone asleep -> OFF
+      - action: off
+        variable: isEveryoneAsleep
+        value: true
+      # Priority 3: Someone home and awake -> ON
+      - action: on
+        variable: isAnyoneHomeAndAwake
+        value: true
+      # Priority 4: TV not playing -> ON (for ambient lighting)
+      - action: on
+        variable: isTVPlaying
+        value: false
     increase_brightness_if_true: isHaveGuests
     transition_seconds: 30
+
   - hue_group: Primary Suite
     hass_area_id: master_bedroom
-    on_if_true: ~
-    on_if_false: isMasterAsleep
-    off_if_true: isMasterAsleep
-    off_if_false: isAnyoneHome
+    conditions:
+      # Priority 1: No one home -> OFF
+      - action: off
+        variable: isAnyoneHome
+        value: false
+      # Priority 2: Master asleep -> OFF
+      - action: off
+        variable: isMasterAsleep
+        value: true
+      # Priority 3: Master not asleep -> ON
+      - action: on
+        variable: isMasterAsleep
+        value: false
     increase_brightness_if_true: ~
     transition_seconds: 180
+
   - hue_group: Sitting Room
     hass_area_id: dining_room
-    on_if_true: isAnyoneHomeAndAwake
-    on_if_false: ~
-    off_if_true: isEveryoneAsleep
-    off_if_false: isAnyoneHome
+    conditions:
+      # Priority 1: No one home -> OFF
+      - action: off
+        variable: isAnyoneHome
+        value: false
+      # Priority 2: Everyone asleep -> OFF
+      - action: off
+        variable: isEveryoneAsleep
+        value: true
+      # Priority 3: Someone home and awake -> ON
+      - action: on
+        variable: isAnyoneHomeAndAwake
+        value: true
     increase_brightness_if_true: ~
     transition_seconds: 120
+
   - hue_group: Front of House
     hass_area_id: front_of_house
-    on_if_true:
-      - isHaveGuests
-      - didOwnerJustReturnHome
-      - isFrontOfHousePersonPresent
-    on_if_false: ~
-    off_if_true: isEveryoneAsleep
-    off_if_false:
-      - isHaveGuests
-      - didOwnerJustReturnHome
-      - isFrontOfHousePersonPresent
+    conditions:
+      # Priority 1: Everyone asleep -> OFF
+      - action: off
+        variable: isEveryoneAsleep
+        value: true
+      # Priority 2-4: Any presence indicator -> ON
+      - action: on
+        variable: isHaveGuests
+        value: true
+      - action: on
+        variable: didOwnerJustReturnHome
+        value: true
+      - action: on
+        variable: isFrontOfHousePersonPresent
+        value: true
+      # Priority 5-7: No presence indicators -> OFF
+      - action: off
+        variable: isHaveGuests
+        value: false
+      - action: off
+        variable: didOwnerJustReturnHome
+        value: false
+      - action: off
+        variable: isFrontOfHousePersonPresent
+        value: false
     increase_brightness_if_true: ~
     transition_seconds: 15
+
   - hue_group: Decorative Outdoor Lights
     hass_area_id: front_of_house
-    on_if_true: didOwnerJustReturnHome
-    on_if_false: ~
-    off_if_true: isEveryoneAsleep
-    off_if_false: didOwnerJustReturnHome
+    conditions:
+      # Priority 1: Everyone asleep -> OFF
+      - action: off
+        variable: isEveryoneAsleep
+        value: true
+      # Priority 2: Owner just returned -> ON
+      - action: on
+        variable: didOwnerJustReturnHome
+        value: true
+      # Priority 3: Owner did not just return -> OFF
+      - action: off
+        variable: didOwnerJustReturnHome
+        value: false
     increase_brightness_if_true: ~
     transition_seconds: ~
+
   - hue_group: N Office
     hass_area_id: n_office
-    on_if_true: isNickOfficeOccupied
-    on_if_false: ~
-    off_if_true: ~
-    off_if_false: isNickOfficeOccupied
+    conditions:
+      # Priority 1: Office not occupied -> OFF
+      - action: off
+        variable: isNickOfficeOccupied
+        value: false
+      # Priority 2: Office occupied -> ON
+      - action: on
+        variable: isNickOfficeOccupied
+        value: true
     increase_brightness_if_true: ~
     transition_seconds: 2
+
   - hue_group: Kitchen
     hass_area_id: kitchen
-    on_if_true: isKitchenOccupied
-    on_if_false: ~
-    off_if_true: ~
-    off_if_false: isAnyoneHomeAndAwake
+    conditions:
+      # Priority 1: No one home and awake -> OFF
+      - action: off
+        variable: isAnyoneHomeAndAwake
+        value: false
+      # Priority 2: Kitchen occupied -> ON
+      - action: on
+        variable: isKitchenOccupied
+        value: true
     increase_brightness_if_true: ~
     transition_seconds: 5
+
   - hue_group: C Office
     hass_area_id: c_office
-    on_if_true: ~
-    on_if_false: ~
-    off_if_true: ~
-    off_if_false: isAnyoneHomeAndAwake
+    conditions:
+      # Priority 1: No one home and awake -> OFF
+      - action: off
+        variable: isAnyoneHomeAndAwake
+        value: false
     increase_brightness_if_true: ~
     transition_seconds: 2

--- a/homeautomation-go/internal/plugins/lighting/config.go
+++ b/homeautomation-go/internal/plugins/lighting/config.go
@@ -1,41 +1,42 @@
 package lighting
 
 import (
+	"fmt"
 	"os"
 
 	"gopkg.in/yaml.v3"
 )
 
+// LightingCondition represents a single condition for controlling a room's lighting
+// Conditions are evaluated in order - the first matching condition wins
+type LightingCondition struct {
+	Action   string      `yaml:"action"`   // "on" or "off"
+	Variable string      `yaml:"variable"` // state variable name to check
+	Value    interface{} `yaml:"value"`    // expected value for the condition to match
+}
+
 // RoomConfig represents the configuration for a single room/area
 type RoomConfig struct {
-	HueGroup                 string      `yaml:"hue_group"`
-	HASSAreaID               string      `yaml:"hass_area_id"`
-	OnIfTrue                 interface{} `yaml:"on_if_true"`                  // Can be string or []string
-	OnIfFalse                interface{} `yaml:"on_if_false"`                 // Can be string or []string
-	OffIfTrue                interface{} `yaml:"off_if_true"`                 // Can be string or []string
-	OffIfFalse               interface{} `yaml:"off_if_false"`                // Can be string or []string
-	IncreaseBrightnessIfTrue interface{} `yaml:"increase_brightness_if_true"` // Can be string or []string
-	TransitionSeconds        *int        `yaml:"transition_seconds"`          // Pointer to handle nil/~ values
+	HueGroup                 string              `yaml:"hue_group"`
+	HASSAreaID               string              `yaml:"hass_area_id"`
+	Conditions               []LightingCondition `yaml:"conditions"`                  // Ordered list of conditions (first match wins)
+	IncreaseBrightnessIfTrue interface{}         `yaml:"increase_brightness_if_true"` // Can be string or []string
+	TransitionSeconds        *int                `yaml:"transition_seconds"`          // Pointer to handle nil/~ values
 }
 
-// GetOnIfTrueConditions returns the list of on_if_true conditions
-func (r *RoomConfig) GetOnIfTrueConditions() []string {
-	return interfaceToStringSlice(r.OnIfTrue)
-}
+// GetConditionVariables returns a list of all unique state variable names used in conditions
+func (r *RoomConfig) GetConditionVariables() []string {
+	seen := make(map[string]bool)
+	result := make([]string, 0)
 
-// GetOnIfFalseConditions returns the list of on_if_false conditions
-func (r *RoomConfig) GetOnIfFalseConditions() []string {
-	return interfaceToStringSlice(r.OnIfFalse)
-}
+	for _, cond := range r.Conditions {
+		if cond.Variable != "" && !seen[cond.Variable] {
+			seen[cond.Variable] = true
+			result = append(result, cond.Variable)
+		}
+	}
 
-// GetOffIfTrueConditions returns the list of off_if_true conditions
-func (r *RoomConfig) GetOffIfTrueConditions() []string {
-	return interfaceToStringSlice(r.OffIfTrue)
-}
-
-// GetOffIfFalseConditions returns the list of off_if_false conditions
-func (r *RoomConfig) GetOffIfFalseConditions() []string {
-	return interfaceToStringSlice(r.OffIfFalse)
+	return result
 }
 
 // GetIncreaseBrightnessIfTrueConditions returns the list of increase_brightness_if_true conditions
@@ -68,6 +69,12 @@ func interfaceToStringSlice(val interface{}) []string {
 	default:
 		return []string{}
 	}
+}
+
+// valuesMatch compares two interface{} values for equality using string representation
+// This matches the pattern used in the music plugin for flexible type comparison
+func valuesMatch(a, b interface{}) bool {
+	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
 }
 
 // HueConfig represents the Hue lighting configuration

--- a/homeautomation-go/internal/plugins/lighting/config_test.go
+++ b/homeautomation-go/internal/plugins/lighting/config_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	// Create a temporary config file
+	// Create a temporary config file with the new conditions format
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "hue_config.yaml")
 
@@ -15,30 +15,47 @@ func TestLoadConfig(t *testing.T) {
 rooms:
   - hue_group: Living Room
     hass_area_id: living_room_2
-    on_if_true: isAnyoneHomeAndAwake
-    on_if_false: isTVPlaying
-    off_if_true: isEveryoneAsleep
-    off_if_false: isAnyoneHome
+    conditions:
+      - action: off
+        variable: isAnyoneHome
+        value: false
+      - action: off
+        variable: isEveryoneAsleep
+        value: true
+      - action: on
+        variable: isAnyoneHomeAndAwake
+        value: true
+      - action: on
+        variable: isTVPlaying
+        value: false
     increase_brightness_if_true: isHaveGuests
     transition_seconds: 30
   - hue_group: Primary Suite
     hass_area_id: master_bedroom
-    on_if_true: ~
-    on_if_false: isMasterAsleep
-    off_if_true: isMasterAsleep
-    off_if_false: isAnyoneHome
+    conditions:
+      - action: off
+        variable: isAnyoneHome
+        value: false
+      - action: off
+        variable: isMasterAsleep
+        value: true
+      - action: on
+        variable: isMasterAsleep
+        value: false
     increase_brightness_if_true: ~
     transition_seconds: 180
   - hue_group: Front of House
     hass_area_id: front_of_house
-    on_if_true:
-      - isHaveGuests
-      - didOwnerJustReturnHome
-    on_if_false: ~
-    off_if_true: isEveryoneAsleep
-    off_if_false:
-      - isHaveGuests
-      - didOwnerJustReturnHome
+    conditions:
+      - action: off
+        variable: isEveryoneAsleep
+        value: true
+      - action: on
+        variable: isHaveGuests
+        value: true
+      - action: on
+        variable: didOwnerJustReturnHome
+        value: true
     increase_brightness_if_true: ~
     transition_seconds: 120
 `
@@ -69,6 +86,20 @@ rooms:
 	if *livingRoom.TransitionSeconds != 30 {
 		t.Errorf("Expected TransitionSeconds 30, got %d", *livingRoom.TransitionSeconds)
 	}
+	if len(livingRoom.Conditions) != 4 {
+		t.Errorf("Expected 4 conditions for Living Room, got %d", len(livingRoom.Conditions))
+	}
+
+	// Verify first condition (off if !isAnyoneHome)
+	if livingRoom.Conditions[0].Action != "off" {
+		t.Errorf("Expected first condition action 'off', got '%s'", livingRoom.Conditions[0].Action)
+	}
+	if livingRoom.Conditions[0].Variable != "isAnyoneHome" {
+		t.Errorf("Expected first condition variable 'isAnyoneHome', got '%s'", livingRoom.Conditions[0].Variable)
+	}
+	if livingRoom.Conditions[0].Value != false {
+		t.Errorf("Expected first condition value false, got %v", livingRoom.Conditions[0].Value)
+	}
 
 	// Check Primary Suite config
 	primarySuite := config.Rooms[1]
@@ -79,7 +110,7 @@ rooms:
 		t.Errorf("Expected TransitionSeconds 180, got %d", *primarySuite.TransitionSeconds)
 	}
 
-	// Check Front of House config (with array conditions)
+	// Check Front of House config
 	frontOfHouse := config.Rooms[2]
 	if frontOfHouse.HueGroup != "Front of House" {
 		t.Errorf("Expected HueGroup 'Front of House', got '%s'", frontOfHouse.HueGroup)
@@ -87,130 +118,200 @@ rooms:
 	if *frontOfHouse.TransitionSeconds != 120 {
 		t.Errorf("Expected TransitionSeconds 120, got %d", *frontOfHouse.TransitionSeconds)
 	}
+	if len(frontOfHouse.Conditions) != 3 {
+		t.Errorf("Expected 3 conditions for Front of House, got %d", len(frontOfHouse.Conditions))
+	}
 }
 
-func TestRoomConfigGetters(t *testing.T) {
+func TestGetConditionVariables(t *testing.T) {
 	tests := []struct {
-		name     string
-		room     RoomConfig
-		expected struct {
-			onIfTrue                 []string
-			onIfFalse                []string
-			offIfTrue                []string
-			offIfFalse               []string
-			increaseBrightnessIfTrue []string
-		}
+		name       string
+		room       RoomConfig
+		wantVars   []string
+		wantLength int
 	}{
 		{
-			name: "Single string conditions",
+			name: "Multiple unique conditions",
 			room: RoomConfig{
-				OnIfTrue:                 "isAnyoneHomeAndAwake",
-				OnIfFalse:                "isTVPlaying",
-				OffIfTrue:                "isEveryoneAsleep",
-				OffIfFalse:               "isAnyoneHome",
-				IncreaseBrightnessIfTrue: "isHaveGuests",
+				Conditions: []LightingCondition{
+					{Action: "off", Variable: "isAnyoneHome", Value: false},
+					{Action: "off", Variable: "isEveryoneAsleep", Value: true},
+					{Action: "on", Variable: "isAnyoneHomeAndAwake", Value: true},
+				},
 			},
-			expected: struct {
-				onIfTrue                 []string
-				onIfFalse                []string
-				offIfTrue                []string
-				offIfFalse               []string
-				increaseBrightnessIfTrue []string
-			}{
-				onIfTrue:                 []string{"isAnyoneHomeAndAwake"},
-				onIfFalse:                []string{"isTVPlaying"},
-				offIfTrue:                []string{"isEveryoneAsleep"},
-				offIfFalse:               []string{"isAnyoneHome"},
-				increaseBrightnessIfTrue: []string{"isHaveGuests"},
-			},
+			wantVars:   []string{"isAnyoneHome", "isEveryoneAsleep", "isAnyoneHomeAndAwake"},
+			wantLength: 3,
 		},
 		{
-			name: "Array conditions",
+			name: "Duplicate variables are deduplicated",
 			room: RoomConfig{
-				OnIfTrue:   []interface{}{"isHaveGuests", "didOwnerJustReturnHome"},
-				OffIfFalse: []interface{}{"isHaveGuests", "didOwnerJustReturnHome"},
+				Conditions: []LightingCondition{
+					{Action: "off", Variable: "isMasterAsleep", Value: true},
+					{Action: "on", Variable: "isMasterAsleep", Value: false},
+				},
 			},
-			expected: struct {
-				onIfTrue                 []string
-				onIfFalse                []string
-				offIfTrue                []string
-				offIfFalse               []string
-				increaseBrightnessIfTrue []string
-			}{
-				onIfTrue:                 []string{"isHaveGuests", "didOwnerJustReturnHome"},
-				onIfFalse:                []string{},
-				offIfTrue:                []string{},
-				offIfFalse:               []string{"isHaveGuests", "didOwnerJustReturnHome"},
-				increaseBrightnessIfTrue: []string{},
+			wantVars:   []string{"isMasterAsleep"},
+			wantLength: 1,
+		},
+		{
+			name: "Empty conditions",
+			room: RoomConfig{
+				Conditions: []LightingCondition{},
 			},
+			wantVars:   []string{},
+			wantLength: 0,
 		},
 		{
 			name: "Nil conditions",
 			room: RoomConfig{
-				OnIfTrue:  nil,
-				OnIfFalse: nil,
+				Conditions: nil,
 			},
-			expected: struct {
-				onIfTrue                 []string
-				onIfFalse                []string
-				offIfTrue                []string
-				offIfFalse               []string
-				increaseBrightnessIfTrue []string
-			}{
-				onIfTrue:                 []string{},
-				onIfFalse:                []string{},
-				offIfTrue:                []string{},
-				offIfFalse:               []string{},
-				increaseBrightnessIfTrue: []string{},
-			},
+			wantVars:   []string{},
+			wantLength: 0,
 		},
 		{
-			name: "Empty string conditions",
+			name: "Empty variable names are skipped",
 			room: RoomConfig{
-				OnIfTrue:  "",
-				OnIfFalse: "",
+				Conditions: []LightingCondition{
+					{Action: "on", Variable: "", Value: true},
+					{Action: "off", Variable: "isAnyoneHome", Value: false},
+				},
 			},
-			expected: struct {
-				onIfTrue                 []string
-				onIfFalse                []string
-				offIfTrue                []string
-				offIfFalse               []string
-				increaseBrightnessIfTrue []string
-			}{
-				onIfTrue:                 []string{},
-				onIfFalse:                []string{},
-				offIfTrue:                []string{},
-				offIfFalse:               []string{},
-				increaseBrightnessIfTrue: []string{},
-			},
+			wantVars:   []string{"isAnyoneHome"},
+			wantLength: 1,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			onIfTrue := tt.room.GetOnIfTrueConditions()
-			if !stringSlicesEqual(onIfTrue, tt.expected.onIfTrue) {
-				t.Errorf("GetOnIfTrueConditions() = %v, want %v", onIfTrue, tt.expected.onIfTrue)
+			got := tt.room.GetConditionVariables()
+			if len(got) != tt.wantLength {
+				t.Errorf("GetConditionVariables() returned %d variables, want %d", len(got), tt.wantLength)
 			}
-
-			onIfFalse := tt.room.GetOnIfFalseConditions()
-			if !stringSlicesEqual(onIfFalse, tt.expected.onIfFalse) {
-				t.Errorf("GetOnIfFalseConditions() = %v, want %v", onIfFalse, tt.expected.onIfFalse)
+			// Check that all expected variables are present
+			for _, want := range tt.wantVars {
+				found := false
+				for _, g := range got {
+					if g == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("GetConditionVariables() missing expected variable '%s'", want)
+				}
 			}
+		})
+	}
+}
 
-			offIfTrue := tt.room.GetOffIfTrueConditions()
-			if !stringSlicesEqual(offIfTrue, tt.expected.offIfTrue) {
-				t.Errorf("GetOffIfTrueConditions() = %v, want %v", offIfTrue, tt.expected.offIfTrue)
+func TestValuesMatch(t *testing.T) {
+	tests := []struct {
+		name string
+		a    interface{}
+		b    interface{}
+		want bool
+	}{
+		{
+			name: "Boolean true matches true",
+			a:    true,
+			b:    true,
+			want: true,
+		},
+		{
+			name: "Boolean false matches false",
+			a:    false,
+			b:    false,
+			want: true,
+		},
+		{
+			name: "Boolean true does not match false",
+			a:    true,
+			b:    false,
+			want: false,
+		},
+		{
+			name: "String matches string",
+			a:    "test",
+			b:    "test",
+			want: true,
+		},
+		{
+			name: "Different strings don't match",
+			a:    "test1",
+			b:    "test2",
+			want: false,
+		},
+		{
+			name: "Integer matches integer",
+			a:    42,
+			b:    42,
+			want: true,
+		},
+		{
+			name: "Different integers don't match",
+			a:    42,
+			b:    43,
+			want: false,
+		},
+		{
+			name: "String 'true' does not match boolean true",
+			a:    "true",
+			b:    true,
+			want: true, // Both convert to "true" string
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := valuesMatch(tt.a, tt.b); got != tt.want {
+				t.Errorf("valuesMatch(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
 			}
+		})
+	}
+}
 
-			offIfFalse := tt.room.GetOffIfFalseConditions()
-			if !stringSlicesEqual(offIfFalse, tt.expected.offIfFalse) {
-				t.Errorf("GetOffIfFalseConditions() = %v, want %v", offIfFalse, tt.expected.offIfFalse)
-			}
+func TestGetIncreaseBrightnessIfTrueConditions(t *testing.T) {
+	tests := []struct {
+		name     string
+		room     RoomConfig
+		expected []string
+	}{
+		{
+			name: "Single string condition",
+			room: RoomConfig{
+				IncreaseBrightnessIfTrue: "isHaveGuests",
+			},
+			expected: []string{"isHaveGuests"},
+		},
+		{
+			name: "Array conditions",
+			room: RoomConfig{
+				IncreaseBrightnessIfTrue: []interface{}{"isHaveGuests", "isPartyMode"},
+			},
+			expected: []string{"isHaveGuests", "isPartyMode"},
+		},
+		{
+			name: "Nil condition",
+			room: RoomConfig{
+				IncreaseBrightnessIfTrue: nil,
+			},
+			expected: []string{},
+		},
+		{
+			name: "Empty string condition",
+			room: RoomConfig{
+				IncreaseBrightnessIfTrue: "",
+			},
+			expected: []string{},
+		},
+	}
 
-			increaseBrightness := tt.room.GetIncreaseBrightnessIfTrueConditions()
-			if !stringSlicesEqual(increaseBrightness, tt.expected.increaseBrightnessIfTrue) {
-				t.Errorf("GetIncreaseBrightnessIfTrueConditions() = %v, want %v", increaseBrightness, tt.expected.increaseBrightnessIfTrue)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.room.GetIncreaseBrightnessIfTrueConditions()
+			if !stringSlicesEqual(got, tt.expected) {
+				t.Errorf("GetIncreaseBrightnessIfTrueConditions() = %v, want %v", got, tt.expected)
 			}
 		})
 	}

--- a/homeautomation-go/internal/plugins/lighting/manager.go
+++ b/homeautomation-go/internal/plugins/lighting/manager.go
@@ -271,7 +271,7 @@ func (m *Manager) handleSleepStateChange(key string, oldValue, newValue interfac
 	m.evaluateAllRooms(dayPhase, key)
 }
 
-// collectConditionVariables collects all unique variables from room on/off conditions
+// collectConditionVariables collects all unique variables from room conditions
 // These are variables like isNickOfficeOccupied, isKitchenOccupied that need subscriptions
 func (m *Manager) collectConditionVariables() []string {
 	// Use a map to collect unique variables
@@ -289,25 +289,10 @@ func (m *Manager) collectConditionVariables() []string {
 	}
 
 	for _, room := range m.config.Rooms {
-		// Collect from all condition types
-		for _, condition := range room.GetOnIfTrueConditions() {
-			if condition != "" && !alreadySubscribed[condition] {
-				varMap[condition] = true
-			}
-		}
-		for _, condition := range room.GetOnIfFalseConditions() {
-			if condition != "" && !alreadySubscribed[condition] {
-				varMap[condition] = true
-			}
-		}
-		for _, condition := range room.GetOffIfTrueConditions() {
-			if condition != "" && !alreadySubscribed[condition] {
-				varMap[condition] = true
-			}
-		}
-		for _, condition := range room.GetOffIfFalseConditions() {
-			if condition != "" && !alreadySubscribed[condition] {
-				varMap[condition] = true
+		// Collect all condition variables from this room
+		for _, varName := range room.GetConditionVariables() {
+			if varName != "" && !alreadySubscribed[varName] {
+				varMap[varName] = true
 			}
 		}
 	}
@@ -372,37 +357,30 @@ func (m *Manager) evaluateAndActivateRoom(room *RoomConfig, dayPhase string, tri
 		zap.String("day_phase", dayPhase),
 		zap.String("trigger", trigger))
 
-	// Evaluate on/off conditions
-	shouldTurnOn := m.evaluateOnConditions(room)
-	shouldTurnOff := m.evaluateOffConditions(room)
+	// Evaluate conditions in order - first matching condition wins
+	action, matchedVar := m.evaluateConditions(room)
 
 	m.logger.Debug("Room evaluation result",
 		zap.String("room", room.HueGroup),
-		zap.Bool("should_turn_on", shouldTurnOn),
-		zap.Bool("should_turn_off", shouldTurnOff))
+		zap.String("action", action),
+		zap.String("matched_variable", matchedVar))
 
-	// If both are true, prioritize turning ON (matches Node-RED behavior)
-	if shouldTurnOn {
+	switch action {
+	case "on":
 		m.logger.Info("Room should be turned on with scene",
 			zap.String("room", room.HueGroup),
-			zap.String("day_phase", dayPhase))
-		if shouldTurnOff {
-			m.logger.Debug("ON takes precedence over OFF",
-				zap.String("room", room.HueGroup))
-		}
+			zap.String("day_phase", dayPhase),
+			zap.String("matched_condition", matchedVar))
 		m.activateScene(room, dayPhase, trigger)
-		return
-	}
-
-	if shouldTurnOff {
+	case "off":
 		m.logger.Info("Room should be turned off",
-			zap.String("room", room.HueGroup))
+			zap.String("room", room.HueGroup),
+			zap.String("matched_condition", matchedVar))
 		m.turnOffRoom(room, trigger)
-		return
+	default:
+		m.logger.Debug("No action needed for room",
+			zap.String("room", room.HueGroup))
 	}
-
-	m.logger.Debug("No action needed for room",
-		zap.String("room", room.HueGroup))
 }
 
 // isTopicRelevant checks if a state variable change is relevant to a room's conditions
@@ -414,14 +392,8 @@ func (m *Manager) isTopicRelevant(room *RoomConfig, trigger string) bool {
 	}
 
 	// Check if trigger appears in any of the room's conditions
-	allConditions := []string{}
-	allConditions = append(allConditions, room.GetOnIfTrueConditions()...)
-	allConditions = append(allConditions, room.GetOnIfFalseConditions()...)
-	allConditions = append(allConditions, room.GetOffIfTrueConditions()...)
-	allConditions = append(allConditions, room.GetOffIfFalseConditions()...)
-
-	for _, condition := range allConditions {
-		if condition == trigger {
+	for _, cond := range room.Conditions {
+		if cond.Variable == trigger {
 			return true
 		}
 	}
@@ -429,75 +401,58 @@ func (m *Manager) isTopicRelevant(room *RoomConfig, trigger string) bool {
 	return false
 }
 
-// evaluateOnConditions evaluates whether a room should turn on
-func (m *Manager) evaluateOnConditions(room *RoomConfig) bool {
-	// Check on_if_true conditions
-	onIfTrueConditions := room.GetOnIfTrueConditions()
-	for _, condition := range onIfTrueConditions {
-		if m.evaluateCondition(condition) {
-			m.logger.Debug("on_if_true condition is true",
+// evaluateConditions evaluates room conditions in order and returns the action to take
+// Returns the action ("on", "off", or "" for no action) and the variable that matched
+func (m *Manager) evaluateConditions(room *RoomConfig) (action string, matchedVariable string) {
+	for _, cond := range room.Conditions {
+		if cond.Variable == "" {
+			continue
+		}
+
+		// Get the current value of the state variable
+		currentValue, err := m.getStateValue(cond.Variable)
+		if err != nil {
+			m.logger.Warn("Failed to get state value for condition",
 				zap.String("room", room.HueGroup),
-				zap.String("condition", condition))
-			return true
+				zap.String("variable", cond.Variable),
+				zap.Error(err))
+			continue
+		}
+
+		// Check if the condition matches using flexible type comparison
+		if valuesMatch(currentValue, cond.Value) {
+			m.logger.Debug("Condition matched",
+				zap.String("room", room.HueGroup),
+				zap.String("variable", cond.Variable),
+				zap.Any("expected", cond.Value),
+				zap.Any("actual", currentValue),
+				zap.String("action", cond.Action))
+			return cond.Action, cond.Variable
 		}
 	}
 
-	// Check on_if_false conditions
-	onIfFalseConditions := room.GetOnIfFalseConditions()
-	for _, condition := range onIfFalseConditions {
-		if !m.evaluateCondition(condition) {
-			m.logger.Debug("on_if_false condition is false",
-				zap.String("room", room.HueGroup),
-				zap.String("condition", condition))
-			return true
-		}
-	}
-
-	return false
+	// No condition matched
+	return "", ""
 }
 
-// evaluateOffConditions evaluates whether a room should turn off
-func (m *Manager) evaluateOffConditions(room *RoomConfig) bool {
-	// Check off_if_true conditions
-	offIfTrueConditions := room.GetOffIfTrueConditions()
-	for _, condition := range offIfTrueConditions {
-		if m.evaluateCondition(condition) {
-			m.logger.Debug("off_if_true condition is true",
-				zap.String("room", room.HueGroup),
-				zap.String("condition", condition))
-			return true
-		}
+// getStateValue retrieves a state variable value, trying different types
+func (m *Manager) getStateValue(variable string) (interface{}, error) {
+	// Try boolean first (most common for lighting conditions)
+	if val, err := m.stateManager.GetBool(variable); err == nil {
+		return val, nil
 	}
 
-	// Check off_if_false conditions
-	offIfFalseConditions := room.GetOffIfFalseConditions()
-	for _, condition := range offIfFalseConditions {
-		if !m.evaluateCondition(condition) {
-			m.logger.Debug("off_if_false condition is false",
-				zap.String("room", room.HueGroup),
-				zap.String("condition", condition))
-			return true
-		}
+	// Try string
+	if val, err := m.stateManager.GetString(variable); err == nil {
+		return val, nil
 	}
 
-	return false
-}
-
-// evaluateCondition evaluates a boolean state variable condition
-func (m *Manager) evaluateCondition(condition string) bool {
-	if condition == "" {
-		return false
+	// Try number
+	if val, err := m.stateManager.GetNumber(variable); err == nil {
+		return val, nil
 	}
 
-	value, err := m.stateManager.GetBool(condition)
-	if err != nil {
-		m.logger.Warn("Failed to evaluate condition",
-			zap.String("condition", condition),
-			zap.Error(err))
-		return false
-	}
-
-	return value
+	return nil, fmt.Errorf("failed to get value for variable %s", variable)
 }
 
 // toSnakeCase converts a string to snake_case format

--- a/homeautomation-go/internal/plugins/lighting/manager_test.go
+++ b/homeautomation-go/internal/plugins/lighting/manager_test.go
@@ -10,8 +10,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// createTestConfig creates a test hue configuration
-// Note: Only using state variables that exist in the state manager
+// createTestConfig creates a test hue configuration using the new conditions format
 func createTestConfig() *HueConfig {
 	transition30 := 30
 	transition180 := 180
@@ -19,22 +18,32 @@ func createTestConfig() *HueConfig {
 	return &HueConfig{
 		Rooms: []RoomConfig{
 			{
-				HueGroup:                 "Living Room",
-				HASSAreaID:               "living_room_2",
-				OnIfTrue:                 "isAnyoneHome",
-				OnIfFalse:                "isTVPlaying",
-				OffIfTrue:                "isEveryoneAsleep",
-				OffIfFalse:               "isAnyoneHome",
+				HueGroup:   "Living Room",
+				HASSAreaID: "living_room_2",
+				Conditions: []LightingCondition{
+					// Priority 1: No one home -> OFF
+					{Action: "off", Variable: "isAnyoneHome", Value: false},
+					// Priority 2: Everyone asleep -> OFF
+					{Action: "off", Variable: "isEveryoneAsleep", Value: true},
+					// Priority 3: Someone home -> ON
+					{Action: "on", Variable: "isAnyoneHome", Value: true},
+					// Priority 4: TV not playing -> ON
+					{Action: "on", Variable: "isTVPlaying", Value: false},
+				},
 				IncreaseBrightnessIfTrue: "isHaveGuests",
 				TransitionSeconds:        &transition30,
 			},
 			{
-				HueGroup:                 "Primary Suite",
-				HASSAreaID:               "master_bedroom",
-				OnIfTrue:                 nil,
-				OnIfFalse:                "isMasterAsleep",
-				OffIfTrue:                "isMasterAsleep",
-				OffIfFalse:               "isNickHome",
+				HueGroup:   "Primary Suite",
+				HASSAreaID: "master_bedroom",
+				Conditions: []LightingCondition{
+					// Priority 1: No one home -> OFF
+					{Action: "off", Variable: "isNickHome", Value: false},
+					// Priority 2: Master asleep -> OFF
+					{Action: "off", Variable: "isMasterAsleep", Value: true},
+					// Priority 3: Master not asleep -> ON
+					{Action: "on", Variable: "isMasterAsleep", Value: false},
+				},
 				IncreaseBrightnessIfTrue: nil,
 				TransitionSeconds:        &transition180,
 			},
@@ -57,40 +66,7 @@ func TestNewManager(t *testing.T) {
 	assert.False(t, manager.readOnly)
 }
 
-func TestEvaluateCondition(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
-	config := createTestConfig()
-	mockClient := ha.NewMockClient()
-	stateManager := state.NewManager(mockClient, logger, false)
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
-
-	// Set test conditions
-	err := stateManager.SetBool("isAnyoneHome", true)
-	assert.NoError(t, err)
-
-	err = stateManager.SetBool("isEveryoneAsleep", false)
-	assert.NoError(t, err)
-
-	tests := []struct {
-		name      string
-		condition string
-		expected  bool
-	}{
-		{"Empty condition", "", false},
-		{"True condition", "isAnyoneHome", true},
-		{"False condition", "isEveryoneAsleep", false},
-		{"Nonexistent condition", "nonexistent", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := manager.evaluateCondition(tt.condition)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestEvaluateOnConditions(t *testing.T) {
+func TestEvaluateConditions(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
@@ -101,50 +77,82 @@ func TestEvaluateOnConditions(t *testing.T) {
 		name           string
 		setupState     func()
 		roomIndex      int
-		expectedResult bool
+		expectedAction string
+		expectedVar    string
 	}{
 		{
-			name: "Living room - on_if_true is true",
+			name: "Living room - no one home -> OFF (first match)",
 			setupState: func() {
-				_ = stateManager.SetBool("isAnyoneHome", true)
+				_ = stateManager.SetBool("isAnyoneHome", false)
+				_ = stateManager.SetBool("isEveryoneAsleep", false)
 				_ = stateManager.SetBool("isTVPlaying", true)
 			},
 			roomIndex:      0,
-			expectedResult: true,
+			expectedAction: "off",
+			expectedVar:    "isAnyoneHome",
 		},
 		{
-			name: "Living room - on_if_false is false",
+			name: "Living room - everyone asleep -> OFF (second priority)",
 			setupState: func() {
-				_ = stateManager.SetBool("isAnyoneHome", false)
+				_ = stateManager.SetBool("isAnyoneHome", true)
+				_ = stateManager.SetBool("isEveryoneAsleep", true)
+				_ = stateManager.SetBool("isTVPlaying", true)
+			},
+			roomIndex:      0,
+			expectedAction: "off",
+			expectedVar:    "isEveryoneAsleep",
+		},
+		{
+			name: "Living room - someone home and awake -> ON",
+			setupState: func() {
+				_ = stateManager.SetBool("isAnyoneHome", true)
+				_ = stateManager.SetBool("isEveryoneAsleep", false)
+				_ = stateManager.SetBool("isTVPlaying", true)
+			},
+			roomIndex:      0,
+			expectedAction: "on",
+			expectedVar:    "isAnyoneHome",
+		},
+		{
+			name: "Living room - TV not playing -> ON (last priority)",
+			setupState: func() {
+				_ = stateManager.SetBool("isAnyoneHome", true)
+				_ = stateManager.SetBool("isEveryoneAsleep", false)
 				_ = stateManager.SetBool("isTVPlaying", false)
 			},
 			roomIndex:      0,
-			expectedResult: true,
+			expectedAction: "on",
+			expectedVar:    "isAnyoneHome", // First matching condition wins
 		},
 		{
-			name: "Living room - neither condition met",
+			name: "Primary suite - nick not home -> OFF",
 			setupState: func() {
-				_ = stateManager.SetBool("isAnyoneHome", false)
-				_ = stateManager.SetBool("isTVPlaying", true)
-			},
-			roomIndex:      0,
-			expectedResult: false,
-		},
-		{
-			name: "Primary suite - on_if_false is false",
-			setupState: func() {
+				_ = stateManager.SetBool("isNickHome", false)
 				_ = stateManager.SetBool("isMasterAsleep", false)
 			},
 			roomIndex:      1,
-			expectedResult: true,
+			expectedAction: "off",
+			expectedVar:    "isNickHome",
 		},
 		{
-			name: "Primary suite - on_if_false is true",
+			name: "Primary suite - master asleep -> OFF",
 			setupState: func() {
+				_ = stateManager.SetBool("isNickHome", true)
 				_ = stateManager.SetBool("isMasterAsleep", true)
 			},
 			roomIndex:      1,
-			expectedResult: false,
+			expectedAction: "off",
+			expectedVar:    "isMasterAsleep",
+		},
+		{
+			name: "Primary suite - master not asleep -> ON",
+			setupState: func() {
+				_ = stateManager.SetBool("isNickHome", true)
+				_ = stateManager.SetBool("isMasterAsleep", false)
+			},
+			roomIndex:      1,
+			expectedAction: "on",
+			expectedVar:    "isMasterAsleep",
 		},
 	}
 
@@ -152,79 +160,35 @@ func TestEvaluateOnConditions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupState()
 			room := &config.Rooms[tt.roomIndex]
-			result := manager.evaluateOnConditions(room)
-			assert.Equal(t, tt.expectedResult, result)
+			action, matchedVar := manager.evaluateConditions(room)
+			assert.Equal(t, tt.expectedAction, action)
+			assert.Equal(t, tt.expectedVar, matchedVar)
 		})
 	}
 }
 
-func TestEvaluateOffConditions(t *testing.T) {
+func TestEvaluateConditionsNoMatch(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
-	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
+
+	// Create a room with no conditions
+	config := &HueConfig{
+		Rooms: []RoomConfig{
+			{
+				HueGroup:   "Empty Room",
+				HASSAreaID: "empty_room",
+				Conditions: []LightingCondition{},
+			},
+		},
+	}
+
 	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
 
-	tests := []struct {
-		name           string
-		setupState     func()
-		roomIndex      int
-		expectedResult bool
-	}{
-		{
-			name: "Living room - off_if_true is true",
-			setupState: func() {
-				_ = stateManager.SetBool("isEveryoneAsleep", true)
-				_ = stateManager.SetBool("isAnyoneHome", true)
-			},
-			roomIndex:      0,
-			expectedResult: true,
-		},
-		{
-			name: "Living room - off_if_false is false",
-			setupState: func() {
-				_ = stateManager.SetBool("isEveryoneAsleep", false)
-				_ = stateManager.SetBool("isAnyoneHome", false)
-			},
-			roomIndex:      0,
-			expectedResult: true,
-		},
-		{
-			name: "Living room - neither condition met",
-			setupState: func() {
-				_ = stateManager.SetBool("isEveryoneAsleep", false)
-				_ = stateManager.SetBool("isAnyoneHome", true)
-			},
-			roomIndex:      0,
-			expectedResult: false,
-		},
-		{
-			name: "Primary suite - off_if_true is true",
-			setupState: func() {
-				_ = stateManager.SetBool("isMasterAsleep", true)
-			},
-			roomIndex:      1,
-			expectedResult: true,
-		},
-		{
-			name: "Primary suite - off_if_true is false, off_if_false is false",
-			setupState: func() {
-				_ = stateManager.SetBool("isMasterAsleep", false)
-				_ = stateManager.SetBool("isNickHome", false)
-			},
-			roomIndex:      1,
-			expectedResult: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tt.setupState()
-			room := &config.Rooms[tt.roomIndex]
-			result := manager.evaluateOffConditions(room)
-			assert.Equal(t, tt.expectedResult, result)
-		})
-	}
+	room := &config.Rooms[0]
+	action, matchedVar := manager.evaluateConditions(room)
+	assert.Equal(t, "", action, "No action expected when no conditions")
+	assert.Equal(t, "", matchedVar, "No matched variable when no conditions")
 }
 
 func TestActivateSceneReadOnly(t *testing.T) {
@@ -360,13 +324,24 @@ func TestEvaluateAndActivateRoom(t *testing.T) {
 		shouldCallService bool
 	}{
 		{
-			name: "Room should turn off",
+			name: "Room should turn off - no one home",
 			setupState: func() {
-				// Set OFF condition to true
-				_ = stateManager.SetBool("isEveryoneAsleep", true)
-				// Make sure ON conditions are false
 				_ = stateManager.SetBool("isAnyoneHome", false)
-				_ = stateManager.SetBool("isTVPlaying", true) // OnIfFalse should be false
+				_ = stateManager.SetBool("isEveryoneAsleep", false)
+				_ = stateManager.SetBool("isTVPlaying", true)
+			},
+			roomIndex:         0,
+			dayPhase:          "Night",
+			expectedService:   "turn_off",
+			expectedDomain:    "light",
+			shouldCallService: true,
+		},
+		{
+			name: "Room should turn off - everyone asleep",
+			setupState: func() {
+				_ = stateManager.SetBool("isAnyoneHome", true)
+				_ = stateManager.SetBool("isEveryoneAsleep", true)
+				_ = stateManager.SetBool("isTVPlaying", true)
 			},
 			roomIndex:         0,
 			dayPhase:          "Night",
@@ -377,8 +352,9 @@ func TestEvaluateAndActivateRoom(t *testing.T) {
 		{
 			name: "Room should turn on with scene",
 			setupState: func() {
-				_ = stateManager.SetBool("isEveryoneAsleep", false)
 				_ = stateManager.SetBool("isAnyoneHome", true)
+				_ = stateManager.SetBool("isEveryoneAsleep", false)
+				_ = stateManager.SetBool("isTVPlaying", true)
 			},
 			roomIndex:         0,
 			dayPhase:          "Morning",
@@ -459,6 +435,7 @@ func TestLightingManager_Stop(t *testing.T) {
 			{
 				HueGroup:   "Living Room",
 				HASSAreaID: "living_room",
+				Conditions: []LightingCondition{},
 			},
 		},
 	}
@@ -506,4 +483,138 @@ func TestManagerReset(t *testing.T) {
 	// Reset should re-apply lighting scenes for all rooms
 	err = manager.Reset()
 	assert.NoError(t, err)
+}
+
+func TestIsTopicRelevant(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	config := createTestConfig()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+
+	tests := []struct {
+		name     string
+		room     *RoomConfig
+		trigger  string
+		expected bool
+	}{
+		{
+			name:     "dayPhase is always relevant",
+			room:     &config.Rooms[0],
+			trigger:  "dayPhase",
+			expected: true,
+		},
+		{
+			name:     "sunevent is always relevant",
+			room:     &config.Rooms[0],
+			trigger:  "sunevent",
+			expected: true,
+		},
+		{
+			name:     "reset is always relevant",
+			room:     &config.Rooms[0],
+			trigger:  "reset",
+			expected: true,
+		},
+		{
+			name:     "empty trigger is always relevant",
+			room:     &config.Rooms[0],
+			trigger:  "",
+			expected: true,
+		},
+		{
+			name:     "isAnyoneHome is relevant to Living Room",
+			room:     &config.Rooms[0],
+			trigger:  "isAnyoneHome",
+			expected: true,
+		},
+		{
+			name:     "isMasterAsleep is not relevant to Living Room",
+			room:     &config.Rooms[0],
+			trigger:  "isMasterAsleep",
+			expected: false,
+		},
+		{
+			name:     "isMasterAsleep is relevant to Primary Suite",
+			room:     &config.Rooms[1],
+			trigger:  "isMasterAsleep",
+			expected: true,
+		},
+		{
+			name:     "unrelated variable is not relevant",
+			room:     &config.Rooms[0],
+			trigger:  "isKitchenOccupied",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := manager.isTopicRelevant(tt.room, tt.trigger)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetStateValue(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	config := createTestConfig()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+
+	// Use real registered state variables
+	// Boolean: isAnyoneHome (registered in state manager)
+	err := stateManager.SetBool("isAnyoneHome", true)
+	assert.NoError(t, err)
+
+	// String: dayPhase (registered in state manager)
+	err = stateManager.SetString("dayPhase", "morning")
+	assert.NoError(t, err)
+
+	// Test boolean retrieval
+	val, err := manager.getStateValue("isAnyoneHome")
+	assert.NoError(t, err)
+	assert.Equal(t, true, val)
+
+	// Test string retrieval
+	val, err = manager.getStateValue("dayPhase")
+	assert.NoError(t, err)
+	assert.Equal(t, "morning", val)
+
+	// Test nonexistent variable
+	_, err = manager.getStateValue("nonexistent")
+	assert.Error(t, err)
+}
+
+func TestCollectConditionVariables(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	config := createTestConfig()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+
+	vars := manager.collectConditionVariables()
+
+	// Should not include variables that are already subscribed to explicitly
+	// (dayPhase, sunevent, isAnyoneHome, isTVPlaying, isEveryoneAsleep, isMasterAsleep, isHaveGuests)
+	for _, v := range vars {
+		assert.NotEqual(t, "dayPhase", v)
+		assert.NotEqual(t, "sunevent", v)
+		assert.NotEqual(t, "isAnyoneHome", v)
+		assert.NotEqual(t, "isTVPlaying", v)
+		assert.NotEqual(t, "isEveryoneAsleep", v)
+		assert.NotEqual(t, "isMasterAsleep", v)
+		assert.NotEqual(t, "isHaveGuests", v)
+	}
+
+	// Should include isNickHome (from Primary Suite config) which is not in the standard list
+	found := false
+	for _, v := range vars {
+		if v == "isNickHome" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Should include isNickHome from Primary Suite config")
 }

--- a/homeautomation-go/internal/plugins/lighting/occupancy_scenario_test.go
+++ b/homeautomation-go/internal/plugins/lighting/occupancy_scenario_test.go
@@ -22,15 +22,15 @@ package lighting
 //
 // CONFIGURATION REFERENCE:
 // - File: configs/hue_config.yaml
-// - Relevant room configs:
-//   - N Office: on_if_true: isNickOfficeOccupied, off_if_false: isNickOfficeOccupied
-//   - Kitchen: on_if_true: isKitchenOccupied, off_if_false: isAnyoneHomeAndAwake
+// - Relevant room configs (using ordered conditions format):
+//   - N Office: conditions with priority: 1. off if !isNickOfficeOccupied, 2. on if isNickOfficeOccupied
+//   - Kitchen: conditions with priority: 1. off if !isAnyoneHomeAndAwake, 2. on if isKitchenOccupied
 //
 // IMPLEMENTATION:
 // The Lighting Manager (internal/plugins/lighting/manager.go) implements:
 //
 // 1. collectConditionVariables(): Parses all unique variables from room configs
-//    - Extracts variables from OnIfTrue, OnIfFalse, OffIfTrue, OffIfFalse fields
+//    - Extracts variables from each room's Conditions list
 //    - Example: "isNickOfficeOccupied", "isKitchenOccupied", "isAnyoneHomeAndAwake"
 //
 // 2. Subscribe to state changes for these variables in Start()
@@ -39,9 +39,8 @@ package lighting
 //
 // 3. handleOccupancyChange(): When a subscribed variable changes
 //    - Identifies which rooms use that variable in their conditions
-//    - For each affected room, evaluates the on/off conditions
-//    - If on_if_true matches: activates the appropriate scene (scene.turn_on)
-//    - If off_if_false matches: turns off lights (light.turn_off)
+//    - For each affected room, evaluates conditions in priority order
+//    - First matching condition determines the action (on/off)
 //
 // 4. Scene naming convention:
 //    - Scene entity_id format: scene.{snake_case(hue_group + " " + dayPhase)}
@@ -74,21 +73,25 @@ func createOccupancyTestConfig() *HueConfig {
 	return &HueConfig{
 		Rooms: []RoomConfig{
 			{
-				HueGroup:          "N Office",
-				HASSAreaID:        "n_office",
-				OnIfTrue:          "isNickOfficeOccupied",
-				OnIfFalse:         nil,
-				OffIfTrue:         nil,
-				OffIfFalse:        "isNickOfficeOccupied",
+				HueGroup:   "N Office",
+				HASSAreaID: "n_office",
+				Conditions: []LightingCondition{
+					// Priority 1: Office not occupied -> OFF
+					{Action: "off", Variable: "isNickOfficeOccupied", Value: false},
+					// Priority 2: Office occupied -> ON
+					{Action: "on", Variable: "isNickOfficeOccupied", Value: true},
+				},
 				TransitionSeconds: &transition2,
 			},
 			{
-				HueGroup:          "Kitchen",
-				HASSAreaID:        "kitchen",
-				OnIfTrue:          "isKitchenOccupied",
-				OnIfFalse:         nil,
-				OffIfTrue:         nil,
-				OffIfFalse:        "isAnyoneHomeAndAwake",
+				HueGroup:   "Kitchen",
+				HASSAreaID: "kitchen",
+				Conditions: []LightingCondition{
+					// Priority 1: No one home and awake -> OFF
+					{Action: "off", Variable: "isAnyoneHomeAndAwake", Value: false},
+					// Priority 2: Kitchen occupied -> ON
+					{Action: "on", Variable: "isKitchenOccupied", Value: true},
+				},
 				TransitionSeconds: &transition5,
 			},
 		},

--- a/homeautomation-go/test/integration/testdata/hue_config_test.yaml
+++ b/homeautomation-go/test/integration/testdata/hue_config_test.yaml
@@ -3,17 +3,39 @@
 rooms:
   - hue_group: Living Room
     hass_area_id: living_room
-    on_if_true: isAnyoneHome
-    on_if_false: isTVPlaying
-    off_if_true: isEveryoneAsleep
-    off_if_false: isAnyoneHome
+    conditions:
+      # Priority 1: No one home -> OFF
+      - action: off
+        variable: isAnyoneHome
+        value: false
+      # Priority 2: Everyone asleep -> OFF
+      - action: off
+        variable: isEveryoneAsleep
+        value: true
+      # Priority 3: Someone home -> ON
+      - action: on
+        variable: isAnyoneHome
+        value: true
+      # Priority 4: TV not playing -> ON
+      - action: on
+        variable: isTVPlaying
+        value: false
     increase_brightness_if_true: isHaveGuests
     transition_seconds: 5
   - hue_group: Master Bedroom
     hass_area_id: master_bedroom
-    on_if_true: ~
-    on_if_false: isMasterAsleep
-    off_if_true: isMasterAsleep
-    off_if_false: isAnyoneHome
+    conditions:
+      # Priority 1: No one home -> OFF
+      - action: off
+        variable: isAnyoneHome
+        value: false
+      # Priority 2: Master asleep -> OFF
+      - action: off
+        variable: isMasterAsleep
+        value: true
+      # Priority 3: Master not asleep -> ON
+      - action: on
+        variable: isMasterAsleep
+        value: false
     increase_brightness_if_true: ~
     transition_seconds: 5


### PR DESCRIPTION
## Summary

- Replaces the `on_if_true`, `on_if_false`, `off_if_true`, `off_if_false` config format with a new `conditions` array
- Conditions are now evaluated in order - **first matching condition wins**
- Makes priority logic explicit and configurable in YAML rather than hardcoded in Go
- Removes the implicit "ON takes precedence over OFF" rule

## Motivation

The previous config format had implicit precedence rules that were hard to understand and debug. The new format makes priorities explicit through ordering in the YAML file, with clear comments documenting each priority level.

**Before:**
```yaml
- hue_group: Living Room
  on_if_true: isAnyoneHomeAndAwake
  on_if_false: isTVPlaying
  off_if_true: isEveryoneAsleep
  off_if_false: isAnyoneHome
```

**After:**
```yaml
- hue_group: Living Room
  conditions:
    # Priority 1: No one home -> OFF
    - action: off
      variable: isAnyoneHome
      value: false
    # Priority 2: Everyone asleep -> OFF
    - action: off
      variable: isEveryoneAsleep
      value: true
    # Priority 3: Someone home and awake -> ON
    - action: on
      variable: isAnyoneHomeAndAwake
      value: true
```

## Changes

- `configs/hue_config.yaml`: Migrated all rooms to new format with explicit priority comments
- `config.go`: Replaced 4 getters with `GetConditionVariables()` and added `valuesMatch()` helper
- `manager.go`: Replaced `evaluateOnConditions()`/`evaluateOffConditions()` with single `evaluateConditions()` that returns first match
- Tests updated for new format with ~700 lines changed across test files

## Test plan

- [ ] Run `make pre-push` to verify all tests pass
- [ ] Verify behavior matches Node-RED for each room configuration
- [ ] Deploy in READ_ONLY mode and compare lighting decisions with production

🤖 Generated with [Claude Code](https://claude.com/claude-code)