### PR TITLE
feat(devcontainer): install Claude Code and Playwright in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,9 @@
-# Devcontainer Dockerfile with pre-installed Playwright dependencies
-# This caches system packages so rebuilds are faster
+# Devcontainer Dockerfile with pre-installed Claude Code and Playwright
+# This caches system packages and tools so rebuilds are faster
 
 FROM mcr.microsoft.com/devcontainers/go:1.25
 
-# Install Playwright browser dependencies
+# Install Playwright browser dependencies and system utilities
 # These are the system libraries required for Chromium to run
 RUN apt-get update && apt-get install -y --no-install-recommends \
     # Core Chromium dependencies
@@ -17,3 +17,39 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Utilities used by Claude Code
     bc \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js LTS (needed for Claude Code and Playwright)
+ARG NODE_VERSION=20
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Claude Code CLI globally
+RUN npm install -g @anthropic-ai/claude-code
+
+# Create directories for vscode user with correct ownership
+RUN mkdir -p /home/vscode/.claude/tmp \
+    && mkdir -p /home/vscode/.claude/plugins/cache \
+    && mkdir -p /home/vscode/.claude/plugins/marketplaces \
+    && mkdir -p /home/vscode/.cache/ms-playwright \
+    && chown -R vscode:vscode /home/vscode/.claude \
+    && chown -R vscode:vscode /home/vscode/.cache
+
+# Switch to vscode user for plugin installation
+USER vscode
+WORKDIR /home/vscode
+
+# Set TMPDIR to avoid EXDEV errors during plugin installation
+ENV TMPDIR=/home/vscode/.claude/tmp
+
+# Install playwright-skill plugin
+RUN claude plugin marketplace add lackeyjb/playwright-skill \
+    && claude plugin install playwright-skill@playwright-skill
+
+# Install Playwright npm dependencies and browser
+RUN cd ~/.claude/plugins/cache/playwright-skill/playwright-skill/*/skills/playwright-skill \
+    && npm install \
+    && npx playwright install chromium
+
+# Switch back to root for any remaining operations
+USER root

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,8 +6,6 @@
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/node:1": {},
-    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": "latest",
       "moby": "false"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -35,23 +35,7 @@ else
     echo "Warning: repository root $REPO_ROOT not found; skipping git hooks installation."
 fi
 
-# Claude Code playwright-skill plugin
-echo "Installing playwright-skill plugin..."
-
-# Workaround for EXDEV error: /tmp and /home/vscode are on different filesystems
-# in devcontainers. Setting TMPDIR to a path on the same filesystem fixes
-# the "cross-device link not permitted" error during plugin installation.
-export TMPDIR="$HOME/.claude/tmp"
-mkdir -p "$TMPDIR"
-
-claude plugin marketplace add lackeyjb/playwright-skill
-claude plugin install playwright-skill@playwright-skill
-
-# Note: Playwright browser dependencies (apt packages) are now installed
+# Note: Claude Code and playwright-skill plugin are now pre-installed
 # in the Dockerfile for faster rebuilds via Docker layer caching.
-
-echo "Setting up Playwright (installing browser)..."
-cd ~/.claude/plugins/marketplaces/playwright-skill/skills/playwright-skill
-npm run setup
 
 echo "=== Devcontainer setup complete ==="


### PR DESCRIPTION
## Summary

- Move Claude Code installation from devcontainer feature to Dockerfile for better Docker layer caching
- Pre-install playwright-skill plugin and Chromium browser in the image
- Simplify post-create.sh by removing redundant plugin installation steps

## Changes

**Dockerfile:**
- Add Node.js 20 LTS installation
- Install Claude Code CLI globally via `npm install -g @anthropic-ai/claude-code`
- Pre-install playwright-skill plugin and Chromium browser
- Set up proper directory ownership for vscode user

**devcontainer.json:**
- Remove `ghcr.io/anthropics/devcontainer-features/claude-code:1.0` feature
- Remove `ghcr.io/devcontainers/features/node:1` feature (now in Dockerfile)

**post-create.sh:**
- Remove Claude plugin installation section (now in Dockerfile)
- Keep only: DNS fix, Go modules setup, git hooks installation

## Benefits

- Faster container rebuilds due to Docker layer caching
- ~280MB Playwright browser downloads cached in image layer
- More consistent installations across container rebuilds

## Test plan

- [x] Docker build completes successfully
- [x] `claude --version` returns 2.0.76
- [x] Playwright plugin installed at `~/.claude/plugins/cache/playwright-skill/`
- [x] Playwright browsers installed at `~/.cache/ms-playwright/`
- [ ] Full devcontainer rebuild and verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)