### PR TITLE
refactor(tests): Suppress log output to reduce AI tool context usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,9 +183,14 @@ dev-ui: build-go
 	@echo ""
 	cd homeautomation-go && DEV_MODE=true ./homeautomation
 
-#test-go: @ Run Go tests with race detection and coverage
+#test-go: @ Run Go tests with race detection and coverage (quiet mode for AI tools)
 test-go:
-	cd homeautomation-go && go test ./... -race -v -coverprofile=coverage.out
+	cd homeautomation-go && go test ./... -race -coverprofile=coverage.out
+	cd homeautomation-go && go tool cover -func=coverage.out | grep total
+
+#test-go-verbose: @ Run Go tests with verbose output (for debugging)
+test-go-verbose:
+	cd homeautomation-go && TEST_VERBOSE=true go test ./... -race -v -coverprofile=coverage.out
 	cd homeautomation-go && go tool cover -func=coverage.out | grep total
 
 #docker-build-go: @ Build Docker image for the Go application
@@ -376,7 +381,7 @@ ci-unit-tests:
 	@echo "🧪 Running unit tests (excluding integration tests, pkg/testutil, and cmd/diagramgen)..."
 	@cd homeautomation-go && go build ./...
 	@cd homeautomation-go && go test $$(go list ./... | grep -v /test/integration | grep -v /pkg/testutil | grep -v /cmd/diagramgen) \
-	  -race -v -coverprofile=coverage.out -covermode=atomic -timeout=5m
+	  -race -coverprofile=coverage.out -covermode=atomic -timeout=5m
 	@cd homeautomation-go && \
 	  coverage=$$(go tool cover -func=coverage.out | grep total | awk '{print $$3}' | sed 's/%//') && \
 	  echo "Total coverage: $${coverage}%" && \
@@ -390,7 +395,7 @@ ci-unit-tests:
 #ci-integration-tests: @ Run integration tests with race detector (used by CI)
 ci-integration-tests:
 	@echo "🧪 Running integration tests..."
-	@cd homeautomation-go && go test ./test/integration/... -race -v -timeout=10m
+	@cd homeautomation-go && go test ./test/integration/... -race -timeout=10m
 	@echo "✅ Integration tests passed"
 
 #pre-push: @ Run comprehensive pre-push validation (build, tests, race detector, coverage ≥70%)
@@ -425,7 +430,7 @@ pre-push:
 	  rm -f coverage.out
 	@echo ""
 	@echo "🔗 Step 5/5: Running integration tests with race detector..."
-	@cd homeautomation-go && go test ./test/integration/... -race -v -timeout=10m
+	@cd homeautomation-go && go test ./test/integration/... -race -timeout=10m
 	@echo "✅ Integration tests passed"
 	@echo ""
 	@echo "════════════════════════════════════════════════════════════════════════════"

--- a/homeautomation-go/internal/api/server_test.go
+++ b/homeautomation-go/internal/api/server_test.go
@@ -11,13 +11,12 @@ import (
 	"homeautomation/internal/logbuffer"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
-
-	"go.uber.org/zap"
+	"homeautomation/internal/testlogger"
 )
 
 func TestHandleGetState(t *testing.T) {
 	// Create logger
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Create mock HA client
 	mockClient := ha.NewMockClient()
@@ -105,7 +104,7 @@ func TestHandleGetState(t *testing.T) {
 }
 
 func TestHandleGetStateMethodNotAllowed(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
@@ -123,7 +122,7 @@ func TestHandleGetStateMethodNotAllowed(t *testing.T) {
 }
 
 func TestHandleHealth(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
@@ -149,7 +148,7 @@ func TestHandleHealth(t *testing.T) {
 }
 
 func TestHandleSitemap(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
@@ -200,7 +199,7 @@ func TestHandleSitemap(t *testing.T) {
 }
 
 func TestHandleSitemapHTML(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
@@ -253,7 +252,7 @@ func TestHandleSitemapHTML(t *testing.T) {
 }
 
 func TestHandleSitemapMethodNotAllowed(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
@@ -271,7 +270,7 @@ func TestHandleSitemapMethodNotAllowed(t *testing.T) {
 }
 
 func TestHandleSitemapNonRootPath(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
@@ -307,7 +306,7 @@ func TestHandleSitemapNonRootPath(t *testing.T) {
 
 func TestHandleGetStatesByPlugin(t *testing.T) {
 	// Create logger
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Create mock HA client
 	mockClient := ha.NewMockClient()
@@ -457,7 +456,7 @@ func TestHandleGetStatesByPlugin(t *testing.T) {
 }
 
 func TestHandleGetStatesByPluginMethodNotAllowed(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
@@ -476,7 +475,7 @@ func TestHandleGetStatesByPluginMethodNotAllowed(t *testing.T) {
 
 func TestHandleGetStatesByPluginEmptyState(t *testing.T) {
 	// Test with default/empty state values
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
@@ -564,7 +563,7 @@ func TestPluginRegistryCompleteness(t *testing.T) {
 
 func TestHandleGetLightingShadowState(t *testing.T) {
 	// Create logger
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Create mock HA client
 	mockClient := ha.NewMockClient()
@@ -619,7 +618,7 @@ func TestHandleGetLightingShadowState(t *testing.T) {
 
 func TestHandleGetLightingShadowState_NotFound(t *testing.T) {
 	// Create logger
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Create mock HA client
 	mockClient := ha.NewMockClient()
@@ -648,7 +647,7 @@ func TestHandleGetLightingShadowState_NotFound(t *testing.T) {
 
 func TestHandleGetSecurityShadowState(t *testing.T) {
 	// Create logger
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Create mock HA client
 	mockClient := ha.NewMockClient()
@@ -713,7 +712,7 @@ func TestHandleGetSecurityShadowState(t *testing.T) {
 
 func TestHandleGetSecurityShadowState_NotFound(t *testing.T) {
 	// Create logger
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Create mock HA client
 	mockClient := ha.NewMockClient()
@@ -742,7 +741,7 @@ func TestHandleGetSecurityShadowState_NotFound(t *testing.T) {
 
 func TestHandleGetAllShadowStates(t *testing.T) {
 	// Create logger
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Create mock HA client
 	mockClient := ha.NewMockClient()
@@ -818,7 +817,7 @@ func TestAddLocalTimestamps(t *testing.T) {
 	}
 
 	// Create mock dependencies
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
@@ -949,7 +948,7 @@ func TestAddLocalTimestamps(t *testing.T) {
 
 func TestHandleDashboard(t *testing.T) {
 	// Create logger
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Create mock HA client
 	mockClient := ha.NewMockClient()
@@ -1011,7 +1010,7 @@ func TestHandleDashboard(t *testing.T) {
 }
 
 func TestHandleDashboardMethodNotAllowed(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
@@ -1036,7 +1035,7 @@ func TestWriteJSONWithLocalTimestamps(t *testing.T) {
 	}
 
 	// Create mock dependencies
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
@@ -1084,7 +1083,7 @@ func TestWriteJSONWithLocalTimestamps(t *testing.T) {
 
 func TestHandleTimelineEvents(t *testing.T) {
 	// Create logger and dependencies
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()

--- a/homeautomation-go/internal/config/loader_test.go
+++ b/homeautomation-go/internal/config/loader_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"homeautomation/internal/testlogger"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 func setupTestConfigDir(t *testing.T) string {
@@ -103,7 +103,7 @@ groups:
 }
 
 func TestLoader_LoadAll(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	configDir := setupTestConfigDir(t)
 
 	loader := NewLoader(configDir, logger)
@@ -131,7 +131,7 @@ func TestLoader_LoadAll(t *testing.T) {
 }
 
 func TestLoader_LoadMusicConfig(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	configDir := setupTestConfigDir(t)
 
 	loader := NewLoader(configDir, logger)
@@ -145,7 +145,7 @@ func TestLoader_LoadMusicConfig(t *testing.T) {
 }
 
 func TestLoader_LoadHueConfig(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	configDir := setupTestConfigDir(t)
 
 	loader := NewLoader(configDir, logger)
@@ -159,7 +159,7 @@ func TestLoader_LoadHueConfig(t *testing.T) {
 }
 
 func TestLoader_LoadScheduleConfig(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	configDir := setupTestConfigDir(t)
 
 	loader := NewLoader(configDir, logger)
@@ -178,7 +178,7 @@ func TestLoader_LoadScheduleConfig(t *testing.T) {
 }
 
 func TestLoader_GetTodaysSchedule(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	configDir := setupTestConfigDir(t)
 
 	loader := NewLoader(configDir, logger)
@@ -211,7 +211,7 @@ func TestLoader_GetTodaysSchedule(t *testing.T) {
 }
 
 func TestLoader_MissingFile(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	configDir := t.TempDir() // Empty directory
 
 	loader := NewLoader(configDir, logger)
@@ -220,7 +220,7 @@ func TestLoader_MissingFile(t *testing.T) {
 }
 
 func TestLoader_GetTodaysSchedule_NotLoaded(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	configDir := t.TempDir()
 
 	loader := NewLoader(configDir, logger)
@@ -232,7 +232,7 @@ func TestLoader_GetTodaysSchedule_NotLoaded(t *testing.T) {
 }
 
 func TestLoader_GetTodaysSchedule_InvalidTime(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	tmpDir := t.TempDir()
 
 	// Create schedule config with invalid time format (7 entries for all days of the week)
@@ -301,7 +301,7 @@ func TestLoader_GetTodaysSchedule_InvalidTime(t *testing.T) {
 }
 
 func TestLoader_StartAutoReload_Stop(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	configDir := setupTestConfigDir(t)
 
 	loader := NewLoader(configDir, logger)
@@ -323,7 +323,7 @@ func TestLoader_StartAutoReload_Stop(t *testing.T) {
 }
 
 func TestLoader_Stop_MultipleCalls(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	configDir := setupTestConfigDir(t)
 
 	loader := NewLoader(configDir, logger)
@@ -340,7 +340,7 @@ func TestLoader_Stop_MultipleCalls(t *testing.T) {
 }
 
 func TestLoader_GetTodaysSchedule_ParseErrors(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Helper to create 7 identical schedule entries (one for each day of week)
 	makeScheduleWithSevenEntries := func(entry string) string {
@@ -450,7 +450,7 @@ func TestLoader_GetTodaysSchedule_ParseErrors(t *testing.T) {
 }
 
 func TestLoader_GetTodaysScheduleInTimezone(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	configDir := setupTestConfigDir(t)
 
 	loader := NewLoader(configDir, logger)
@@ -480,7 +480,7 @@ func TestLoader_GetTodaysScheduleInTimezone(t *testing.T) {
 }
 
 func TestLoader_SetTimezone(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	configDir := setupTestConfigDir(t)
 
 	loader := NewLoader(configDir, logger)

--- a/homeautomation-go/internal/dayphase/calculator_test.go
+++ b/homeautomation-go/internal/dayphase/calculator_test.go
@@ -5,13 +5,13 @@ import (
 	"time"
 
 	"homeautomation/internal/config"
+	"homeautomation/internal/testlogger"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
 )
 
 func TestCalculator_UpdateSunTimes(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	// Austin, TX coordinates
 	calc := NewCalculator(32.85486, -97.50515, logger)
 
@@ -40,7 +40,7 @@ func TestCalculator_UpdateSunTimes(t *testing.T) {
 }
 
 func TestCalculator_GetSunEvent(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	calc := NewCalculator(32.85486, -97.50515, logger)
 
 	err := calc.UpdateSunTimes()
@@ -63,7 +63,7 @@ func TestCalculator_GetSunEvent(t *testing.T) {
 }
 
 func TestCalculator_CalculateDayPhase(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	calc := NewCalculator(32.85486, -97.50515, logger)
 
 	err := calc.UpdateSunTimes()
@@ -104,7 +104,7 @@ func TestCalculator_CalculateDayPhase(t *testing.T) {
 }
 
 func TestCalculator_CalculateDayPhaseWithoutSchedule(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	calc := NewCalculator(32.85486, -97.50515, logger)
 
 	err := calc.UpdateSunTimes()
@@ -133,7 +133,7 @@ func setSunTimesForTest(calc *Calculator, now time.Time, dawn, sunrise, sunriseE
 }
 
 func TestCalculator_GetSunEventAllPeriods(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	calc := NewCalculator(32.85486, -97.50515, logger)
 
 	now := time.Now()
@@ -267,7 +267,7 @@ func TestCalculator_GetSunEventAllPeriods(t *testing.T) {
 }
 
 func TestCalculator_CalculateDayPhaseAllCases(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	now := time.Now()
 
@@ -634,7 +634,7 @@ func TestCalculator_CalculateDayPhaseAllCases(t *testing.T) {
 
 // TestCalculator_CalculateDayPhaseEdgeCases tests edge cases in day phase calculation
 func TestCalculator_CalculateDayPhaseEdgeCases(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	calc := NewCalculator(32.85486, -97.50515, logger)
 
 	now := time.Now()
@@ -659,7 +659,7 @@ func TestCalculator_CalculateDayPhaseEdgeCases(t *testing.T) {
 }
 
 func TestCalculator_AutoUpdateSunTimes(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	calc := NewCalculator(32.85486, -97.50515, logger)
 
 	// Test that GetSunEvent auto-updates if lastUpdate is zero
@@ -675,7 +675,7 @@ func TestCalculator_AutoUpdateSunTimes(t *testing.T) {
 }
 
 func TestCalculator_StartPeriodicUpdate(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	calc := NewCalculator(32.85486, -97.50515, logger)
 
 	// Start periodic updates
@@ -744,7 +744,7 @@ func TestDayPhaseConstants(t *testing.T) {
 }
 
 func TestCalculator_GetSunTimes(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	calc := NewCalculator(32.85486, -97.50515, logger)
 
 	// Before update, should return empty map

--- a/homeautomation-go/internal/devserver/devserver_test.go
+++ b/homeautomation-go/internal/devserver/devserver_test.go
@@ -2,17 +2,17 @@ package devserver
 
 import (
 	"fmt"
+	"homeautomation/internal/testlogger"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 func TestNewDevServer(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	t.Run("default port", func(t *testing.T) {
 		ds := NewDevServer(logger, 0)
@@ -28,7 +28,7 @@ func TestNewDevServer(t *testing.T) {
 }
 
 func TestDevServer_StartStop(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Use a unique port for testing
 	ds := NewDevServer(logger, 19876)
@@ -53,7 +53,7 @@ func TestDevServer_StartStop(t *testing.T) {
 }
 
 func TestDevServer_GetURLs(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	ds := NewDevServer(logger, 12345)
 
 	assert.Equal(t, "ws://localhost:12345/api/websocket", ds.GetWebSocketURL())
@@ -61,7 +61,7 @@ func TestDevServer_GetURLs(t *testing.T) {
 }
 
 func TestDevServer_SampleData(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Use a unique port for testing
 	ds := NewDevServer(logger, 19877)

--- a/homeautomation-go/internal/ha/client_test.go
+++ b/homeautomation-go/internal/ha/client_test.go
@@ -3,6 +3,7 @@ package ha
 import (
 	"encoding/json"
 	"fmt"
+	"homeautomation/internal/testlogger"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -54,7 +55,7 @@ func standardAuthFlow(t *testing.T, conn *websocket.Conn, token string) {
 }
 
 func TestClient_Connect(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	token := "test_token"
 
 	t.Run("successful connection", func(t *testing.T) {
@@ -144,7 +145,7 @@ func TestClient_Connect(t *testing.T) {
 }
 
 func TestClient_GetAllStates(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	token := "test_token"
 
 	server := mockHAServer(t, func(conn *websocket.Conn) {
@@ -208,7 +209,7 @@ func TestClient_GetAllStates(t *testing.T) {
 }
 
 func TestClient_GetState(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	token := "test_token"
 
 	server := mockHAServer(t, func(conn *websocket.Conn) {
@@ -264,7 +265,7 @@ func TestClient_GetState(t *testing.T) {
 }
 
 func TestClient_CallService(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	token := "test_token"
 
 	server := mockHAServer(t, func(conn *websocket.Conn) {
@@ -312,7 +313,7 @@ func TestClient_CallService(t *testing.T) {
 }
 
 func TestClient_SetInputBoolean(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	token := "test_token"
 
 	testCases := []struct {
@@ -370,7 +371,7 @@ func TestClient_SetInputBoolean(t *testing.T) {
 }
 
 func TestClient_SetInputNumber(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	token := "test_token"
 
 	server := mockHAServer(t, func(conn *websocket.Conn) {
@@ -416,7 +417,7 @@ func TestClient_SetInputNumber(t *testing.T) {
 }
 
 func TestClient_SetInputText(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	token := "test_token"
 
 	server := mockHAServer(t, func(conn *websocket.Conn) {
@@ -738,7 +739,7 @@ func TestIsRetryableError(t *testing.T) {
 
 // TestClient_CallServiceRetry verifies that CallService retries on transient errors
 func TestClient_CallServiceRetry(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	token := "test_token"
 
 	t.Run("succeeds after transient failure", func(t *testing.T) {
@@ -857,7 +858,7 @@ func TestClient_CallServiceRetry(t *testing.T) {
 // TestClient_PingPongKeepalive verifies that the client sends ping frames
 // and properly handles pong responses to keep the connection alive.
 func TestClient_PingPongKeepalive(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	token := "test_token"
 
 	// Track ping messages received by the server

--- a/homeautomation-go/internal/plugins/dayphase/manager_test.go
+++ b/homeautomation-go/internal/plugins/dayphase/manager_test.go
@@ -8,13 +8,13 @@ import (
 	dayphaselib "homeautomation/internal/dayphase"
 	"homeautomation/internal/ha"
 	"homeautomation/internal/state"
+	"homeautomation/internal/testlogger"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
 )
 
 func TestNewManager(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	configLoader := config.NewLoader("../../../configs", logger)
@@ -31,7 +31,7 @@ func TestNewManager(t *testing.T) {
 }
 
 func TestManagerStartStop(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	configLoader := config.NewLoader("../../../configs", logger)
@@ -51,7 +51,7 @@ func TestManagerStartStop(t *testing.T) {
 }
 
 func TestUpdateSunEventAndDayPhase(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -90,7 +90,7 @@ func TestUpdateSunEventAndDayPhase(t *testing.T) {
 }
 
 func TestUpdateSunEventAndDayPhaseReadOnly(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, true) // READ ONLY
 
@@ -113,7 +113,7 @@ func TestUpdateSunEventAndDayPhaseReadOnly(t *testing.T) {
 }
 
 func TestManagerPeriodicUpdate(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	configLoader := config.NewLoader("../../../configs", logger)
@@ -142,7 +142,7 @@ func TestManagerPeriodicUpdate(t *testing.T) {
 }
 
 func TestManagerWithDifferentCoordinates(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	configLoader := config.NewLoader("../../../configs", logger)
@@ -167,7 +167,7 @@ func TestManagerWithDifferentCoordinates(t *testing.T) {
 }
 
 func TestUpdateSunEventNoChange(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	configLoader := config.NewLoader("../../../configs", logger)
@@ -194,7 +194,7 @@ func TestUpdateSunEventNoChange(t *testing.T) {
 }
 
 func TestUpdateDayPhaseNoChange(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	configLoader := config.NewLoader("../../../configs", logger)
@@ -221,7 +221,7 @@ func TestUpdateDayPhaseNoChange(t *testing.T) {
 }
 
 func TestManagerStopBeforeStart(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	configLoader := config.NewLoader("../../../configs", logger)
@@ -236,7 +236,7 @@ func TestManagerStopBeforeStart(t *testing.T) {
 }
 
 func TestManagerReset(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	configLoader := config.NewLoader("../../../configs", logger)
@@ -266,7 +266,7 @@ func TestManagerReset(t *testing.T) {
 func TestManager_ShadowState_NextTransitionUpdated(t *testing.T) {
 	// Test that shadow state outputs.NextTransitionTime and NextTransitionPhase are populated
 	// This test catches the bug where UpdateNextTransition() was never called
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	configLoader := config.NewLoader("../../../configs", logger)
@@ -310,7 +310,7 @@ func TestManager_ShadowState_NextTransitionUpdated(t *testing.T) {
 
 func TestManager_ShadowState_SunEventAndDayPhaseUpdated(t *testing.T) {
 	// Test that shadow state outputs for sun event and day phase are populated
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	configLoader := config.NewLoader("../../../configs", logger)

--- a/homeautomation-go/internal/plugins/energy/manager_test.go
+++ b/homeautomation-go/internal/plugins/energy/manager_test.go
@@ -8,6 +8,7 @@ import (
 
 	"homeautomation/internal/ha"
 	"homeautomation/internal/state"
+	"homeautomation/internal/testlogger"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
@@ -65,7 +66,7 @@ func createTestConfig() *EnergyConfig {
 }
 
 func TestDetermineBatteryEnergyLevel(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
@@ -98,7 +99,7 @@ func TestDetermineBatteryEnergyLevel(t *testing.T) {
 }
 
 func TestDetermineSolarEnergyLevel(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
@@ -129,7 +130,7 @@ func TestDetermineSolarEnergyLevel(t *testing.T) {
 }
 
 func TestDetermineOverallEnergyLevel(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
@@ -173,7 +174,7 @@ func TestDetermineOverallEnergyLevel(t *testing.T) {
 }
 
 func TestIsFreeEnergyTime(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
@@ -227,7 +228,7 @@ func TestLoadConfigFromRepoFile(t *testing.T) {
 }
 
 func TestFreeEnergyTimeSpansMidnight(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
@@ -266,7 +267,7 @@ func TestFreeEnergyTimeSpansMidnight(t *testing.T) {
 
 // TestManagerStartAndHandlers tests the manager lifecycle and handlers
 func TestManagerStartAndHandlers(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 
@@ -362,7 +363,7 @@ func TestManagerStartAndHandlers(t *testing.T) {
 
 // TestDetermineOverallEnergyLevel_EdgeCases tests edge cases
 func TestDetermineOverallEnergyLevel_EdgeCases(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
@@ -388,7 +389,7 @@ func TestLoadConfigError(t *testing.T) {
 
 // TestIsFreeEnergyTime_EdgeCases tests edge cases for free energy time
 func TestIsFreeEnergyTime_EdgeCases(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -552,7 +553,7 @@ func TestTimezoneHandling(t *testing.T) {
 }
 
 func TestManagerReset(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := createTestConfig()
@@ -710,7 +711,7 @@ func TestHandleGridAvailabilityChange(t *testing.T) {
 }
 
 func TestIndicatorLightsDiscovery(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := createTestConfig()
@@ -745,7 +746,7 @@ func TestIndicatorLightsDiscovery(t *testing.T) {
 }
 
 func TestIndicatorLightsServiceCall(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -815,7 +816,7 @@ func TestIndicatorLightsServiceCall(t *testing.T) {
 }
 
 func TestIndicatorLightsReadOnlyMode(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := createTestConfig()
@@ -860,7 +861,7 @@ func TestIndicatorLightsReadOnlyMode(t *testing.T) {
 }
 
 func TestIndicatorLightsNoEntitiesDiscovered(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := createTestConfig()
@@ -899,7 +900,7 @@ func TestIndicatorLightsNoEntitiesDiscovered(t *testing.T) {
 }
 
 func TestIndicatorLightsDiscoveryCaseInsensitive(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := createTestConfig()
@@ -934,7 +935,7 @@ func TestIndicatorLightsDiscoveryCaseInsensitive(t *testing.T) {
 }
 
 func TestIndicatorLightsDiscoveryInvalidPattern(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := createTestConfig()
@@ -960,7 +961,7 @@ func TestIndicatorLightsDiscoveryInvalidPattern(t *testing.T) {
 }
 
 func TestIndicatorLightsDiscoveryCustomPattern(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := createTestConfig()
@@ -992,7 +993,7 @@ func TestIndicatorLightsDiscoveryCustomPattern(t *testing.T) {
 }
 
 func TestIndicatorLightsServiceCallError(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := createTestConfig()
@@ -1041,7 +1042,7 @@ func TestIndicatorLightsServiceCallError(t *testing.T) {
 }
 
 func TestIndicatorLightsUnknownEnergyLevel(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := createTestConfig()
@@ -1080,7 +1081,7 @@ func TestIndicatorLightsUnknownEnergyLevel(t *testing.T) {
 }
 
 func TestIndicatorLightsInitialUpdateOnStartup(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := createTestConfig()
@@ -1189,7 +1190,7 @@ func TestExtractDeviceID(t *testing.T) {
 }
 
 func TestCalculateAdaptiveBrightness(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -1241,7 +1242,7 @@ func TestCalculateAdaptiveBrightness(t *testing.T) {
 }
 
 func TestCalculateAdaptiveBrightnessDefaultCurve(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -1281,7 +1282,7 @@ func TestCalculateAdaptiveBrightnessDefaultCurve(t *testing.T) {
 }
 
 func TestLuxSensorDiscovery(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -1323,7 +1324,7 @@ func TestLuxSensorDiscovery(t *testing.T) {
 }
 
 func TestLuxSensorDiscoveryNoMatch(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -1360,7 +1361,7 @@ func TestLuxSensorDiscoveryNoMatch(t *testing.T) {
 }
 
 func TestAdaptiveBrightnessDisabled(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -1413,7 +1414,7 @@ func TestAdaptiveBrightnessDisabled(t *testing.T) {
 }
 
 func TestAdaptiveBrightnessPerDevice(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -1480,7 +1481,7 @@ func TestAdaptiveBrightnessPerDevice(t *testing.T) {
 }
 
 func TestHysteresisPreventsOscillation(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -1525,7 +1526,7 @@ func TestHysteresisPreventsOscillation(t *testing.T) {
 }
 
 func TestDebouncing(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -1596,7 +1597,7 @@ func TestDebouncing(t *testing.T) {
 }
 
 func TestFallbackToStaticBrightness(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -1646,7 +1647,7 @@ func TestFallbackToStaticBrightness(t *testing.T) {
 }
 
 func TestHandleLuxChangeWithInvalidValues(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -1708,7 +1709,7 @@ func TestHandleLuxChangeWithInvalidValues(t *testing.T) {
 }
 
 func TestHysteresisDoesNotBlockLargeJumps(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -1752,7 +1753,7 @@ func TestHysteresisDoesNotBlockLargeJumps(t *testing.T) {
 }
 
 func TestNegativeLuxValue(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -1779,7 +1780,7 @@ func TestNegativeLuxValue(t *testing.T) {
 // ============================================================================
 
 func TestBaselineCalibrationEnabled(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -1806,7 +1807,7 @@ func TestBaselineCalibrationEnabled(t *testing.T) {
 }
 
 func TestBaselineCalibrationDisabled(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -1827,7 +1828,7 @@ func TestBaselineCalibrationDisabled(t *testing.T) {
 }
 
 func TestGetBaselineLux(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -1861,7 +1862,7 @@ func TestGetBaselineLux(t *testing.T) {
 }
 
 func TestCalibrationStateTracking(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -1897,7 +1898,7 @@ func TestCalibrationStateTracking(t *testing.T) {
 }
 
 func TestUpdateIndicatorLightsSkipsCalibrating(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -1956,7 +1957,7 @@ func TestUpdateIndicatorLightsSkipsCalibrating(t *testing.T) {
 }
 
 func TestUpdateIndicatorLightsUsesBaseline(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -2024,7 +2025,7 @@ func TestUpdateIndicatorLightsUsesBaseline(t *testing.T) {
 }
 
 func TestRestoreLightAfterCalibration(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -2097,7 +2098,7 @@ func TestRestoreLightAfterCalibration(t *testing.T) {
 func TestCalibrationShutdownDuringStartupDelay(t *testing.T) {
 	// This test verifies that the calibration goroutine can be stopped during
 	// the initial 10-second startup delay without blocking or racing.
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -2147,7 +2148,7 @@ func TestCalibrationShutdownDuringStartupDelay(t *testing.T) {
 func TestCalibrationWithNoLuxReadingYet(t *testing.T) {
 	// This test verifies behavior when calibration runs but no lux reading has
 	// been received yet (e.g., sensor hasn't updated since dimming).
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -2207,7 +2208,7 @@ func TestCalibrationWithNoLuxReadingYet(t *testing.T) {
 }
 
 func TestSetLightBrightness(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -2248,7 +2249,7 @@ func TestSetLightBrightness(t *testing.T) {
 }
 
 func TestSetLightBrightnessReadOnly(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -2274,7 +2275,7 @@ func TestSetLightBrightnessReadOnly(t *testing.T) {
 }
 
 func TestRunCalibrationCycleWithNoLights(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -2308,7 +2309,7 @@ func TestRunCalibrationCycleWithNoLights(t *testing.T) {
 }
 
 func TestRunCalibrationCycleLightWithoutLuxSensor(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 

--- a/homeautomation-go/internal/plugins/lighting/manager_test.go
+++ b/homeautomation-go/internal/plugins/lighting/manager_test.go
@@ -5,6 +5,7 @@ import (
 
 	"homeautomation/internal/ha"
 	"homeautomation/internal/state"
+	"homeautomation/internal/testlogger"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
@@ -52,7 +53,7 @@ func createTestConfig() *HueConfig {
 }
 
 func TestNewManager(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
@@ -67,7 +68,7 @@ func TestNewManager(t *testing.T) {
 }
 
 func TestEvaluateConditions(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
@@ -168,7 +169,7 @@ func TestEvaluateConditions(t *testing.T) {
 }
 
 func TestEvaluateConditionsNoMatch(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 
@@ -192,7 +193,7 @@ func TestEvaluateConditionsNoMatch(t *testing.T) {
 }
 
 func TestActivateSceneReadOnly(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
@@ -210,7 +211,7 @@ func TestActivateSceneReadOnly(t *testing.T) {
 }
 
 func TestActivateScene(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
@@ -239,7 +240,7 @@ func TestActivateScene(t *testing.T) {
 // Home Assistant would activate an unexpected scene (e.g., "energize" instead of "dusk").
 // This test verifies that only entity_id is passed, ensuring the correct scene activates.
 func TestActivateSceneDusk(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
@@ -267,7 +268,7 @@ func TestActivateSceneDusk(t *testing.T) {
 }
 
 func TestTurnOffRoomReadOnly(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
@@ -284,7 +285,7 @@ func TestTurnOffRoomReadOnly(t *testing.T) {
 }
 
 func TestTurnOffRoom(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
@@ -308,7 +309,7 @@ func TestTurnOffRoom(t *testing.T) {
 }
 
 func TestEvaluateAndActivateRoom(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
@@ -393,7 +394,7 @@ func TestEvaluateAndActivateRoom(t *testing.T) {
 }
 
 func TestStart(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
@@ -466,7 +467,7 @@ func TestLightingManager_Stop(t *testing.T) {
 }
 
 func TestManagerReset(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	hueConfig := createTestConfig()
@@ -486,7 +487,7 @@ func TestManagerReset(t *testing.T) {
 }
 
 func TestIsTopicRelevant(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
@@ -557,7 +558,7 @@ func TestIsTopicRelevant(t *testing.T) {
 }
 
 func TestGetStateValue(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
@@ -588,7 +589,7 @@ func TestGetStateValue(t *testing.T) {
 }
 
 func TestCollectConditionVariables(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	config := createTestConfig()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)

--- a/homeautomation-go/internal/plugins/loadshedding/manager_test.go
+++ b/homeautomation-go/internal/plugins/loadshedding/manager_test.go
@@ -6,13 +6,13 @@ import (
 
 	"homeautomation/internal/ha"
 	"homeautomation/internal/state"
+	"homeautomation/internal/testlogger"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
 )
 
 func TestLoadShedding_EnergyStateRed(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 
 	// Initialize thermostat hold switches in mock (start with them off)
@@ -71,7 +71,7 @@ func TestLoadShedding_EnergyStateRed(t *testing.T) {
 }
 
 func TestLoadShedding_EnergyStateBlack(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 
 	// Initialize thermostat hold switches in mock (start with them off)
@@ -108,7 +108,7 @@ func TestLoadShedding_EnergyStateBlack(t *testing.T) {
 }
 
 func TestLoadShedding_EnergyStateGreen(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 
 	// Initialize thermostat hold switches in mock (start with them on - load shedding active)
@@ -153,7 +153,7 @@ func TestLoadShedding_EnergyStateGreen(t *testing.T) {
 }
 
 func TestLoadShedding_EnergyStateWhite(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 
 	// Initialize thermostat hold switches in mock (start with them on - load shedding active)
@@ -193,7 +193,7 @@ func TestLoadShedding_EnergyStateWhite(t *testing.T) {
 }
 
 func TestLoadShedding_RateLimiting(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 
 	// Initialize thermostat hold switches in mock (start with them off)
@@ -236,7 +236,7 @@ func TestLoadShedding_RateLimiting(t *testing.T) {
 }
 
 func TestLoadShedding_StartStop(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 
 	// Initialize thermostat hold switches in mock (start with them off)
@@ -269,7 +269,7 @@ func TestLoadShedding_StartStop(t *testing.T) {
 }
 
 func TestLoadShedding_UnknownState(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 
 	// Initialize thermostat hold switches in mock (start with them off)
@@ -300,7 +300,7 @@ func TestLoadShedding_UnknownState(t *testing.T) {
 }
 
 func TestLoadShedding_RedToGreenTransition(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 
 	// Initialize thermostat hold switches in mock (start with them off)
@@ -354,7 +354,7 @@ func TestLoadShedding_RedToGreenTransition(t *testing.T) {
 }
 
 func TestManagerReset(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 

--- a/homeautomation-go/internal/plugins/reset/coordinator_test.go
+++ b/homeautomation-go/internal/plugins/reset/coordinator_test.go
@@ -7,8 +7,7 @@ import (
 
 	"homeautomation/internal/ha"
 	"homeautomation/internal/state"
-
-	"go.uber.org/zap"
+	"homeautomation/internal/testlogger"
 )
 
 // mockResettable is a mock plugin that tracks Reset() calls
@@ -24,7 +23,7 @@ func (m *mockResettable) Reset() error {
 
 // createTestManager creates a state manager for testing
 func createTestManager(t *testing.T) *state.Manager {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	mockClient.SetState("input_boolean.reset", "off", map[string]interface{}{})
 	mockClient.Connect()
@@ -38,7 +37,7 @@ func createTestManager(t *testing.T) *state.Manager {
 
 // TestCoordinator_Start tests coordinator startup
 func TestCoordinator_Start(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	stateManager := createTestManager(t)
 
 	plugins := []PluginWithName{
@@ -56,7 +55,7 @@ func TestCoordinator_Start(t *testing.T) {
 
 // TestCoordinator_ResetTrigger tests that reset triggers plugin Reset() calls
 func TestCoordinator_ResetTrigger(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	stateManager := createTestManager(t)
 
 	// Create mock plugins
@@ -103,7 +102,7 @@ func TestCoordinator_ResetTrigger(t *testing.T) {
 
 // TestCoordinator_ResetError tests that coordinator continues on plugin errors
 func TestCoordinator_ResetError(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	stateManager := createTestManager(t)
 
 	// Create plugins - one that fails, one that succeeds
@@ -150,7 +149,7 @@ func TestCoordinator_ResetError(t *testing.T) {
 
 // TestCoordinator_ReadOnlyMode tests coordinator in read-only mode
 func TestCoordinator_ReadOnlyMode(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	mockClient.SetState("input_boolean.reset", "off", map[string]interface{}{})
 	mockClient.Connect()
@@ -186,7 +185,7 @@ func TestCoordinator_ReadOnlyMode(t *testing.T) {
 
 // TestCoordinator_NoPlugins tests coordinator with no plugins
 func TestCoordinator_NoPlugins(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	stateManager := createTestManager(t)
 
 	// Create coordinator with no plugins
@@ -217,7 +216,7 @@ func TestCoordinator_NoPlugins(t *testing.T) {
 
 // TestCoordinator_ResetFalse tests that setting reset to false doesn't trigger
 func TestCoordinator_ResetFalse(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	stateManager := createTestManager(t)
 
 	plugin := &mockResettable{}
@@ -248,7 +247,7 @@ func TestCoordinator_ResetFalse(t *testing.T) {
 
 // TestCoordinator_Stop tests coordinator shutdown
 func TestCoordinator_Stop(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	stateManager := createTestManager(t)
 
 	plugins := []PluginWithName{

--- a/homeautomation-go/internal/state/computed_test.go
+++ b/homeautomation-go/internal/state/computed_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 
 	"homeautomation/internal/ha"
+	"homeautomation/internal/testlogger"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 func TestSetupComputedState(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	mockClient.SetState("input_boolean.anyone_home", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
@@ -62,7 +62,7 @@ func TestComputedState_IsAnyoneHomeAndAwake_InitialComputation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			logger, _ := zap.NewDevelopment()
+			logger := testlogger.New()
 			mockClient := ha.NewMockClient()
 			mockClient.SetState("input_boolean.anyone_home", tc.isAnyoneHome, map[string]interface{}{})
 			mockClient.SetState("input_boolean.anyone_asleep", tc.isAnyoneAsleep, map[string]interface{}{})
@@ -84,7 +84,7 @@ func TestComputedState_IsAnyoneHomeAndAwake_InitialComputation(t *testing.T) {
 }
 
 func TestComputedState_IsAnyoneHomeAndAwake_ReactsToIsAnyoneHomeChange(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	// Start with nobody home and nobody asleep
 	mockClient.SetState("input_boolean.anyone_home", "off", map[string]interface{}{})
@@ -119,7 +119,7 @@ func TestComputedState_IsAnyoneHomeAndAwake_ReactsToIsAnyoneHomeChange(t *testin
 }
 
 func TestComputedState_IsAnyoneHomeAndAwake_ReactsToIsAnyoneAsleepChange(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	// Start with someone home and awake
 	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
@@ -154,7 +154,7 @@ func TestComputedState_IsAnyoneHomeAndAwake_ReactsToIsAnyoneAsleepChange(t *test
 }
 
 func TestComputedState_IsAnyoneHomeAndAwake_SyncsToHA(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
@@ -191,7 +191,7 @@ func TestComputedState_IsAnyoneHomeAndAwake_SyncsToHA(t *testing.T) {
 }
 
 func TestComputedState_IsAnyoneHomeAndAwake_WorksInReadOnlyMode(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
@@ -226,7 +226,7 @@ func TestComputedState_IsAnyoneHomeAndAwake_ComputedOutputFlag(t *testing.T) {
 }
 
 func TestComputedState_IsAnyoneHomeAndAwake_SubscriberNotification(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	mockClient.SetState("input_boolean.anyone_home", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})

--- a/homeautomation-go/internal/state/helpers_test.go
+++ b/homeautomation-go/internal/state/helpers_test.go
@@ -5,13 +5,13 @@ import (
 	"time"
 
 	"homeautomation/internal/ha"
+	"homeautomation/internal/testlogger"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
 )
 
 func TestDerivedStateHelper_IsAnyoneHome(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	manager := NewManager(mockClient, logger, false)
 
@@ -61,7 +61,7 @@ func TestDerivedStateHelper_IsAnyoneHome(t *testing.T) {
 }
 
 func TestDerivedStateHelper_IsEveryoneAsleep(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	manager := NewManager(mockClient, logger, false)
 
@@ -111,7 +111,7 @@ func TestDerivedStateHelper_IsEveryoneAsleep(t *testing.T) {
 }
 
 func TestDerivedStateHelper_AutoGuestSleep(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	manager := NewManager(mockClient, logger, false)
 
@@ -143,7 +143,7 @@ func TestDerivedStateHelper_AutoGuestSleep(t *testing.T) {
 }
 
 func TestDerivedStateHelper_AutoGuestSleepNoOneHome(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	manager := NewManager(mockClient, logger, false)
 
@@ -173,7 +173,7 @@ func TestDerivedStateHelper_AutoGuestSleepNoOneHome(t *testing.T) {
 }
 
 func TestDerivedStateHelper_AutoGuestSleepNoGuests(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	manager := NewManager(mockClient, logger, false)
 
@@ -205,7 +205,7 @@ func TestDerivedStateHelper_AutoGuestSleepNoGuests(t *testing.T) {
 func TestDerivedStateHelper_CallbackFiresOnStartup(t *testing.T) {
 	// This test verifies that the callback fires on startup even when
 	// derived values already match current state (issue #155)
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	manager := NewManager(mockClient, logger, false)
 

--- a/homeautomation-go/internal/state/manager_test.go
+++ b/homeautomation-go/internal/state/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"homeautomation/internal/ha"
+	"homeautomation/internal/testlogger"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,7 +15,7 @@ import (
 )
 
 func TestNewManager(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 
 	manager := NewManager(mockClient, logger, false)
@@ -23,7 +24,7 @@ func TestNewManager(t *testing.T) {
 }
 
 func TestManager_SyncFromHA(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 
 	// Setup mock states
@@ -59,7 +60,7 @@ func TestManager_SyncFromHA(t *testing.T) {
 }
 
 func TestManager_GetBool(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	mockClient.SetState("input_boolean.nick_home", "on", map[string]interface{}{})
 	mockClient.Connect()
@@ -94,7 +95,7 @@ func TestManager_GetBool(t *testing.T) {
 }
 
 func TestManager_SetBool(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	mockClient.SetState("input_boolean.expecting_someone", "off", map[string]interface{}{})
 	mockClient.Connect()
@@ -144,7 +145,7 @@ func TestManager_SetBool(t *testing.T) {
 }
 
 func TestManager_GetSetString(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	mockClient.SetState("input_text.day_phase", "morning", map[string]interface{}{})
 	mockClient.Connect()
@@ -175,7 +176,7 @@ func TestManager_GetSetString(t *testing.T) {
 }
 
 func TestManager_GetSetNumber(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	mockClient.SetState("input_number.alarm_time", "1668524400000", map[string]interface{}{})
 	mockClient.Connect()
@@ -206,7 +207,7 @@ func TestManager_GetSetNumber(t *testing.T) {
 }
 
 func TestManager_ChangeDetection(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	mockClient.SetState("input_boolean.nick_home", "off", map[string]interface{}{})
 	mockClient.SetState("input_text.day_phase", "morning", map[string]interface{}{})
@@ -297,7 +298,7 @@ func TestManager_ChangeDetection(t *testing.T) {
 }
 
 func TestManager_CompareAndSwapBool(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	mockClient.SetState("input_boolean.fade_out_in_progress", "off", map[string]interface{}{})
 	mockClient.Connect()
@@ -332,7 +333,7 @@ func TestManager_CompareAndSwapBool(t *testing.T) {
 }
 
 func TestManager_Subscribe(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	mockClient.SetState("input_boolean.nick_home", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.caroline_home", "off", map[string]interface{}{})
@@ -452,7 +453,7 @@ func TestManagerNotifySubscribersRecoversFromPanics(t *testing.T) {
 }
 
 func TestManager_GetAllValues(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	mockClient.SetState("input_boolean.nick_home", "on", map[string]interface{}{})
 	mockClient.SetState("input_text.day_phase", "morning", map[string]interface{}{})
@@ -487,7 +488,7 @@ func TestExtractEntityName(t *testing.T) {
 }
 
 func TestManager_GetJSON(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 
 	manager := NewManager(mockClient, logger, false)
@@ -526,7 +527,7 @@ func TestManager_GetJSON(t *testing.T) {
 }
 
 func TestManager_SetJSON(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	mockClient.Connect()
 
@@ -558,7 +559,7 @@ func TestManager_SetJSON(t *testing.T) {
 }
 
 func TestManager_ConcurrentAccess(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	mockClient.SetState("input_boolean.nick_home", "off", map[string]interface{}{})
 	mockClient.Connect()
@@ -602,7 +603,7 @@ func TestVariablesByEntityID(t *testing.T) {
 }
 
 func TestManager_ReadOnlyMode(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	mockClient.SetState("input_boolean.expecting_someone", "off", map[string]interface{}{})
 	mockClient.SetState("input_text.battery_energy_level", "green", map[string]interface{}{})

--- a/homeautomation-go/internal/testlogger/logger.go
+++ b/homeautomation-go/internal/testlogger/logger.go
@@ -1,0 +1,28 @@
+// Package testlogger provides a test logger that suppresses output by default.
+// This reduces noise during test runs while allowing verbose output when needed.
+package testlogger
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+)
+
+// New returns a logger appropriate for tests.
+// By default, it returns a no-op logger (zap.NewNop()) to reduce test output noise.
+// Set TEST_VERBOSE=true environment variable to get full development logging.
+//
+// Example usage:
+//
+//	logger := testlogger.New()
+//
+// To run tests with verbose logging:
+//
+//	TEST_VERBOSE=true go test ./...
+func New() *zap.Logger {
+	if os.Getenv("TEST_VERBOSE") == "true" {
+		logger, _ := zap.NewDevelopment()
+		return logger
+	}
+	return zap.NewNop()
+}

--- a/homeautomation-go/pkg/testutil/harness.go
+++ b/homeautomation-go/pkg/testutil/harness.go
@@ -8,6 +8,7 @@ import (
 	"homeautomation/internal/ha"
 	"homeautomation/internal/plugins/statetracking"
 	"homeautomation/internal/state"
+	"homeautomation/internal/testlogger"
 	pkgha "homeautomation/pkg/ha"
 	pkgstate "homeautomation/pkg/state"
 
@@ -43,7 +44,7 @@ type TestEnv struct {
 //
 //	// Use env.HAClient and env.StateManager in your plugin tests
 func NewTestEnv(addr, token string) (*TestEnv, error) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Start mock HA server
 	server := NewMockHAServer(addr, token)

--- a/homeautomation-go/pkg/testutil/logger.go
+++ b/homeautomation-go/pkg/testutil/logger.go
@@ -1,0 +1,19 @@
+// Package testutil provides testing utilities for home automation plugins.
+package testutil
+
+import (
+	"homeautomation/internal/testlogger"
+
+	"go.uber.org/zap"
+)
+
+// TestLogger returns a logger appropriate for tests.
+// By default, it returns a no-op logger to reduce test output noise.
+// Set TEST_VERBOSE=true environment variable to get full development logging.
+//
+// Deprecated: Use testlogger.New() directly for internal packages to avoid
+// circular imports. This function is kept for backward compatibility with
+// external packages that use pkg/testutil.
+func TestLogger() *zap.Logger {
+	return testlogger.New()
+}

--- a/homeautomation-go/test/integration/integration_test.go
+++ b/homeautomation-go/test/integration/integration_test.go
@@ -8,10 +8,10 @@ import (
 
 	"homeautomation/internal/ha"
 	"homeautomation/internal/state"
+	"homeautomation/internal/testlogger"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 const (
@@ -21,7 +21,7 @@ const (
 
 func setupTest(t *testing.T) (*MockHAServer, *ha.Client, *state.Manager, func()) {
 	// Create logger
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Start mock HA server
 	server := NewMockHAServer(testAddr, testToken)
@@ -415,7 +415,7 @@ func TestCompareAndSwapRaceCondition(t *testing.T) {
 
 // TestReconnection tests client reconnection behavior
 func TestReconnection(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Start server
 	server := NewMockHAServer(testAddr, testToken)
@@ -464,7 +464,7 @@ func TestReconnection(t *testing.T) {
 // TestReconnectionMessageIDReset tests that message IDs are reset after reconnection
 // This prevents the "id_reuse - Identifier values have to increase" error from HA
 func TestReconnectionMessageIDReset(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Start server
 	server := NewMockHAServer(testAddr, testToken)

--- a/homeautomation-go/test/integration/scenario_48hr_simulation_test.go
+++ b/homeautomation-go/test/integration/scenario_48hr_simulation_test.go
@@ -9,10 +9,10 @@ import (
 	"homeautomation/internal/config"
 	"homeautomation/internal/dayphase"
 	dayphaseplugin "homeautomation/internal/plugins/dayphase"
+	"homeautomation/internal/testlogger"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 // ============================================================================
@@ -49,7 +49,7 @@ func setupDayPhaseSimulation(t *testing.T, timezone *time.Location, startTime ti
 	server, client, stateManager, baseCleanup := setupTest(t)
 
 	// Create logger
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Create mock clock starting at the specified time
 	mockClock := clock.NewMockClock(startTime)
@@ -486,7 +486,7 @@ func BenchmarkSimulation_1Day(b *testing.B) {
 	startTime := time.Date(2025, 1, 15, 0, 0, 0, 0, et)
 
 	for i := 0; i < b.N; i++ {
-		logger, _ := zap.NewDevelopment()
+		logger := testlogger.New()
 		mockClock := clock.NewMockClock(startTime)
 		calculator := dayphase.NewCalculator(32.85486, -97.50515, logger)
 		calculator.SetClock(mockClock)

--- a/homeautomation-go/test/integration/scenario_computed_state_test.go
+++ b/homeautomation-go/test/integration/scenario_computed_state_test.go
@@ -7,10 +7,10 @@ import (
 
 	"homeautomation/internal/ha"
 	"homeautomation/internal/state"
+	"homeautomation/internal/testlogger"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 // ============================================================================
@@ -25,7 +25,7 @@ import (
 
 // setupComputedStateTest creates a test environment with computed state initialized
 func setupComputedStateTest(t *testing.T) (*MockHAServer, *ha.Client, *state.Manager, func()) {
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Start mock HA server
 	server := NewMockHAServer(testAddr, testToken)
@@ -96,7 +96,7 @@ func TestScenario_ComputedState_IsAnyoneHomeAndAwake_InitialComputation(t *testi
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			logger, _ := zap.NewDevelopment()
+			logger := testlogger.New()
 
 			// Start mock HA server with specific initial state
 			server := NewMockHAServer(testAddr, testToken)

--- a/homeautomation-go/test/integration/scenario_energy_test.go
+++ b/homeautomation-go/test/integration/scenario_energy_test.go
@@ -8,10 +8,10 @@ import (
 	"homeautomation/internal/ha"
 	"homeautomation/internal/plugins/energy"
 	"homeautomation/internal/state"
+	"homeautomation/internal/testlogger"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 // ============================================================================
@@ -31,7 +31,7 @@ func setupEnergyScenarioTest(t *testing.T) (*MockHAServer, *energy.Manager, *sta
 	require.NoError(t, err, "Failed to load test energy config")
 
 	// Create logger
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Use a fixed timezone for testing (UTC)
 	timezone := time.UTC
@@ -169,7 +169,7 @@ func TestScenario_GridAvailability_RecalculatesFreeEnergy(t *testing.T) {
 	require.NoError(t, err, "Failed to load test energy config")
 
 	// Create logger
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Create a timezone that makes current time 12:00 noon (clearly outside 21:00-07:00 window)
 	now := time.Now()
@@ -245,7 +245,7 @@ func TestScenario_OverallEnergyLevel_ReflectsWorstState(t *testing.T) {
 	require.NoError(t, err, "Failed to load test energy config")
 
 	// Create logger
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Create a timezone that makes current time 12:00 noon (clearly outside 21:00-07:00 window)
 	now := time.Now()
@@ -336,7 +336,7 @@ func TestScenario_FreeEnergyTimeWindow_OverridesEnergyLevel(t *testing.T) {
 	energyConfig, err := energy.LoadConfig(configPath)
 	require.NoError(t, err)
 
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	energyMgr := energy.NewManager(client, manager, energyConfig, logger, false, testTimezone, nil)
 	err = energyMgr.Start()
 	require.NoError(t, err)

--- a/homeautomation-go/test/integration/scenario_lighting_test.go
+++ b/homeautomation-go/test/integration/scenario_lighting_test.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"homeautomation/internal/plugins/lighting"
+	"homeautomation/internal/testlogger"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 // ============================================================================
@@ -29,7 +29,7 @@ func setupLightingScenarioTest(t *testing.T) (*MockHAServer, *lighting.Manager, 
 	require.NoError(t, err, "Failed to load test lighting config")
 
 	// Create logger
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Create lighting plugin (read-only mode for testing)
 	lightingMgr := lighting.NewManager(client, manager, lightingConfig, logger, false, nil)

--- a/homeautomation-go/test/integration/scenario_multi_plugin_test.go
+++ b/homeautomation-go/test/integration/scenario_multi_plugin_test.go
@@ -11,6 +11,7 @@ import (
 	"homeautomation/internal/plugins/statetracking"
 	"homeautomation/internal/plugins/tv"
 	"homeautomation/internal/state"
+	"homeautomation/internal/testlogger"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,7 +40,7 @@ func setupMultiPluginTest(t *testing.T) (*pluginTestEnv, func()) {
 	// Setup base test infrastructure
 	server, client, manager, baseCleanup := setupTest(t)
 
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Load test configs
 	lightingConfig := loadTestLightingConfig(t)

--- a/homeautomation-go/test/integration/scenario_security_test.go
+++ b/homeautomation-go/test/integration/scenario_security_test.go
@@ -8,10 +8,10 @@ import (
 	"homeautomation/internal/plugins/security"
 	"homeautomation/internal/plugins/statetracking"
 	"homeautomation/internal/state"
+	"homeautomation/internal/testlogger"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 // setupSecurityScenarioTest creates a test environment with State Tracking and Security plugins
@@ -19,7 +19,7 @@ func setupSecurityScenarioTest(t *testing.T) (*MockHAServer, *statetracking.Mana
 	server, client, stateManager, baseCleanup := setupTest(t)
 
 	// Create logger
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Create and start State Tracking plugin (must start before Security)
 	stateTracking := statetracking.NewManager(client, stateManager, logger, false, nil)
@@ -43,7 +43,7 @@ func setupSecurityScenarioTestWithMockClock(t *testing.T) (*MockHAServer, *state
 	server, client, stateManager, baseCleanup := setupTest(t)
 
 	// Create logger
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Create mock clock
 	mockClock := clock.NewMockClock(time.Now())

--- a/homeautomation-go/test/integration/scenario_sexmode_test.go
+++ b/homeautomation-go/test/integration/scenario_sexmode_test.go
@@ -6,10 +6,10 @@ import (
 
 	"homeautomation/internal/plugins/sexmode"
 	"homeautomation/internal/state"
+	"homeautomation/internal/testlogger"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 // getNumericValue converts interface{} to int, handling both int and float64 types
@@ -31,7 +31,7 @@ func setupSexModeScenarioTest(t *testing.T) (*MockHAServer, *sexmode.Manager, *s
 	server, client, stateManager, baseCleanup := setupTest(t)
 
 	// Create logger
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Initialize sex mode toggle to off
 	server.SetState("input_boolean.sex", "off", nil)
@@ -449,7 +449,7 @@ func TestScenario_SexModeReset_SyncsState(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Now create and start the sex mode manager
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 	sexModeManager := sexmode.NewManager(client, stateManager, logger, false, nil)
 	require.NoError(t, sexModeManager.Start(), "Sex Mode manager should start successfully")
 

--- a/homeautomation-go/test/integration/scenario_sleephygiene_test.go
+++ b/homeautomation-go/test/integration/scenario_sleephygiene_test.go
@@ -7,10 +7,10 @@ import (
 
 	"homeautomation/internal/config"
 	"homeautomation/internal/plugins/sleephygiene"
+	"homeautomation/internal/testlogger"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 // ============================================================================
@@ -25,7 +25,7 @@ func setupSleepHygieneScenarioTest(t *testing.T) (*MockHAServer, *sleephygiene.M
 	server, client, manager, baseCleanup := setupTest(t)
 
 	// Create logger
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Create config loader pointing to the real config directory
 	configLoader := config.NewLoader("../../configs", logger)
@@ -51,7 +51,7 @@ func setupSleepHygieneScenarioTestWithTime(t *testing.T, fixedTime time.Time) (*
 	server, client, manager, baseCleanup := setupTest(t)
 
 	// Create logger
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Create config loader pointing to the real config directory
 	configLoader := config.NewLoader("../../configs", logger)

--- a/homeautomation-go/test/integration/scenario_tv_test.go
+++ b/homeautomation-go/test/integration/scenario_tv_test.go
@@ -6,10 +6,10 @@ import (
 
 	"homeautomation/internal/plugins/tv"
 	"homeautomation/internal/state"
+	"homeautomation/internal/testlogger"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 // setupTVScenarioTest creates a test environment with the TV plugin running
@@ -17,7 +17,7 @@ func setupTVScenarioTest(t *testing.T) (*MockHAServer, *state.Manager, func()) {
 	server, client, stateManager, baseCleanup := setupTest(t)
 
 	// Create logger for TV plugin
-	logger, _ := zap.NewDevelopment()
+	logger := testlogger.New()
 
 	// Create and start TV plugin
 	tvManager := tv.NewManager(client, stateManager, logger, false, nil)


### PR DESCRIPTION
## Summary

- Add silent test logger (`internal/testlogger`) that returns `zap.NewNop()` by default
- Replace 200+ `zap.NewDevelopment()` calls with `testlogger.New()` across all test files
- Remove `-v` flag from Makefile test targets to reduce output
- Add `test-go-verbose` target for when verbose output is needed

**Output reduction:**
- Energy plugin tests: 1,420 → 297 lines (79% reduction)
- Full test suite: 2,761 → 32 lines without `-v` flag
- Pre-push validation: 72 lines total

## Test plan

- [x] All tests pass with `make pre-push`
- [x] Verbose mode works with `TEST_VERBOSE=true go test ./...`
- [x] New `make test-go-verbose` target works for debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)