### PR TITLE
fix(sleephygiene): rename light.master_bedroom to light.primary_suite

### DIFF
--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -278,7 +278,7 @@ Each plugin corresponds to a Node-RED flow and implements domain-specific automa
 - **Sleep Detection**: Monitor bedroom lights/doors → Update sleep states
 - **Arrival Notifications**: On owner arrival → Announce via TTS
 
-**Events Consumed:** `ha.binary_sensor.*.changed`, `ha.light.master_bedroom.*.changed`
+**Events Consumed:** `ha.binary_sensor.*.changed`, `ha.light.primary_suite.*.changed`
 
 **Events Published:** `state.presence.changed`, `state.sleep.changed`
 

--- a/homeautomation-go/internal/plugins/sleephygiene/manager.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager.go
@@ -749,7 +749,7 @@ func (m *Manager) turnOnMasterBedroomLights() {
 
 	// First, ensure lights start dim and white
 	if err := m.haClient.CallService("light", "turn_on", map[string]interface{}{
-		"entity_id":      "light.master_bedroom",
+		"entity_id":      "light.primary_suite",
 		"transition":     0,
 		"color_temp":     290,
 		"brightness_pct": 1,
@@ -760,7 +760,7 @@ func (m *Manager) turnOnMasterBedroomLights() {
 
 	// Then start slow transition to full brightness over 30 minutes
 	if err := m.haClient.CallService("light", "turn_on", map[string]interface{}{
-		"entity_id":      "light.master_bedroom",
+		"entity_id":      "light.primary_suite",
 		"transition":     1800, // 30 minutes in seconds
 		"color_temp":     290,
 		"brightness_pct": 100,

--- a/homeautomation-go/internal/plugins/sleephygiene/manager_shadow_test.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager_shadow_test.go
@@ -431,11 +431,11 @@ func TestSleepHygieneShadowState_BedroomLightsChange(t *testing.T) {
 
 	// Simulate bedroom lights state change
 	newState := &ha.State{
-		EntityID: "light.master_bedroom",
+		EntityID: "light.primary_suite",
 		State:    "off",
 	}
 
-	manager.handleBedroomLightsChange("light.master_bedroom", nil, newState)
+	manager.handleBedroomLightsChange("light.primary_suite", nil, newState)
 
 	shadowState := manager.GetShadowState()
 

--- a/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
@@ -223,19 +223,19 @@ func TestWake_AllConditionsMet(t *testing.T) {
 		t.Errorf("Expected at least 2 service calls, got %d", len(calls))
 	}
 
-	// Check that light service was called for master bedroom
-	foundMasterBedroom := false
+	// Check that light service was called for primary suite
+	foundPrimarySuite := false
 
 	for _, call := range calls {
 		if call.Domain == "light" && call.Service == "turn_on" {
-			if entityID, ok := call.Data["entity_id"].(string); ok && entityID == "light.master_bedroom" {
-				foundMasterBedroom = true
+			if entityID, ok := call.Data["entity_id"].(string); ok && entityID == "light.primary_suite" {
+				foundPrimarySuite = true
 			}
 		}
 	}
 
-	if !foundMasterBedroom {
-		t.Error("Expected light.turn_on call for master bedroom")
+	if !foundPrimarySuite {
+		t.Error("Expected light.turn_on call for primary suite")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes entity ID mismatch causing wake sequence failures
- Updates `light.master_bedroom` → `light.primary_suite` in sleephygiene plugin

## Background

The bedroom light entity was renamed in Home Assistant from `light.master_bedroom` to `light.primary_suite` on 2026-01-01. This caused the wake sequence to fail with:

```
WARNING [homeassistant.helpers.service] Referenced entities light.master_bedroom are missing or not currently available
```

The Go application continued trying to control the old entity ID, exhausting retries and failing silently.

## Changes

| File | Change |
|------|--------|
| `sleephygiene/manager.go` | Update entity ID in `turnOnMasterBedroomLights()` |
| `sleephygiene/manager_test.go` | Update test assertions |
| `sleephygiene/manager_shadow_test.go` | Update test fixtures |
| `docs/architecture/ARCHITECTURE.md` | Update documentation |

## Test plan

- [x] Unit tests pass
- [x] Integration tests pass
- [ ] Deploy and verify wake sequence controls `light.primary_suite`

🤖 Generated with [Claude Code](https://claude.com/claude-code)