### PR TITLE
fix(ci): remove invalid workflows permission from claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,7 +55,6 @@ jobs:
       id-token: write
       actions: read
       packages: read
-      workflows: write  # Required to push branches when repo contains workflow files
 
     steps:
       - name: Checkout repository
@@ -147,7 +146,6 @@ jobs:
       issues: write
       id-token: write
       packages: read
-      workflows: write  # Required to push branches when repo contains workflow files
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Remove invalid `workflows: write` permission from job-level permissions in `claude.yml`

## Problem
The `workflows` permission is only valid at the workflow level, not at job level. Having it in job permissions causes YAML parsing errors that prevent the workflow from running.

This was the same issue fixed in d113a0e for `claude-code-review.yml`, but `claude.yml` still had the invalid permission on lines 58 and 150.

This is why issue #314 did not trigger any Claude runs.

## Changes
- Removed `workflows: write` from the `claude` job permissions
- Removed `workflows: write` from the `resolve-issue` job permissions

## Test Plan
- After merge, create a new issue and verify it triggers the `resolve-issue` job
- Verify the `claude-started` label gets added to the issue

Fixes the root cause of #314 not being auto-resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)