### PR TITLE
fix: handle multiple check runs in verify step

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -638,7 +638,7 @@ jobs:
           MAX_ATTEMPTS=6
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null || echo "")
+            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null | head -1 || echo "")
 
             if [ "$STATUS" = "success" ]; then
               echo "✅ All Required Tests passed on current commit"
@@ -770,7 +770,7 @@ jobs:
           MAX_ATTEMPTS=6
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null || echo "")
+            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null | head -1 || echo "")
 
             if [ "$STATUS" = "success" ]; then
               echo "✅ All Required Tests passed on current commit"
@@ -905,7 +905,7 @@ jobs:
           MAX_ATTEMPTS=6
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null || echo "")
+            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null | head -1 || echo "")
 
             if [ "$STATUS" = "success" ]; then
               echo "✅ All Required Tests passed on current commit"
@@ -1050,7 +1050,7 @@ jobs:
           MAX_ATTEMPTS=6
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null || echo "")
+            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null | head -1 || echo "")
 
             if [ "$STATUS" = "success" ]; then
               echo "✅ All Required Tests passed on current commit"


### PR DESCRIPTION
## Summary

Fixes the verify step failing even when "All Required Tests" shows success.

## Root Cause

The jq query returns multiple values when there are multiple check runs with the same name (e.g., from workflow re-runs or multiple test runs on the same commit):

```
STATUS=$(gh api .../check-runs --jq '... | .conclusion')
# Returns:
# success
# success
```

The string comparison `[ "$STATUS" = "success" ]` fails because `$STATUS` contains `success\nsuccess` (multiple lines), not just `success`.

This caused all 4 verify steps to set `verified=false` even though the tests passed, which caused:
- test-review to skip
- concurrency-review to skip  
- docs-review to skip
- merge-decision to skip

## Fix

Add `| head -1` to only take the first result from the jq query.

## Test plan

- [ ] Verify YAML syntax is valid
- [ ] After merge, create a test PR and confirm all 5 review agents post comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)