### PR TITLE
fix(ci): include go.mod hash in Go tools cache key

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/go/bin
-          key: go-tools-${{ runner.os }}-v1
+          key: go-tools-${{ runner.os }}-${{ hashFiles('homeautomation-go/go.mod') }}-v1
 
       - name: Run style checks
         run: make ci-style-checks


### PR DESCRIPTION
## Summary

- Fixed Go tools cache incompatibility when upgrading Go versions
- The cache key now includes a hash of `go.mod`, so the cache is automatically invalidated when the Go version changes

## Problem

The CI was failing with:
> "module requires at least go1.24.0, but Staticcheck was built with go1.23.12"

The cached `staticcheck` binary from Go 1.23 was incompatible with the Go 1.24 module requirements.

## Solution

Changed the cache key from:
```yaml
key: go-tools-${{ runner.os }}-v1
```

To:
```yaml
key: go-tools-${{ runner.os }}-${{ hashFiles('homeautomation-go/go.mod') }}-v1
```

This ensures the Go tools cache is invalidated whenever `go.mod` changes, which includes Go version upgrades.

## Test plan

- [x] Pre-push hook passes locally
- [ ] PR Tests workflow runs successfully with the new cache key

Fixes discussion in #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)