### PR TITLE
refactor: Use shared TimeProvider from pkg/plugin

### DIFF
--- a/homeautomation-go/internal/plugins/music/manager.go
+++ b/homeautomation-go/internal/plugins/music/manager.go
@@ -12,6 +12,7 @@ import (
 	"homeautomation/internal/ha"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
+	"homeautomation/pkg/plugin"
 
 	"go.uber.org/zap"
 )
@@ -49,28 +50,6 @@ type SpeakerGroupResult struct {
 	LeadActive  bool            // Whether the lead speaker is available
 }
 
-// TimeProvider is an interface for getting the current time
-// This allows tests to inject a fixed time instead of using time.Now()
-type TimeProvider interface {
-	Now() time.Time
-}
-
-// RealTimeProvider returns the actual current time
-type RealTimeProvider struct{}
-
-func (r RealTimeProvider) Now() time.Time {
-	return time.Now()
-}
-
-// FixedTimeProvider returns a fixed time (for testing)
-type FixedTimeProvider struct {
-	FixedTime time.Time
-}
-
-func (f FixedTimeProvider) Now() time.Time {
-	return f.FixedTime
-}
-
 // SleepFunc is a function type for sleeping (allows test injection)
 type SleepFunc func(time.Duration)
 
@@ -81,7 +60,7 @@ type Manager struct {
 	config       *MusicConfig
 	logger       *zap.Logger
 	readOnly     bool
-	timeProvider TimeProvider
+	timeProvider plugin.TimeProvider
 	sleepFunc    SleepFunc // Injectable sleep function for testing
 
 	// Playback state
@@ -107,10 +86,10 @@ type Manager struct {
 }
 
 // NewManager creates a new Music manager
-// If timeProvider is nil, it defaults to RealTimeProvider
-func NewManager(haClient ha.HAClient, stateManager *state.Manager, config *MusicConfig, logger *zap.Logger, readOnly bool, timeProvider TimeProvider) *Manager {
+// If timeProvider is nil, it defaults to plugin.RealTimeProvider
+func NewManager(haClient ha.HAClient, stateManager *state.Manager, config *MusicConfig, logger *zap.Logger, readOnly bool, timeProvider plugin.TimeProvider) *Manager {
 	if timeProvider == nil {
-		timeProvider = RealTimeProvider{}
+		timeProvider = plugin.RealTimeProvider{}
 	}
 	return &Manager{
 		haClient:           haClient,

--- a/homeautomation-go/internal/plugins/music/manager_shadow_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_shadow_test.go
@@ -6,6 +6,7 @@ import (
 
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
+	"homeautomation/pkg/plugin"
 
 	"go.uber.org/zap"
 )
@@ -46,7 +47,7 @@ func TestMusicShadowState_RecordAction(t *testing.T) {
 		Music: make(map[string]MusicMode),
 	}
 	fixedTime := time.Date(2025, 11, 28, 12, 0, 0, 0, time.UTC)
-	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 	manager := NewManager(nil, stateManager, mockConfig, zap.NewNop(), true, timeProvider)
 
 	// Record an action

--- a/homeautomation-go/internal/plugins/music/manager_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_test.go
@@ -11,6 +11,7 @@ import (
 
 	"homeautomation/internal/ha"
 	"homeautomation/internal/state"
+	"homeautomation/pkg/plugin"
 
 	"go.uber.org/zap"
 )
@@ -140,7 +141,7 @@ func TestMusicManager_SelectAppropriateMusicMode(t *testing.T) {
 			// Use a fixed time provider with a Monday (not Sunday) for testing
 			// This ensures tests are independent of what day they run on
 			fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC) // Monday, January 6, 2025
-			timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+			timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 			// Create manager
 			manager := NewManager(mockHA, stateMgr, config, logger, true, timeProvider)
@@ -184,7 +185,7 @@ func TestMusicManager_DetermineMusicModeFromDayPhase(t *testing.T) {
 
 	// Use a fixed time provider with a Monday (not Sunday) for testing
 	fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC) // Monday, January 6, 2025
-	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 	manager := NewManager(mockHA, stateMgr, config, logger, true, timeProvider)
 
@@ -233,7 +234,7 @@ func TestMusicManager_StateChangeHandling(t *testing.T) {
 
 	// Use a fixed time provider with a Monday (not Sunday) for testing
 	fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC) // Monday, January 6, 2025
-	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 	manager := NewManager(mockHA, stateMgr, config, logger, true, timeProvider)
 
@@ -573,7 +574,7 @@ func TestRateLimiting(t *testing.T) {
 
 	// Use a fixed time for testing
 	fixedTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
-	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 	manager := NewManager(mockClient, stateManager, config, logger, true, timeProvider)
 
@@ -1298,7 +1299,7 @@ func TestManagerReset(t *testing.T) {
 	stateManager.SetBool("isAnyoneHome", true)
 	stateManager.SetBool("isAnyoneAsleep", false)
 
-	manager := NewManager(mockClient, stateManager, musicConfig, logger, false, &RealTimeProvider{})
+	manager := NewManager(mockClient, stateManager, musicConfig, logger, false, &plugin.RealTimeProvider{})
 
 	err := manager.Start()
 	if err != nil {
@@ -1441,7 +1442,7 @@ func TestCurrentlyPlayingMusicUri_UpdateOnModeChange(t *testing.T) {
 
 	// Use a fixed time for testing (to avoid rate limiting)
 	fixedTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
-	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 	manager := NewManager(mockClient, stateManager, config, logger, true, timeProvider)
 
@@ -1498,7 +1499,7 @@ func TestFadeInSpeaker_SafeUnmuteSequence(t *testing.T) {
 	}
 
 	fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)
-	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 	// NOT read-only so service calls actually go through
 	manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider)
@@ -1594,7 +1595,7 @@ func TestFadeInSpeaker_VolumeNormalization(t *testing.T) {
 			}
 
 			fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)
-			timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+			timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 			manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider)
 			// Skip sleep delays in tests (fade-in uses very slow timing to match Node-RED behavior)
 			manager.SetSleepFunc(func(d time.Duration) {})
@@ -1648,7 +1649,7 @@ func TestFadeInSpeaker_InitialVolumeSetFailure(t *testing.T) {
 	}
 
 	fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)
-	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 	manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider)
 	// Skip sleep delays in tests (fade-in uses very slow timing to match Node-RED behavior)
 	manager.SetSleepFunc(func(d time.Duration) {})
@@ -1687,7 +1688,7 @@ func TestFadeInSpeaker_UnmuteFailure(t *testing.T) {
 	}
 
 	fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)
-	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 	manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider)
 	// Skip sleep delays in tests (fade-in uses very slow timing to match Node-RED behavior)
 	manager.SetSleepFunc(func(d time.Duration) {})

--- a/homeautomation-go/internal/plugins/music/occupancy_scenario_test.go
+++ b/homeautomation-go/internal/plugins/music/occupancy_scenario_test.go
@@ -61,6 +61,7 @@ import (
 
 	"homeautomation/internal/ha"
 	"homeautomation/internal/state"
+	"homeautomation/pkg/plugin"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
@@ -151,7 +152,7 @@ func TestScenario_OfficeSpeaker_UnmutedWhenOccupied(t *testing.T) {
 
 	// Use fixed time provider for deterministic testing
 	fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC) // Monday 10am
-	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
 
@@ -231,7 +232,7 @@ func TestScenario_OfficeSpeaker_MutedWhenUnoccupied(t *testing.T) {
 
 	// Use fixed time provider
 	fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
-	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
 
@@ -297,7 +298,7 @@ func TestScenario_OfficeSpeaker_UnmuteOnOccupancyChangeDuringPlayback(t *testing
 
 	// Use fixed time provider
 	fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
-	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
 
@@ -378,7 +379,7 @@ func TestScenario_KitchenSpeaker_AlwaysUnmuted(t *testing.T) {
 	config := createOccupancyMusicConfig()
 
 	fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
-	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
 

--- a/homeautomation-go/internal/plugins/music/register.go
+++ b/homeautomation-go/internal/plugins/music/register.go
@@ -3,7 +3,6 @@ package music
 import (
 	"fmt"
 	"path/filepath"
-	"time"
 
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
@@ -40,24 +39,9 @@ func createPlugin(ctx *plugin.Context) (plugin.Plugin, error) {
 		return nil, fmt.Errorf("failed to load music config: %w", err)
 	}
 
-	// Convert plugin.TimeProvider to music.TimeProvider if provided
-	// Both interfaces are identical (Now() time.Time), so we can use a type adapter
-	var timeProvider TimeProvider
-	if ctx.TimeProvider != nil {
-		timeProvider = timeProviderAdapter{ctx.TimeProvider}
-	}
-
-	manager := NewManager(haClient, stateManager, config, ctx.Logger, ctx.ReadOnly, timeProvider)
+	// Pass the TimeProvider directly (NewManager handles nil by defaulting to RealTimeProvider)
+	manager := NewManager(haClient, stateManager, config, ctx.Logger, ctx.ReadOnly, ctx.TimeProvider)
 	return &pluginAdapter{manager: manager}, nil
-}
-
-// timeProviderAdapter adapts plugin.TimeProvider to music.TimeProvider
-type timeProviderAdapter struct {
-	provider plugin.TimeProvider
-}
-
-func (a timeProviderAdapter) Now() time.Time {
-	return a.provider.Now()
 }
 
 // pluginAdapter wraps the Manager to implement the plugin.Plugin interface.

--- a/homeautomation-go/internal/plugins/music/wakeup_scenario_test.go
+++ b/homeautomation-go/internal/plugins/music/wakeup_scenario_test.go
@@ -102,6 +102,7 @@ import (
 
 	"homeautomation/internal/ha"
 	"homeautomation/internal/state"
+	"homeautomation/pkg/plugin"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -234,7 +235,7 @@ func TestScenario_WakeUpDuringMorning_TriggersMorningMusic(t *testing.T) {
 	// Use fixed time: Monday 7:00 AM (not Sunday!)
 	fixedTime := time.Date(2024, 1, 15, 7, 0, 0, 0, time.UTC) // Monday
 	require.Equal(t, time.Monday, fixedTime.Weekday(), "Test requires Monday")
-	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
 
@@ -335,7 +336,7 @@ func TestScenario_WakeUpOnSunday_TriggersDayMusic(t *testing.T) {
 	// Use fixed time: Sunday 8:00 AM
 	fixedTime := time.Date(2024, 1, 14, 8, 0, 0, 0, time.UTC) // Sunday
 	require.Equal(t, time.Sunday, fixedTime.Weekday(), "Test requires Sunday")
-	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
 
@@ -400,7 +401,7 @@ func TestScenario_DayPhaseChangesToMorning_TriggersDayMusic(t *testing.T) {
 
 	// Monday 6:00 AM
 	fixedTime := time.Date(2024, 1, 15, 6, 0, 0, 0, time.UTC)
-	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
 
@@ -459,7 +460,7 @@ func TestScenario_NoOneHome_StopsMusic(t *testing.T) {
 	config := createWakeupTestConfig()
 
 	fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
-	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
 
@@ -517,7 +518,7 @@ func TestScenario_SomeoneFallsAsleep_TriggersSleepMusic(t *testing.T) {
 	config := createWakeupTestConfig()
 
 	fixedTime := time.Date(2024, 1, 15, 22, 0, 0, 0, time.UTC) // 10 PM
-	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
 
@@ -591,7 +592,7 @@ func TestScenario_SleepMusicPersistsDuringWinddown(t *testing.T) {
 	config := createWakeupTestConfig()
 
 	fixedTime := time.Date(2024, 1, 15, 21, 0, 0, 0, time.UTC) // 9 PM
-	timeProvider := FixedTimeProvider{FixedTime: fixedTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
 

--- a/homeautomation-go/internal/plugins/sleephygiene/manager.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager.go
@@ -9,31 +9,10 @@ import (
 	"homeautomation/internal/ha"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
+	"homeautomation/pkg/plugin"
 
 	"go.uber.org/zap"
 )
-
-// TimeProvider is an interface for getting the current time
-// This allows tests to inject a fixed time instead of using time.Now()
-type TimeProvider interface {
-	Now() time.Time
-}
-
-// RealTimeProvider returns the actual current time
-type RealTimeProvider struct{}
-
-func (r RealTimeProvider) Now() time.Time {
-	return time.Now()
-}
-
-// FixedTimeProvider returns a fixed time (for testing)
-type FixedTimeProvider struct {
-	FixedTime time.Time
-}
-
-func (f FixedTimeProvider) Now() time.Time {
-	return f.FixedTime
-}
 
 // Eight Sleep Pod sensor entity IDs
 const (
@@ -62,7 +41,7 @@ type Manager struct {
 	configLoader    *config.Loader
 	logger          *zap.Logger
 	readOnly        bool
-	timeProvider    TimeProvider
+	timeProvider    plugin.TimeProvider
 	timezone        *time.Location
 	stopChan        chan struct{}
 	ticker          *time.Ticker
@@ -77,11 +56,11 @@ type Manager struct {
 }
 
 // NewManager creates a new Sleep Hygiene manager
-// If timeProvider is nil, it defaults to RealTimeProvider
+// If timeProvider is nil, it defaults to plugin.RealTimeProvider
 // If timezone is nil, it defaults to time.Local
-func NewManager(haClient ha.HAClient, stateManager *state.Manager, configLoader *config.Loader, logger *zap.Logger, readOnly bool, timeProvider TimeProvider, timezone *time.Location) *Manager {
+func NewManager(haClient ha.HAClient, stateManager *state.Manager, configLoader *config.Loader, logger *zap.Logger, readOnly bool, timeProvider plugin.TimeProvider, timezone *time.Location) *Manager {
 	if timeProvider == nil {
-		timeProvider = RealTimeProvider{}
+		timeProvider = plugin.RealTimeProvider{}
 	}
 	if timezone == nil {
 		timezone = time.Local

--- a/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"homeautomation/internal/config"
 	"homeautomation/internal/ha"
 	"homeautomation/internal/state"
+	"homeautomation/pkg/plugin"
 
 	"go.uber.org/zap"
 )
@@ -31,7 +32,7 @@ func setupTest(t *testing.T, currentTime time.Time) (*Manager, *ha.MockClient, *
 	configLoader := config.NewLoader("../../../configs", logger)
 
 	// Create manager with fixed time provider and nil timezone (defaults to time.Local)
-	timeProvider := FixedTimeProvider{FixedTime: currentTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: currentTime}
 	manager := NewManager(mockHA, stateManager, configLoader, logger, false, timeProvider, nil)
 
 	return manager, mockHA, stateManager, configLoader
@@ -50,7 +51,7 @@ func TestNewManager(t *testing.T) {
 	}
 
 	if manager.timeProvider == nil {
-		t.Error("timeProvider should default to RealTimeProvider")
+		t.Error("timeProvider should default to plugin.RealTimeProvider")
 	}
 
 	if manager.haClient != mockHA {
@@ -336,7 +337,7 @@ func TestReadOnlyMode(t *testing.T) {
 	stateManager.SetString("musicPlaybackType", "sleep")
 
 	// Create manager in READ-ONLY mode
-	timeProvider := FixedTimeProvider{FixedTime: now}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: now}
 	manager := NewManager(mockHA, stateManager, configLoader, logger, true, timeProvider, nil)
 
 	// Clear previous calls
@@ -556,7 +557,7 @@ func TestHandleGoToBed_ReadOnly(t *testing.T) {
 	stateManager.SetString("musicPlaybackType", "winddown")
 
 	configLoader := config.NewLoader("../../../configs", logger)
-	timeProvider := FixedTimeProvider{FixedTime: now}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: now}
 	manager := NewManager(mockHA, stateManager, configLoader, logger, true, timeProvider, nil) // READ-ONLY
 
 	mockHA.ClearServiceCalls()
@@ -577,9 +578,9 @@ func TestHandleGoToBed_ReadOnly(t *testing.T) {
 	}
 }
 
-// TestRealTimeProvider tests the RealTimeProvider
+// TestRealTimeProvider tests the plugin.RealTimeProvider
 func TestRealTimeProvider(t *testing.T) {
-	provider := RealTimeProvider{}
+	provider := plugin.RealTimeProvider{}
 	now := provider.Now()
 
 	// Verify it returns a reasonable time (within last minute)
@@ -588,10 +589,10 @@ func TestRealTimeProvider(t *testing.T) {
 	}
 }
 
-// TestFixedTimeProvider tests the FixedTimeProvider
+// TestFixedTimeProvider tests the plugin.FixedTimeProvider
 func TestFixedTimeProvider(t *testing.T) {
 	fixedTime := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
-	provider := FixedTimeProvider{FixedTime: fixedTime}
+	provider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 	if provider.Now() != fixedTime {
 		t.Errorf("FixedTimeProvider did not return fixed time")
@@ -607,7 +608,7 @@ func TestCheckTimeTriggers_ErrorGettingSchedule(t *testing.T) {
 
 	// Use a config loader pointing to non-existent directory
 	configLoader := config.NewLoader("/nonexistent/path", logger)
-	timeProvider := FixedTimeProvider{FixedTime: now}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: now}
 	manager := NewManager(mockHA, stateManager, configLoader, logger, false, timeProvider, nil)
 
 	// Check triggers - should handle error gracefully
@@ -628,7 +629,7 @@ func TestHandleWake_ErrorGettingState(t *testing.T) {
 
 	// Don't initialize states - will cause errors
 	configLoader := config.NewLoader("../../../configs", logger)
-	timeProvider := FixedTimeProvider{FixedTime: now}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: now}
 	manager := NewManager(mockHA, stateManager, configLoader, logger, false, timeProvider, nil)
 
 	mockHA.ClearServiceCalls()
@@ -656,7 +657,7 @@ func TestHandleBeginWake_ReadOnly(t *testing.T) {
 	stateManager.SetString("musicPlaybackType", "sleep")
 
 	configLoader := config.NewLoader("../../../configs", logger)
-	timeProvider := FixedTimeProvider{FixedTime: now}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: now}
 	manager := NewManager(mockHA, stateManager, configLoader, logger, true, timeProvider, nil) // READ-ONLY
 
 	mockHA.ClearServiceCalls()
@@ -688,7 +689,7 @@ func TestHandleWake_ReadOnly(t *testing.T) {
 	stateManager.SetBool("isCarolineHome", true)
 
 	configLoader := config.NewLoader("../../../configs", logger)
-	timeProvider := FixedTimeProvider{FixedTime: now}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: now}
 	manager := NewManager(mockHA, stateManager, configLoader, logger, true, timeProvider, nil) // READ-ONLY
 
 	mockHA.ClearServiceCalls()
@@ -715,7 +716,7 @@ func TestHandleStopScreens_ReadOnly(t *testing.T) {
 	stateManager.SetBool("isEveryoneAsleep", false)
 
 	configLoader := config.NewLoader("../../../configs", logger)
-	timeProvider := FixedTimeProvider{FixedTime: now}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: now}
 	manager := NewManager(mockHA, stateManager, configLoader, logger, true, timeProvider, nil) // READ-ONLY
 
 	mockHA.ClearServiceCalls()
@@ -832,7 +833,7 @@ func TestRunTimerLoop_MidnightRollover(t *testing.T) {
 	}
 
 	// Update time provider to next day
-	manager.timeProvider = FixedTimeProvider{FixedTime: time.Date(2024, 1, 16, 0, 1, 0, 0, time.UTC)}
+	manager.timeProvider = plugin.FixedTimeProvider{FixedTime: time.Date(2024, 1, 16, 0, 1, 0, 0, time.UTC)}
 
 	// Manually simulate what the timer loop does
 	nextDay := manager.timeProvider.Now()
@@ -1483,7 +1484,7 @@ func TestManagerReset(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	configLoader := config.NewLoader("../../../configs", logger)
-	timeProvider := RealTimeProvider{}
+	timeProvider := plugin.RealTimeProvider{}
 
 	manager := NewManager(mockClient, stateManager, configLoader, logger, false, timeProvider, nil)
 
@@ -1714,7 +1715,7 @@ func TestEightSleepAlarm_NewDayResetsDeduplication(t *testing.T) {
 
 	// Reset isFadeOutInProgress and update time provider to today
 	stateManager.SetBool("isFadeOutInProgress", false)
-	manager.timeProvider = FixedTimeProvider{FixedTime: today}
+	manager.timeProvider = plugin.FixedTimeProvider{FixedTime: today}
 
 	// Trigger alarm today - should work because it's a new day
 	manager.handleEightSleepAlarm("sensor.nick_s_eight_sleep_side_bed_state_type", oldState, newState)

--- a/homeautomation-go/internal/plugins/sleephygiene/register.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/register.go
@@ -2,7 +2,6 @@ package sleephygiene
 
 import (
 	"fmt"
-	"time"
 
 	"homeautomation/internal/config"
 	pkgha "homeautomation/pkg/ha"
@@ -40,24 +39,9 @@ func createPlugin(ctx *plugin.Context) (plugin.Plugin, error) {
 		return nil, fmt.Errorf("failed to load schedule config: %w", err)
 	}
 
-	// Convert plugin.TimeProvider to sleephygiene.TimeProvider if provided
-	// Both interfaces are identical (Now() time.Time), so we can use a type adapter
-	var timeProvider TimeProvider
-	if ctx.TimeProvider != nil {
-		timeProvider = timeProviderAdapter{ctx.TimeProvider}
-	}
-
-	manager := NewManager(haClient, stateManager, configLoader, ctx.Logger, ctx.ReadOnly, timeProvider, ctx.Timezone)
+	// Pass the TimeProvider directly (NewManager handles nil by defaulting to RealTimeProvider)
+	manager := NewManager(haClient, stateManager, configLoader, ctx.Logger, ctx.ReadOnly, ctx.TimeProvider, ctx.Timezone)
 	return &pluginAdapter{manager: manager}, nil
-}
-
-// timeProviderAdapter adapts plugin.TimeProvider to sleephygiene.TimeProvider
-type timeProviderAdapter struct {
-	provider plugin.TimeProvider
-}
-
-func (a timeProviderAdapter) Now() time.Time {
-	return a.provider.Now()
 }
 
 // pluginAdapter wraps the Manager to implement the plugin.Plugin interface.

--- a/homeautomation-go/test/integration/scenario_sleephygiene_test.go
+++ b/homeautomation-go/test/integration/scenario_sleephygiene_test.go
@@ -8,6 +8,7 @@ import (
 	"homeautomation/internal/config"
 	"homeautomation/internal/plugins/sleephygiene"
 	"homeautomation/internal/testlogger"
+	"homeautomation/pkg/plugin"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -57,7 +58,7 @@ func setupSleepHygieneScenarioTestWithTime(t *testing.T, fixedTime time.Time) (*
 	configLoader := config.NewLoader("../../configs", logger)
 
 	// Create fixed time provider
-	timeProvider := sleephygiene.FixedTimeProvider{FixedTime: fixedTime}
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 	// Create sleep hygiene plugin with fixed time
 	// Use nil for timezone to default to time.Local


### PR DESCRIPTION
## Summary
- Removes duplicate `TimeProvider`, `RealTimeProvider`, and `FixedTimeProvider` definitions from the music and sleephygiene plugins
- Both plugins now use the existing shared types from `pkg/plugin/time.go`
- Simplifies `register.go` files by removing the now-unnecessary type adapter layer

## Changes
| File | Change |
|------|--------|
| `internal/plugins/music/manager.go` | Use `plugin.TimeProvider` instead of local type |
| `internal/plugins/sleephygiene/manager.go` | Use `plugin.TimeProvider` instead of local type |
| `internal/plugins/music/register.go` | Remove type adapter, pass `ctx.TimeProvider` directly |
| `internal/plugins/sleephygiene/register.go` | Remove type adapter, pass `ctx.TimeProvider` directly |
| Test files | Update to use `plugin.FixedTimeProvider` and `plugin.RealTimeProvider` |

## Impact
- **Lines saved:** 68 net lines removed
- **Risk:** Low - purely mechanical refactoring
- Tests pass: All unit and integration tests pass

## Test plan
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Code compiles cleanly
- [x] Pre-push validation passed

Fixes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)