### PR TITLE
fix(ci): add concurrency control to prevent duplicate review comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,6 +29,13 @@ on:
         required: true
         type: string
 
+# Prevent duplicate reviews when multiple PR Tests complete around the same time
+# Uses branch name for concurrency group
+# cancel-in-progress: false ensures we complete the first review rather than restarting
+concurrency:
+  group: claude-review-${{ github.event_name == 'workflow_dispatch' && inputs.head_ref || github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
 env:
   # Note: must be lowercase for Docker compatibility
   DEVCONTAINER_IMAGE: ghcr.io/nickborgers/home-automation-devcontainer


### PR DESCRIPTION
## Summary
- Adds workflow-level concurrency control to `claude-code-review.yml`
- Ensures only one Claude Code Review runs at a time per branch
- Subsequent workflow runs wait rather than creating duplicate reviews

## Root Cause
When commits are pushed or a PR is synced, multiple "PR Tests" workflow runs can trigger (e.g., from both `push` and `pull_request` events). Each completed PR Tests run fires a separate `workflow_run` event, triggering multiple Claude Code Review workflows that post duplicate comments.

## Fix
The `concurrency` block uses the branch name as the group key with `cancel-in-progress: false`, ensuring the first review completes while subsequent runs wait in queue.

Fixes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)