### PR TITLE
fix(plugins): correct GetShadowState return type for dashboard registration

### DIFF
--- a/homeautomation-go/internal/plugins/christmas/register.go
+++ b/homeautomation-go/internal/plugins/christmas/register.go
@@ -5,6 +5,7 @@ import (
 
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
+	"homeautomation/pkg/shadowstate"
 )
 
 func init() {
@@ -52,7 +53,7 @@ func (p *pluginAdapter) Reset() error {
 }
 
 // Implement plugin.ShadowStateProvider
-func (p *pluginAdapter) GetShadowState() interface{} {
+func (p *pluginAdapter) GetShadowState() shadowstate.PluginShadowState {
 	return p.manager.GetShadowState()
 }
 

--- a/homeautomation-go/internal/plugins/dayphase/register.go
+++ b/homeautomation-go/internal/plugins/dayphase/register.go
@@ -7,6 +7,7 @@ import (
 	dayphaselib "homeautomation/internal/dayphase"
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
+	"homeautomation/pkg/shadowstate"
 	pkgstate "homeautomation/pkg/state"
 )
 
@@ -70,7 +71,7 @@ func (p *pluginAdapter) Reset() error {
 }
 
 // Implement plugin.ShadowStateProvider
-func (p *pluginAdapter) GetShadowState() interface{} {
+func (p *pluginAdapter) GetShadowState() shadowstate.PluginShadowState {
 	return p.manager.GetShadowState()
 }
 

--- a/homeautomation-go/internal/plugins/energy/register.go
+++ b/homeautomation-go/internal/plugins/energy/register.go
@@ -6,6 +6,7 @@ import (
 
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
+	"homeautomation/pkg/shadowstate"
 	pkgstate "homeautomation/pkg/state"
 )
 
@@ -66,7 +67,7 @@ func (p *pluginAdapter) Reset() error {
 }
 
 // Implement plugin.ShadowStateProvider
-func (p *pluginAdapter) GetShadowState() interface{} {
+func (p *pluginAdapter) GetShadowState() shadowstate.PluginShadowState {
 	return p.manager.GetShadowState()
 }
 

--- a/homeautomation-go/internal/plugins/lighting/register.go
+++ b/homeautomation-go/internal/plugins/lighting/register.go
@@ -6,6 +6,7 @@ import (
 
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
+	"homeautomation/pkg/shadowstate"
 	pkgstate "homeautomation/pkg/state"
 )
 
@@ -66,7 +67,7 @@ func (p *pluginAdapter) Reset() error {
 }
 
 // Implement plugin.ShadowStateProvider
-func (p *pluginAdapter) GetShadowState() interface{} {
+func (p *pluginAdapter) GetShadowState() shadowstate.PluginShadowState {
 	return p.manager.GetShadowState()
 }
 

--- a/homeautomation-go/internal/plugins/loadshedding/register.go
+++ b/homeautomation-go/internal/plugins/loadshedding/register.go
@@ -5,6 +5,7 @@ import (
 
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
+	"homeautomation/pkg/shadowstate"
 	pkgstate "homeautomation/pkg/state"
 )
 
@@ -58,7 +59,7 @@ func (p *pluginAdapter) Reset() error {
 }
 
 // Implement plugin.ShadowStateProvider
-func (p *pluginAdapter) GetShadowState() interface{} {
+func (p *pluginAdapter) GetShadowState() shadowstate.PluginShadowState {
 	return p.manager.GetShadowState()
 }
 

--- a/homeautomation-go/internal/plugins/music/register.go
+++ b/homeautomation-go/internal/plugins/music/register.go
@@ -6,6 +6,7 @@ import (
 
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
+	"homeautomation/pkg/shadowstate"
 	pkgstate "homeautomation/pkg/state"
 )
 
@@ -67,7 +68,7 @@ func (p *pluginAdapter) Reset() error {
 }
 
 // Implement plugin.ShadowStateProvider
-func (p *pluginAdapter) GetShadowState() interface{} {
+func (p *pluginAdapter) GetShadowState() shadowstate.PluginShadowState {
 	return p.manager.GetShadowState()
 }
 

--- a/homeautomation-go/internal/plugins/security/register.go
+++ b/homeautomation-go/internal/plugins/security/register.go
@@ -5,6 +5,7 @@ import (
 
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
+	"homeautomation/pkg/shadowstate"
 	pkgstate "homeautomation/pkg/state"
 )
 
@@ -58,7 +59,7 @@ func (p *pluginAdapter) Reset() error {
 }
 
 // Implement plugin.ShadowStateProvider
-func (p *pluginAdapter) GetShadowState() interface{} {
+func (p *pluginAdapter) GetShadowState() shadowstate.PluginShadowState {
 	return p.manager.GetShadowState()
 }
 

--- a/homeautomation-go/internal/plugins/sexmode/register.go
+++ b/homeautomation-go/internal/plugins/sexmode/register.go
@@ -5,6 +5,7 @@ import (
 
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
+	"homeautomation/pkg/shadowstate"
 	pkgstate "homeautomation/pkg/state"
 )
 
@@ -58,7 +59,7 @@ func (p *pluginAdapter) Reset() error {
 }
 
 // Implement plugin.ShadowStateProvider
-func (p *pluginAdapter) GetShadowState() interface{} {
+func (p *pluginAdapter) GetShadowState() shadowstate.PluginShadowState {
 	return p.manager.GetShadowState()
 }
 

--- a/homeautomation-go/internal/plugins/sleephygiene/register.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/register.go
@@ -6,6 +6,7 @@ import (
 	"homeautomation/internal/config"
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
+	"homeautomation/pkg/shadowstate"
 	pkgstate "homeautomation/pkg/state"
 )
 
@@ -67,7 +68,7 @@ func (p *pluginAdapter) Reset() error {
 }
 
 // Implement plugin.ShadowStateProvider
-func (p *pluginAdapter) GetShadowState() interface{} {
+func (p *pluginAdapter) GetShadowState() shadowstate.PluginShadowState {
 	return p.manager.GetShadowState()
 }
 

--- a/homeautomation-go/internal/plugins/statetracking/register.go
+++ b/homeautomation-go/internal/plugins/statetracking/register.go
@@ -5,6 +5,7 @@ import (
 
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
+	"homeautomation/pkg/shadowstate"
 	pkgstate "homeautomation/pkg/state"
 )
 
@@ -58,7 +59,7 @@ func (p *pluginAdapter) Reset() error {
 }
 
 // Implement plugin.ShadowStateProvider
-func (p *pluginAdapter) GetShadowState() interface{} {
+func (p *pluginAdapter) GetShadowState() shadowstate.PluginShadowState {
 	return p.manager.GetShadowState()
 }
 

--- a/homeautomation-go/internal/plugins/tv/register.go
+++ b/homeautomation-go/internal/plugins/tv/register.go
@@ -5,6 +5,7 @@ import (
 
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
+	"homeautomation/pkg/shadowstate"
 	pkgstate "homeautomation/pkg/state"
 )
 
@@ -53,7 +54,7 @@ func (p *pluginAdapter) Stop() {
 }
 
 // Implement plugin.ShadowStateProvider
-func (p *pluginAdapter) GetShadowState() interface{} {
+func (p *pluginAdapter) GetShadowState() shadowstate.PluginShadowState {
 	return p.manager.GetShadowState()
 }
 


### PR DESCRIPTION
## Summary
- Fixed return type mismatch in all 11 plugin `register.go` files
- Changed `GetShadowState() interface{}` to `GetShadowState() shadowstate.PluginShadowState`
- This allows plugins to properly satisfy the `plugin.ShadowStateProvider` interface

## Problem
As identified in [PR #271 comment](https://github.com/NickBorgersOnLowSecurityNode/home-automation/pull/271#issuecomment-3704076062), plugins were missing from the dashboard because:

1. Each plugin's `pluginAdapter.GetShadowState()` returned `interface{}`
2. The `ShadowStateProvider` interface requires `shadowstate.PluginShadowState`
3. Go's strict interface matching meant the type assertion at `run.go:248` failed
4. Plugins were never registered with the shadow state tracker

This resolves https://github.com/NickBorgers/home-automation-plus-security/issues/27

## Test plan
- [x] All unit tests pass (70% coverage)
- [x] All integration tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)