### PR TITLE
Fix #413: Expand docs-review agent scope to include CLAUDE_GHA_PIPELINES.md

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -993,6 +993,7 @@ jobs:
             - Plugin changes → VISUAL_ARCHITECTURE.md, ARCHITECTURE.md, docs/flows/
             - New Subscribe() → State Variable Dependency Graph
             - Concurrency fix → CONCURRENCY_LESSONS.md
+            - Workflow changes (.github/workflows/*.yml) → docs/operations/CLAUDE_GHA_PIPELINES.md
 
             If Mermaid edits needed: run \`make validate-mermaid\` after editing.
 

--- a/docs/operations/CLAUDE_GHA_PIPELINES.md
+++ b/docs/operations/CLAUDE_GHA_PIPELINES.md
@@ -256,6 +256,7 @@ Documentation synchronization review.
 | State variable added | migration_mapping.md, VISUAL_ARCHITECTURE.md |
 | Concurrency fix | CONCURRENCY_LESSONS.md |
 | Plugin logic | Relevant logic flow diagram |
+| Workflow changes (.github/workflows/*.yml) | CLAUDE_GHA_PIPELINES.md |
 
 **Actions**: Updates documentation, validates Mermaid diagrams
 


### PR DESCRIPTION
Resolves #413

## Summary

- Updated the docs-review agent prompt in `claude-code-review.yml` to include a new mapping: workflow changes (`.github/workflows/*.yml`) → `docs/operations/CLAUDE_GHA_PIPELINES.md`
- Updated the docs-review section in `CLAUDE_GHA_PIPELINES.md` to document this new mapping in the focus areas table

This ensures that when workflow files are modified, the docs-review agent will check if the pipeline documentation needs corresponding updates, preventing documentation drift.

## Test Plan

- [x] Pre-push hook passed (all unit and integration tests pass)
- [ ] Verify by making a trivial workflow change in a future PR and confirming docs-review flags it

🤖 Generated with [Claude Code](https://claude.com/claude-code)