### PR TITLE
fix(sleephygiene): Clear isFadeOutInProgress when speaker volume already at 0

### DIFF
--- a/homeautomation-go/internal/plugins/sleephygiene/manager.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager.go
@@ -444,6 +444,8 @@ func (m *Manager) fadeOutSpeaker(speakerEntityID string) {
 				m.logger.Error("Failed to clear isFadeOutInProgress", zap.Error(err))
 			}
 		}
+		// Mark fade-out as inactive in shadow state (consistent with other abort paths)
+		m.shadowTracker.UpdateFadeOutProgress(speakerEntityID, 0)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Fixed bug where `isFadeOutInProgress` remained stuck at `true` indefinitely when the bedroom speaker volume was already at 0 during wake sequence

## Problem Observed

On 2026-01-08, `isFadeOutInProgress` was stuck at `true` for hours after the wake sequence completed, causing incorrect lighting behavior in the Primary Suite.

### Log Timeline (CST times)

**08:19:09** - Eight Sleep alarm detected, triggered `begin_wake`:
```json
{"level":"info","ts":"2026-01-08T14:19:09.067Z","logger":"sleephygiene","msg":"Eight Sleep alarm detected, triggering begin_wake"}
{"level":"info","ts":"2026-01-08T14:19:09.067Z","logger":"sleephygiene","msg":"Conditions met for begin_wake, starting fade out"}
```

**08:50:13** - Backup wake triggered, but speaker was already muted - **BUG: early return without clearing flag**:
```json
{"level":"info","ts":"2026-01-08T14:50:12.861Z","logger":"sleephygiene","msg":"Eight Sleep unavailable, triggering backup wake"}
{"level":"info","ts":"2026-01-08T14:50:13.028Z","logger":"sleephygiene","msg":"Speaker volume already at 0, skipping fade-out","speaker":"media_player.bedroom"}
```

**09:17:23** - `isMasterAsleep` changed to `false`, but `isFadeOutInProgress` stayed `true`:
```json
{"level":"info","ts":"2026-01-08T15:17:23.130Z","msg":"State changed","key":"isMasterAsleep","old":true,"new":false}
```

**11:27:03** - Lighting plugin still seeing `isFadeOutInProgress=true`, hours later:
```json
{"level":"info","ts":"2026-01-08T17:27:03.216Z","logger":"lighting","msg":"Room should be turned on with scene","room":"Primary Suite","matched_condition":"isFadeOutInProgress"}
```

**11:38:53** - State dump still shows `isFadeOutInProgress: true`:
```json
{"level":"info","ts":"2026-01-08T17:38:53.799Z","msg":"  isFadeOutInProgress: true"}
```

## Root Cause

In `fadeOutSpeaker()`, when the speaker volume is already at 0, the function returns early without clearing the `isFadeOutInProgress` flag:

```go
if currentVolume == 0 {
    m.logger.Info("Speaker volume already at 0, skipping fade-out", ...)
    return  // BUG: isFadeOutInProgress stays true!
}
```

The flag is only cleared at the end of the fade-out loop (line 527), which is never reached when the early return is taken.

## Fix

Clear `isFadeOutInProgress` in the early return path:

```go
if currentVolume == 0 {
    m.logger.Info("Speaker volume already at 0, skipping fade-out", ...)
    if !m.readOnly {
        if err := m.stateManager.SetBool("isFadeOutInProgress", false); err != nil {
            m.logger.Error("Failed to clear isFadeOutInProgress", zap.Error(err))
        }
    }
    return
}
```

## Test plan
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Code compiles with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)