### PR TITLE
fix: add retry loop to verify tests step to fix race condition

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -627,17 +627,28 @@ jobs:
           HEAD_SHA=$(gh api repos/${{ github.repository }}/pulls/${{ needs.get-context.outputs.pr_number }} --jq '.head.sha')
           echo "Checking test status for commit $HEAD_SHA"
 
-          # Check for "All Required Tests" check run (not a commit status)
-          STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null || echo "")
+          # Retry loop - check run may not be visible immediately after workflow triggers
+          MAX_ATTEMPTS=6
+          ATTEMPT=1
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null || echo "")
 
-          if [ "$STATUS" = "success" ]; then
-            echo "✅ All Required Tests passed on current commit"
-            echo "verified=true" >> $GITHUB_OUTPUT
-          else
-            echo "⚠️ Tests have not passed on current commit (status: ${STATUS:-not found})"
-            echo "Skipping review - tests must pass first"
-            echo "verified=false" >> $GITHUB_OUTPUT
-          fi
+            if [ "$STATUS" = "success" ]; then
+              echo "✅ All Required Tests passed on current commit"
+              echo "verified=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+
+            if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+              echo "Attempt $ATTEMPT/$MAX_ATTEMPTS: Check run not found yet (status: ${STATUS:-not found}), waiting 10s..."
+              sleep 10
+            fi
+            ATTEMPT=$((ATTEMPT + 1))
+          done
+
+          echo "⚠️ Tests have not passed on current commit after $MAX_ATTEMPTS attempts (status: ${STATUS:-not found})"
+          echo "Skipping review - tests must pass first"
+          echo "verified=false" >> $GITHUB_OUTPUT
 
       - name: Checkout PR branch
         if: steps.verify-tests.outputs.verified == 'true'
@@ -748,17 +759,28 @@ jobs:
           HEAD_SHA=$(gh api repos/${{ github.repository }}/pulls/${{ needs.get-context.outputs.pr_number }} --jq '.head.sha')
           echo "Checking test status for commit $HEAD_SHA"
 
-          # Check for "All Required Tests" check run (not a commit status)
-          STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null || echo "")
+          # Retry loop - check run may not be visible immediately after workflow triggers
+          MAX_ATTEMPTS=6
+          ATTEMPT=1
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null || echo "")
 
-          if [ "$STATUS" = "success" ]; then
-            echo "✅ All Required Tests passed on current commit"
-            echo "verified=true" >> $GITHUB_OUTPUT
-          else
-            echo "⚠️ Tests have not passed on current commit (status: ${STATUS:-not found})"
-            echo "Skipping review - tests must pass first"
-            echo "verified=false" >> $GITHUB_OUTPUT
-          fi
+            if [ "$STATUS" = "success" ]; then
+              echo "✅ All Required Tests passed on current commit"
+              echo "verified=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+
+            if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+              echo "Attempt $ATTEMPT/$MAX_ATTEMPTS: Check run not found yet (status: ${STATUS:-not found}), waiting 10s..."
+              sleep 10
+            fi
+            ATTEMPT=$((ATTEMPT + 1))
+          done
+
+          echo "⚠️ Tests have not passed on current commit after $MAX_ATTEMPTS attempts (status: ${STATUS:-not found})"
+          echo "Skipping review - tests must pass first"
+          echo "verified=false" >> $GITHUB_OUTPUT
 
       - name: Checkout PR branch
         if: steps.verify-tests.outputs.verified == 'true'
@@ -872,17 +894,28 @@ jobs:
           HEAD_SHA=$(gh api repos/${{ github.repository }}/pulls/${{ needs.get-context.outputs.pr_number }} --jq '.head.sha')
           echo "Checking test status for commit $HEAD_SHA"
 
-          # Check for "All Required Tests" check run (not a commit status)
-          STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null || echo "")
+          # Retry loop - check run may not be visible immediately after workflow triggers
+          MAX_ATTEMPTS=6
+          ATTEMPT=1
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null || echo "")
 
-          if [ "$STATUS" = "success" ]; then
-            echo "✅ All Required Tests passed on current commit"
-            echo "verified=true" >> $GITHUB_OUTPUT
-          else
-            echo "⚠️ Tests have not passed on current commit (status: ${STATUS:-not found})"
-            echo "Skipping review - tests must pass first"
-            echo "verified=false" >> $GITHUB_OUTPUT
-          fi
+            if [ "$STATUS" = "success" ]; then
+              echo "✅ All Required Tests passed on current commit"
+              echo "verified=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+
+            if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+              echo "Attempt $ATTEMPT/$MAX_ATTEMPTS: Check run not found yet (status: ${STATUS:-not found}), waiting 10s..."
+              sleep 10
+            fi
+            ATTEMPT=$((ATTEMPT + 1))
+          done
+
+          echo "⚠️ Tests have not passed on current commit after $MAX_ATTEMPTS attempts (status: ${STATUS:-not found})"
+          echo "Skipping review - tests must pass first"
+          echo "verified=false" >> $GITHUB_OUTPUT
 
       - name: Checkout PR branch
         if: steps.verify-tests.outputs.verified == 'true'
@@ -1006,15 +1039,27 @@ jobs:
           HEAD_SHA=$(gh api repos/${{ github.repository }}/pulls/${{ needs.get-context.outputs.pr_number }} --jq '.head.sha')
           echo "Checking test status for commit $HEAD_SHA"
 
-          STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null || echo "")
+          # Retry loop - check run may not be visible immediately after workflow triggers
+          MAX_ATTEMPTS=6
+          ATTEMPT=1
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null || echo "")
 
-          if [ "$STATUS" = "success" ]; then
-            echo "✅ All Required Tests passed on current commit"
-            echo "verified=true" >> $GITHUB_OUTPUT
-          else
-            echo "⚠️ Tests have not passed on current commit (status: ${STATUS:-not found})"
-            echo "verified=false" >> $GITHUB_OUTPUT
-          fi
+            if [ "$STATUS" = "success" ]; then
+              echo "✅ All Required Tests passed on current commit"
+              echo "verified=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+
+            if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+              echo "Attempt $ATTEMPT/$MAX_ATTEMPTS: Check run not found yet (status: ${STATUS:-not found}), waiting 10s..."
+              sleep 10
+            fi
+            ATTEMPT=$((ATTEMPT + 1))
+          done
+
+          echo "⚠️ Tests have not passed on current commit after $MAX_ATTEMPTS attempts (status: ${STATUS:-not found})"
+          echo "verified=false" >> $GITHUB_OUTPUT
 
       - name: Checkout PR branch
         if: steps.verify-tests.outputs.verified == 'true'


### PR DESCRIPTION
## Summary

Fixes a race condition that caused `test-review`, `concurrency-review`, `docs-review`, and `merge-decision` agents to skip their reviews even when tests passed.

## Problem

The "Verify tests passed on current commit" step queries GitHub's Check Runs API for the "All Required Tests" status. However, the check run isn't immediately visible after the workflow triggers, causing the verify step to fail and skip all subsequent review steps.

This was discovered when investigating PR #384 - only `claude-review` posted a comment because it doesn't have a verify step, while the other 3 reviewers silently skipped.

## Fix

Add a retry loop to all 4 verify steps:
- 6 attempts maximum
- 10 second delay between attempts
- Total wait time: up to 60 seconds

This gives GitHub's API time to propagate the check run status before giving up.

## Test plan

- [ ] Verify YAML syntax is valid
- [ ] Open a test PR and confirm all review agents run (not just claude-review)
- [ ] Check workflow logs show retry attempts if needed

Fixes part of the issue discovered in #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)