### PR TITLE
fix(ha): trigger immediate reconnect on ping write failure

### DIFF
--- a/homeautomation-go/internal/ha/client.go
+++ b/homeautomation-go/internal/ha/client.go
@@ -612,9 +612,11 @@ func (c *Client) sendPings() {
 			c.writeMu.Unlock()
 
 			if err != nil {
-				c.logger.Warn("Failed to send application ping", zap.Error(err))
-				// Don't trigger disconnect here - let receiveMessages handle it
-				// when the read deadline expires
+				c.logger.Warn("Failed to send application ping, closing connection", zap.Error(err))
+				// Close the connection to immediately unblock receiveMessages,
+				// which will call handleDisconnect() to trigger reconnection.
+				// This is faster than waiting for the read deadline to expire.
+				conn.Close()
 				return
 			}
 		}


### PR DESCRIPTION
When an application-level ping write fails (indicating network issues), close the connection immediately to unblock the blocked ReadJSON call in receiveMessages. This triggers handleDisconnect() right away rather than waiting up to 60 seconds for the read deadline to expire.

Before: ping fails → receiveMessages blocked → waits for read deadline → 26+ sec delay
After: ping fails → conn.Close() → ReadJSON fails → handleDisconnect() → immediate reconnect

This complements the application-level ping/pong implementation from #270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)