### PR TITLE
Fix #450: Use configured timezone for Sunday check in music manager

### DIFF
--- a/homeautomation-go/internal/plugins/music/manager.go
+++ b/homeautomation-go/internal/plugins/music/manager.go
@@ -62,7 +62,8 @@ type Manager struct {
 	logger       *zap.Logger
 	readOnly     bool
 	timeProvider plugin.TimeProvider
-	sleepFunc    SleepFunc // Injectable sleep function for testing
+	timezone     *time.Location // Configured timezone for day-of-week checks
+	sleepFunc    SleepFunc      // Injectable sleep function for testing
 
 	// Playback state
 	playlistNumbers    map[string]int // Tracks playlist rotation per music type
@@ -88,9 +89,13 @@ type Manager struct {
 
 // NewManager creates a new Music manager
 // If timeProvider is nil, it defaults to plugin.RealTimeProvider
-func NewManager(haClient ha.HAClient, stateManager *state.Manager, config *MusicConfig, logger *zap.Logger, readOnly bool, timeProvider plugin.TimeProvider) *Manager {
+// If timezone is nil, it defaults to time.Local
+func NewManager(haClient ha.HAClient, stateManager *state.Manager, config *MusicConfig, logger *zap.Logger, readOnly bool, timeProvider plugin.TimeProvider, timezone *time.Location) *Manager {
 	if timeProvider == nil {
 		timeProvider = plugin.RealTimeProvider{}
+	}
+	if timezone == nil {
+		timezone = time.Local
 	}
 	return &Manager{
 		haClient:           haClient,
@@ -99,6 +104,7 @@ func NewManager(haClient ha.HAClient, stateManager *state.Manager, config *Music
 		logger:             logger.Named("music"),
 		readOnly:           readOnly,
 		timeProvider:       timeProvider,
+		timezone:           timezone,
 		sleepFunc:          time.Sleep,
 		playlistNumbers:    make(map[string]int),
 		shadowState:        shadowstate.NewMusicShadowState(),
@@ -313,7 +319,10 @@ func (m *Manager) determineMusicModeFromDayPhase(dayPhase string, currentMusicTy
 		// Otherwise, fall back to day music during morning phase
 		if isWakeUpEvent {
 			// Check if it's Sunday (no morning music on Sundays)
-			if m.timeProvider.Now().Weekday() == time.Sunday {
+			// Use configured timezone to avoid UTC-based weekday check issues
+			// (e.g., 6 PM CST Saturday = 00:00 UTC Sunday)
+			nowLocal := m.timeProvider.Now().In(m.timezone)
+			if nowLocal.Weekday() == time.Sunday {
 				m.logger.Debug("Sunday detected, using day mode instead of morning")
 				return "day"
 			}

--- a/homeautomation-go/internal/plugins/music/manager_shadow_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_shadow_test.go
@@ -23,7 +23,7 @@ func TestMusicShadowState_CaptureInputs(t *testing.T) {
 	mockConfig := &MusicConfig{
 		Music: make(map[string]MusicMode),
 	}
-	manager := NewManager(nil, stateManager, mockConfig, zap.NewNop(), true, nil)
+	manager := NewManager(nil, stateManager, mockConfig, zap.NewNop(), true, nil, nil)
 
 	// Capture inputs (should not fail even if state variables don't exist)
 	inputs := manager.captureCurrentInputs()
@@ -54,7 +54,7 @@ func TestMusicShadowState_RecordAction(t *testing.T) {
 	}
 	fixedTime := time.Date(2025, 11, 28, 12, 0, 0, 0, time.UTC)
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
-	manager := NewManager(nil, stateManager, mockConfig, zap.NewNop(), true, timeProvider)
+	manager := NewManager(nil, stateManager, mockConfig, zap.NewNop(), true, timeProvider, nil)
 
 	// Record an action
 	manager.updateShadowState("start_playback", "Test playback started", "test_trigger")
@@ -94,7 +94,7 @@ func TestMusicShadowState_UpdateOutputs(t *testing.T) {
 	mockConfig := &MusicConfig{
 		Music: make(map[string]MusicMode),
 	}
-	manager := NewManager(nil, stateManager, mockConfig, zap.NewNop(), true, nil)
+	manager := NewManager(nil, stateManager, mockConfig, zap.NewNop(), true, nil, nil)
 
 	// Create test data
 	playlistInfo := &shadowstate.PlaylistInfo{
@@ -167,7 +167,7 @@ func TestMusicShadowState_GetShadowState(t *testing.T) {
 	mockConfig := &MusicConfig{
 		Music: make(map[string]MusicMode),
 	}
-	manager := NewManager(nil, stateManager, mockConfig, zap.NewNop(), true, nil)
+	manager := NewManager(nil, stateManager, mockConfig, zap.NewNop(), true, nil, nil)
 
 	// Record some state
 	manager.updateShadowState("test_action", "Test reason", "test_trigger")
@@ -216,7 +216,7 @@ func TestMusicShadowState_ConcurrentAccess(t *testing.T) {
 	mockConfig := &MusicConfig{
 		Music: make(map[string]MusicMode),
 	}
-	manager := NewManager(nil, stateManager, mockConfig, zap.NewNop(), true, nil)
+	manager := NewManager(nil, stateManager, mockConfig, zap.NewNop(), true, nil, nil)
 
 	// Run concurrent operations
 	done := make(chan bool)
@@ -257,7 +257,7 @@ func TestMusicShadowState_PlaylistRotation(t *testing.T) {
 	mockConfig := &MusicConfig{
 		Music: make(map[string]MusicMode),
 	}
-	manager := NewManager(nil, stateManager, mockConfig, zap.NewNop(), true, nil)
+	manager := NewManager(nil, stateManager, mockConfig, zap.NewNop(), true, nil, nil)
 
 	// Set some playlist rotation state
 	manager.playlistNumbers["morning"] = 2

--- a/homeautomation-go/internal/plugins/music/manager_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_test.go
@@ -147,7 +147,7 @@ func TestMusicManager_SelectAppropriateMusicMode(t *testing.T) {
 			timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 			// Create manager
-			manager := NewManager(mockHA, stateMgr, config, logger, true, timeProvider)
+			manager := NewManager(mockHA, stateMgr, config, logger, true, timeProvider, nil)
 
 			// Set up initial state
 			if err := stateMgr.SetBool("isAnyoneHome", tt.isAnyoneHome); err != nil {
@@ -191,7 +191,7 @@ func TestMusicManager_DetermineMusicModeFromDayPhase(t *testing.T) {
 	fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC) // Monday, January 6, 2025
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
-	manager := NewManager(mockHA, stateMgr, config, logger, true, timeProvider)
+	manager := NewManager(mockHA, stateMgr, config, logger, true, timeProvider, nil)
 
 	tests := []struct {
 		dayPhase          string
@@ -242,7 +242,7 @@ func TestMusicManager_StateChangeHandling(t *testing.T) {
 	fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC) // Monday, January 6, 2025
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
-	manager := NewManager(mockHA, stateMgr, config, logger, true, timeProvider)
+	manager := NewManager(mockHA, stateMgr, config, logger, true, timeProvider, nil)
 
 	// Set initial state
 	if err := stateMgr.SetBool("isAnyoneHome", true); err != nil {
@@ -328,7 +328,7 @@ func TestMusicManager_Stop(t *testing.T) {
 	}
 
 	// Create manager
-	manager := NewManager(mockHA, stateMgr, config, logger, true, nil)
+	manager := NewManager(mockHA, stateMgr, config, logger, true, nil, nil)
 
 	// Set initial state
 	if err := stateMgr.SetBool("isAnyoneHome", true); err != nil {
@@ -471,7 +471,7 @@ func TestMusicManager_ReadOnlyMode(t *testing.T) {
 		},
 	}
 
-	manager := NewManager(mockClient, stateManager, config, logger, true, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, true, nil, nil)
 
 	// Test selecting music mode in read-only mode - should handle gracefully
 	manager.selectAppropriateMusicMode()
@@ -495,7 +495,7 @@ func TestCalculateVolume(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	tests := []struct {
 		name       string
@@ -529,7 +529,7 @@ func TestPlaylistRotation(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Test rotation for "day" music type with 3 playlists
 	musicType := "day"
@@ -593,7 +593,7 @@ func TestRateLimiting(t *testing.T) {
 	fixedTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
-	manager := NewManager(mockClient, stateManager, config, logger, true, timeProvider)
+	manager := NewManager(mockClient, stateManager, config, logger, true, timeProvider, nil)
 
 	// First playback should succeed
 	manager.handleMusicPlaybackTypeChange("musicPlaybackType", "", "day")
@@ -640,7 +640,7 @@ func TestDoubleActivationPrevention(t *testing.T) {
 		},
 	}
 
-	manager := NewManager(mockClient, stateManager, config, logger, true, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, true, nil, nil)
 
 	// First playback
 	manager.handleMusicPlaybackTypeChange("musicPlaybackType", "", "day")
@@ -665,7 +665,7 @@ func TestMuteConditionEvaluation(t *testing.T) {
 	_ = stateManager.SetBool("isMasterAsleep", false)
 
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	tests := []struct {
 		name          string
@@ -721,7 +721,7 @@ func TestGetSpeakerEntityID(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	tests := []struct {
 		speakerName string
@@ -763,7 +763,7 @@ func TestStopPlayback(t *testing.T) {
 		},
 	}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Set up currently playing music
 	manager.currentlyPlaying = &CurrentlyPlayingMusic{
@@ -802,7 +802,7 @@ func TestOrchestratePlayback(t *testing.T) {
 		},
 	}
 
-	manager := NewManager(mockClient, stateManager, config, logger, true, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, true, nil, nil)
 
 	// Test orchestration
 	err := manager.orchestratePlayback("day", "test_trigger")
@@ -866,7 +866,7 @@ func TestValuesMatch(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	tests := []struct {
 		name     string
@@ -907,7 +907,7 @@ func TestGetStateValue(t *testing.T) {
 	_ = stateManager.SetNumber("alarmTime", 7.5)
 
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Test getting boolean
 	val, err := manager.getStateValue("isTVPlaying")
@@ -952,7 +952,7 @@ func TestCallService(t *testing.T) {
 	config := &MusicConfig{Music: map[string]MusicMode{}}
 
 	// Test in normal mode
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 	err := manager.callService("media_player", "play_media", map[string]interface{}{
 		"entity_id": "media_player.kitchen",
 	})
@@ -961,7 +961,7 @@ func TestCallService(t *testing.T) {
 	}
 
 	// Test in read-only mode
-	managerRO := NewManager(mockClient, stateManager, config, logger, true, nil)
+	managerRO := NewManager(mockClient, stateManager, config, logger, true, nil, nil)
 	err = managerRO.callService("media_player", "play_media", map[string]interface{}{
 		"entity_id": "media_player.kitchen",
 	})
@@ -988,7 +988,7 @@ func TestHandleMusicPlaybackTypeChange_EmptyString(t *testing.T) {
 		},
 	}
 
-	manager := NewManager(mockClient, stateManager, config, logger, true, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, true, nil, nil)
 
 	// Set up currently playing music
 	manager.currentlyPlaying = &CurrentlyPlayingMusic{
@@ -1012,7 +1012,7 @@ func TestHandleMusicPlaybackTypeChange_InvalidType(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Pass non-string value (should log error and return)
 	manager.handleMusicPlaybackTypeChange("musicPlaybackType", "", 123)
@@ -1033,7 +1033,7 @@ func TestExecutePlayback(t *testing.T) {
 	_ = stateManager.SetString("musicPlaybackType", "day")
 
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Set up mock to return "playing" state for playback verification
 	mockClient.SetState("media_player.kitchen", "playing", nil)
@@ -1074,7 +1074,7 @@ func TestBuildSpeakerGroup(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Clear any previous calls
 	mockClient.ClearServiceCalls()
@@ -1145,7 +1145,7 @@ func TestBuildSpeakerGroupRetrySuccess(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Use no-op sleep to make test fast
 	manager.SetSleepFunc(func(d time.Duration) {})
@@ -1180,7 +1180,7 @@ func TestBuildSpeakerGroupPartialSuccess(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Use no-op sleep to make test fast
 	manager.SetSleepFunc(func(d time.Duration) {})
@@ -1246,7 +1246,7 @@ func TestBuildSpeakerGroupAllFail(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Use no-op sleep to make test fast
 	manager.SetSleepFunc(func(d time.Duration) {})
@@ -1295,7 +1295,7 @@ func TestBuildSpeakerGroupRetryOnSecondAttempt(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Use no-op sleep to make test fast
 	manager.SetSleepFunc(func(d time.Duration) {})
@@ -1341,7 +1341,7 @@ func TestManagerReset(t *testing.T) {
 	stateManager.SetBool("isAnyoneHome", true)
 	stateManager.SetBool("isAnyoneAsleep", false)
 
-	manager := NewManager(mockClient, stateManager, musicConfig, logger, false, &plugin.RealTimeProvider{})
+	manager := NewManager(mockClient, stateManager, musicConfig, logger, false, &plugin.RealTimeProvider{}, nil)
 
 	err := manager.Start()
 	if err != nil {
@@ -1376,7 +1376,7 @@ func TestManagerReset_WhenNoOneHome_StopsMusic(t *testing.T) {
 	stateManager.SetBool("isAnyoneAsleep", false)
 	stateManager.SetString("musicPlaybackType", "morning")
 
-	manager := NewManager(mockClient, stateManager, musicConfig, logger, false, &plugin.RealTimeProvider{})
+	manager := NewManager(mockClient, stateManager, musicConfig, logger, false, &plugin.RealTimeProvider{}, nil)
 
 	err := manager.Start()
 	if err != nil {
@@ -1421,7 +1421,7 @@ func TestManagerReset_WhenSomeoneAsleep_SelectsSleepMode(t *testing.T) {
 	stateManager.SetBool("isAnyoneAsleep", true)
 	stateManager.SetString("musicPlaybackType", "morning")
 
-	manager := NewManager(mockClient, stateManager, musicConfig, logger, false, &plugin.RealTimeProvider{})
+	manager := NewManager(mockClient, stateManager, musicConfig, logger, false, &plugin.RealTimeProvider{}, nil)
 
 	err := manager.Start()
 	if err != nil {
@@ -1468,7 +1468,7 @@ func TestCurrentlyPlayingMusicUri_SetOnPlayback(t *testing.T) {
 		},
 	}
 
-	manager := NewManager(mockClient, stateManager, config, logger, true, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, true, nil, nil)
 
 	// Orchestrate playback
 	err := manager.orchestratePlayback("day", "test_trigger")
@@ -1510,7 +1510,7 @@ func TestCurrentlyPlayingMusicUri_ClearOnStop(t *testing.T) {
 		},
 	}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Set up currently playing music and URI
 	manager.currentlyPlaying = &CurrentlyPlayingMusic{
@@ -1578,7 +1578,7 @@ func TestCurrentlyPlayingMusicUri_UpdateOnModeChange(t *testing.T) {
 	fixedTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
-	manager := NewManager(mockClient, stateManager, config, logger, true, timeProvider)
+	manager := NewManager(mockClient, stateManager, config, logger, true, timeProvider, nil)
 
 	// Start with day music
 	err := manager.orchestratePlayback("day", "test_trigger")
@@ -1637,7 +1637,7 @@ func TestFadeInSpeaker_SafeUnmuteSequence(t *testing.T) {
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
 	// NOT read-only so service calls actually go through
-	manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider, nil)
 	// Skip sleep delays in tests (fade-in uses very slow timing to match Node-RED behavior)
 	manager.SetSleepFunc(func(d time.Duration) {})
 
@@ -1733,7 +1733,7 @@ func TestFadeInSpeaker_VolumeNormalization(t *testing.T) {
 
 			fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)
 			timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
-			manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider)
+			manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider, nil)
 			// Skip sleep delays in tests (fade-in uses very slow timing to match Node-RED behavior)
 			manager.SetSleepFunc(func(d time.Duration) {})
 
@@ -1788,7 +1788,7 @@ func TestFadeInSpeaker_InitialVolumeSetFailure(t *testing.T) {
 
 	fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
-	manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider, nil)
 	// Skip sleep delays in tests (fade-in uses very slow timing to match Node-RED behavior)
 	manager.SetSleepFunc(func(d time.Duration) {})
 
@@ -1828,7 +1828,7 @@ func TestFadeInSpeaker_UnmuteFailure(t *testing.T) {
 
 	fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
-	manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider, nil)
 	// Skip sleep delays in tests (fade-in uses very slow timing to match Node-RED behavior)
 	manager.SetSleepFunc(func(d time.Duration) {})
 
@@ -1875,7 +1875,7 @@ func TestRefreshAvailableSpeakers(t *testing.T) {
 		},
 	}
 
-	manager := NewManager(mockHA, stateManager, config, logger, false, nil)
+	manager := NewManager(mockHA, stateManager, config, logger, false, nil, nil)
 
 	// Set up mock states with various entity types
 	mockHA.SetState("media_player.kitchen", "idle", nil)
@@ -1930,7 +1930,7 @@ func TestCallServiceWithRetry_Success(t *testing.T) {
 		},
 	}
 
-	manager := NewManager(mockHA, stateManager, config, logger, false, nil)
+	manager := NewManager(mockHA, stateManager, config, logger, false, nil, nil)
 
 	// Set up a speaker entity
 	mockHA.SetState("media_player.kitchen", "idle", nil)
@@ -1972,7 +1972,7 @@ func TestCallServiceWithRetry_PersistentError(t *testing.T) {
 		},
 	}
 
-	manager := NewManager(mockHA, stateManager, config, logger, false, nil)
+	manager := NewManager(mockHA, stateManager, config, logger, false, nil, nil)
 
 	// Set up a speaker entity so refresh will find it (retry path is triggered)
 	mockHA.SetState("media_player.kitchen", "idle", nil)
@@ -2011,7 +2011,7 @@ func TestCallServiceWithRetry_SpeakerNotAvailable(t *testing.T) {
 		},
 	}
 
-	manager := NewManager(mockHA, stateManager, config, logger, false, nil)
+	manager := NewManager(mockHA, stateManager, config, logger, false, nil, nil)
 
 	// Don't set up any media_player entities - speaker doesn't exist
 
@@ -2041,7 +2041,7 @@ func TestBreakSpeakerGroups(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Use no-op sleep to make test fast
 	manager.SetSleepFunc(func(d time.Duration) {})
@@ -2098,7 +2098,7 @@ func TestBreakSpeakerGroups_UnjoinFailure(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Use no-op sleep to make test fast
 	manager.SetSleepFunc(func(d time.Duration) {})
@@ -2158,7 +2158,7 @@ func TestExecutePlayback_BreakThenBuildSequence(t *testing.T) {
 	_ = stateManager.SetString("musicPlaybackType", "day")
 
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Use no-op sleep to make test fast
 	manager.SetSleepFunc(func(d time.Duration) {})
@@ -2225,7 +2225,7 @@ func TestExecutePlayback_BreakThenBuildSequence_SingleSpeaker(t *testing.T) {
 	_ = stateManager.SetString("musicPlaybackType", "day")
 
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Use no-op sleep to make test fast
 	manager.SetSleepFunc(func(d time.Duration) {})
@@ -2318,7 +2318,7 @@ func TestStartValidatesSpeakers(t *testing.T) {
 		t.Fatalf("Failed to set musicPlaybackType: %v", err)
 	}
 
-	manager := NewManager(mockHA, stateManager, config, logger, false, nil)
+	manager := NewManager(mockHA, stateManager, config, logger, false, nil, nil)
 
 	// Set up only one of the configured speakers
 	mockHA.SetState("media_player.kitchen", "idle", nil)
@@ -2395,7 +2395,7 @@ func TestLoadPlaylistRotationFromHA(t *testing.T) {
 					"evening": {PlaybackOptions: []PlaybackOption{{URI: "test1"}, {URI: "test2"}}},
 				},
 			}
-			manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+			manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 			// Load rotation from HA
 			manager.loadPlaylistRotationFromHA()
@@ -2440,7 +2440,7 @@ func TestLoadPlaylistRotationBoundsCheck(t *testing.T) {
 			"unknown": {PlaybackOptions: []PlaybackOption{}},                                               // empty options
 		},
 	}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Load rotation from HA
 	manager.loadPlaylistRotationFromHA()
@@ -2472,7 +2472,7 @@ func TestLoadPlaylistRotationUnconfiguredType(t *testing.T) {
 			"morning": {PlaybackOptions: []PlaybackOption{{URI: "test1"}, {URI: "test2"}, {URI: "test3"}}},
 		},
 	}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Load rotation from HA
 	manager.loadPlaylistRotationFromHA()
@@ -2503,7 +2503,7 @@ func TestSyncPlaylistRotationToHA(t *testing.T) {
 			"day": {PlaybackOptions: []PlaybackOption{{URI: "test1"}, {URI: "test2"}, {URI: "test3"}}},
 		},
 	}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Call getNextPlaylistIndex which should trigger a sync
 	index := manager.getNextPlaylistIndex("day", 3)
@@ -2562,7 +2562,7 @@ func TestPlaylistRotationSyncReadOnlyMode(t *testing.T) {
 			"day": {PlaybackOptions: []PlaybackOption{{URI: "test1"}, {URI: "test2"}, {URI: "test3"}}},
 		},
 	}
-	manager := NewManager(mockClient, stateManager, config, logger, true, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, true, nil, nil)
 
 	// Call getNextPlaylistIndex
 	index := manager.getNextPlaylistIndex("day", 3)
@@ -2628,7 +2628,7 @@ func TestPlaybackVerification(t *testing.T) {
 			stateManager := state.NewManager(mockClient, logger, false)
 
 			config := &MusicConfig{Music: map[string]MusicMode{}}
-			manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+			manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 			// Use no-op sleep to make test fast
 			manager.SetSleepFunc(func(d time.Duration) {})
@@ -2680,7 +2680,7 @@ func TestIsPlaybackActive(t *testing.T) {
 			stateManager := state.NewManager(mockClient, logger, false)
 
 			config := &MusicConfig{Music: map[string]MusicMode{}}
-			manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+			manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 			mockClient.SetState("media_player.kitchen", tt.speakerState, nil)
 
@@ -2707,7 +2707,7 @@ func TestPlaybackVerification_RecoveryAfterNudge(t *testing.T) {
 	stateManager := state.NewManager(mockClient, logger, false)
 
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Use no-op sleep to make test fast
 	manager.SetSleepFunc(func(d time.Duration) {})
@@ -2765,7 +2765,7 @@ func TestPlaybackVerification_RecoveryOnSecondAttempt(t *testing.T) {
 	stateManager := state.NewManager(mockClient, logger, false)
 
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Use no-op sleep to make test fast
 	manager.SetSleepFunc(func(d time.Duration) {})
@@ -2815,7 +2815,7 @@ func TestShouldIncludeInZone_NoConditions(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	participant := Participant{
 		PlayerName:   "Kitchen",
@@ -2836,7 +2836,7 @@ func TestShouldIncludeInZone_ConditionNotMatched(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Set up state: isMasterAsleep = false
 	if err := stateManager.SetBool("isMasterAsleep", false); err != nil {
@@ -2866,7 +2866,7 @@ func TestShouldIncludeInZone_ConditionMatched(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Set up state: isMasterAsleep = true
 	if err := stateManager.SetBool("isMasterAsleep", true); err != nil {
@@ -2895,7 +2895,7 @@ func TestShouldIncludeInZone_MultipleConditions(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	tests := []struct {
 		name             string
@@ -2987,7 +2987,7 @@ func TestOrchestratePlayback_WithExcludeIf(t *testing.T) {
 		},
 	}
 
-	manager := NewManager(mockClient, stateManager, config, logger, true, nil) // read-only mode
+	manager := NewManager(mockClient, stateManager, config, logger, true, nil, nil) // read-only mode
 
 	// Set up state: isMasterAsleep = true (Bedroom should be excluded)
 	if err := stateManager.SetBool("isMasterAsleep", true); err != nil {
@@ -3066,7 +3066,7 @@ func TestOrchestratePlayback_AllSpeakersExcluded(t *testing.T) {
 		},
 	}
 
-	manager := NewManager(mockClient, stateManager, config, logger, true, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, true, nil, nil)
 
 	// Set up state: all speakers excluded
 	if err := stateManager.SetBool("isMasterAsleep", true); err != nil {
@@ -3129,7 +3129,7 @@ func TestCollectMuteConditionVariables_IncludesExcludeIf(t *testing.T) {
 		},
 	}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	variables := manager.collectMuteConditionVariables()
 
@@ -3185,7 +3185,7 @@ func TestExcludeIf_LeadPlayerSelection(t *testing.T) {
 		},
 	}
 
-	manager := NewManager(mockClient, stateManager, config, logger, true, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, true, nil, nil)
 
 	// Set up state: first participant (Bedroom) is excluded
 	if err := stateManager.SetBool("isMasterAsleep", true); err != nil {
@@ -3235,7 +3235,7 @@ func TestExcludeIf_ParticipantWithVolumePreservesExcludeIf(t *testing.T) {
 		},
 	}
 
-	manager := NewManager(mockClient, stateManager, config, logger, true, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, true, nil, nil)
 
 	// Kitchen is not excluded (isMasterAsleep is false by default)
 	if err := stateManager.SetBool("isMasterAsleep", false); err != nil {

--- a/homeautomation-go/internal/plugins/music/occupancy_scenario_test.go
+++ b/homeautomation-go/internal/plugins/music/occupancy_scenario_test.go
@@ -155,7 +155,7 @@ func TestScenario_OfficeSpeaker_UnmutedWhenOccupied(t *testing.T) {
 	fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC) // Monday 10am
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider, nil)
 	manager.SetSleepFunc(func(d time.Duration) {}) // Skip internal sleeps for fast tests
 
 	// Initialize required state variables
@@ -237,7 +237,7 @@ func TestScenario_OfficeSpeaker_MutedWhenUnoccupied(t *testing.T) {
 	fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider, nil)
 	manager.SetSleepFunc(func(d time.Duration) {}) // Skip internal sleeps for fast tests
 
 	// Initialize - office IS occupied
@@ -305,7 +305,7 @@ func TestScenario_OfficeSpeaker_UnmuteOnOccupancyChangeDuringPlayback(t *testing
 	fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider, nil)
 	manager.SetSleepFunc(func(d time.Duration) {}) // Skip internal sleeps for fast tests
 
 	// Initialize required state variables - music will start playing
@@ -388,7 +388,7 @@ func TestScenario_KitchenSpeaker_AlwaysUnmuted(t *testing.T) {
 	fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider, nil)
 	manager.SetSleepFunc(func(d time.Duration) {}) // Skip internal sleeps for fast tests
 
 	// Kitchen speaker has no mute conditions - empty array

--- a/homeautomation-go/internal/plugins/music/playback_verification_scenario_test.go
+++ b/homeautomation-go/internal/plugins/music/playback_verification_scenario_test.go
@@ -98,7 +98,7 @@ func TestScenario_PlaybackVerificationSucceeds_FadeInProceeds(t *testing.T) {
 	fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider, nil)
 	manager.SetSleepFunc(func(d time.Duration) {}) // Skip sleeps for fast test
 
 	// Initialize state
@@ -250,7 +250,7 @@ func TestScenario_PlaybackVerificationFails_FadeInStillProceeds(t *testing.T) {
 	fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider, nil)
 	manager.SetSleepFunc(func(d time.Duration) {}) // Skip sleeps for fast test
 
 	// Initialize state
@@ -346,7 +346,7 @@ func TestScenario_PlaybackVerificationFails_FadeInStillProceeds(t *testing.T) {
 	// Run again with info logger to capture the completion message
 	mockClient2 := ha.NewMockClient()
 	stateManager2 := state.NewManager(mockClient2, loggerInfo, false)
-	manager2 := NewManager(mockClient2, stateManager2, config, loggerInfo, false, timeProvider)
+	manager2 := NewManager(mockClient2, stateManager2, config, loggerInfo, false, timeProvider, nil)
 	manager2.SetSleepFunc(func(d time.Duration) {})
 
 	_ = stateManager2.SetString("dayPhase", "day")
@@ -432,7 +432,7 @@ func TestScenario_MultiSpeaker_VerificationFailureAllSpeakersFadeIn(t *testing.T
 	fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider, nil)
 	manager.SetSleepFunc(func(d time.Duration) {}) // Skip sleeps
 
 	// Initialize state

--- a/homeautomation-go/internal/plugins/music/register.go
+++ b/homeautomation-go/internal/plugins/music/register.go
@@ -40,8 +40,8 @@ func createPlugin(ctx *plugin.Context) (plugin.Plugin, error) {
 		return nil, fmt.Errorf("failed to load music config: %w", err)
 	}
 
-	// Pass the TimeProvider directly (NewManager handles nil by defaulting to RealTimeProvider)
-	manager := NewManager(haClient, stateManager, config, ctx.Logger, ctx.ReadOnly, ctx.TimeProvider)
+	// Pass the TimeProvider and Timezone directly (NewManager handles nil by defaulting to RealTimeProvider and time.Local)
+	manager := NewManager(haClient, stateManager, config, ctx.Logger, ctx.ReadOnly, ctx.TimeProvider, ctx.Timezone)
 	return &pluginAdapter{manager: manager}, nil
 }
 

--- a/homeautomation-go/internal/plugins/music/wakeup_scenario_test.go
+++ b/homeautomation-go/internal/plugins/music/wakeup_scenario_test.go
@@ -238,7 +238,7 @@ func TestScenario_WakeUpDuringMorning_TriggersMorningMusic(t *testing.T) {
 	require.Equal(t, time.Monday, fixedTime.Weekday(), "Test requires Monday")
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider, nil)
 	manager.SetSleepFunc(func(d time.Duration) {}) // Skip internal sleeps for fast tests
 
 	// ==========================================================
@@ -341,7 +341,7 @@ func TestScenario_WakeUpOnSunday_TriggersDayMusic(t *testing.T) {
 	require.Equal(t, time.Sunday, fixedTime.Weekday(), "Test requires Sunday")
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider, nil)
 	manager.SetSleepFunc(func(d time.Duration) {}) // Skip internal sleeps for fast tests
 
 	// Initial state: Morning phase, someone asleep
@@ -378,6 +378,81 @@ func TestScenario_WakeUpOnSunday_TriggersDayMusic(t *testing.T) {
 }
 
 // =============================================================================
+// TEST: Sunday Check Uses Configured Timezone (Issue #450)
+// =============================================================================
+//
+// SCENARIO (BUG CASE):
+// - UTC time: Sunday 00:30 AM (January 14, 2024)
+// - CST time: Saturday 6:30 PM (January 13, 2024) - NOT Sunday locally!
+// - Event: Wake-up during morning phase
+//
+// BUG BEHAVIOR (before fix):
+// → Used UTC weekday, incorrectly detected Sunday, played DAY music
+//
+// CORRECT BEHAVIOR (after fix):
+// → Uses configured timezone (CST), correctly detects Saturday, plays MORNING music
+//
+// This tests the fix for Issue #450: The music manager's Sunday check must use
+// the configured local timezone instead of UTC to avoid edge cases at midnight.
+func TestScenario_WakeUp_UsesLocalTimezoneForSundayCheck(t *testing.T) {
+	t.Parallel()
+	logger := zap.NewNop()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	config := createWakeupTestConfig()
+
+	// Load CST timezone (America/Chicago)
+	cst, err := time.LoadLocation("America/Chicago")
+	require.NoError(t, err, "Failed to load America/Chicago timezone")
+
+	// Create a time that is:
+	// - Sunday 00:30 AM UTC (January 14, 2024)
+	// - Saturday 6:30 PM CST (January 13, 2024)
+	utcTime := time.Date(2024, 1, 14, 0, 30, 0, 0, time.UTC)
+	require.Equal(t, time.Sunday, utcTime.Weekday(), "Test requires Sunday in UTC")
+	require.Equal(t, time.Saturday, utcTime.In(cst).Weekday(), "Test requires Saturday in CST")
+
+	timeProvider := plugin.FixedTimeProvider{FixedTime: utcTime}
+
+	// Pass CST as the configured timezone
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider, cst)
+	manager.SetSleepFunc(func(d time.Duration) {}) // Skip internal sleeps for fast tests
+
+	// Initial state: Morning phase, someone asleep
+	_ = stateManager.SetString("dayPhase", "morning")
+	_ = stateManager.SetString("musicPlaybackType", "sleep")
+	_ = stateManager.SetBool("isAnyoneHome", true)
+	_ = stateManager.SetBool("isAnyoneAsleep", true)
+	_ = stateManager.SetBool("isMasterAsleep", true)
+	_ = stateManager.SetBool("isGuestAsleep", false)
+	_ = stateManager.SetBool("isTVPlaying", false)
+	_ = stateManager.SetBool("isNickOfficeOccupied", false)
+
+	err = manager.Start()
+	require.NoError(t, err)
+	defer manager.Stop()
+
+	time.Sleep(50 * time.Millisecond)
+	mockClient.ClearServiceCalls()
+
+	// ACTION: Wake-up event
+	// UTC: Sunday 00:30 AM (but CST: Saturday 6:30 PM)
+	mockClient.SimulateStateChange("input_boolean.anyone_asleep", "off")
+	mockClient.SimulateStateChange("input_boolean.master_asleep", "off")
+
+	time.Sleep(50 * time.Millisecond)
+
+	// VERIFICATION: Should use local timezone (CST = Saturday)
+	// NOT Sunday, so morning music should play
+	musicType, err := stateManager.GetString("musicPlaybackType")
+	require.NoError(t, err)
+
+	assert.Equal(t, "morning", musicType,
+		"Wake-up when UTC=Sunday but CST=Saturday should trigger MORNING music "+
+			"(Issue #450: Sunday check must use configured timezone, not UTC)")
+}
+
+// =============================================================================
 // TEST: Day Phase Change (Not Wake-Up) Should Trigger Day Music
 // =============================================================================
 //
@@ -408,7 +483,7 @@ func TestScenario_DayPhaseChangesToMorning_TriggersDayMusic(t *testing.T) {
 	fixedTime := time.Date(2024, 1, 15, 6, 0, 0, 0, time.UTC)
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider, nil)
 	manager.SetSleepFunc(func(d time.Duration) {}) // Skip internal sleeps for fast tests
 
 	// Initial state: Night phase, no one asleep (maybe they stayed up late)
@@ -469,7 +544,7 @@ func TestScenario_NoOneHome_StopsMusic(t *testing.T) {
 	fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider, nil)
 	manager.SetSleepFunc(func(d time.Duration) {}) // Skip internal sleeps for fast tests
 
 	// Initial state: Day music playing
@@ -529,7 +604,7 @@ func TestScenario_SomeoneFallsAsleep_TriggersSleepMusic(t *testing.T) {
 	fixedTime := time.Date(2024, 1, 15, 22, 0, 0, 0, time.UTC) // 10 PM
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider, nil)
 	manager.SetSleepFunc(func(d time.Duration) {}) // Skip internal sleeps for fast tests
 
 	// Initial state: Winddown music playing
@@ -605,7 +680,7 @@ func TestScenario_SleepMusicPersistsDuringWinddown(t *testing.T) {
 	fixedTime := time.Date(2024, 1, 15, 21, 0, 0, 0, time.UTC) // 9 PM
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider, nil)
 	manager.SetSleepFunc(func(d time.Duration) {}) // Skip internal sleeps for fast tests
 
 	// Initial state: Dusk phase (valid dayPhase), no one asleep but sleep music manually started
@@ -678,7 +753,7 @@ func TestScenario_FullWakeUpCycle(t *testing.T) {
 	require.Equal(t, time.Monday, fixedTime.Weekday())
 	timeProvider := &MutableTimeProvider{CurrentTime: fixedTime}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider, nil)
 	manager.SetSleepFunc(func(d time.Duration) {}) // Skip internal sleeps for fast tests
 
 	// ==========================================================


### PR DESCRIPTION
Resolves #450

## Summary
- Add timezone field to music Manager struct
- Update NewManager constructor to accept timezone parameter from plugin context
- Convert UTC time to configured local timezone before checking weekday in `determineMusicModeFromDayPhase`
- Add comprehensive test case verifying timezone handling for Sunday check edge case

The music manager's check for "no morning music on Sundays" was using UTC time instead of the configured local timezone. This caused incorrect weekday detection when UTC and local time fell on different days (e.g., at 6 PM CST on Saturday, which is 00:00 UTC on Sunday, the old code would incorrectly detect Sunday and skip morning music).

## Test Plan
- [x] Added new test `TestScenario_WakeUp_UsesLocalTimezoneForSundayCheck` that verifies:
  - Time is Sunday in UTC but Saturday in CST
  - With CST timezone configured, manager correctly uses local Saturday
  - Morning music plays instead of incorrectly triggering Sunday override
- [x] All existing music tests pass with updated NewManager signature
- [x] Unit tests pass with 70.8% coverage
- [x] Integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)