### PR TITLE
fix(ci): use WORKFLOW_PAT for checkout to enable workflow file modifications

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -221,7 +221,7 @@ jobs:
           ref: ${{ needs.get-context.outputs.head_ref }}
           repository: ${{ needs.get-context.outputs.head_repo }}
           fetch-depth: 0
-          token: ${{ github.token }}
+          token: ${{ secrets.WORKFLOW_PAT }}  # PAT required to push workflow file changes
 
       - name: Increment fix attempt counter
         env:
@@ -440,7 +440,7 @@ jobs:
           ref: ${{ needs.get-context.outputs.head_ref }}
           repository: ${{ needs.get-context.outputs.head_repo }}
           fetch-depth: 0
-          token: ${{ github.token }}
+          token: ${{ secrets.WORKFLOW_PAT }}  # PAT required to push workflow file changes
 
       - name: Create gh config directory for devcontainer mount
         run: mkdir -p ~/.config/gh
@@ -527,7 +527,7 @@ jobs:
           ref: ${{ needs.get-context.outputs.head_ref }}
           repository: ${{ needs.get-context.outputs.head_repo }}
           fetch-depth: 0
-          token: ${{ github.token }}
+          token: ${{ secrets.WORKFLOW_PAT }}  # PAT required to push workflow file changes
 
       - name: Pull latest changes
         run: git pull origin ${{ needs.get-context.outputs.head_ref }} || true
@@ -601,7 +601,7 @@ jobs:
           ref: ${{ needs.get-context.outputs.head_ref }}
           repository: ${{ needs.get-context.outputs.head_repo }}
           fetch-depth: 0
-          token: ${{ github.token }}
+          token: ${{ secrets.WORKFLOW_PAT }}  # PAT required to push workflow file changes
 
       - name: Pull latest changes
         run: git pull origin ${{ needs.get-context.outputs.head_ref }} || true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,6 +61,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.WORKFLOW_PAT }}  # PAT required to push workflow file changes
 
       - name: Create gh config directory for devcontainer mount
         run: mkdir -p ~/.config/gh
@@ -152,6 +153,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.WORKFLOW_PAT }}  # PAT required to push workflow file changes
 
       - name: Create gh config directory for devcontainer mount
         run: mkdir -p ~/.config/gh


### PR DESCRIPTION
## Summary
- Use fine-grained PAT (`WORKFLOW_PAT`) in checkout steps for all Claude-running jobs
- This enables agents to push changes to `.github/workflows/` files

## Background

Issue #319 revealed that Claude agents cannot push workflow file changes because:

1. **`workflows` permission at job-level is invalid** - causes YAML parsing errors
2. **`GITHUB_TOKEN` cannot modify workflow files** - even with `contents:write`, this is a GitHub security restriction

The solution is to use a fine-grained PAT with `Contents` and `Workflows` read/write permissions.

## Changes

Updated checkout steps to use `${{ secrets.WORKFLOW_PAT }}` in:

| Workflow | Job |
|----------|-----|
| `claude.yml` | `claude` |
| `claude.yml` | `resolve-issue` |
| `claude-code-review.yml` | `fix-test-failures` |
| `claude-code-review.yml` | `claude-review` |
| `claude-code-review.yml` | `test-review` |
| `claude-code-review.yml` | `concurrency-review` |

## Test Plan
- [ ] Verify workflows still run (no YAML parsing errors)
- [ ] Create a test issue requiring workflow file modification to confirm fix works

🤖 Generated with [Claude Code](https://claude.com/claude-code)