### PR TITLE
fix: enable diagnosis for Claude Code workflow failures

### DIFF
--- a/.github/workflows/claude-diagnose-workflow-failure.yml
+++ b/.github/workflows/claude-diagnose-workflow-failure.yml
@@ -12,6 +12,8 @@ on:
       - "Publish-Screenshots"
       - "Trigger Private Security Rebuild"
       - "Notify Private Repo of PR Merge"
+      - "Claude Code"
+      - "Claude Code Review"
     types:
       - completed
 
@@ -56,9 +58,10 @@ jobs:
             exit 0
           fi
 
-          # Skip diagnosis for Claude-related workflows to avoid infinite loops
-          if [[ "$WORKFLOW_NAME" == *"Claude"* ]]; then
-            echo "Skipping diagnosis of Claude workflow to prevent loops"
+          # Skip diagnosis for THIS workflow only to avoid infinite loops
+          # Other Claude workflows (Claude Code, Claude Code Review) should be diagnosed
+          if [[ "$WORKFLOW_NAME" == "Claude Diagnose Workflow Failure" ]]; then
+            echo "Skipping diagnosis of diagnosis workflow to prevent infinite loops"
             echo "should_diagnose=false" >> $GITHUB_OUTPUT
             exit 0
           fi


### PR DESCRIPTION
## Summary
- Add "Claude Code" and "Claude Code Review" to the list of monitored workflows in `claude-diagnose-workflow-failure.yml`
- Narrow the skip logic from skipping all `*Claude*` workflows to only skipping the exact workflow name `Claude Diagnose Workflow Failure`

This addresses the issue where Claude workflow failures (like [run #20665628214](https://github.com/NickBorgers/home-automation/actions/runs/20665628214/job/59337244277)) were not being investigated because the skip logic was too broad.

The infinite loop prevention remains intact - only the diagnosis workflow itself is skipped.

## Test plan
- [ ] Verify the PR Tests workflow still gets diagnosed on failure
- [ ] Verify Claude Code workflow failures will now trigger diagnosis
- [ ] Verify Claude Diagnose Workflow Failure itself is still skipped (no infinite loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)