### PR TITLE
fix(ha): Increase retry coverage to handle HA restarts

### DIFF
--- a/homeautomation-go/internal/ha/client.go
+++ b/homeautomation-go/internal/ha/client.go
@@ -44,16 +44,16 @@ const (
 // Retry constants for service calls
 const (
 	// maxRetries is the number of retry attempts for transient network errors.
-	// With exponential backoff (500ms, 1s, 2s, 4s, 8s, 15s, 15s, 15s, 15s),
-	// this provides approximately 75 seconds of retry coverage to handle
-	// network outages lasting up to 1 minute.
-	maxRetries = 9
+	// With exponential backoff (500ms, 1s, 2s, 4s, 8s, 16s, 30s, 30s, 30s, 30s, 30s, 30s),
+	// this provides approximately 3 minutes of retry coverage to handle
+	// Home Assistant restarts which can take 1.5-2 minutes.
+	maxRetries = 12
 
 	// initialRetryDelay is the base delay before first retry
 	initialRetryDelay = 500 * time.Millisecond
 
 	// maxRetryDelay caps the exponential backoff
-	maxRetryDelay = 15 * time.Second
+	maxRetryDelay = 30 * time.Second
 )
 
 // Health tracking constants

--- a/homeautomation-go/internal/plugins/music/manager_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_test.go
@@ -809,7 +809,7 @@ func TestStopPlayback_OnlyAffectsActiveSpeakers(t *testing.T) {
 		},
 	}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// Set up currently playing as EVENING mode (which does NOT include Soundbar)
 	manager.currentlyPlaying = &CurrentlyPlayingMusic{
@@ -869,7 +869,7 @@ func TestStopPlayback_NoCurrentPlayback(t *testing.T) {
 		},
 	}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, nil)
+	manager := NewManager(mockClient, stateManager, config, logger, false, nil, nil)
 
 	// No currently playing music
 	manager.currentlyPlaying = nil
@@ -1982,7 +1982,7 @@ func TestFadeInSpeaker_HumanOverrideDetection(t *testing.T) {
 
 	fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
-	manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider, nil)
 
 	var volumeStep int
 	manager.SetSleepFunc(func(d time.Duration) {
@@ -2043,7 +2043,7 @@ func TestFadeInSpeaker_NoHumanOverrideWithMatchingVolume(t *testing.T) {
 
 	fixedTime := time.Date(2025, 1, 6, 9, 0, 0, 0, time.UTC)
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
-	manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockHA, stateManager, config, logger, false, timeProvider, nil)
 
 	var volumeStep int
 	manager.SetSleepFunc(func(d time.Duration) {

--- a/homeautomation-go/internal/plugins/music/occupancy_scenario_test.go
+++ b/homeautomation-go/internal/plugins/music/occupancy_scenario_test.go
@@ -404,7 +404,7 @@ func TestScenario_MutedSpeaker_GetsTargetVolumeSetDuringPlayback(t *testing.T) {
 	fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
 	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
 
-	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider)
+	manager := NewManager(mockClient, stateManager, config, logger, false, timeProvider, nil)
 	manager.SetSleepFunc(func(d time.Duration) {}) // Skip internal sleeps for fast tests
 
 	// Initialize state - Office is NOT occupied, so Office speaker should be muted


### PR DESCRIPTION
## Summary
- Increase service call retry parameters to handle Home Assistant restarts (1.5-2 minutes)
- `maxRetries`: 9 → 12, `maxRetryDelay`: 15s → 30s
- New retry coverage: ~4 minutes (was ~75 seconds)

## Context
Morning music playback failed because the fade-in volume_set calls aborted when HA was restarting. The supervisor logs confirmed HA restarted at 11:53:40 and became running at 11:55:06 (~86 seconds), exceeding the previous 75-second retry window.

## Test plan
- [x] Unit tests pass
- [x] Integration tests pass
- [ ] Verify next HA restart doesn't cause fade-in failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)