### PR TITLE
Fix: prevent duplicate Code Review comments in claude-review job

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,6 +44,11 @@ jobs:
   # Extract PR and Issue context from workflow_run or workflow_dispatch event
   get-context:
     runs-on: ubuntu-latest
+    # Skip if PR Tests was triggered by 'push' event - only run for 'pull_request' triggered tests
+    # This prevents duplicate reviews when both push and pull_request events fire for the same commit
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.event == 'pull_request'
     outputs:
       pr_number: ${{ steps.get-pr.outputs.pr_number }}
       pr_title: ${{ steps.get-pr.outputs.pr_title }}
@@ -521,6 +526,9 @@ jobs:
 
             For HIGH SEVERITY issues (broken tests, obvious bugs, missing error handling),
             fix them directly, commit, and push. Use conventional commit messages.
+
+            IMPORTANT: Post exactly ONE comprehensive review comment. Do not post multiple comments.
+            Combine all findings (summary, issues found, fixes made) into a single comment.
 
             Post your review using:
             gh pr comment ${PR_NUMBER} --body 'YOUR_REVIEW_HERE'


### PR DESCRIPTION
## Summary
Fix duplicate reviews in the Claude Code Review workflow. Two issues addressed:

### Issue 1: Duplicate workflow runs (PR #354)
PR Tests triggers on both `push` and `pull_request` events for `claude/*` branches. When Claude pushes to a PR branch, both events fire, causing **two complete sets of reviews** (Code Review, Test Review, Concurrency Review, Documentation Review).

**Fix**: Add condition to `get-context` job to skip when PR Tests was triggered by `push` event - only run for `pull_request`-triggered tests.

### Issue 2: Multiple comments per review session (PR #346)  
The `claude-review` job could post multiple "Code Review" comments in a single session because the prompt didn't explicitly require a single comment.

**Fix**: Add explicit instruction to post exactly ONE comprehensive comment.

## Changes
```yaml
# Skip push-triggered PR Tests (prevents duplicate workflow runs)
get-context:
  if: |
    github.event_name == 'workflow_dispatch' ||
    github.event.workflow_run.event == 'pull_request'

# Explicit single-comment instruction in claude-review prompt
IMPORTANT: Post exactly ONE comprehensive review comment. Do not post multiple comments.
Combine all findings (summary, issues found, fixes made) into a single comment.
```

## Test plan
- [ ] Verify on next PR that only one set of reviews is posted (not duplicates)
- [ ] Verify Code Review posts exactly one comment per review session

🤖 Generated with [Claude Code](https://claude.com/claude-code)