### PR TITLE
fix(ha): reduce ping interval and detect write failures for faster reconnect

### DIFF
--- a/homeautomation-go/internal/ha/client.go
+++ b/homeautomation-go/internal/ha/client.go
@@ -18,13 +18,14 @@ import (
 // on application-layer JSON activity. See: https://developers.home-assistant.io/docs/api/websocket/
 const (
 	// pingInterval is how often we send application-level JSON pings.
-	// Set well under HA's ~2 minute idle timeout and typical proxy timeouts (60-90s).
-	pingInterval = 30 * time.Second
+	// Set aggressively low (15s) because Tailscale DERP relays and some NATs
+	// may timeout connections as early as 30-45 seconds of inactivity.
+	pingInterval = 15 * time.Second
 
 	// pongWait is the max time to wait for a pong response.
 	// If no pong received within this time, connection is considered dead.
-	// Set to 2x pingInterval to tolerate one missed ping.
-	pongWait = 60 * time.Second
+	// Set to 3x pingInterval to tolerate up to two missed pings.
+	pongWait = 45 * time.Second
 
 	// writeWait is the time allowed to write a message (including pings).
 	writeWait = 10 * time.Second
@@ -412,6 +413,13 @@ func (c *Client) sendMessage(msg interface{}) (*Message, error) {
 	}()
 
 	if err != nil {
+		// If write failed with timeout, the connection is likely dead.
+		// Close it immediately to trigger reconnection rather than waiting
+		// for the next ping or accumulating more failed retries.
+		if strings.Contains(err.Error(), "i/o timeout") {
+			c.logger.Warn("Write timeout detected, closing connection to trigger reconnect", zap.Error(err))
+			conn.Close()
+		}
 		return nil, fmt.Errorf("failed to send message: %w", err)
 	}
 
@@ -619,6 +627,7 @@ func (c *Client) sendPings() {
 				conn.Close()
 				return
 			}
+			c.logger.Debug("Application ping sent successfully", zap.Int("id", msgID))
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Reduce ping interval from 30s to 15s to catch dead connections faster
- Detect write timeout errors and immediately close connection to trigger reconnect
- Add debug logging for successful pings to aid future debugging

## Problem
Logs showed a pattern where:
1. Connection dies around 40-45 seconds after establishment
2. Service call retries accumulate on the dead connection
3. Ping at 60s (or next scheduled ping) finally detects the issue
4. Reconnect happens, but 15-30+ seconds of failed writes have accumulated

## Root Cause
The Tailscale network path (likely DERP relay or NAT) appears to timeout connections after ~40-45 seconds of inactivity. The previous 30s ping interval was borderline, and any delay or jitter meant connections would die before the next ping.

## Solution
1. **Reduce ping interval to 15s** - Well under the ~40s timeout, ensuring at least 2 pings during the danger window
2. **Reduce pongWait to 45s** - Adjusted to 3x pingInterval
3. **Add write timeout detection** - When a write fails with "i/o timeout", immediately close the connection rather than accumulating failed retries
4. **Add debug logging** - Log successful pings to help debug any remaining issues

## Test plan
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Coverage maintained at 70%
- [ ] Monitor production logs after deployment for reduction in write failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)