### PR TITLE
fix: add checkout step to all-reviews-passed job

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1171,6 +1171,9 @@ jobs:
       pull-requests: write  # Required to add label
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Check review results
         id: check-results
         run: |


### PR DESCRIPTION
## Summary
- Fixes the `gh pr comment` failure in the `all-reviews-passed` job
- The GitHub CLI requires git context even when `--repo` is specified
- Adding `actions/checkout@v4` resolves the "not a git repository" error

Fixes #404

## Test plan
- [ ] Verify the workflow completes successfully on a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)