### PR TITLE
feat(security): Add off-wait-on sequence to lockdown activation

### DIFF
--- a/homeautomation-go/internal/plugins/security/manager.go
+++ b/homeautomation-go/internal/plugins/security/manager.go
@@ -15,6 +15,10 @@ import (
 
 // Timer duration constants
 const (
+	// LockdownClearDelay is how long to wait after turning off lockdown before turning it back on
+	// This ensures a clear activation signal even if lockdown was already on
+	LockdownClearDelay = 30 * time.Second
+
 	// LockdownResetDelay is how long to wait before auto-resetting lockdown
 	LockdownResetDelay = 5 * time.Second
 
@@ -201,22 +205,40 @@ func (m *Manager) handleAnyoneHomeChange(key string, oldValue, newValue interfac
 }
 
 // activateLockdown turns on the lockdown input_boolean
+// It first turns lockdown off, waits 30 seconds, then turns it on to ensure
+// a clear activation signal even if lockdown was already on
 func (m *Manager) activateLockdown(reason string, trigger string) {
 	// Record action in shadow state before executing
 	m.recordLockdownAction(true, reason, trigger)
 
 	if m.readOnly {
-		m.logger.Info("READ-ONLY: Would activate lockdown", zap.String("reason", reason))
+		m.logger.Info("READ-ONLY: Would activate lockdown (turn off, wait 30s, turn on)", zap.String("reason", reason))
 		return
 	}
 
-	if err := m.haClient.CallService("input_boolean", "turn_on", map[string]interface{}{
-		"entity_id": "input_boolean.lockdown",
-	}); err != nil {
-		m.logger.Error("Failed to activate lockdown", zap.Error(err))
-	} else {
-		m.logger.Info("Lockdown activated", zap.String("reason", reason))
-	}
+	// Run the off-wait-on sequence in a goroutine to avoid blocking
+	go func() {
+		// Step 1: Turn lockdown off first
+		if err := m.haClient.CallService("input_boolean", "turn_off", map[string]interface{}{
+			"entity_id": "input_boolean.lockdown",
+		}); err != nil {
+			m.logger.Error("Failed to turn off lockdown before activation", zap.Error(err))
+			return
+		}
+		m.logger.Info("Lockdown turned off, waiting 30 seconds before activation", zap.String("reason", reason))
+
+		// Step 2: Wait 30 seconds
+		m.clock.Sleep(LockdownClearDelay)
+
+		// Step 3: Turn lockdown on
+		if err := m.haClient.CallService("input_boolean", "turn_on", map[string]interface{}{
+			"entity_id": "input_boolean.lockdown",
+		}); err != nil {
+			m.logger.Error("Failed to activate lockdown", zap.Error(err))
+		} else {
+			m.logger.Info("Lockdown activated", zap.String("reason", reason))
+		}
+	}()
 }
 
 // handleLockdownActivated auto-resets lockdown after 5 seconds

--- a/homeautomation-go/internal/plugins/security/manager_test.go
+++ b/homeautomation-go/internal/plugins/security/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"homeautomation/internal/clock"
 	"homeautomation/internal/ha"
 	"homeautomation/internal/state"
 
@@ -23,6 +24,11 @@ func TestSecurityManager_LockdownOnEveryoneAsleep(t *testing.T) {
 
 	// Create security manager (not read-only so it can call services)
 	securityManager := NewManager(mockHA, stateManager, logger, false, nil)
+
+	// Use MockClock so the 30-second delay is instant (MockClock.Sleep is a no-op)
+	mockClock := clock.NewMockClock(time.Now())
+	securityManager.SetClock(mockClock)
+
 	if err := securityManager.Start(); err != nil {
 		t.Fatalf("Failed to start security manager: %v", err)
 	}
@@ -35,23 +41,34 @@ func TestSecurityManager_LockdownOnEveryoneAsleep(t *testing.T) {
 		t.Fatalf("Failed to set isEveryoneAsleep: %v", err)
 	}
 
-	// Wait for async processing
+	// Wait for async processing (goroutine runs off-wait-on sequence instantly with MockClock)
 	time.Sleep(100 * time.Millisecond)
 
-	// Verify lockdown was activated
+	// Verify lockdown activation sequence: turn_off first, then turn_on
 	calls := mockHA.GetServiceCalls()
-	found := false
-	for _, call := range calls {
-		if call.Domain == "input_boolean" && call.Service == "turn_on" {
+	turnOffIdx := -1
+	turnOnIdx := -1
+
+	for i, call := range calls {
+		if call.Domain == "input_boolean" {
 			if entityID, ok := call.Data["entity_id"].(string); ok && entityID == "input_boolean.lockdown" {
-				found = true
-				break
+				if call.Service == "turn_off" && turnOffIdx == -1 {
+					turnOffIdx = i
+				} else if call.Service == "turn_on" && turnOnIdx == -1 {
+					turnOnIdx = i
+				}
 			}
 		}
 	}
 
-	if !found {
-		t.Errorf("Expected lockdown to be activated, but service was not called")
+	if turnOffIdx == -1 {
+		t.Errorf("Expected lockdown to be turned off first, but turn_off was not called")
+	}
+	if turnOnIdx == -1 {
+		t.Errorf("Expected lockdown to be activated, but turn_on was not called")
+	}
+	if turnOffIdx != -1 && turnOnIdx != -1 && turnOffIdx >= turnOnIdx {
+		t.Errorf("Expected turn_off (idx %d) to happen before turn_on (idx %d)", turnOffIdx, turnOnIdx)
 	}
 }
 
@@ -68,6 +85,11 @@ func TestSecurityManager_LockdownOnNoOneHome(t *testing.T) {
 
 	// Create security manager
 	securityManager := NewManager(mockHA, stateManager, logger, false, nil)
+
+	// Use MockClock so the 30-second delay is instant (MockClock.Sleep is a no-op)
+	mockClock := clock.NewMockClock(time.Now())
+	securityManager.SetClock(mockClock)
+
 	if err := securityManager.Start(); err != nil {
 		t.Fatalf("Failed to start security manager: %v", err)
 	}
@@ -80,23 +102,34 @@ func TestSecurityManager_LockdownOnNoOneHome(t *testing.T) {
 		t.Fatalf("Failed to set isAnyoneHome: %v", err)
 	}
 
-	// Wait for async processing
+	// Wait for async processing (goroutine runs off-wait-on sequence instantly with MockClock)
 	time.Sleep(100 * time.Millisecond)
 
-	// Verify lockdown was activated
+	// Verify lockdown activation sequence: turn_off first, then turn_on
 	calls := mockHA.GetServiceCalls()
-	found := false
-	for _, call := range calls {
-		if call.Domain == "input_boolean" && call.Service == "turn_on" {
+	turnOffIdx := -1
+	turnOnIdx := -1
+
+	for i, call := range calls {
+		if call.Domain == "input_boolean" {
 			if entityID, ok := call.Data["entity_id"].(string); ok && entityID == "input_boolean.lockdown" {
-				found = true
-				break
+				if call.Service == "turn_off" && turnOffIdx == -1 {
+					turnOffIdx = i
+				} else if call.Service == "turn_on" && turnOnIdx == -1 {
+					turnOnIdx = i
+				}
 			}
 		}
 	}
 
-	if !found {
-		t.Errorf("Expected lockdown to be activated when no one is home, but service was not called")
+	if turnOffIdx == -1 {
+		t.Errorf("Expected lockdown to be turned off first, but turn_off was not called")
+	}
+	if turnOnIdx == -1 {
+		t.Errorf("Expected lockdown to be activated, but turn_on was not called")
+	}
+	if turnOffIdx != -1 && turnOnIdx != -1 && turnOffIdx >= turnOnIdx {
+		t.Errorf("Expected turn_off (idx %d) to happen before turn_on (idx %d)", turnOffIdx, turnOnIdx)
 	}
 }
 


### PR DESCRIPTION
## Summary
- When activating lockdown, first turn it off, wait 30 seconds, then turn it on
- This ensures there is always a clear activation signal even if lockdown happened to be on already
- Lockdown activates when everyone is asleep (`isEveryoneAsleep = true`) or when no one is home (`isAnyoneHome = false`)

## Test plan
- [x] Updated lockdown activation tests to verify off-wait-on sequence
- [x] Tests use MockClock to avoid 30-second real-time delays
- [x] All 16 security plugin tests pass
- [x] Full test suite passes with race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)