### PR TITLE
test(sleephygiene): add scenario test verifying wake sequence volume fades out

### DIFF
--- a/homeautomation-go/internal/plugins/sleephygiene/manager.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager.go
@@ -34,6 +34,9 @@ const (
 	wakeDelayAfterFadeOut = 5 * time.Minute
 )
 
+// SleepFunc is the type for sleep functions (for testing)
+type SleepFunc func(time.Duration)
+
 // Manager handles sleep hygiene automations including wake-up sequences
 type Manager struct {
 	haClient        ha.HAClient
@@ -53,6 +56,9 @@ type Manager struct {
 
 	// Shadow state tracking
 	shadowTracker *shadowstate.SleepHygieneTracker
+
+	// Injectable sleep function for testing
+	sleepFunc SleepFunc
 }
 
 // NewManager creates a new Sleep Hygiene manager
@@ -78,7 +84,13 @@ func NewManager(haClient ha.HAClient, stateManager *state.Manager, configLoader 
 		haSubscriptions: make([]ha.Subscription, 0),
 		triggeredToday:  make(map[string]time.Time),
 		shadowTracker:   shadowstate.NewSleepHygieneTracker(),
+		sleepFunc:       time.Sleep,
 	}
+}
+
+// SetSleepFunc allows overriding the sleep function for testing
+func (m *Manager) SetSleepFunc(fn SleepFunc) {
+	m.sleepFunc = fn
 }
 
 // Start begins monitoring state changes and managing sleep hygiene
@@ -505,7 +517,7 @@ func (m *Manager) fadeOutSpeaker(speakerEntityID string) {
 			zap.String("speaker", speakerEntityID),
 			zap.Int("delay_seconds", delaySeconds))
 
-		time.Sleep(time.Duration(delaySeconds) * time.Second)
+		m.sleepFunc(time.Duration(delaySeconds) * time.Second)
 	}
 
 	m.logger.Info("Fade out complete - speaker volume reached 0",
@@ -994,6 +1006,50 @@ func (m *Manager) recordAction(actionType string, reason string, trigger string)
 // GetShadowState returns the current shadow state
 func (m *Manager) GetShadowState() *shadowstate.SleepHygieneShadowState {
 	return m.shadowTracker.GetState()
+}
+
+// TriggerBeginWakeForTest is a test helper that directly triggers the begin_wake sequence.
+// This allows tests to exercise the fade-out logic without waiting for time triggers.
+// Note: This runs the fade-out synchronously (not in a goroutine) for easier testing.
+func (m *Manager) TriggerBeginWakeForTest() {
+	m.logger.Info("Test: Triggering begin_wake directly")
+
+	// Check conditions first (same as handleBeginWake)
+	isAnyoneHome, err := m.stateManager.GetBool("isAnyoneHome")
+	if err != nil || !isAnyoneHome {
+		m.logger.Debug("Test: Skipping begin_wake - no one home")
+		return
+	}
+
+	isMasterAsleep, err := m.stateManager.GetBool("isMasterAsleep")
+	if err != nil || !isMasterAsleep {
+		m.logger.Debug("Test: Skipping begin_wake - master not asleep")
+		return
+	}
+
+	musicPlaybackType, err := m.stateManager.GetString("musicPlaybackType")
+	if err != nil || musicPlaybackType != "sleep" {
+		m.logger.Debug("Test: Skipping begin_wake - not playing sleep music")
+		return
+	}
+
+	// Set fade out in progress flag
+	if !m.readOnly {
+		if err := m.stateManager.SetBool("isFadeOutInProgress", true); err != nil {
+			m.logger.Error("Test: Failed to set isFadeOutInProgress", zap.Error(err))
+		}
+	}
+
+	// Get bedroom speakers from currentlyPlayingMusic
+	bedroomSpeakers := m.getBedroomSpeakers()
+	if len(bedroomSpeakers) == 0 {
+		bedroomSpeakers = []string{"media_player.bedroom"}
+	}
+
+	// Run fade-out SYNCHRONOUSLY for testing (not in goroutine)
+	for _, speaker := range bedroomSpeakers {
+		m.fadeOutSpeaker(speaker)
+	}
 }
 
 // Reset re-checks all wake-up triggers for current day

--- a/homeautomation-go/test/integration/scenario_sleephygiene_test.go
+++ b/homeautomation-go/test/integration/scenario_sleephygiene_test.go
@@ -451,6 +451,114 @@ func TestScenario_MultipleAlarms_UpdatesCorrectly(t *testing.T) {
 	t.Log("SUCCESS: Multiple alarm times handled correctly")
 }
 
+// TestScenario_WakeSequence_VolumeFadesOutMonotonically validates that
+// the wake sequence fade-out correctly DECREASES speaker volume over time.
+// This test verifies that each volume_set call has a LOWER volume_level
+// than the previous call, ensuring the fade-out is truly fading OUT (not up).
+//
+// This is a regression test for a production issue where network chaos
+// caused volume_set commands to be retried out of order, potentially
+// resulting in unexpected volume changes.
+func TestScenario_WakeSequence_VolumeFadesOutMonotonically(t *testing.T) {
+	server, sleepMgr, cleanup := setupSleepHygieneScenarioTest(t)
+	defer cleanup()
+
+	// Skip internal sleeps so the fade-out completes quickly
+	sleepMgr.SetSleepFunc(func(d time.Duration) {})
+
+	// GIVEN: Conditions for begin_wake are met, bedroom speaker at 10% volume
+	t.Log("GIVEN: Someone is home, master is asleep, playing sleep music")
+	t.Log("       Bedroom speaker is at 10% volume (0.10)")
+
+	server.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
+	server.SetState("input_boolean.master_asleep", "on", map[string]interface{}{})
+	server.SetState("input_text.music_playback_type", "sleep", map[string]interface{}{})
+	server.SetState("input_boolean.fade_out_in_progress", "off", map[string]interface{}{})
+
+	// Set up bedroom speaker with initial volume at 10%
+	server.SetState("media_player.bedroom", "playing", map[string]interface{}{
+		"volume_level": 0.10, // 10% volume = volume value of 10
+	})
+
+	// Set up currentlyPlayingMusic state with bedroom speaker
+	currentMusicJSON := `{"participants":[{"player_name":"media_player.bedroom","volume":10}]}`
+	server.SetState("input_text.currently_playing_music", currentMusicJSON, map[string]interface{}{})
+
+	time.Sleep(50 * time.Millisecond)
+	server.ClearServiceCalls()
+
+	// WHEN: Begin wake sequence triggers the fade-out
+	t.Log("WHEN: Begin wake sequence is triggered")
+
+	// Directly call the exported method that triggers begin_wake
+	// We use a goroutine because fadeOutSpeaker runs synchronously
+	done := make(chan struct{})
+	go func() {
+		sleepMgr.TriggerBeginWakeForTest()
+		close(done)
+	}()
+
+	// Wait for fade-out to complete (with no-op sleep, this is fast)
+	select {
+	case <-done:
+		t.Log("Fade-out completed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Fade-out did not complete within timeout")
+	}
+
+	// Give a moment for any final service calls to be recorded
+	time.Sleep(50 * time.Millisecond)
+
+	// THEN: Verify all volume_set calls show monotonically DECREASING volume
+	t.Log("THEN: Verify all volume_set calls show monotonically decreasing volume")
+
+	calls := server.GetServiceCalls()
+	volumeCalls := filterServiceCalls(calls, "media_player", "volume_set")
+
+	// Should have multiple volume_set calls (one for each step from 10 down to 0)
+	t.Logf("Total volume_set calls: %d", len(volumeCalls))
+	require.GreaterOrEqual(t, len(volumeCalls), 2,
+		"Expected at least 2 volume_set calls during fade-out")
+
+	// Extract all volume levels in order
+	var volumeLevels []float64
+	for _, call := range volumeCalls {
+		volumeLevel, ok := call.ServiceData["volume_level"].(float64)
+		if !ok {
+			t.Logf("WARNING: volume_set call missing volume_level: %+v", call.ServiceData)
+			continue
+		}
+		volumeLevels = append(volumeLevels, volumeLevel)
+	}
+
+	t.Logf("Volume levels in order: %v", volumeLevels)
+
+	// CRITICAL ASSERTION: Each volume level must be LESS THAN the previous one
+	// This proves the fade-out is truly fading OUT, not up
+	for i := 1; i < len(volumeLevels); i++ {
+		prevVolume := volumeLevels[i-1]
+		currVolume := volumeLevels[i]
+
+		assert.Less(t, currVolume, prevVolume,
+			"Volume must DECREASE during fade-out: call %d (%.3f) should be less than call %d (%.3f)",
+			i+1, currVolume, i, prevVolume)
+	}
+
+	// Verify the sequence ends at 0 (complete fade-out)
+	if len(volumeLevels) > 0 {
+		finalVolume := volumeLevels[len(volumeLevels)-1]
+		assert.Equal(t, 0.0, finalVolume,
+			"Fade-out should end with volume at 0, got %.3f", finalVolume)
+	}
+
+	// Log the full fade-out sequence for debugging
+	t.Log("SUCCESS: Volume faded out monotonically from 10% to 0%")
+	t.Log("Volume sequence (should be strictly decreasing):")
+	for i, v := range volumeLevels {
+		t.Logf("  Call %d: volume_level = %.2f (%.0f%%)", i+1, v, v*100)
+	}
+}
+
 // TestScenario_SleepStateIntegration_ChecksConditions validates that wake
 // sequences only trigger when isMasterAsleep is true
 func TestScenario_SleepStateIntegration_ChecksConditions(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `TestScenario_WakeSequence_VolumeFadesOutMonotonically` to verify the wake sequence fade-out correctly DECREASES speaker volume over time
- Adds testability to sleephygiene manager via injectable sleep function (following the pattern from the music plugin)
- Adds `TriggerBeginWakeForTest()` helper for direct fade-out testing without waiting for time triggers

This is a regression test for a production issue where network instability caused `volume_set` commands to be retried out of order, potentially resulting in unexpected volume changes.

## Test Output

The test captures all `volume_set` service calls and verifies they form a monotonically decreasing sequence:

```
Volume levels in order: [0.09 0.08 0.07 0.06 0.05 0.04 0.03 0.02 0.01 0]

  Call 1: volume_level = 0.09 (9%)
  Call 2: volume_level = 0.08 (8%)
  Call 3: volume_level = 0.07 (7%)
  ...
  Call 10: volume_level = 0.00 (0%)
```

## Test plan

- [x] Unit tests pass (`make unit-tests`)
- [x] Integration tests pass (`make integration-tests`)
- [x] New test verifies volume_set calls are strictly decreasing
- [x] Pre-push hook validation passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)