### PR TITLE
feat: reduce review verbosity and add merge-decision agent

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1066,7 +1066,7 @@ jobs:
               --max-turns 150 \
               "You are the FINAL DECISION MAKER for PR #${PR_NUMBER}.
 
-            You have authority to approve or reject this PR for merge to main and deployment to production.
+            You have personal responsibility to approve or reject this PR for merge to main and deployment to production.
 
             **REVIEW STATUS:**
             - Code Review: ${CLAUDE_REVIEW_RESULT}


### PR DESCRIPTION
## Summary

- Update all 4 reviewer prompts to only output actionable feedback
- Add new `merge-decision` agent that provides final GO/NO-GO recommendation

## Changes

**Brevity improvements to existing reviewers:**
- Added "BE BRIEF" instruction to each prompt (claude-review, test-review, concurrency-review, docs-review)
- Prompts now instruct agents to skip sections with no issues
- Short approval format: `"✅ Approved - No issues found"` instead of verbose checklists
- Removed template sections for items that don't need changes

**New merge-decision agent:**
- Runs after all other reviews complete
- Reads all review comments on the PR
- Checks for merge conflicts (resolves them if PR should otherwise merge)
- Posts GO/NO-GO recommendation (does NOT auto-merge)

## Test plan

- [ ] Verify YAML syntax is valid
- [ ] Open a test PR and observe reduced verbosity in review comments
- [ ] Verify merge-decision agent posts final recommendation

🤖 Generated with [Claude Code](https://claude.com/claude-code)