### PR TITLE
chore: Add PyYAML to devcontainer for YAML validation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcairo2 libpango-1.0-0 \
     # Utilities used by Claude Code
     bc \
+    # Python YAML library for YAML validation
+    python3-yaml \
     && rm -rf /var/lib/apt/lists/* \
     # Set zsh as default shell for vscode user
     && chsh -s /usr/bin/zsh vscode


### PR DESCRIPTION
## Summary
- Adds `python3-yaml` package to the devcontainer Dockerfile
- Enables Claude Code to validate YAML files using Python directly instead of falling back to `npx yaml`

## Context
Claude Code frequently validates YAML files using this pattern:
```
python3 -c "import yaml; yaml.safe_load(open('file.yml'))"
# fails with ModuleNotFoundError
npx yaml < file.yml > /dev/null
# works but requires installing npm package each time
```

With this change, the first attempt will succeed, avoiding the overhead of npm package installation.

## Test plan
- [ ] Rebuild devcontainer
- [ ] Verify `python3 -c "import yaml"` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)