### PR TITLE
Fix stopPlayback to only affect speakers in active playback group

### DIFF
--- a/homeautomation-go/internal/plugins/music/manager.go
+++ b/homeautomation-go/internal/plugins/music/manager.go
@@ -562,6 +562,7 @@ func (m *Manager) muteSpeaker(participant ParticipantWithVolume) {
 // stopPlayback stops all music playback
 func (m *Manager) stopPlayback() {
 	m.mu.Lock()
+	lastPlaying := m.currentlyPlaying // Save before clearing
 	m.currentlyPlaying = nil
 	m.mu.Unlock()
 
@@ -577,22 +578,27 @@ func (m *Manager) stopPlayback() {
 		return
 	}
 
-	// Set all speakers to volume 0
-	for _, mode := range m.config.Music {
-		for _, participant := range mode.Participants {
-			entityID := m.getSpeakerEntityID(participant.PlayerName)
-			if err := m.callServiceWithRetry("media_player", "volume_set", map[string]interface{}{
-				"entity_id":    entityID,
-				"volume_level": 0,
-			}); err != nil {
-				m.logger.Error("Failed to set speaker volume to 0",
-					zap.String("speaker", participant.PlayerName),
-					zap.Error(err))
-			}
+	// Only set volume to 0 for speakers that were actually playing
+	if lastPlaying == nil {
+		m.logger.Debug("No active playback to stop")
+		return
+	}
+
+	for _, participant := range lastPlaying.Participants {
+		entityID := m.getSpeakerEntityID(participant.PlayerName)
+		if err := m.callServiceWithRetry("media_player", "volume_set", map[string]interface{}{
+			"entity_id":    entityID,
+			"volume_level": 0,
+		}); err != nil {
+			m.logger.Error("Failed to set speaker volume to 0",
+				zap.String("speaker", participant.PlayerName),
+				zap.Error(err))
 		}
 	}
 
-	m.logger.Info("Music playback stopped")
+	m.logger.Info("Music playback stopped",
+		zap.String("type", lastPlaying.Type),
+		zap.Int("speaker_count", len(lastPlaying.Participants)))
 }
 
 // orchestratePlayback coordinates the complete playback flow

--- a/homeautomation-go/internal/plugins/music/manager_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_test.go
@@ -780,6 +780,112 @@ func TestStopPlayback(t *testing.T) {
 	}
 }
 
+// TestStopPlayback_OnlyAffectsActiveSpeakers verifies that stopPlayback only
+// sets volume to 0 for speakers that were in the currentlyPlaying group,
+// not all speakers across all modes in the config.
+func TestStopPlayback_OnlyAffectsActiveSpeakers(t *testing.T) {
+	t.Parallel()
+	logger := zap.NewNop()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+
+	// Config has speakers in multiple modes
+	config := &MusicConfig{
+		Music: map[string]MusicMode{
+			"morning": {
+				Participants: []Participant{
+					{PlayerName: "Kitchen", BaseVolume: 9},
+					{PlayerName: "Soundbar", BaseVolume: 10}, // Soundbar only in morning mode
+				},
+				PlaybackOptions: []PlaybackOption{},
+			},
+			"evening": {
+				Participants: []Participant{
+					{PlayerName: "Kitchen", BaseVolume: 9},
+					{PlayerName: "Living Room", BaseVolume: 10}, // No Soundbar in evening
+				},
+				PlaybackOptions: []PlaybackOption{},
+			},
+		},
+	}
+
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+
+	// Set up currently playing as EVENING mode (which does NOT include Soundbar)
+	manager.currentlyPlaying = &CurrentlyPlayingMusic{
+		Type: "evening",
+		URI:  "spotify:playlist:evening",
+		Participants: []ParticipantWithVolume{
+			{PlayerName: "Kitchen", Volume: 9},
+			{PlayerName: "Living Room", Volume: 10},
+		},
+	}
+
+	// Stop playback
+	manager.stopPlayback()
+
+	// Get all volume_set calls
+	calls := mockClient.GetServiceCalls()
+	volumeSetCalls := make(map[string]bool)
+	for _, call := range calls {
+		if call.Domain == "media_player" && call.Service == "volume_set" {
+			if entityID, ok := call.Data["entity_id"].(string); ok {
+				volumeSetCalls[entityID] = true
+			}
+		}
+	}
+
+	// Should have called volume_set on Kitchen and Living Room (evening mode speakers)
+	if !volumeSetCalls["media_player.kitchen"] {
+		t.Error("Expected volume_set call for Kitchen (was in evening mode)")
+	}
+	if !volumeSetCalls["media_player.living_room"] {
+		t.Error("Expected volume_set call for Living Room (was in evening mode)")
+	}
+
+	// Should NOT have called volume_set on Soundbar (not in evening mode)
+	if volumeSetCalls["media_player.soundbar"] {
+		t.Error("Unexpected volume_set call for Soundbar (was NOT in evening mode)")
+	}
+}
+
+// TestStopPlayback_NoCurrentPlayback verifies that stopPlayback handles
+// the case where there is no active playback gracefully.
+func TestStopPlayback_NoCurrentPlayback(t *testing.T) {
+	t.Parallel()
+	logger := zap.NewNop()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+
+	config := &MusicConfig{
+		Music: map[string]MusicMode{
+			"morning": {
+				Participants: []Participant{
+					{PlayerName: "Kitchen", BaseVolume: 9},
+					{PlayerName: "Soundbar", BaseVolume: 10},
+				},
+				PlaybackOptions: []PlaybackOption{},
+			},
+		},
+	}
+
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+
+	// No currently playing music
+	manager.currentlyPlaying = nil
+
+	// Stop playback - should not panic and should not call any volume_set
+	manager.stopPlayback()
+
+	// Should NOT have any volume_set calls since nothing was playing
+	calls := mockClient.GetServiceCalls()
+	for _, call := range calls {
+		if call.Domain == "media_player" && call.Service == "volume_set" {
+			t.Errorf("Unexpected volume_set call when nothing was playing: %v", call.Data)
+		}
+	}
+}
+
 // TestOrchestratePlayback tests the main orchestration flow
 func TestOrchestratePlayback(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- Fixed `stopPlayback()` to only set volume to 0 for speakers that were actually in the current playback group
- Previously, the function iterated through ALL music modes and affected ALL configured speakers, causing the soundbar to have its volume reduced even when it wasn't playing music (e.g., when evening music stopped but soundbar was playing TV audio)

## Test plan

- [x] Added `TestStopPlayback_OnlyAffectsActiveSpeakers` - verifies only speakers in the active playback group get volume reset
- [x] Added `TestStopPlayback_NoCurrentPlayback` - verifies graceful handling when no music was playing
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Coverage at 70.2% (above 65% threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)