### PR TITLE
fix: allow agent reviews when push precedes PR creation

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,11 +44,9 @@ jobs:
   # Extract PR and Issue context from workflow_run or workflow_dispatch event
   get-context:
     runs-on: ubuntu-latest
-    # Skip if PR Tests was triggered by 'push' event - only run for 'pull_request' triggered tests
-    # This prevents duplicate reviews when both push and pull_request events fire for the same commit
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.event == 'pull_request'
+    # Note: We don't filter by event type here. The concurrency group (line 36) prevents
+    # duplicate runs for the same branch, and downstream jobs skip if no PR is found.
+    # This allows reviews to run even when push happens before PR creation.
     outputs:
       pr_number: ${{ steps.get-pr.outputs.pr_number }}
       pr_title: ${{ steps.get-pr.outputs.pr_title }}


### PR DESCRIPTION
## Summary

Fixes the issue where PR #374 didn't trigger agent reviews.

The `get-context` job was filtering to only run when `workflow_run.event` was `pull_request`. This broke reviews for PRs where the commit was pushed before the PR was created (common with automation like Claude Code that pushes first, then runs `gh pr create`).

**Root cause analysis:**
- PR #374's commit was pushed at 23:22:45Z
- PR Tests started at 23:24:39Z (triggered by `push` event)
- PR was created at 23:24:57Z (18 seconds after PR Tests started)
- Since the PR didn't exist when the push happened, GitHub only fired a `push` event, not `pull_request`
- Claude Code Review's `get-context` job filtered out `push` events, so reviews were skipped

**The fix:** Remove the event-type filter. The concurrency group already prevents duplicate runs for the same branch, and downstream jobs skip if no PR is found, so the filter was redundant and overly restrictive.

## Test plan

- [x] Verify PR Tests triggers for this branch
- [ ] Verify agent reviews run after tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)