### PR TITLE
Fix #451: Use jq for safe JSON escaping of PR title in notify-pr-merged.yml

### DIFF
--- a/.github/workflows/notify-pr-merged.yml
+++ b/.github/workflows/notify-pr-merged.yml
@@ -14,21 +14,33 @@ jobs:
 
     steps:
       - name: Trigger private repository review
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
+          # Use jq to safely construct JSON payload with proper escaping
+          # (avoids issues with special characters in PR titles - see issue #451)
+          PAYLOAD=$(jq -n \
+            --arg ref "${{ github.ref }}" \
+            --arg sha "${{ github.event.pull_request.merge_commit_sha }}" \
+            --arg pr_number "${{ github.event.pull_request.number }}" \
+            --arg pr_title "$PR_TITLE" \
+            --arg pr_url "${{ github.event.pull_request.html_url }}" \
+            '{
+              event_type: "upstream-pr-merged",
+              client_payload: {
+                ref: $ref,
+                sha: $sha,
+                pr_number: $pr_number,
+                pr_title: $pr_title,
+                pr_url: $pr_url
+              }
+            }')
+
           HTTP_STATUS=$(curl -s -o response.json -w "%{http_code}" -X POST \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ secrets.PRIVATE_REPO_TRIGGER_TOKEN }}" \
             https://api.github.com/repos/NickBorgers/home-automation-plus-security/dispatches \
-            -d '{
-              "event_type": "upstream-pr-merged",
-              "client_payload": {
-                "ref": "${{ github.ref }}",
-                "sha": "${{ github.event.pull_request.merge_commit_sha }}",
-                "pr_number": "${{ github.event.pull_request.number }}",
-                "pr_title": "${{ github.event.pull_request.title }}",
-                "pr_url": "${{ github.event.pull_request.html_url }}"
-              }
-            }')
+            -d "$PAYLOAD")
 
           if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
             echo "✅ Successfully notified private repo of PR merge"


### PR DESCRIPTION
Resolves #451

## Summary

Fixed a potential JSON syntax error in `notify-pr-merged.yml` when a PR title contains special characters (double quotes, backslashes, or newlines).

**Before:** The PR title was embedded directly into the JSON payload without escaping:
```yaml
-d '{"pr_title": "${{ github.event.pull_request.title }}"}'
```

A PR title like `Fix the "broken" feature` would produce invalid JSON:
```json
{"pr_title": "Fix the "broken" feature"}
```

**After:** Use `jq` to safely construct the JSON payload with proper escaping:
```yaml
PAYLOAD=$(jq -n --arg pr_title "$PR_TITLE" '{pr_title: $pr_title}')
curl ... -d "$PAYLOAD"
```

This approach:
- Properly escapes double quotes → `\"`
- Properly escapes backslashes → `\\`
- Properly escapes newlines → `\n`

This is the same pattern used in #445 to fix a similar issue in `claude.yml`.

## Test Plan

1. The fix uses `jq`, which is available on all GitHub Actions runners by default
2. Tested locally that `jq` properly escapes special characters:
   ```bash
   export PR_TITLE='Fix the "broken" feature with \backslash and
   newline'
   jq -n --arg pr_title "$PR_TITLE" '{pr_title: $pr_title}'
   # Output: {"pr_title":"Fix the \"broken\" feature with \\backslash and\nnewline"}
   ```
3. All unit tests and integration tests pass

🤖 Generated with Claude Code
