### PR TITLE
fix: move plugins/all from internal to pkg for downstream forks

### DIFF
--- a/homeautomation-go/cmd/main.go
+++ b/homeautomation-go/cmd/main.go
@@ -12,7 +12,7 @@
 //		"homeautomation/cmd/app"
 //
 //		// Import all public plugins
-//		_ "homeautomation/internal/plugins/all"
+//		_ "homeautomation/pkg/plugins/all"
 //
 //		// Import private overrides (higher priority wins)
 //		_ "github.com/your-org/your-private-security-plugin"
@@ -27,7 +27,7 @@ import (
 	"homeautomation/cmd/app"
 
 	// Import all plugins via the convenience package
-	_ "homeautomation/internal/plugins/all"
+	_ "homeautomation/pkg/plugins/all"
 )
 
 func main() {

--- a/homeautomation-go/pkg/plugins/all/all.go
+++ b/homeautomation-go/pkg/plugins/all/all.go
@@ -8,7 +8,7 @@
 //	    "homeautomation/cmd/app"
 //
 //	    // Import all public plugins
-//	    _ "homeautomation/internal/plugins/all"
+//	    _ "homeautomation/pkg/plugins/all"
 //
 //	    // Import private overrides (these take priority)
 //	    _ "github.com/your-org/your-private-security-plugin"


### PR DESCRIPTION
## Summary
- Relocated `internal/plugins/all` package to `pkg/plugins/all`
- Updated import paths in `cmd/main.go` and package documentation
- Enables downstream forks to import the plugin aggregator package

## Problem
Go's language-level visibility rules prevent external modules from importing `internal/*` packages. This was causing CI build failures in downstream forks (like the private security plugin repository) with:
```
cmd/main.go:8:2: use of internal package homeautomation/internal/plugins/all not allowed
```

## Solution
Move the package to `pkg/plugins/all` where Go's visibility rules allow external imports. Downstream forks can now:
```go
import (
    _ "homeautomation/pkg/plugins/all"           // Import all public plugins
    _ "github.com/your-org/your-private-plugin"  // Override with private implementation
)
```

Fixes #265

## Test plan
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Code compiles with new import path
- [ ] Verify downstream fork can import `pkg/plugins/all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)