### PR TITLE
fix(ci): add workflows:write permission for Claude push operations

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -161,6 +161,7 @@ jobs:
       id-token: write
       packages: read
       actions: write  # Required to trigger PR Tests workflow via workflow_dispatch
+      workflows: write  # Required to push branches when repo contains workflow files
 
     steps:
       - name: Checkout PR branch
@@ -322,6 +323,7 @@ jobs:
       issues: write
       id-token: write
       packages: read
+      workflows: write  # Required to push branches when repo contains workflow files
 
     steps:
       - name: Checkout PR branch
@@ -409,6 +411,7 @@ jobs:
       issues: write
       id-token: write
       packages: read
+      workflows: write  # Required to push branches when repo contains workflow files
 
     steps:
       - name: Checkout PR branch
@@ -483,6 +486,7 @@ jobs:
       issues: write
       id-token: write
       packages: read
+      workflows: write  # Required to push branches when repo contains workflow files
 
     steps:
       - name: Checkout PR branch

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,6 +55,7 @@ jobs:
       id-token: write
       actions: read
       packages: read
+      workflows: write  # Required to push branches when repo contains workflow files
 
     steps:
       - name: Checkout repository
@@ -146,6 +147,7 @@ jobs:
       issues: write
       id-token: write
       packages: read
+      workflows: write  # Required to push branches when repo contains workflow files
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Fixes the GitHub App permissions issue that prevented Claude from pushing branches in issue #306.

The error was:
> "refusing to allow a GitHub App to create or update workflow `.github/workflows/claude-code-review.yml` without `workflows` permission"

GitHub requires `workflows: write` permission when pushing to repositories that contain workflow files, even if those workflow files aren't being modified in the push.

### Changes
Added `workflows: write` permission to all jobs that can push code:
- `claude.yml`: `claude`, `resolve-issue` jobs
- `claude-code-review.yml`: `fix-test-failures`, `claude-review`, `test-review`, `concurrency-review` jobs

## Test Plan
- [ ] Verify workflows still trigger correctly
- [ ] Create a new issue mentioning @claude to test the resolve-issue job can now push

Resolves #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)