### PR TITLE
Fix #424: Increase energy indicator light calibration interval to 30 minutes

### DIFF
--- a/configs/energy_config.yaml
+++ b/configs/energy_config.yaml
@@ -23,7 +23,7 @@ energy:
       # This prevents the LED's own emission (2000+ lux at 100%) from overwhelming the sensor.
       baseline_calibration:
         enabled: true
-        calibration_interval_sec: 300  # Run calibration every 5 minutes
+        calibration_interval_sec: 1800  # Run calibration every 30 minutes
         calibration_brightness_pct: 5  # Dim to 5% during measurement
         calibration_wait_sec: 65       # Wait 65 seconds for fresh lux reading (sensors update every ~60s)
   energy_states:

--- a/homeautomation-go/internal/plugins/energy/config.go
+++ b/homeautomation-go/internal/plugins/energy/config.go
@@ -70,7 +70,7 @@ type BaselineCalibrationConfig struct {
 	// When enabled, the system periodically dims LEDs to measure true ambient light.
 	Enabled bool `yaml:"enabled"`
 
-	// CalibrationIntervalSec is how often to run calibration cycles (default: 300 = 5 minutes)
+	// CalibrationIntervalSec is how often to run calibration cycles (default: 1800 = 30 minutes)
 	CalibrationIntervalSec int `yaml:"calibration_interval_sec"`
 
 	// CalibrationBrightnessPct is the brightness level during measurement (default: 5)

--- a/homeautomation-go/internal/plugins/energy/manager.go
+++ b/homeautomation-go/internal/plugins/energy/manager.go
@@ -895,10 +895,10 @@ func (m *Manager) Reset() error {
 func (m *Manager) runBaselineCalibration() {
 	calibConfig := m.config.Energy.IndicatorLights.AdaptiveBrightness.BaselineCalibration
 
-	// Get calibration interval (default 10 minutes)
+	// Get calibration interval (default 30 minutes)
 	intervalSec := calibConfig.CalibrationIntervalSec
 	if intervalSec <= 0 {
-		intervalSec = 600
+		intervalSec = 1800
 	}
 
 	ticker := time.NewTicker(time.Duration(intervalSec) * time.Second)


### PR DESCRIPTION
Resolves #424

## Summary
- Increased the energy indicator light calibration interval from 5 minutes to 30 minutes
- The calibration process temporarily dims LEDs to measure true ambient light levels, which was occurring too frequently and was perceived as annoying
- Updated the config file value, code default, and documentation comments to all reflect the new 30-minute interval

## Test Plan
- [x] Unit tests pass (`make unit-tests`)
- [x] Integration tests pass (`make integration-tests`) 
- [x] Pre-commit checks pass (`make pre-commit`)
- [ ] Deploy and verify calibration runs every 30 minutes instead of every 5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)