### PR TITLE
fix(ci): create commit status after workflow_dispatch PR Tests passes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -212,6 +212,7 @@ jobs:
       id-token: write
       packages: read
       actions: write  # Required to trigger PR Tests workflow via workflow_dispatch
+      statuses: write  # Required to create commit status after tests pass
 
     steps:
       - name: Checkout PR branch
@@ -378,10 +379,22 @@ jobs:
               exit 0
             fi
 
-            # If tests passed, trigger claude-code-review via workflow_dispatch
+            # If tests passed, create a commit status and trigger reviews
             # (workflow_run events don't fire for workflow_dispatch-triggered runs)
             if [ "$CONCLUSION" = "success" ]; then
-              echo "Tests passed! Triggering Claude Code Review..."
+              echo "Tests passed!"
+
+              # Create a commit status for the PR's head SHA so the PR check shows as passed
+              # This is needed because workflow_dispatch runs don't automatically create PR status checks
+              echo "Creating commit status for $CURRENT_HEAD..."
+              gh api repos/${{ github.repository }}/statuses/$CURRENT_HEAD \
+                -f state="success" \
+                -f target_url="https://github.com/${{ github.repository }}/actions/runs/$RUN_ID" \
+                -f description="All required tests passed (via automated fix)" \
+                -f context="All Required Tests"
+              echo "Commit status created successfully"
+
+              echo "Triggering Claude Code Review..."
               gh workflow run "Claude Code Review" \
                 --ref "main" \
                 --repo ${{ github.repository }} \


### PR DESCRIPTION
## Summary
When Claude fixes tests and triggers PR Tests via `workflow_dispatch`, the PR's status checks don't update because workflow_dispatch runs don't automatically create status checks for the PR's head commit.

This fix creates a commit status using the GitHub API after the workflow_dispatch PR Tests run completes successfully. This ensures the PR shows "All Required Tests" as passed.

## Changes
1. Added `gh api repos/.../statuses/$SHA` call to create commit status after tests pass
2. Added `statuses: write` permission to fix-test-failures job

## Test plan
- [ ] Merge this PR
- [ ] Re-break test on PR #302
- [ ] Verify full cycle: tests fail → fix pushed → tests pass → **status check shows on PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)