### PR TITLE
feat(devcontainer): consolidate features into Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,14 @@
 # Devcontainer Dockerfile with pre-installed Claude Code and Playwright
 # This caches system packages and tools so rebuilds are faster
+# Consolidates devcontainer features into Dockerfile for better layer caching
 
 FROM mcr.microsoft.com/devcontainers/go:1.25
 
-# Install Playwright browser dependencies and system utilities
-# These are the system libraries required for Chromium to run
+# Install system packages: Playwright browser dependencies, zsh, and utilities
+# Consolidates what was previously in common-utils feature
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Shell and common utilities (from common-utils feature)
+    zsh \
     # Core Chromium dependencies
     libglib2.0-0 libnss3 libnspr4 libdbus-1-3 libatk1.0-0 \
     libatk-bridge2.0-0 libcups2 libdrm2 libxkbcommon0 libatspi2.0-0 \
@@ -16,6 +19,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcairo2 libpango-1.0-0 \
     # Utilities used by Claude Code
     bc \
+    && rm -rf /var/lib/apt/lists/* \
+    # Set zsh as default shell for vscode user
+    && chsh -s /usr/bin/zsh vscode
+
+# Note: oh-my-zsh is already included in the base Go devcontainer image
+
+# Install GitHub CLI (from github-cli feature)
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js LTS (needed for Claude Code and Playwright)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,8 +4,6 @@
     "dockerfile": "Dockerfile"
   },
   "features": {
-    "ghcr.io/devcontainers/features/common-utils:2": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": "latest",
       "moby": "false"


### PR DESCRIPTION
## Summary

- Move `common-utils` devcontainer feature functionality into Dockerfile (zsh installation)
- Move `github-cli` devcontainer feature into Dockerfile
- Only `docker-in-docker` remains as a feature (requires runtime privileges)

This continues the work from #295 to consolidate more devcontainer features into the Dockerfile for better Docker layer caching.

## Changes

**Dockerfile:**
- Add zsh installation and set as default shell for vscode user
- Install GitHub CLI from official apt repository
- Note that oh-my-zsh is already included in the base Go devcontainer image

**devcontainer.json:**
- Remove `ghcr.io/devcontainers/features/common-utils:2` feature
- Remove `ghcr.io/devcontainers/features/github-cli:1` feature
- Keep only `docker-in-docker` (cannot be moved - requires runtime privileges)

## Benefits

- Faster container rebuilds via Docker layer caching
- Fewer external feature dependencies during container creation
- More consistent installations across rebuilds

## Test plan

- [x] Docker build completes successfully
- [x] `zsh --version` returns 5.9
- [x] `gh --version` returns 2.83.2
- [x] Default shell for vscode user is `/usr/bin/zsh`
- [x] `claude --version` works (from #295)
- [x] Playwright browsers installed (from #295)
- [ ] Full devcontainer rebuild and verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)