### PR TITLE
fix: Skip review summary when only fix agent ran

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1525,10 +1525,13 @@ jobs:
           echo "To re-run reviews: close and reopen the PR."
 
       - name: Post review summary comment
+        # Only post summary when reviews actually ran (tests_passed == true)
+        # When tests failed, fix-test-failures triggers a new workflow run that will post the summary
         if: |
           always() &&
           needs.get-context.outputs.pr_number != '' &&
-          needs.get-context.outputs.reviews_already_passed != 'true'
+          needs.get-context.outputs.reviews_already_passed != 'true' &&
+          needs.get-context.outputs.tests_passed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ needs.get-context.outputs.pr_number }}


### PR DESCRIPTION
## Summary
- Skip posting Agent Review Summary when tests_passed=false
- Prevents misleading "All reviews completed successfully" message when only fix agent ran
- The actual review workflow (triggered by fix agent) will post the summary after reviews complete

## Root Cause
When tests fail, the `fix-test-failures` agent runs and triggers a new workflow run with `tests_passed=true`. The `all-reviews-passed` job was posting a summary after just the fix agent completed, misleadingly saying "All reviews completed successfully" when the actual review agents hadn't run yet.

The summary table correctly only showed the fix agent (because `TESTS_PASSED == false`), but the status line was confusing.

## Fix
Added `needs.get-context.outputs.tests_passed == 'true'` to the condition for posting the summary comment. Now the summary is only posted when reviews actually ran.

## Test plan
- [x] Verify workflow YAML syntax is valid
- [ ] On next PR with failing tests, confirm no premature summary is posted
- [ ] Confirm the triggered review workflow posts the summary after reviews complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)