### PR TITLE
fix(workflow): move comments outside devcontainer env blocks

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -128,6 +128,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Note: GH_TOKEN uses WORKFLOW_PAT because PRs created with GITHUB_TOKEN don't trigger workflows
       - name: Run Claude in devcontainer
         uses: devcontainers/ci@v0.3
         with:
@@ -136,7 +137,6 @@ jobs:
           push: never
           env: |
             CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-            # PAT required: PRs created with GITHUB_TOKEN don't trigger workflows
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             COMMENT_BODY=${{ steps.comment.outputs.body }}
             ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
@@ -256,6 +256,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Note: GH_TOKEN uses WORKFLOW_PAT because PRs created with GITHUB_TOKEN don't trigger workflows
       - name: Resolve issue in devcontainer
         uses: devcontainers/ci@v0.3
         with:
@@ -264,7 +265,6 @@ jobs:
           push: never
           env: |
             CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-            # PAT required: PRs created with GITHUB_TOKEN don't trigger workflows
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             ISSUE_NUMBER=${{ github.event.issue.number }}
             ISSUE_TITLE=${{ github.event.issue.title }}


### PR DESCRIPTION
## Problem

When the `resolve-issue` job runs for a new GitHub issue (like #352), Claude Code inside the devcontainer cannot authenticate with the `gh` CLI despite the workflow correctly specifying `GH_TOKEN=${{ secrets.WORKFLOW_PAT }}`.

### Evidence from Issue #352 Workflow Run

Workflow run [20663918839](https://github.com/NickBorgers/home-automation/actions/runs/20663918839) (triggered at 18:17:58Z for issue #352) shows:

1. **First `gh` command failed immediately** with `HTTP 401: Bad credentials`
2. **CLAUDE_CODE_OAUTH_TOKEN worked** - Claude Code itself ran successfully
3. **GH_TOKEN didn't work** - All `gh` commands failed with 401
4. **Git push worked** - Because it uses credentials from `actions/checkout` with `token: ${{ secrets.WORKFLOW_PAT }}`

The conversation log artifact shows the very first command Claude attempted:
```
gh issue view 352
-> Exit code 1
-> HTTP 401: Bad credentials (https://api.github.com/graphql)
-> Try authenticating with:  gh auth login
```

### Root Cause Analysis

The `env` block in `devcontainers/ci@v0.3` had this format:
```yaml
env: |
  CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
  # PAT required: PRs created with GITHUB_TOKEN don't trigger workflows
  GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
```

The `devcontainers/ci` action processes the `env` parameter as a multiline string of `KEY=VALUE` pairs. Lines starting with `#` (shell-style comments) may cause parsing issues:
- Variables **before** the comment line → properly set (CLAUDE_CODE_OAUTH_TOKEN works)
- Variables **after** the comment line → not set or parsing stops (GH_TOKEN fails)

This explains why:
- ✅ Claude Code authenticates successfully (CLAUDE_CODE_OAUTH_TOKEN is before the comment)
- ❌ `gh` commands fail with 401 (GH_TOKEN is after the comment)
- ✅ `git push` works (uses checkout action's persisted credentials, not GH_TOKEN)

### Connection to PR #330

PR #330 correctly identified that `GH_TOKEN` needed to be `WORKFLOW_PAT` instead of `github.token` to trigger downstream workflows. However, it also added a comment line explaining this change:
```yaml
# PAT required: PRs created with GITHUB_TOKEN don't trigger workflows
GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
```

This comment inadvertently broke the env var parsing, causing `GH_TOKEN` to not be set properly inside the devcontainer.

## Solution

Move the explanatory comments from inside the `env:` block (where they may break parsing) to regular YAML comments above the step (where they're properly handled):

```yaml
# Note: GH_TOKEN uses WORKFLOW_PAT because PRs created with GITHUB_TOKEN don't trigger workflows
- name: Run Claude in devcontainer
  uses: devcontainers/ci@v0.3
  with:
    env: |
      CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
      GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
```

This preserves the documentation while ensuring all env vars are properly passed to the devcontainer.

## Files Changed

- `.github/workflows/claude.yml` - Moved comments in both `claude` and `resolve-issue` jobs

## Test Plan

1. After merging, open a new test issue
2. Verify the `resolve-issue` job can run `gh` commands successfully
3. Verify Claude can create a PR via `gh pr create`

## Note on Other Workflow Files

Checked `claude-code-review.yml` and `claude-diagnose-workflow-failure.yml` - they don't have comments inside their `env` blocks, so they're not affected by this specific issue. (They do have the separate issue #352 regarding using `github.token` vs `WORKFLOW_PAT`, but that's a different problem.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)