### PR TITLE
feat(health): Detect degraded WebSocket connections for auto-restart

### DIFF
--- a/homeautomation-go/cmd/app/run.go
+++ b/homeautomation-go/cmd/app/run.go
@@ -207,7 +207,7 @@ func Run() {
 	logger.Info("Subscription Registry created for automatic input tracking")
 
 	// Start HTTP API server
-	apiServer := api.NewServer(stateManager, shadowTracker, logBuffer, logger, httpPort, timezone)
+	apiServer := api.NewServer(client, stateManager, shadowTracker, logBuffer, logger, httpPort, timezone)
 	if err := apiServer.Start(); err != nil {
 		logger.Fatal("Failed to start HTTP API server", zap.Error(err))
 	}

--- a/homeautomation-go/internal/api/server.go
+++ b/homeautomation-go/internal/api/server.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"homeautomation/internal/ha"
 	"homeautomation/internal/logbuffer"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
@@ -24,6 +25,7 @@ var timelineHTML string
 
 // Server provides HTTP API endpoints for the home automation system
 type Server struct {
+	haClient      ha.HAClient
 	stateManager  *state.Manager
 	shadowTracker *shadowstate.Tracker
 	logBuffer     *logbuffer.Buffer
@@ -33,8 +35,9 @@ type Server struct {
 }
 
 // NewServer creates a new API server
-func NewServer(stateManager *state.Manager, shadowTracker *shadowstate.Tracker, logBuffer *logbuffer.Buffer, logger *zap.Logger, port int, timezone *time.Location) *Server {
+func NewServer(haClient ha.HAClient, stateManager *state.Manager, shadowTracker *shadowstate.Tracker, logBuffer *logbuffer.Buffer, logger *zap.Logger, port int, timezone *time.Location) *Server {
 	s := &Server{
+		haClient:      haClient,
 		stateManager:  stateManager,
 		shadowTracker: shadowTracker,
 		logBuffer:     logBuffer,
@@ -344,10 +347,20 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	healthy := s.haClient.IsHealthy()
+	status := "ok"
+	httpCode := http.StatusOK
+
+	if !healthy {
+		status = "unhealthy"
+		httpCode = http.StatusServiceUnavailable
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{
-		"status": "ok",
+	w.WriteHeader(httpCode)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":       status,
+		"ha_connected": s.haClient.IsConnected(),
 	})
 }
 

--- a/homeautomation-go/internal/api/server_test.go
+++ b/homeautomation-go/internal/api/server_test.go
@@ -34,7 +34,7 @@ func TestHandleGetState(t *testing.T) {
 
 	// Create API server
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/state", nil)
@@ -109,7 +109,7 @@ func TestHandleGetStateMethodNotAllowed(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Test POST method (should be rejected)
 	req := httptest.NewRequest(http.MethodPost, "/api/state", nil)
@@ -125,27 +125,57 @@ func TestHandleGetStateMethodNotAllowed(t *testing.T) {
 func TestHandleHealth(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	mockClient := ha.NewMockClient()
+	mockClient.Connect() // Connect so IsHealthy returns true
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
-	req := httptest.NewRequest(http.MethodGet, "/health", nil)
-	w := httptest.NewRecorder()
+	t.Run("healthy when connected", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		w := httptest.NewRecorder()
 
-	server.handleHealth(w, req)
+		server.handleHealth(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected status 200, got %d", w.Code)
-	}
+		if w.Code != http.StatusOK {
+			t.Errorf("Expected status 200, got %d", w.Code)
+		}
 
-	var response map[string]string
-	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-		t.Fatalf("Failed to decode response: %v", err)
-	}
+		var response map[string]interface{}
+		if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+			t.Fatalf("Failed to decode response: %v", err)
+		}
 
-	if response["status"] != "ok" {
-		t.Errorf("Expected status 'ok', got '%s'", response["status"])
-	}
+		if response["status"] != "ok" {
+			t.Errorf("Expected status 'ok', got '%v'", response["status"])
+		}
+		if response["ha_connected"] != true {
+			t.Errorf("Expected ha_connected true, got '%v'", response["ha_connected"])
+		}
+	})
+
+	t.Run("unhealthy when disconnected", func(t *testing.T) {
+		mockClient.Disconnect()
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		w := httptest.NewRecorder()
+
+		server.handleHealth(w, req)
+
+		if w.Code != http.StatusServiceUnavailable {
+			t.Errorf("Expected status 503, got %d", w.Code)
+		}
+
+		var response map[string]interface{}
+		if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+			t.Fatalf("Failed to decode response: %v", err)
+		}
+
+		if response["status"] != "unhealthy" {
+			t.Errorf("Expected status 'unhealthy', got '%v'", response["status"])
+		}
+		if response["ha_connected"] != false {
+			t.Errorf("Expected ha_connected false, got '%v'", response["ha_connected"])
+		}
+	})
 }
 
 func TestHandleSitemap(t *testing.T) {
@@ -153,7 +183,7 @@ func TestHandleSitemap(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
@@ -204,7 +234,7 @@ func TestHandleSitemapHTML(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Accept", "text/html")
@@ -257,7 +287,7 @@ func TestHandleSitemapMethodNotAllowed(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Test POST method (should be rejected)
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -275,7 +305,7 @@ func TestHandleSitemapNonRootPath(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Test non-root path (should return 404 without sitemap)
 	req := httptest.NewRequest(http.MethodGet, "/nonexistent", nil)
@@ -329,7 +359,7 @@ func TestHandleGetStatesByPlugin(t *testing.T) {
 
 	// Create API server
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/states", nil)
@@ -461,7 +491,7 @@ func TestHandleGetStatesByPluginMethodNotAllowed(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Test POST method (should be rejected)
 	req := httptest.NewRequest(http.MethodPost, "/api/states", nil)
@@ -480,7 +510,7 @@ func TestHandleGetStatesByPluginEmptyState(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/states", nil)
 	w := httptest.NewRecorder()
@@ -582,7 +612,7 @@ func TestHandleGetLightingShadowState(t *testing.T) {
 	shadowTracker.RegisterPlugin("lighting", lightingState)
 
 	// Create API server
-	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/shadow/lighting", nil)
@@ -631,7 +661,7 @@ func TestHandleGetLightingShadowState_NotFound(t *testing.T) {
 	shadowTracker := shadowstate.NewTracker()
 
 	// Create API server
-	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/shadow/lighting", nil)
@@ -668,7 +698,7 @@ func TestHandleGetSecurityShadowState(t *testing.T) {
 	shadowTracker.RegisterPlugin("security", securityState)
 
 	// Create API server
-	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/shadow/security", nil)
@@ -725,7 +755,7 @@ func TestHandleGetSecurityShadowState_NotFound(t *testing.T) {
 	shadowTracker := shadowstate.NewTracker()
 
 	// Create API server
-	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/shadow/security", nil)
@@ -763,7 +793,7 @@ func TestHandleGetAllShadowStates(t *testing.T) {
 	shadowTracker.RegisterPlugin("security", securityState)
 
 	// Create API server
-	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/shadow", nil)
@@ -822,7 +852,7 @@ func TestAddLocalTimestamps(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, estLocation)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, estLocation)
 
 	// Test cases
 	tests := []struct {
@@ -933,7 +963,7 @@ func TestAddLocalTimestamps(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.name == "nil timezone returns original" {
 				// Test with nil timezone
-				nilTzServer := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, nil)
+				nilTzServer := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, nil)
 				result := nilTzServer.addLocalTimestamps(tc.input)
 				m := result.(map[string]interface{})
 				if _, ok := m["tsLocal"]; ok {
@@ -964,7 +994,7 @@ func TestHandleDashboard(t *testing.T) {
 	shadowTracker.RegisterPlugin("lighting", lightingState)
 
 	// Create API server
-	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
@@ -1015,7 +1045,7 @@ func TestHandleDashboardMethodNotAllowed(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
 
 	// Test POST method (should be rejected)
 	req := httptest.NewRequest(http.MethodPost, "/dashboard", nil)
@@ -1040,7 +1070,7 @@ func TestWriteJSONWithLocalTimestamps(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, estLocation)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, estLocation)
 
 	// Create a test struct with a timestamp
 	type TestData struct {
@@ -1105,7 +1135,7 @@ func TestHandleTimelineEvents(t *testing.T) {
 		})
 	}
 
-	server := NewServer(stateManager, shadowTracker, buffer, logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, buffer, logger, 8080, time.UTC)
 
 	t.Run("basic request", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/timeline/events", nil)

--- a/homeautomation-go/internal/ha/client.go
+++ b/homeautomation-go/internal/ha/client.go
@@ -42,11 +42,24 @@ const (
 	maxRetryDelay = 15 * time.Second
 )
 
+// Health tracking constants
+const (
+	// healthWindowSize is the number of recent service call results to track
+	healthWindowSize = 10
+
+	// unhealthyThreshold is the failure rate above which the client is considered unhealthy
+	unhealthyThreshold = 0.5
+
+	// minResultsForHealth is the minimum number of results needed before declaring unhealthy
+	minResultsForHealth = 3
+)
+
 // HAClient defines the interface for Home Assistant WebSocket client
 type HAClient interface {
 	Connect() error
 	Disconnect() error
 	IsConnected() bool
+	IsHealthy() bool
 	GetState(entityID string) (*State, error)
 	GetAllStates() ([]*State, error)
 	CallService(domain, service string, data map[string]interface{}) error
@@ -71,6 +84,7 @@ type subscriberEntry struct {
 //  4. pendingMu - pending response channels
 //  5. subsMu - subscribers
 //  6. nextSubIDMu - subscription ID counter
+//  7. healthMu - health tracking (acquired last, never held while acquiring others)
 //
 // Note: msgIDMu has been eliminated; msgID is now protected by writeMu to ensure
 // message IDs are allocated and sent atomically, preventing out-of-order sends.
@@ -93,6 +107,12 @@ type Client struct {
 	ctxMu       sync.RWMutex // Protects ctx and cancel
 	reconnect   bool
 	writeMu     sync.Mutex // Protects websocket writes AND msgID counter
+
+	// Health tracking for service calls (rolling window)
+	healthMu      sync.RWMutex
+	recentResults []bool // circular buffer: true=success, false=failure
+	resultIndex   int    // next write position in circular buffer
+	resultCount   int    // how many results recorded (up to healthWindowSize)
 }
 
 func (c *Client) clearSubscribers() {
@@ -123,14 +143,15 @@ func (c *Client) resetContext() {
 func NewClient(url, token string, logger *zap.Logger) *Client {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Client{
-		url:         url,
-		token:       token,
-		logger:      logger,
-		pending:     make(map[int]chan Message),
-		subscribers: make(map[string][]subscriberEntry),
-		ctx:         ctx,
-		cancel:      cancel,
-		reconnect:   true,
+		url:           url,
+		token:         token,
+		logger:        logger,
+		pending:       make(map[int]chan Message),
+		subscribers:   make(map[string][]subscriberEntry),
+		ctx:           ctx,
+		cancel:        cancel,
+		reconnect:     true,
+		recentResults: make([]bool, healthWindowSize),
 	}
 }
 
@@ -277,6 +298,47 @@ func (c *Client) IsConnected() bool {
 	c.connMu.RLock()
 	defer c.connMu.RUnlock()
 	return c.connected
+}
+
+// recordServiceResult records the result of a service call for health tracking.
+// Uses a circular buffer to track the last healthWindowSize results.
+func (c *Client) recordServiceResult(success bool) {
+	c.healthMu.Lock()
+	defer c.healthMu.Unlock()
+
+	c.recentResults[c.resultIndex] = success
+	c.resultIndex = (c.resultIndex + 1) % healthWindowSize
+	if c.resultCount < healthWindowSize {
+		c.resultCount++
+	}
+}
+
+// IsHealthy returns true if the client is connected and service calls are succeeding.
+// Returns false if disconnected or if more than 50% of recent service calls failed.
+// Requires at least minResultsForHealth results before declaring unhealthy.
+func (c *Client) IsHealthy() bool {
+	if !c.IsConnected() {
+		return false
+	}
+
+	c.healthMu.RLock()
+	defer c.healthMu.RUnlock()
+
+	// Not enough data to determine health - assume healthy
+	if c.resultCount < minResultsForHealth {
+		return true
+	}
+
+	// Count failures in the tracked results
+	failures := 0
+	for i := 0; i < c.resultCount; i++ {
+		if !c.recentResults[i] {
+			failures++
+		}
+	}
+
+	failureRate := float64(failures) / float64(c.resultCount)
+	return failureRate < unhealthyThreshold
 }
 
 // nextMsgID returns the next message ID.
@@ -658,6 +720,7 @@ func (c *Client) CallService(domain, service string, data map[string]interface{}
 
 		_, err := c.sendMessage(req)
 		if err == nil {
+			c.recordServiceResult(true)
 			if attempt > 0 {
 				c.logger.Info("Service call succeeded after retry",
 					zap.String("domain", domain),
@@ -672,10 +735,12 @@ func (c *Client) CallService(domain, service string, data map[string]interface{}
 
 		// Only retry for transient network errors
 		if !isRetryableError(err) {
+			c.recordServiceResult(false)
 			return err
 		}
 	}
 
+	c.recordServiceResult(false)
 	return fmt.Errorf("service call failed after %d attempts: %w", maxRetries+1, lastErr)
 }
 

--- a/homeautomation-go/internal/ha/client_test.go
+++ b/homeautomation-go/internal/ha/client_test.go
@@ -918,3 +918,109 @@ func TestClient_PingPongKeepalive(t *testing.T) {
 	// the mechanism is wired up correctly. Full keepalive testing would
 	// require integration tests with actual timing.
 }
+
+func TestClient_IsHealthy(t *testing.T) {
+	logger := zap.NewNop()
+
+	t.Run("unhealthy when disconnected", func(t *testing.T) {
+		client := NewClient("ws://localhost", "token", logger)
+		// Not connected
+		assert.False(t, client.IsHealthy())
+	})
+
+	t.Run("healthy with no service calls", func(t *testing.T) {
+		client := NewClient("ws://localhost", "token", logger)
+		// Simulate connected state
+		client.connMu.Lock()
+		client.connected = true
+		client.connMu.Unlock()
+
+		// No service calls yet - should be healthy (not enough data)
+		assert.True(t, client.IsHealthy())
+	})
+
+	t.Run("healthy with successful service calls", func(t *testing.T) {
+		client := NewClient("ws://localhost", "token", logger)
+		client.connMu.Lock()
+		client.connected = true
+		client.connMu.Unlock()
+
+		// Record 5 successes
+		for i := 0; i < 5; i++ {
+			client.recordServiceResult(true)
+		}
+
+		assert.True(t, client.IsHealthy())
+	})
+
+	t.Run("unhealthy with majority failures", func(t *testing.T) {
+		client := NewClient("ws://localhost", "token", logger)
+		client.connMu.Lock()
+		client.connected = true
+		client.connMu.Unlock()
+
+		// Record 2 successes and 4 failures (>50% failures)
+		client.recordServiceResult(true)
+		client.recordServiceResult(true)
+		client.recordServiceResult(false)
+		client.recordServiceResult(false)
+		client.recordServiceResult(false)
+		client.recordServiceResult(false)
+
+		assert.False(t, client.IsHealthy())
+	})
+
+	t.Run("unhealthy at exactly 50% failures", func(t *testing.T) {
+		client := NewClient("ws://localhost", "token", logger)
+		client.connMu.Lock()
+		client.connected = true
+		client.connMu.Unlock()
+
+		// Record 3 successes and 3 failures (exactly 50%)
+		for i := 0; i < 3; i++ {
+			client.recordServiceResult(true)
+			client.recordServiceResult(false)
+		}
+
+		// At exactly 50%, should be unhealthy (threshold is >= 50%)
+		assert.False(t, client.IsHealthy())
+	})
+
+	t.Run("healthy just below 50% failures", func(t *testing.T) {
+		client := NewClient("ws://localhost", "token", logger)
+		client.connMu.Lock()
+		client.connected = true
+		client.connMu.Unlock()
+
+		// Record 4 successes and 3 failures (42.8% failures < 50%)
+		client.recordServiceResult(true)
+		client.recordServiceResult(true)
+		client.recordServiceResult(true)
+		client.recordServiceResult(true)
+		client.recordServiceResult(false)
+		client.recordServiceResult(false)
+		client.recordServiceResult(false)
+
+		assert.True(t, client.IsHealthy())
+	})
+
+	t.Run("rolling window behavior", func(t *testing.T) {
+		client := NewClient("ws://localhost", "token", logger)
+		client.connMu.Lock()
+		client.connected = true
+		client.connMu.Unlock()
+
+		// Fill with failures (10 failures = 100% failure rate)
+		for i := 0; i < healthWindowSize; i++ {
+			client.recordServiceResult(false)
+		}
+		assert.False(t, client.IsHealthy())
+
+		// Now add enough successes to push out old failures
+		// After 6 successes, we have 6 success + 4 failures = 40% failure rate
+		for i := 0; i < 6; i++ {
+			client.recordServiceResult(true)
+		}
+		assert.True(t, client.IsHealthy())
+	})
+}

--- a/homeautomation-go/internal/ha/mock.go
+++ b/homeautomation-go/internal/ha/mock.go
@@ -132,6 +132,11 @@ func (m *MockClient) IsConnected() bool {
 	return m.connected
 }
 
+// IsHealthy returns true for mock client (always healthy in tests)
+func (m *MockClient) IsHealthy() bool {
+	return m.IsConnected()
+}
+
 // GetState retrieves a mock state
 func (m *MockClient) GetState(entityID string) (*State, error) {
 	// Track the GetState call

--- a/homeautomation-go/internal/shadowstate/subscription_helper_test.go
+++ b/homeautomation-go/internal/shadowstate/subscription_helper_test.go
@@ -41,6 +41,7 @@ func newMockHAClient() *mockHAClient {
 func (m *mockHAClient) Connect() error                     { return nil }
 func (m *mockHAClient) Disconnect() error                  { return nil }
 func (m *mockHAClient) IsConnected() bool                  { return true }
+func (m *mockHAClient) IsHealthy() bool                    { return true }
 func (m *mockHAClient) GetAllStates() ([]*ha.State, error) { return nil, nil }
 func (m *mockHAClient) CallService(domain, service string, data map[string]interface{}) error {
 	return nil


### PR DESCRIPTION
## Summary

- Adds `IsHealthy()` method to HA client that tracks service call success/failure rates
- Uses a rolling window (last 10 calls) to detect degraded WebSocket connections
- Health endpoint returns 503 when >50% of recent service calls fail, triggering container restart
- Requires minimum 3 results before declaring unhealthy to avoid false positives

## Motivation

The WebSocket connection to Home Assistant can enter a degraded state where `IsConnected()` returns true but writes are failing silently. This causes the container to appear healthy while automation commands aren't actually being executed.

By tracking service call success rates and exposing this via the `/health` endpoint, Docker/Kubernetes health checks will now detect this condition and restart the container to re-establish a clean connection.

## Test plan

- [x] Unit tests for `IsHealthy()` with various failure rate scenarios
- [x] Unit tests for rolling window behavior
- [x] Updated API server tests for healthy/unhealthy responses
- [x] All existing tests pass with `-race` flag

🤖 Generated with [Claude Code](https://claude.ai/claude-code)