### PR TITLE
fix(workflow): Fetch issue body via API to avoid escaping issues

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -268,7 +268,6 @@ jobs:
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             ISSUE_NUMBER=${{ github.event.issue.number }}
             ISSUE_TITLE=${{ github.event.issue.title }}
-            ISSUE_BODY=${{ github.event.issue.body }}
             REPO=${{ github.repository }}
             CLAUDE_CONFIG_DIR=/workspaces/home-automation/.claude-session
           runCmd: |
@@ -276,6 +275,11 @@ jobs:
             # Use tee to capture output for artifact upload
             # Use --verbose and --output-format stream-json for complete conversation logs
             mkdir -p "${CLAUDE_CONFIG_DIR}"
+
+            # Fetch issue body via API to avoid multi-line env var escaping issues
+            # (see https://github.com/NickBorgers/home-automation/issues/441)
+            ISSUE_BODY=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '.body')
+
             claude --print \
               --verbose \
               --output-format stream-json \


### PR DESCRIPTION
## Summary
- Removed `ISSUE_BODY` from the devcontainer `env:` block where multi-line content with special characters breaks argument parsing
- Now fetches issue body via `gh api` inside the container where escaping is not a concern
- Added comment linking to issue #441 for context

## Root Cause
The `devcontainers/ci@v0.3` action passes env vars via `--remote-env` flags. When `ISSUE_BODY` contains multi-line markdown, backticks, or special characters, the command-line argument parsing breaks, causing errors like:
```
Unknown arguments: " ", S, i, n, c, e
```

## Why Only One Occurrence?
Most issue bodies are simple enough to not trigger this. Issue #440 had complex multi-line markdown with code blocks that exposed the bug.

Fixes #441

## Test Plan
- [ ] Create a test issue with multi-line body containing backticks and markdown
- [ ] Verify the `resolve-issue` job fetches the body correctly and doesn't fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)