### PR TITLE
fix: auto-detect Eight Sleep min temperature from HA entity attributes

### DIFF
--- a/homeautomation-go/internal/plugins/sexmode/manager.go
+++ b/homeautomation-go/internal/plugins/sexmode/manager.go
@@ -14,8 +14,9 @@ import (
 
 // EightSleep climate control constants
 const (
-	// EightSleepMinTemp is the minimum temperature setting for Eight Sleep (-100 to 100 range)
-	EightSleepMinTemp = -100 // Coldest setting
+	// EightSleepMinTemp is the fallback minimum temperature if auto-detection fails
+	// Note: The actual min_temp is auto-detected from the HA entity attributes
+	EightSleepMinTemp = 55 // Fallback: 55°F (coldest setting in HA's temperature scale)
 
 	// EightSleepNickEntity is Nick's Eight Sleep climate entity
 	EightSleepNickEntity = "climate.nick_s_eight_sleep_side_climate"
@@ -290,39 +291,90 @@ func (m *Manager) reevaluatePrimarySuiteLighting() {
 	}
 }
 
+// getEightSleepMinTemp retrieves the minimum temperature for an Eight Sleep climate entity
+// by querying its attributes from Home Assistant. Returns the fallback value if detection fails.
+func (m *Manager) getEightSleepMinTemp(entityID string) float64 {
+	state, err := m.haClient.GetState(entityID)
+	if err != nil {
+		m.logger.Warn("Failed to get Eight Sleep entity state, using fallback min temp",
+			zap.String("entity_id", entityID),
+			zap.Float64("fallback", float64(EightSleepMinTemp)),
+			zap.Error(err))
+		return float64(EightSleepMinTemp)
+	}
+
+	if state.Attributes == nil {
+		m.logger.Warn("Eight Sleep entity has no attributes, using fallback min temp",
+			zap.String("entity_id", entityID),
+			zap.Float64("fallback", float64(EightSleepMinTemp)))
+		return float64(EightSleepMinTemp)
+	}
+
+	minTempRaw, ok := state.Attributes["min_temp"]
+	if !ok {
+		m.logger.Warn("Eight Sleep entity missing min_temp attribute, using fallback",
+			zap.String("entity_id", entityID),
+			zap.Float64("fallback", float64(EightSleepMinTemp)))
+		return float64(EightSleepMinTemp)
+	}
+
+	// min_temp can come as float64 or int from JSON
+	switch v := minTempRaw.(type) {
+	case float64:
+		m.logger.Debug("Auto-detected Eight Sleep min temp",
+			zap.String("entity_id", entityID),
+			zap.Float64("min_temp", v))
+		return v
+	case int:
+		m.logger.Debug("Auto-detected Eight Sleep min temp",
+			zap.String("entity_id", entityID),
+			zap.Int("min_temp", v))
+		return float64(v)
+	default:
+		m.logger.Warn("Unexpected min_temp type, using fallback",
+			zap.String("entity_id", entityID),
+			zap.Any("min_temp_value", minTempRaw),
+			zap.Float64("fallback", float64(EightSleepMinTemp)))
+		return float64(EightSleepMinTemp)
+	}
+}
+
 // setEightSleepToColdest sets both Eight Sleep sides to the coldest setting
+// by auto-detecting the minimum temperature from each entity's attributes
 func (m *Manager) setEightSleepToColdest() {
-	m.logger.Info("Setting Eight Sleep to coldest",
-		zap.Int("temperature", EightSleepMinTemp))
+	m.logger.Info("Setting Eight Sleep to coldest (auto-detecting min temps)")
 
 	if m.readOnly {
 		m.logger.Info("READ-ONLY: Would set Eight Sleep to coldest",
 			zap.String("nick_entity", EightSleepNickEntity),
-			zap.String("caroline_entity", EightSleepCarolineEntity),
-			zap.Int("temperature", EightSleepMinTemp))
+			zap.String("caroline_entity", EightSleepCarolineEntity))
 		return
 	}
 
-	// Set Nick's side using climate.set_temperature
+	// Set Nick's side - auto-detect min temp from entity attributes
+	nickMinTemp := m.getEightSleepMinTemp(EightSleepNickEntity)
 	err := m.haClient.CallService("climate", "set_temperature", map[string]interface{}{
 		"entity_id":   EightSleepNickEntity,
-		"temperature": EightSleepMinTemp,
+		"temperature": nickMinTemp,
 	})
 	if err != nil {
 		m.logger.Error("Failed to set Nick's Eight Sleep to coldest", zap.Error(err))
 	} else {
-		m.logger.Info("Nick's Eight Sleep set to coldest")
+		m.logger.Info("Nick's Eight Sleep set to coldest",
+			zap.Float64("temperature", nickMinTemp))
 	}
 
-	// Set Caroline's side using climate.set_temperature
+	// Set Caroline's side - auto-detect min temp from entity attributes
+	carolineMinTemp := m.getEightSleepMinTemp(EightSleepCarolineEntity)
 	err = m.haClient.CallService("climate", "set_temperature", map[string]interface{}{
 		"entity_id":   EightSleepCarolineEntity,
-		"temperature": EightSleepMinTemp,
+		"temperature": carolineMinTemp,
 	})
 	if err != nil {
 		m.logger.Error("Failed to set Caroline's Eight Sleep to coldest", zap.Error(err))
 	} else {
-		m.logger.Info("Caroline's Eight Sleep set to coldest")
+		m.logger.Info("Caroline's Eight Sleep set to coldest",
+			zap.Float64("temperature", carolineMinTemp))
 	}
 }
 

--- a/homeautomation-go/internal/plugins/sexmode/manager_test.go
+++ b/homeautomation-go/internal/plugins/sexmode/manager_test.go
@@ -119,6 +119,15 @@ func TestSexModeManager_ActivationSetsEightSleep(t *testing.T) {
 
 	mockHA := ha.NewMockClient()
 	mockHA.SetState("input_boolean.sex", "off", nil)
+	// Set up Eight Sleep entities with min_temp attribute (auto-detection)
+	mockHA.SetState(EightSleepNickEntity, "heat_cool", map[string]interface{}{
+		"min_temp": float64(55),
+		"max_temp": float64(110),
+	})
+	mockHA.SetState(EightSleepCarolineEntity, "heat_cool", map[string]interface{}{
+		"min_temp": float64(55),
+		"max_temp": float64(110),
+	})
 	mockHA.Connect()
 
 	logger := zap.NewNop()
@@ -141,7 +150,7 @@ func TestSexModeManager_ActivationSetsEightSleep(t *testing.T) {
 	// Wait for async processing
 	time.Sleep(100 * time.Millisecond)
 
-	// Verify Eight Sleep was set to coldest
+	// Verify Eight Sleep was set to coldest (auto-detected min_temp)
 	calls := mockHA.GetServiceCalls()
 	nickFound := false
 	carolineFound := false
@@ -152,25 +161,27 @@ func TestSexModeManager_ActivationSetsEightSleep(t *testing.T) {
 			if !ok {
 				continue
 			}
-			temp, tempOk := call.Data["temperature"].(int)
+			// Temperature is now sent as float64 (auto-detected from entity attributes)
+			temp, tempOk := call.Data["temperature"].(float64)
 			if !tempOk {
 				continue
 			}
 
-			if entityID == EightSleepNickEntity && temp == EightSleepMinTemp {
+			// Should use auto-detected min_temp of 55
+			if entityID == EightSleepNickEntity && temp == 55 {
 				nickFound = true
 			}
-			if entityID == EightSleepCarolineEntity && temp == EightSleepMinTemp {
+			if entityID == EightSleepCarolineEntity && temp == 55 {
 				carolineFound = true
 			}
 		}
 	}
 
 	if !nickFound {
-		t.Errorf("Expected Nick's Eight Sleep to be set to coldest (%d), but service was not called correctly. Calls: %+v", EightSleepMinTemp, calls)
+		t.Errorf("Expected Nick's Eight Sleep to be set to coldest (55), but service was not called correctly. Calls: %+v", calls)
 	}
 	if !carolineFound {
-		t.Errorf("Expected Caroline's Eight Sleep to be set to coldest (%d), but service was not called correctly. Calls: %+v", EightSleepMinTemp, calls)
+		t.Errorf("Expected Caroline's Eight Sleep to be set to coldest (55), but service was not called correctly. Calls: %+v", calls)
 	}
 }
 

--- a/homeautomation-go/test/integration/scenario_sexmode_test.go
+++ b/homeautomation-go/test/integration/scenario_sexmode_test.go
@@ -35,6 +35,17 @@ func setupSexModeScenarioTest(t *testing.T) (*MockHAServer, *sexmode.Manager, *s
 
 	// Initialize sex mode toggle to off
 	server.SetState("input_boolean.sex", "off", nil)
+
+	// Set up Eight Sleep entities with min_temp attribute for auto-detection
+	// HA exposes temperatures in Fahrenheit (55-110°F range)
+	server.SetState(sexmode.EightSleepNickEntity, "heat_cool", map[string]interface{}{
+		"min_temp": float64(55),
+		"max_temp": float64(110),
+	})
+	server.SetState(sexmode.EightSleepCarolineEntity, "heat_cool", map[string]interface{}{
+		"min_temp": float64(55),
+		"max_temp": float64(110),
+	})
 	time.Sleep(50 * time.Millisecond)
 
 	// Create and start Sex Mode plugin
@@ -114,7 +125,7 @@ func TestScenario_SexModeActivation_ActivatesNightScene(t *testing.T) {
 }
 
 // TestScenario_SexModeActivation_SetsEightSleepToColdest tests that activating sex mode
-// sets both Eight Sleep beds to the coldest setting (-100)
+// sets both Eight Sleep beds to the coldest setting (auto-detected from entity attributes)
 func TestScenario_SexModeActivation_SetsEightSleepToColdest(t *testing.T) {
 	server, _, _, cleanup := setupSexModeScenarioTest(t)
 	defer cleanup()
@@ -128,16 +139,19 @@ func TestScenario_SexModeActivation_SetsEightSleepToColdest(t *testing.T) {
 	server.SetState("input_boolean.sex", "on", nil)
 	time.Sleep(100 * time.Millisecond)
 
-	t.Log("THEN: Both Eight Sleep sides should be set to coldest (-100)")
+	t.Log("THEN: Both Eight Sleep sides should be set to coldest (auto-detected min_temp: 55)")
 
 	calls := server.GetServiceCalls()
+
+	// Expected min temp from mock setup (55°F)
+	expectedMinTemp := 55
 
 	// Find Nick's Eight Sleep call
 	nickCall := FindServiceCallWithEntityID(calls, "climate", "set_temperature", sexmode.EightSleepNickEntity)
 	assert.NotNil(t, nickCall, "Nick's Eight Sleep should be set")
 	if nickCall != nil {
 		value := getNumericValue(nickCall.ServiceData["temperature"])
-		assert.Equal(t, sexmode.EightSleepMinTemp, value, "Nick's Eight Sleep should be set to coldest")
+		assert.Equal(t, expectedMinTemp, value, "Nick's Eight Sleep should be set to coldest")
 		t.Logf("✓ Nick's Eight Sleep set to %d", value)
 	}
 
@@ -146,7 +160,7 @@ func TestScenario_SexModeActivation_SetsEightSleepToColdest(t *testing.T) {
 	assert.NotNil(t, carolineCall, "Caroline's Eight Sleep should be set")
 	if carolineCall != nil {
 		value := getNumericValue(carolineCall.ServiceData["temperature"])
-		assert.Equal(t, sexmode.EightSleepMinTemp, value, "Caroline's Eight Sleep should be set to coldest")
+		assert.Equal(t, expectedMinTemp, value, "Caroline's Eight Sleep should be set to coldest")
 		t.Logf("✓ Caroline's Eight Sleep set to %d", value)
 	}
 }


### PR DESCRIPTION
## Summary

- Fix Eight Sleep temperature control during sex mode activation
- The code was sending `-100` (internal heating level) but Home Assistant expects temperatures in Fahrenheit (55-110°F)
- Now auto-detects the `min_temp` attribute from each Eight Sleep climate entity
- Gracefully falls back to 55°F if entity attributes are unavailable

## Root Cause

The Eight Sleep integration in HA maps the internal heating level scale (-100 to 100) to user-friendly temperatures. The coldest setting (-100 heating level) corresponds to 55°F in Home Assistant. The previous hardcoded value of `-100` was being rejected with:

```
Validation error: Provided temperature -100.0 is not valid. Accepted range is 55 to 110
```

## Test plan

- [x] Unit tests pass with updated mocks providing `min_temp` attributes
- [x] Integration tests pass with Eight Sleep entity mock setup
- [x] Manually verify sex mode activation sets Eight Sleep to coldest (55°F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)