### PR TITLE
Fix #410: trigger didOwnerJustReturnHome from near_home when owner is away

### DIFF
--- a/homeautomation-go/internal/plugins/statetracking/manager.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager.go
@@ -130,6 +130,15 @@ func (m *Manager) Start() error {
 		return fmt.Errorf("failed to subscribe to input_boolean.tori_here: %w", err)
 	}
 
+	// Subscribe to near_home presence for owner return detection
+	// These HomeKit automations are more reliable arrival indicators than zone-based helpers
+	if err := m.subHelper.SubscribeToEntity("input_boolean.nick_near_home", m.handleNickNearHomeChange); err != nil {
+		return fmt.Errorf("failed to subscribe to input_boolean.nick_near_home: %w", err)
+	}
+	if err := m.subHelper.SubscribeToEntity("input_boolean.caroline_near_home", m.handleCarolineNearHomeChange); err != nil {
+		return fmt.Errorf("failed to subscribe to input_boolean.caroline_near_home: %w", err)
+	}
+
 	// Initialize shadow state with current input values (after subscriptions registered)
 	m.subHelper.CaptureInitialInputs()
 
@@ -151,6 +160,8 @@ func (m *Manager) Start() error {
 		}),
 		zap.Strings("ownerReturnHome", []string{
 			"isNickHome/isCarolineHome (arrival → didOwnerJustReturnHome=true, 10min auto-reset)",
+			"nick_near_home (on when NOT home → didOwnerJustReturnHome=true)",
+			"caroline_near_home (on when NOT home → didOwnerJustReturnHome=true)",
 		}))
 	return nil
 }
@@ -444,6 +455,76 @@ func (m *Manager) handleToriHereChange(entityID string, oldState, newState *ha.S
 			})
 		} else {
 			m.logger.Debug("Nobody else was home, not announcing Tori's arrival")
+		}
+	}
+}
+
+// handleNickNearHomeChange processes Nick's near_home state changes for arrival detection
+// The near_home geofence is triggered when both arriving AND leaving. We only want to
+// set didOwnerJustReturnHome when arriving (i.e., when Nick is NOT currently marked as home).
+func (m *Manager) handleNickNearHomeChange(entityID string, oldState, newState *ha.State) {
+	if newState == nil || oldState == nil {
+		return
+	}
+
+	// Check if near_home just turned on (state changed to "on" from something else)
+	if newState.State == "on" && oldState.State != "on" {
+		m.logger.Debug("Nick near_home triggered, checking if arriving or leaving",
+			zap.String("entity_id", entityID),
+			zap.String("old_state", oldState.State),
+			zap.String("new_state", newState.State))
+
+		// Check if Nick is currently NOT home (indicating arrival, not departure)
+		isNickHome, err := m.stateManager.GetBool("isNickHome")
+		if err != nil {
+			m.logger.Error("Failed to get isNickHome for near_home check", zap.Error(err))
+			return
+		}
+
+		if !isNickHome {
+			// Nick is NOT home and just triggered near_home → he is ARRIVING
+			m.logger.Info("Nick near_home triggered while NOT home - setting didOwnerJustReturnHome",
+				zap.Bool("isNickHome", isNickHome))
+			m.setOwnerJustReturnedHome()
+		} else {
+			// Nick IS home and just triggered near_home → he is LEAVING, ignore
+			m.logger.Debug("Nick near_home triggered while already home - ignoring (leaving)",
+				zap.Bool("isNickHome", isNickHome))
+		}
+	}
+}
+
+// handleCarolineNearHomeChange processes Caroline's near_home state changes for arrival detection
+// The near_home geofence is triggered when both arriving AND leaving. We only want to
+// set didOwnerJustReturnHome when arriving (i.e., when Caroline is NOT currently marked as home).
+func (m *Manager) handleCarolineNearHomeChange(entityID string, oldState, newState *ha.State) {
+	if newState == nil || oldState == nil {
+		return
+	}
+
+	// Check if near_home just turned on (state changed to "on" from something else)
+	if newState.State == "on" && oldState.State != "on" {
+		m.logger.Debug("Caroline near_home triggered, checking if arriving or leaving",
+			zap.String("entity_id", entityID),
+			zap.String("old_state", oldState.State),
+			zap.String("new_state", newState.State))
+
+		// Check if Caroline is currently NOT home (indicating arrival, not departure)
+		isCarolineHome, err := m.stateManager.GetBool("isCarolineHome")
+		if err != nil {
+			m.logger.Error("Failed to get isCarolineHome for near_home check", zap.Error(err))
+			return
+		}
+
+		if !isCarolineHome {
+			// Caroline is NOT home and just triggered near_home → she is ARRIVING
+			m.logger.Info("Caroline near_home triggered while NOT home - setting didOwnerJustReturnHome",
+				zap.Bool("isCarolineHome", isCarolineHome))
+			m.setOwnerJustReturnedHome()
+		} else {
+			// Caroline IS home and just triggered near_home → she is LEAVING, ignore
+			m.logger.Debug("Caroline near_home triggered while already home - ignoring (leaving)",
+				zap.Bool("isCarolineHome", isCarolineHome))
 		}
 	}
 }

--- a/homeautomation-go/internal/plugins/statetracking/manager_test.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager_test.go
@@ -1246,3 +1246,199 @@ func TestStateTrackingManager_ShadowState_DerivedStatesUpdateOnChange(t *testing
 		t.Error("Expected LastComputation to be updated after state change")
 	}
 }
+
+func TestStateTrackingManager_NickNearHome_SetsOwnerReturnedWhenNotHome(t *testing.T) {
+	t.Parallel()
+	// Test that nick_near_home triggers didOwnerJustReturnHome when Nick is NOT home
+
+	mockHA := ha.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	// Setup: Nick is NOT home
+	if err := stateMgr.SetBool("isNickHome", false); err != nil {
+		t.Fatalf("Failed to set isNickHome: %v", err)
+	}
+	if err := stateMgr.SetBool("didOwnerJustReturnHome", false); err != nil {
+		t.Fatalf("Failed to set didOwnerJustReturnHome: %v", err)
+	}
+
+	// Create and start manager
+	manager := NewManager(mockHA, stateMgr, logger, false, nil)
+	if err := manager.Start(); err != nil {
+		t.Fatalf("Failed to start manager: %v", err)
+	}
+	defer manager.Stop()
+
+	// Verify initial state
+	didOwnerReturn, _ := stateMgr.GetBool("didOwnerJustReturnHome")
+	if didOwnerReturn {
+		t.Error("Expected didOwnerJustReturnHome=false initially")
+	}
+
+	// Simulate nick_near_home going on (off → on)
+	mockHA.SetState("input_boolean.nick_near_home", "off", nil)
+	mockHA.SetState("input_boolean.nick_near_home", "on", nil)
+
+	// Verify didOwnerJustReturnHome was set to true
+	didOwnerReturn, err := stateMgr.GetBool("didOwnerJustReturnHome")
+	if err != nil {
+		t.Fatalf("Failed to get didOwnerJustReturnHome: %v", err)
+	}
+	if !didOwnerReturn {
+		t.Error("Expected didOwnerJustReturnHome=true when nick_near_home triggers while Nick is NOT home")
+	}
+}
+
+func TestStateTrackingManager_NickNearHome_IgnoresWhenAlreadyHome(t *testing.T) {
+	t.Parallel()
+	// Test that nick_near_home does NOT trigger didOwnerJustReturnHome when Nick IS already home
+
+	mockHA := ha.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	// Setup: Nick IS already home
+	if err := stateMgr.SetBool("isNickHome", true); err != nil {
+		t.Fatalf("Failed to set isNickHome: %v", err)
+	}
+	if err := stateMgr.SetBool("didOwnerJustReturnHome", false); err != nil {
+		t.Fatalf("Failed to set didOwnerJustReturnHome: %v", err)
+	}
+
+	// Create and start manager
+	manager := NewManager(mockHA, stateMgr, logger, false, nil)
+	if err := manager.Start(); err != nil {
+		t.Fatalf("Failed to start manager: %v", err)
+	}
+	defer manager.Stop()
+
+	// Simulate nick_near_home going on (off → on) while Nick is already home (leaving)
+	mockHA.SetState("input_boolean.nick_near_home", "off", nil)
+	mockHA.SetState("input_boolean.nick_near_home", "on", nil)
+
+	// Verify didOwnerJustReturnHome was NOT set (since Nick was already home, this is departure)
+	didOwnerReturn, err := stateMgr.GetBool("didOwnerJustReturnHome")
+	if err != nil {
+		t.Fatalf("Failed to get didOwnerJustReturnHome: %v", err)
+	}
+	if didOwnerReturn {
+		t.Error("Expected didOwnerJustReturnHome=false when nick_near_home triggers while Nick IS home (leaving)")
+	}
+}
+
+func TestStateTrackingManager_CarolineNearHome_SetsOwnerReturnedWhenNotHome(t *testing.T) {
+	t.Parallel()
+	// Test that caroline_near_home triggers didOwnerJustReturnHome when Caroline is NOT home
+
+	mockHA := ha.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	// Setup: Caroline is NOT home
+	if err := stateMgr.SetBool("isCarolineHome", false); err != nil {
+		t.Fatalf("Failed to set isCarolineHome: %v", err)
+	}
+	if err := stateMgr.SetBool("didOwnerJustReturnHome", false); err != nil {
+		t.Fatalf("Failed to set didOwnerJustReturnHome: %v", err)
+	}
+
+	// Create and start manager
+	manager := NewManager(mockHA, stateMgr, logger, false, nil)
+	if err := manager.Start(); err != nil {
+		t.Fatalf("Failed to start manager: %v", err)
+	}
+	defer manager.Stop()
+
+	// Verify initial state
+	didOwnerReturn, _ := stateMgr.GetBool("didOwnerJustReturnHome")
+	if didOwnerReturn {
+		t.Error("Expected didOwnerJustReturnHome=false initially")
+	}
+
+	// Simulate caroline_near_home going on (off → on)
+	mockHA.SetState("input_boolean.caroline_near_home", "off", nil)
+	mockHA.SetState("input_boolean.caroline_near_home", "on", nil)
+
+	// Verify didOwnerJustReturnHome was set to true
+	didOwnerReturn, err := stateMgr.GetBool("didOwnerJustReturnHome")
+	if err != nil {
+		t.Fatalf("Failed to get didOwnerJustReturnHome: %v", err)
+	}
+	if !didOwnerReturn {
+		t.Error("Expected didOwnerJustReturnHome=true when caroline_near_home triggers while Caroline is NOT home")
+	}
+}
+
+func TestStateTrackingManager_CarolineNearHome_IgnoresWhenAlreadyHome(t *testing.T) {
+	t.Parallel()
+	// Test that caroline_near_home does NOT trigger didOwnerJustReturnHome when Caroline IS already home
+
+	mockHA := ha.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	// Setup: Caroline IS already home
+	if err := stateMgr.SetBool("isCarolineHome", true); err != nil {
+		t.Fatalf("Failed to set isCarolineHome: %v", err)
+	}
+	if err := stateMgr.SetBool("didOwnerJustReturnHome", false); err != nil {
+		t.Fatalf("Failed to set didOwnerJustReturnHome: %v", err)
+	}
+
+	// Create and start manager
+	manager := NewManager(mockHA, stateMgr, logger, false, nil)
+	if err := manager.Start(); err != nil {
+		t.Fatalf("Failed to start manager: %v", err)
+	}
+	defer manager.Stop()
+
+	// Simulate caroline_near_home going on (off → on) while Caroline is already home (leaving)
+	mockHA.SetState("input_boolean.caroline_near_home", "off", nil)
+	mockHA.SetState("input_boolean.caroline_near_home", "on", nil)
+
+	// Verify didOwnerJustReturnHome was NOT set (since Caroline was already home, this is departure)
+	didOwnerReturn, err := stateMgr.GetBool("didOwnerJustReturnHome")
+	if err != nil {
+		t.Fatalf("Failed to get didOwnerJustReturnHome: %v", err)
+	}
+	if didOwnerReturn {
+		t.Error("Expected didOwnerJustReturnHome=false when caroline_near_home triggers while Caroline IS home (leaving)")
+	}
+}
+
+func TestStateTrackingManager_NearHome_IgnoresNilStates(t *testing.T) {
+	t.Parallel()
+	// Test that near_home handlers gracefully handle nil states (no panic)
+
+	mockHA := ha.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	// Setup: Nick is NOT home
+	if err := stateMgr.SetBool("isNickHome", false); err != nil {
+		t.Fatalf("Failed to set isNickHome: %v", err)
+	}
+	if err := stateMgr.SetBool("didOwnerJustReturnHome", false); err != nil {
+		t.Fatalf("Failed to set didOwnerJustReturnHome: %v", err)
+	}
+
+	// Create and start manager
+	manager := NewManager(mockHA, stateMgr, logger, false, nil)
+	if err := manager.Start(); err != nil {
+		t.Fatalf("Failed to start manager: %v", err)
+	}
+	defer manager.Stop()
+
+	// Simulate state change from unknown (nil oldState) - should not trigger or panic
+	mockHA.SetState("input_boolean.nick_near_home", "on", nil)
+
+	// Verify didOwnerJustReturnHome was NOT set (oldState was nil)
+	didOwnerReturn, err := stateMgr.GetBool("didOwnerJustReturnHome")
+	if err != nil {
+		t.Fatalf("Failed to get didOwnerJustReturnHome: %v", err)
+	}
+	if didOwnerReturn {
+		t.Error("Expected didOwnerJustReturnHome=false when oldState is nil (initial state, not a transition)")
+	}
+}

--- a/homeautomation-go/internal/plugins/statetracking/sleep_detection_test.go
+++ b/homeautomation-go/internal/plugins/statetracking/sleep_detection_test.go
@@ -33,9 +33,9 @@ func TestSleepDetection_HandlersInitialized(t *testing.T) {
 	}
 	defer manager.Stop()
 
-	// Verify HA subscriptions were created (2 for sleep detection + 3 for arrival announcements)
-	if len(manager.subHelper.GetHASubscriptions()) != 5 {
-		t.Errorf("Expected 5 HA subscriptions, got %d", len(manager.subHelper.GetHASubscriptions()))
+	// Verify HA subscriptions were created (2 for sleep detection + 3 for arrival announcements + 2 for near_home)
+	if len(manager.subHelper.GetHASubscriptions()) != 7 {
+		t.Errorf("Expected 7 HA subscriptions, got %d", len(manager.subHelper.GetHASubscriptions()))
 	}
 }
 


### PR DESCRIPTION
Resolves #410

## Summary
- Added subscriptions to `input_boolean.nick_near_home` and `input_boolean.caroline_near_home` in the state tracking plugin
- When these HomeKit geofence automations turn on while the owner is NOT home, `didOwnerJustReturnHome` is set to `true`
- This triggers garage door and front light automations that were previously missed when the zone-based `home` helper failed to trigger

The near_home geofence is triggered when both arriving AND leaving. The key insight is:
- **Arriving**: `[away] → [near_home ON] → [home]` - owner is NOT home when near_home triggers, so we set `didOwnerJustReturnHome=true`
- **Leaving**: `[home] → [near_home ON] → [away]` - owner IS home when near_home triggers, so we ignore it

## Test Plan
- [x] Unit test: mock `near_home` going `on` when owner is NOT home → verify `didOwnerJustReturnHome` is set
- [x] Unit test: mock `near_home` going `on` when owner IS home → verify `didOwnerJustReturnHome` is NOT set  
- [x] Unit test: verify handler handles nil states gracefully (no panic)
- [x] All existing tests pass
- [x] Coverage meets minimum requirement (70.2%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)