### PR TITLE
fix(ci): remove invalid workflows permission from job-level permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -212,7 +212,6 @@ jobs:
       id-token: write
       packages: read
       actions: write  # Required to trigger PR Tests workflow via workflow_dispatch
-      workflows: write  # Required to push branches when repo contains workflow files
 
     steps:
       - name: Checkout PR branch
@@ -420,7 +419,6 @@ jobs:
       issues: write
       id-token: write
       packages: read
-      workflows: write  # Required to push branches when repo contains workflow files
 
     steps:
       - name: Checkout PR branch
@@ -508,7 +506,6 @@ jobs:
       issues: write
       id-token: write
       packages: read
-      workflows: write  # Required to push branches when repo contains workflow files
 
     steps:
       - name: Checkout PR branch
@@ -583,7 +580,6 @@ jobs:
       issues: write
       id-token: write
       packages: read
-      workflows: write  # Required to push branches when repo contains workflow files
 
     steps:
       - name: Checkout PR branch


### PR DESCRIPTION
## Summary
The `workflows` permission is only valid at the workflow level, not at job level. Having it in job permissions blocks causes YAML parsing errors:

```
Invalid Argument - failed to parse workflow: (Line: 215, Col: 7): Unexpected value 'workflows', 
(Line: 423, Col: 7): Unexpected value 'workflows', (Line: 511, Col: 7): Unexpected value 'workflows', 
(Line: 586, Col: 7): Unexpected value 'workflows'
```

**This was the root cause of workflow_run events not triggering claude-code-review.**

## Changes
Removed `workflows: write` from all job-level permissions blocks in `claude-code-review.yml`.

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger tests on PR #302 
- [ ] Verify workflow_run event fires and fix-test-failures runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)