### PR TITLE
fix(ci): trigger agent reviews on reopened PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, reopened]
 
 env:
   DEVCONTAINER_IMAGE: ghcr.io/${{ github.repository }}-devcontainer


### PR DESCRIPTION
## Summary

Add `reopened` to pull_request trigger types so agent reviews run when a PR is reopened, not just when first opened.

This fixes the issue where re-opening PR #290 didn't trigger agent reviews.

## Changes

```yaml
# Before
types: [opened]

# After  
types: [opened, reopened]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)