### PR TITLE
Fix #352: Use WORKFLOW_PAT for triggering subsequent workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -273,7 +273,7 @@ jobs:
           push: never
           env: |
             CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-            GH_TOKEN=${{ github.token }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             PR_TITLE=${{ needs.get-context.outputs.pr_title }}
             PR_BODY_B64=${{ needs.get-context.outputs.pr_body_b64 }}
@@ -485,7 +485,7 @@ jobs:
           push: never
           env: |
             CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-            GH_TOKEN=${{ github.token }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             REPO=${{ github.repository }}
             HEAD_REF=${{ needs.get-context.outputs.head_ref }}
@@ -592,7 +592,7 @@ jobs:
           push: never
           env: |
             CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-            GH_TOKEN=${{ github.token }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             HEAD_REF=${{ needs.get-context.outputs.head_ref }}
           runCmd: |
@@ -716,7 +716,7 @@ jobs:
           push: never
           env: |
             CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-            GH_TOKEN=${{ github.token }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             HEAD_REF=${{ needs.get-context.outputs.head_ref }}
           runCmd: |
@@ -802,7 +802,7 @@ jobs:
           push: never
           env: |
             CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-            GH_TOKEN=${{ github.token }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             PR_TITLE=${{ needs.get-context.outputs.pr_title }}
             PR_BODY_B64=${{ needs.get-context.outputs.pr_body_b64 }}


### PR DESCRIPTION
## Summary
- Changes `GH_TOKEN` from `github.token` to `secrets.WORKFLOW_PAT` in the "Trigger PR Tests and reviews after fix" step

## Problem
GitHub Actions prevents workflow triggers for events created by `GITHUB_TOKEN` to avoid recursive loops. The `gh workflow run` commands were failing to trigger actual workflows.

Fixes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)