### PR TITLE
fix(ci): add actions:write permission for triggering PR Tests

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -160,6 +160,7 @@ jobs:
       issues: write
       id-token: write
       packages: read
+      actions: write  # Required to trigger PR Tests workflow via workflow_dispatch
 
     steps:
       - name: Checkout PR branch


### PR DESCRIPTION
## Summary
Adds `actions: write` permission to the `fix-test-failures` job so it can trigger the PR Tests workflow via `gh workflow run`.

## Problem
After Claude pushes a fix, the "Trigger PR Tests after fix" step failed with:
```
HTTP 403: Resource not accessible by integration
```

## Solution
Add `actions: write` to the fix-test-failures job permissions.

## Test plan
- [ ] Merge this PR
- [ ] Re-test with PR #302
- [ ] Verify full cycle: tests fail → Claude fixes → PR Tests triggered → tests pass → reviews run

🤖 Generated with [Claude Code](https://claude.com/claude-code)