### PR TITLE
Fix #344: Add break existing speaker groups to music flow diagram

### DIFF
--- a/docs/human/VISUAL_ARCHITECTURE.md
+++ b/docs/human/VISUAL_ARCHITECTURE.md
@@ -666,7 +666,8 @@ flowchart TD
     Orchestrate5[Orchestrate Playback] --> SelectPlaylist
     Orchestrate6[Orchestrate Playback] --> SelectPlaylist
 
-    SelectPlaylist[Select Playlist with Rotation<br/>from music_config.yaml] --> BuildGroup[Build Sonos Speaker Group]
+    SelectPlaylist[Select Playlist with Rotation<br/>from music_config.yaml] --> BreakGroups[Break Existing Speaker Groups<br/>media_player.unjoin]
+    BreakGroups --> BuildGroup[Build Sonos Speaker Group]
     BuildGroup --> MuteAll[Mute All Speakers to 0]
     MuteAll --> StartPlayback[Start Playback on Lead Player]
     StartPlayback --> EnableShuffle[Enable Shuffle for Playlists]
@@ -680,11 +681,21 @@ flowchart TD
     style CheckAsleep fill:#fff3e0
     style CheckDayPhase fill:#fff3e0
     style SelectPlaylist fill:#e8f5e9
+    style BreakGroups fill:#e8f5e9
     style StartPlayback fill:#e8f5e9
     style UpdateShadow fill:#f3e5f5
 ```
 
 **Reference:** See `homeautomation-go/internal/plugins/music/manager.go` for implementation details.
+
+**Playback Sequence (matches Node-RED):**
+1. Select playlist with rotation
+2. Break existing speaker groups (media_player.unjoin)
+3. Build new speaker group (media_player.join)
+4. Mute all speakers to 0
+5. Start playback on lead player
+6. Enable shuffle for playlists
+7. Fade in eligible speakers
 
 ---
 


### PR DESCRIPTION
Resolves #344

## Summary
Updated the Music Manager Logic Flow diagram in `docs/human/VISUAL_ARCHITECTURE.md` to include the "Break Existing Speaker Groups" step that was implemented in PR #235. This step (`media_player.unjoin`) is called before building new speaker groups to ensure speakers aren't already grouped together in unpredictable ways.

**Changes:**
- Added `BreakGroups` node to the Mermaid flowchart diagram between `SelectPlaylist` and `BuildGroup`
- Added appropriate styling for the new node (light green for actions)
- Added a text summary of the complete playback sequence below the diagram for quick reference

The playback sequence now correctly shows:
1. Select playlist with rotation
2. Break existing speaker groups (media_player.unjoin)
3. Build new speaker group (media_player.join)
4. Mute all speakers to 0
5. Start playback on lead player
6. Enable shuffle for playlists
7. Fade in eligible speakers

## Test Plan
- [x] Ran `make validate-mermaid` - all 14 diagrams pass validation
- [x] Ran `make unit-tests` - all tests pass with 70.4% coverage
- [x] Pre-push hooks passed including integration tests
- [ ] Preview the updated diagram in GitHub to verify rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)