### PR TITLE
fix: use check-runs API instead of commit status for test verification

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -605,8 +605,8 @@ jobs:
           HEAD_SHA=$(gh api repos/${{ github.repository }}/pulls/${{ needs.get-context.outputs.pr_number }} --jq '.head.sha')
           echo "Checking test status for commit $HEAD_SHA"
 
-          # Check for "All Required Tests" status
-          STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/status --jq '.statuses[] | select(.context == "All Required Tests") | .state' 2>/dev/null || echo "")
+          # Check for "All Required Tests" check run (not a commit status)
+          STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null || echo "")
 
           if [ "$STATUS" = "success" ]; then
             echo "✅ All Required Tests passed on current commit"
@@ -756,8 +756,8 @@ jobs:
           HEAD_SHA=$(gh api repos/${{ github.repository }}/pulls/${{ needs.get-context.outputs.pr_number }} --jq '.head.sha')
           echo "Checking test status for commit $HEAD_SHA"
 
-          # Check for "All Required Tests" status
-          STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/status --jq '.statuses[] | select(.context == "All Required Tests") | .state' 2>/dev/null || echo "")
+          # Check for "All Required Tests" check run (not a commit status)
+          STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null || echo "")
 
           if [ "$STATUS" = "success" ]; then
             echo "✅ All Required Tests passed on current commit"
@@ -878,8 +878,8 @@ jobs:
           HEAD_SHA=$(gh api repos/${{ github.repository }}/pulls/${{ needs.get-context.outputs.pr_number }} --jq '.head.sha')
           echo "Checking test status for commit $HEAD_SHA"
 
-          # Check for "All Required Tests" status
-          STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/status --jq '.statuses[] | select(.context == "All Required Tests") | .state' 2>/dev/null || echo "")
+          # Check for "All Required Tests" check run (not a commit status)
+          STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null || echo "")
 
           if [ "$STATUS" = "success" ]; then
             echo "✅ All Required Tests passed on current commit"


### PR DESCRIPTION
## Summary

- Fixes agent review jobs (test-review, concurrency-review, docs-review) being incorrectly skipped
- Changed API call from `/commits/{sha}/status` to `/commits/{sha}/check-runs`
- "All Required Tests" is a check run created by CI, not a commit status

## Root Cause

The verify-tests step in each review job was checking:
```bash
gh api repos/.../commits/$HEAD_SHA/status --jq '.statuses[] | select(.context == "All Required Tests")'
```

But "All Required Tests" is created as a **check run** by the CI workflow, not a commit status. The query returned empty, causing all specialized reviews to skip with "status: not found".

## Fix

Changed to use the check-runs API:
```bash
gh api repos/.../commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests")'
```

## Evidence

From PR #377 workflow logs:
```
Checking test status for commit 49bbdf41dbb6cf0f39a7ce947509ff879003dbb0
⚠️ Tests have not passed on current commit (status: not found)
Skipping review - tests must pass first
```

The commit only had one status ("All Required Agent Reviews") but had check runs including "All Required Tests" with conclusion "success".

## Test plan

- [ ] Merge this PR
- [ ] Push a change to PR #377 (or any other PR)
- [ ] Verify test-review, concurrency-review, and docs-review now run their full steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)