### PR TITLE
config(music): mute Kitchen player when TV is playing

### DIFF
--- a/configs/music_config.yaml
+++ b/configs/music_config.yaml
@@ -4,7 +4,9 @@ music:
     participants:
       - player_name: "Kitchen"
         base_volume: 9
-        leave_muted_if: []
+        leave_muted_if:
+          - variable: isTVPlaying
+            value: true
       - player_name: "Soundbar"
         base_volume: 10
         leave_muted_if:
@@ -54,7 +56,9 @@ music:
     participants:
       - player_name: "Kitchen"
         base_volume: 9
-        leave_muted_if: []
+        leave_muted_if:
+          - variable: isTVPlaying
+            value: true
       - player_name: "Soundbar"
         base_volume: 10
         leave_muted_if:


### PR DESCRIPTION
## Summary
- Add `leave_muted_if` condition to Kitchen player when `isTVPlaying` is true
- Applied to both normal and specific playback configurations
- Prevents music from playing through Kitchen speakers while TV is in use

## Test plan
- [x] Config syntax is valid YAML
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)