### PR TITLE
fix(ci): use lowercase image name for Docker compatibility

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,15 +32,15 @@ jobs:
 
       - name: Build and run in devcontainer
         uses: devcontainers/ci@v0.3
-        env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
         with:
           imageName: ${{ env.DEVCONTAINER_IMAGE }}
           cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
           push: always
+          env: |
+            CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+            GH_TOKEN=${{ github.token }}
+            PR_NUMBER=${{ github.event.pull_request.number }}
+            REPO=${{ github.repository }}
           runCmd: |
             # Run Claude Code review inside the devcontainer
             claude --print \
@@ -101,14 +101,14 @@ jobs:
 
       - name: Test review in devcontainer
         uses: devcontainers/ci@v0.3
-        env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
           imageName: ${{ env.DEVCONTAINER_IMAGE }}
           cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
           push: always
+          env: |
+            CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+            GH_TOKEN=${{ github.token }}
+            PR_NUMBER=${{ github.event.pull_request.number }}
           runCmd: |
             claude --print \
               --model opus \
@@ -156,14 +156,14 @@ jobs:
 
       - name: Concurrency review in devcontainer
         uses: devcontainers/ci@v0.3
-        env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
           imageName: ${{ env.DEVCONTAINER_IMAGE }}
           cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
           push: always
+          env: |
+            CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+            GH_TOKEN=${{ github.token }}
+            PR_NUMBER=${{ github.event.pull_request.number }}
           runCmd: |
             claude --print \
               --model opus \

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -62,16 +62,16 @@ jobs:
 
       - name: Run Claude in devcontainer
         uses: devcontainers/ci@v0.3
-        env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          GH_TOKEN: ${{ github.token }}
-          COMMENT_BODY: ${{ steps.comment.outputs.body }}
-          ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
         with:
           imageName: ${{ env.DEVCONTAINER_IMAGE }}
           cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
           push: always
+          env: |
+            CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+            GH_TOKEN=${{ github.token }}
+            COMMENT_BODY=${{ steps.comment.outputs.body }}
+            ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
+            REPO=${{ github.repository }}
           runCmd: |
             # Run Claude Code inside the devcontainer with full tool access
             claude --print \
@@ -123,17 +123,17 @@ jobs:
 
       - name: Resolve issue in devcontainer
         uses: devcontainers/ci@v0.3
-        env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          GH_TOKEN: ${{ github.token }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_TITLE: ${{ github.event.issue.title }}
-          ISSUE_BODY: ${{ github.event.issue.body }}
-          REPO: ${{ github.repository }}
         with:
           imageName: ${{ env.DEVCONTAINER_IMAGE }}
           cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
           push: always
+          env: |
+            CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+            GH_TOKEN=${{ github.token }}
+            ISSUE_NUMBER=${{ github.event.issue.number }}
+            ISSUE_TITLE=${{ github.event.issue.title }}
+            ISSUE_BODY=${{ github.event.issue.body }}
+            REPO=${{ github.repository }}
           runCmd: |
             claude --print \
               --model opus \


### PR DESCRIPTION
## Summary

Fix devcontainer build failure caused by uppercase characters in the image name.

### Problem

```
ERROR: failed to build: invalid tag "ghcr.io/NickBorgers/home-automation-devcontainer:latest": repository name must be lowercase
```

The `github.repository` variable returns `NickBorgers/home-automation` with mixed case, but Docker/GHCR requires lowercase repository names.

### Solution

Hardcode the lowercase image name instead of using the variable:
```yaml
# Before
DEVCONTAINER_IMAGE: ghcr.io/${{ github.repository }}-devcontainer

# After
DEVCONTAINER_IMAGE: ghcr.io/nickborgers/home-automation-devcontainer
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)