### PR TITLE
fix: skip agent reviews after they pass once per PR

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,6 +4,9 @@ on:
   workflow_run:
     workflows: ["PR Tests"]
     types: [completed]
+  # Reset reviews when PR is reopened (allows re-triggering full review cycle)
+  pull_request:
+    types: [reopened]
   # Allow manual triggering after workflow_dispatch-triggered PR Tests completes
   # (workflow_run events don't fire for workflow_dispatch triggers)
   workflow_dispatch:
@@ -62,6 +65,7 @@ jobs:
       issue_title: ${{ steps.get-issue.outputs.issue_title }}
       issue_body_b64: ${{ steps.get-issue.outputs.issue_body_b64 }}
       fix_attempts: ${{ steps.count-attempts.outputs.count }}
+      reviews_already_passed: ${{ steps.check-existing-reviews.outputs.already_passed }}
 
     steps:
       - name: Get PR from workflow run or dispatch inputs
@@ -177,11 +181,41 @@ jobs:
           echo "Current fix attempt count: $COUNT"
           echo "count=$COUNT" >> $GITHUB_OUTPUT
 
+      - name: Check if reviews already passed (or reset on reopen)
+        if: steps.get-pr.outputs.pr_number != ''
+        id: check-existing-reviews
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER="${{ steps.get-pr.outputs.pr_number }}"
+          EVENT_NAME="${{ github.event_name }}"
+
+          # If PR was reopened, remove the reviews-passed label to allow re-review
+          if [ "$EVENT_NAME" = "pull_request" ] && [ "${{ github.event.action }}" = "reopened" ]; then
+            echo "PR was reopened - removing agent-reviews-passed label to allow re-review"
+            gh pr edit $PR_NUMBER --remove-label "agent-reviews-passed" --repo ${{ github.repository }} 2>/dev/null || true
+            echo "already_passed=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Check if agent-reviews-passed label exists
+          LABELS=$(gh api repos/${{ github.repository }}/issues/$PR_NUMBER/labels --jq '.[].name' 2>/dev/null || echo "")
+
+          if echo "$LABELS" | grep -q "^agent-reviews-passed$"; then
+            echo "Agent reviews already passed for this PR - skipping review cycle"
+            echo "already_passed=true" >> $GITHUB_OUTPUT
+          else
+            echo "No existing reviews found - will run full review cycle"
+            echo "already_passed=false" >> $GITHUB_OUTPUT
+          fi
+
   # Build and cache devcontainer image first
   build-devcontainer:
     runs-on: ubuntu-latest
     needs: get-context
-    if: needs.get-context.outputs.pr_number != ''
+    if: |
+      needs.get-context.outputs.pr_number != '' &&
+      needs.get-context.outputs.reviews_already_passed != 'true'
     permissions:
       contents: read
       packages: write
@@ -212,6 +246,7 @@ jobs:
     needs: [get-context, build-devcontainer]
     if: |
       needs.get-context.outputs.pr_number != '' &&
+      needs.get-context.outputs.reviews_already_passed != 'true' &&
       needs.get-context.outputs.tests_passed == 'false' &&
       needs.get-context.outputs.fix_attempts < 3
     runs-on: ubuntu-latest
@@ -447,6 +482,7 @@ jobs:
     needs: [get-context, build-devcontainer]
     if: |
       needs.get-context.outputs.pr_number != '' &&
+      needs.get-context.outputs.reviews_already_passed != 'true' &&
       needs.get-context.outputs.tests_passed == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -561,6 +597,7 @@ jobs:
     if: |
       always() &&
       needs.get-context.outputs.pr_number != '' &&
+      needs.get-context.outputs.reviews_already_passed != 'true' &&
       needs.get-context.outputs.tests_passed == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -686,6 +723,7 @@ jobs:
     if: |
       always() &&
       needs.get-context.outputs.pr_number != '' &&
+      needs.get-context.outputs.reviews_already_passed != 'true' &&
       needs.get-context.outputs.tests_passed == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -782,6 +820,7 @@ jobs:
     if: |
       always() &&
       needs.get-context.outputs.pr_number != '' &&
+      needs.get-context.outputs.reviews_already_passed != 'true' &&
       needs.get-context.outputs.tests_passed == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -933,6 +972,7 @@ jobs:
     if: always()
     permissions:
       statuses: write  # Required to create commit status on PR
+      pull-requests: write  # Required to add label
 
     steps:
       - name: Check review results
@@ -948,6 +988,15 @@ jobs:
           # Check if we have a valid PR
           if [ -z "${{ needs.get-context.outputs.pr_number }}" ]; then
             echo "No PR found for this workflow run - skipping reviews"
+            exit 0
+          fi
+
+          # If reviews already passed, signal success but still create commit status
+          REVIEWS_ALREADY_PASSED="${{ needs.get-context.outputs.reviews_already_passed }}"
+          if [ "$REVIEWS_ALREADY_PASSED" = "true" ]; then
+            echo "Reviews already passed for this PR - skipping re-review"
+            echo "To re-run reviews: close and reopen the PR"
+            echo "skipped_with_success=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -1017,8 +1066,13 @@ jobs:
           echo "  Concurrency Review: ${{ needs.concurrency-review.result }}"
           echo "  Docs Review: ${{ needs.docs-review.result }}"
 
+          # Signal that we should add the label
+          echo "should_label=true" >> $GITHUB_OUTPUT
+
       - name: Create commit status for reviews
-        if: needs.get-context.outputs.pr_number != '' && needs.get-context.outputs.tests_passed == 'true'
+        if: |
+          needs.get-context.outputs.pr_number != '' &&
+          (needs.get-context.outputs.tests_passed == 'true' || steps.check-results.outputs.skipped_with_success == 'true')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -1026,13 +1080,42 @@ jobs:
           PR_NUMBER="${{ needs.get-context.outputs.pr_number }}"
           HEAD_SHA=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER --jq '.head.sha')
 
+          # Determine description based on whether this was a skip or full review
+          if [ "${{ steps.check-results.outputs.skipped_with_success }}" = "true" ]; then
+            DESCRIPTION="Agent reviews already passed (skipped re-review)"
+          else
+            DESCRIPTION="All agent reviews completed successfully"
+          fi
+
           echo "Creating commit status for PR #$PR_NUMBER (SHA: $HEAD_SHA)"
 
-          # Create commit status - state depends on whether reviews passed
+          # Create commit status
           gh api repos/${{ github.repository }}/statuses/$HEAD_SHA \
             -f state="success" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            -f description="All agent reviews completed successfully" \
+            -f description="$DESCRIPTION" \
             -f context="All Required Agent Reviews"
 
           echo "Commit status created successfully"
+
+      - name: Add agent-reviews-passed label
+        if: |
+          steps.check-results.outputs.should_label == 'true' &&
+          needs.get-context.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER="${{ needs.get-context.outputs.pr_number }}"
+
+          # Create the label if it doesn't exist
+          gh label create "agent-reviews-passed" \
+            --color "0e8a16" \
+            --description "All agent reviews have passed" \
+            --repo ${{ github.repository }} 2>/dev/null || true
+
+          # Add the label to the PR
+          gh pr edit $PR_NUMBER --add-label "agent-reviews-passed" --repo ${{ github.repository }}
+
+          echo "Added 'agent-reviews-passed' label to PR #$PR_NUMBER"
+          echo "Subsequent pushes will skip agent reviews."
+          echo "To re-run reviews: close and reopen the PR."


### PR DESCRIPTION
## Summary

- Adds `agent-reviews-passed` label when all reviews complete successfully
- Skips expensive review jobs on subsequent pushes if label is present
- Still creates "All Required Agent Reviews" commit status for branch protection
- Close and reopen PR removes the label, allowing re-review

This prevents wasted compute on merge conflict resolutions or minor follow-up changes after reviews have already passed.

## How it works

| Push | Review Jobs | Commit Status Description |
|------|-------------|---------------------------|
| First (no label) | Run fully | "All agent reviews completed successfully" |
| Subsequent (has label) | Skipped | "Agent reviews already passed (skipped re-review)" |
| After close+reopen | Run fully | "All agent reviews completed successfully" |

## Test plan

- [ ] Verify first push triggers full review cycle
- [ ] Verify `agent-reviews-passed` label is added after reviews pass
- [ ] Verify subsequent pushes skip reviews but create commit status
- [ ] Verify closing and reopening PR removes label

🤖 Generated with [Claude Code](https://claude.com/claude-code)