### PR TITLE
fix(ci): correct YAML indentation in notify-pr-merged workflow

### DIFF
--- a/.github/workflows/notify-pr-merged.yml
+++ b/.github/workflows/notify-pr-merged.yml
@@ -1,39 +1,39 @@
 name: Notify Private Repo of PR Merge
 
-  on:
-    pull_request:
-      types: [closed]
-      branches:
-        - main
-        - master
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+      - master
 
-  jobs:
-    notify-downstream:
-      if: github.event.pull_request.merged == true
-      runs-on: ubuntu-latest
+jobs:
+  notify-downstream:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
 
-      steps:
-        - name: Trigger private repository review
-          run: |
-            HTTP_STATUS=$(curl -s -o response.json -w "%{http_code}" -X POST \
-              -H "Accept: application/vnd.github.v3+json" \
-              -H "Authorization: token ${{ secrets.PRIVATE_REPO_TRIGGER_TOKEN }}" \
-              https://api.github.com/repos/NickBorgers/home-automation-plus-security/dispatches \
-              -d '{
-                "event_type": "upstream-pr-merged",
-                "client_payload": {
-                  "ref": "${{ github.ref }}",
-                  "sha": "${{ github.event.pull_request.merge_commit_sha }}",
-                  "pr_number": "${{ github.event.pull_request.number }}",
-                  "pr_title": "${{ github.event.pull_request.title }}",
-                  "pr_url": "${{ github.event.pull_request.html_url }}"
-                }
-              }')
+    steps:
+      - name: Trigger private repository review
+        run: |
+          HTTP_STATUS=$(curl -s -o response.json -w "%{http_code}" -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.PRIVATE_REPO_TRIGGER_TOKEN }}" \
+            https://api.github.com/repos/NickBorgers/home-automation-plus-security/dispatches \
+            -d '{
+              "event_type": "upstream-pr-merged",
+              "client_payload": {
+                "ref": "${{ github.ref }}",
+                "sha": "${{ github.event.pull_request.merge_commit_sha }}",
+                "pr_number": "${{ github.event.pull_request.number }}",
+                "pr_title": "${{ github.event.pull_request.title }}",
+                "pr_url": "${{ github.event.pull_request.html_url }}"
+              }
+            }')
 
-            if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
-              echo "✅ Successfully notified private repo of PR merge"
-            else
-              echo "❌ Failed to notify"
-              cat response.json
-              exit 1
-            fi
+          if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+            echo "✅ Successfully notified private repo of PR merge"
+          else
+            echo "❌ Failed to notify"
+            cat response.json
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Fixed YAML syntax error in `.github/workflows/notify-pr-merged.yml`
- The `on:` and `jobs:` top-level keys had 2 extra spaces of indentation
- This was causing the workflow to fail with "You have an error in your yaml syntax on line 3"

## Test plan
- [x] Verify YAML syntax is valid
- [ ] Confirm workflow runs successfully on next PR merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)