### PR TITLE
feat: Add wake music playback at end of wake sequence

### DIFF
--- a/homeautomation-go/internal/plugins/sleephygiene/manager.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager.go
@@ -27,11 +27,22 @@ const (
 )
 
 // Wake sequence timing constants
+// Total wake sequence: 30 minutes from alarm time
+// - T+0:  Alarm triggers begin_wake (music fade-out starts)
+// - T+5:  Lights start fading in (1% -> 100% over 25 minutes)
+// - T+30: Lights fully up, wake music starts
 const (
 	// wakeDelayAfterFadeOut is the delay between starting the music fade-out
 	// and turning on the bedroom lights. This matches the Node-RED behavior
 	// which waits 5 minutes after begin_wake before starting the light fade-in.
 	wakeDelayAfterFadeOut = 5 * time.Minute
+
+	// lightFadeInDuration is how long the bedroom lights take to fade from 1% to 100%
+	lightFadeInDuration = 25 * time.Minute
+
+	// wakeMusicDelay is the delay after lights start fading before wake music plays.
+	// This equals lightFadeInDuration so music starts when lights are fully up.
+	wakeMusicDelay = lightFadeInDuration
 )
 
 // SleepFunc is the type for sleep functions (for testing)
@@ -709,6 +720,36 @@ func (m *Manager) scheduleWakeSequence() {
 	}
 }
 
+// scheduleWakeMusic waits for the light fade-in to complete and then starts wake music
+// This ensures wake music only plays when the lights are fully up
+func (m *Manager) scheduleWakeMusic() {
+	m.logger.Info("Scheduling wake music",
+		zap.Duration("delay", wakeMusicDelay))
+
+	// Use sleepFunc for testing (can be overridden to skip delays)
+	m.sleepFunc(wakeMusicDelay)
+
+	// Check if wake sequence is still active (user might have cancelled by turning off lights)
+	isWakeActive, err := m.stateManager.GetBool("isWakeSequenceActive")
+	if err != nil || !isWakeActive {
+		m.logger.Info("Wake music cancelled - wake sequence no longer active")
+		return
+	}
+
+	m.logger.Info("Light fade-in complete, starting wake music")
+
+	// Start wake music - triggers music plugin to play gentle wakeup playlist
+	if err := m.stateManager.SetString("musicPlaybackType", "wakeup"); err != nil {
+		m.logger.Error("Failed to set wakeup music", zap.Error(err))
+	} else {
+		m.logger.Info("Wake music activated")
+	}
+
+	// Record action and update status
+	m.recordAction("wake_music", "Starting wake music after lights fully up", "wake_music_timer")
+	m.shadowTracker.UpdateWakeSequenceStatus("complete")
+}
+
 // handleWake handles the wake trigger (turn on lights)
 func (m *Manager) handleWake() {
 	m.logger.Info("Handling wake trigger")
@@ -741,23 +782,19 @@ func (m *Manager) handleWake() {
 
 	if !m.readOnly {
 		// Set wake sequence active flag - protects lights from being turned off
-		// by the lighting plugin during the 30-minute fade-in
+		// by the lighting plugin during the light fade-in
 		if err := m.stateManager.SetBool("isWakeSequenceActive", true); err != nil {
 			m.logger.Error("Failed to set isWakeSequenceActive", zap.Error(err))
 		}
 
-		// Turn on master bedroom lights slowly (30 minute transition)
+		// Turn on master bedroom lights slowly (25 minute transition)
 		m.turnOnMasterBedroomLights()
 
-		// Start wake music - triggers music plugin to play gentle wakeup playlist
-		if err := m.stateManager.SetString("musicPlaybackType", "wakeup"); err != nil {
-			m.logger.Error("Failed to set wakeup music", zap.Error(err))
-		} else {
-			m.logger.Info("Wake music activated")
-		}
+		// Schedule wake music to start when lights are fully up
+		go m.scheduleWakeMusic()
 
-		// Wake sequence complete
-		m.shadowTracker.UpdateWakeSequenceStatus("complete")
+		// Lights are fading in - full sequence completes when wake music starts
+		m.shadowTracker.UpdateWakeSequenceStatus("lights_fading_in")
 	} else {
 		m.logger.Info("READ-ONLY: Would execute wake sequence (lights)")
 	}
@@ -849,9 +886,11 @@ func (m *Manager) handleGoToBed() {
 	}
 }
 
-// turnOnMasterBedroomLights turns on master bedroom lights with a slow 30-minute transition
+// turnOnMasterBedroomLights turns on master bedroom lights with a slow fade-in transition
 func (m *Manager) turnOnMasterBedroomLights() {
-	m.logger.Info("Turning on master bedroom lights slowly")
+	transitionSeconds := int(lightFadeInDuration.Seconds())
+	m.logger.Info("Turning on master bedroom lights slowly",
+		zap.Int("transition_seconds", transitionSeconds))
 
 	// First, ensure lights start dim and white
 	if err := m.haClient.CallService("light", "turn_on", map[string]interface{}{
@@ -866,10 +905,10 @@ func (m *Manager) turnOnMasterBedroomLights() {
 
 	m.logger.Info("Set initial bedroom light state (1% brightness, warm white)")
 
-	// Then start slow transition to full brightness over 30 minutes
+	// Then start slow transition to full brightness
 	if err := m.haClient.CallService("light", "turn_on", map[string]interface{}{
 		"entity_id":      "light.primary_suite",
-		"transition":     1800, // 30 minutes in seconds
+		"transition":     transitionSeconds,
 		"color_temp":     290,
 		"brightness_pct": 100,
 	}); err != nil {
@@ -877,7 +916,8 @@ func (m *Manager) turnOnMasterBedroomLights() {
 		return
 	}
 
-	m.logger.Info("Started 30-minute bedroom light fade-in to 100% brightness")
+	m.logger.Info("Started bedroom light fade-in to 100% brightness",
+		zap.Duration("duration", lightFadeInDuration))
 }
 
 // flashCommonAreaLights flashes lights in common areas as a notification

--- a/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
@@ -200,6 +200,10 @@ func TestWake_AllConditionsMet(t *testing.T) {
 	now := time.Date(2024, 1, 15, 9, 30, 0, 0, time.UTC)
 	manager, mockHA, stateManager, _ := setupTest(t, now)
 
+	// Skip internal sleeps so the test completes quickly
+	// This makes the 25-minute wake music delay instant
+	manager.SetSleepFunc(func(d time.Duration) {})
+
 	// Ensure all conditions are met
 	stateManager.SetBool("isAnyoneHome", true)
 	stateManager.SetBool("isMasterAsleep", true)
@@ -212,6 +216,9 @@ func TestWake_AllConditionsMet(t *testing.T) {
 
 	// Trigger wake
 	manager.handleWake()
+
+	// Wait for goroutine (scheduleWakeMusic) to complete
+	time.Sleep(100 * time.Millisecond)
 
 	// Verify service calls were made
 	calls := mockHA.GetServiceCalls()
@@ -238,7 +245,8 @@ func TestWake_AllConditionsMet(t *testing.T) {
 		t.Error("Expected light.turn_on call for primary suite")
 	}
 
-	// Verify wake music was activated
+	// Verify wake music was activated after the scheduled delay
+	// (sleepFunc is mocked so it's instant)
 	musicType, err := stateManager.GetString("musicPlaybackType")
 	if err != nil {
 		t.Errorf("Failed to get musicPlaybackType: %v", err)

--- a/homeautomation-go/test/integration/scenario_sleephygiene_test.go
+++ b/homeautomation-go/test/integration/scenario_sleephygiene_test.go
@@ -624,7 +624,7 @@ func TestScenario_SleepStateIntegration_ChecksConditions(t *testing.T) {
 //
 // The test validates that:
 // 1. The initial light call sets brightness_pct to 1 with transition=0
-// 2. The follow-up call sets brightness_pct to 100 with transition=1800 (30 min)
+// 2. The follow-up call sets brightness_pct to 100 with transition=1500 (25 min)
 // 3. The two-step process ensures lights start dim and gradually brighten
 func TestScenario_WakeUpLightFadeIn_StartsAtLowBrightness(t *testing.T) {
 	server, sleepMgr, cleanup := setupSleepHygieneScenarioTest(t)
@@ -712,8 +712,8 @@ func TestScenario_WakeUpLightFadeIn_StartsAtLowBrightness(t *testing.T) {
 			if bPct == 1 && trans == 0 {
 				initialBrightnessCall = call
 			}
-			// Second call should be: brightness_pct=100, transition=1800 (30 min fade)
-			if bPct == 100 && trans == 1800 {
+			// Second call should be: brightness_pct=100, transition=1500 (25 min fade)
+			if bPct == 100 && trans == 1500 {
 				fadeInCall = call
 			}
 		}
@@ -733,22 +733,22 @@ func TestScenario_WakeUpLightFadeIn_StartsAtLowBrightness(t *testing.T) {
 	assert.Equal(t, float64(0), initialBrightnessCall.ServiceData["transition"],
 		"Initial transition should be 0 (instant)")
 
-	// CRITICAL ASSERTION 2: Fade-in call should exist with 30-minute transition
+	// CRITICAL ASSERTION 2: Fade-in call should exist with 25-minute transition
 	require.NotNil(t, fadeInCall,
-		"Should find fade-in call with brightness_pct=100, transition=1800")
+		"Should find fade-in call with brightness_pct=100, transition=1500")
 
-	t.Log("SUCCESS: Fade-in call sets brightness to 100% with 30-minute transition")
+	t.Log("SUCCESS: Fade-in call sets brightness to 100% with 25-minute transition")
 
 	assert.Equal(t, float64(100), fadeInCall.ServiceData["brightness_pct"],
 		"Fade-in target brightness should be 100%")
-	assert.Equal(t, float64(1800), fadeInCall.ServiceData["transition"],
-		"Fade-in transition should be 1800 seconds (30 minutes)")
+	assert.Equal(t, float64(1500), fadeInCall.ServiceData["transition"],
+		"Fade-in transition should be 1500 seconds (25 minutes)")
 
 	t.Log("========================================")
 	t.Log("VALIDATION COMPLETE:")
 	t.Log("  - Lights start at 1% brightness (not high)")
 	t.Log("  - Initial transition is instant (0s)")
-	t.Log("  - Gradual 30-minute fade-in to 100% follows")
+	t.Log("  - Gradual 25-minute fade-in to 100% follows")
 	t.Log("  - User concern addressed: no jarring brightness")
 	t.Log("========================================")
 }
@@ -854,21 +854,24 @@ func TestScenario_WakeSequence_LightingPluginYieldsToSleepHygiene(t *testing.T) 
 }
 
 // TestScenario_WakeSequence_ActivatesWakeMusic validates that when the wake
-// sequence completes successfully (lights turn on), wake music is activated.
+// sequence completes successfully (lights fully up), wake music is activated.
 //
 // The wake sequence progression:
 // 1. Eight Sleep alarm triggers begin_wake (music fade-out starts)
 // 2. After 5-minute delay, wake sequence triggers (lights fade-in starts)
-// 3. When lights are activated, musicPlaybackType is set to "wakeup"
+// 3. After 25-minute light fade-in, musicPlaybackType is set to "wakeup"
 // 4. Music plugin receives the state change and plays gentle wake music
 //
+// Total wake sequence: 30 minutes from alarm time (5 min delay + 25 min fade-in)
+//
 // This test validates step 3: that musicPlaybackType becomes "wakeup" after
-// a successful wake sequence completion.
+// the light fade-in completes.
 func TestScenario_WakeSequence_ActivatesWakeMusic(t *testing.T) {
 	server, sleepMgr, cleanup := setupSleepHygieneScenarioTest(t)
 	defer cleanup()
 
 	// Skip internal sleeps so the test completes quickly
+	// This makes the 25-minute wake music delay instant
 	sleepMgr.SetSleepFunc(func(d time.Duration) {})
 
 	// GIVEN: Conditions for wake sequence are met (fade-out already in progress)
@@ -878,6 +881,8 @@ func TestScenario_WakeSequence_ActivatesWakeMusic(t *testing.T) {
 	server.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	server.SetState("input_boolean.master_asleep", "on", map[string]interface{}{})
 	server.SetState("input_boolean.fade_out_in_progress", "on", map[string]interface{}{})
+	// Set wake_sequence_active so it exists when handleWake sets it
+	server.SetState("input_boolean.wake_sequence_active", "off", map[string]interface{}{})
 
 	// Start with sleep music playing (typical state before wake)
 	server.SetState("input_text.music_playback_type", "sleep", map[string]interface{}{})
@@ -888,11 +893,12 @@ func TestScenario_WakeSequence_ActivatesWakeMusic(t *testing.T) {
 	// WHEN: Wake sequence triggers (light fade-in phase, after 5-min delay)
 	t.Log("WHEN: Wake sequence triggers via TriggerWakeForTest")
 	t.Log("      (This simulates the wake timer firing after begin_wake)")
+	t.Log("      (sleepFunc is mocked so 25-min wake music delay is instant)")
 
 	sleepMgr.TriggerWakeForTest()
 
-	// Wait for service calls to be processed
-	time.Sleep(100 * time.Millisecond)
+	// Wait for service calls and goroutine to complete
+	time.Sleep(200 * time.Millisecond)
 
 	// THEN: Verify musicPlaybackType was set to "wakeup"
 	t.Log("THEN: Verify musicPlaybackType is set to 'wakeup'")
@@ -901,9 +907,9 @@ func TestScenario_WakeSequence_ActivatesWakeMusic(t *testing.T) {
 	require.NotNil(t, musicState, "musicPlaybackType state should exist")
 
 	assert.Equal(t, "wakeup", musicState.State,
-		"musicPlaybackType should be 'wakeup' after successful wake sequence")
+		"musicPlaybackType should be 'wakeup' after lights fully up")
 
-	t.Log("SUCCESS: Wake music activated after wake sequence completion")
+	t.Log("SUCCESS: Wake music activated after light fade-in complete")
 
 	// Also verify service call was made to set the state
 	calls := server.GetServiceCalls()
@@ -924,8 +930,9 @@ func TestScenario_WakeSequence_ActivatesWakeMusic(t *testing.T) {
 
 	t.Log("========================================")
 	t.Log("VALIDATION COMPLETE:")
-	t.Log("  - Wake sequence completed successfully")
-	t.Log("  - musicPlaybackType set to 'wakeup'")
+	t.Log("  - Wake sequence triggered successfully")
+	t.Log("  - Lights began fading in (25-minute transition)")
+	t.Log("  - After light fade-in, musicPlaybackType set to 'wakeup'")
 	t.Log("  - Music plugin will receive state change and play wake music")
 	t.Log("========================================")
 }


### PR DESCRIPTION
## Summary

- Adds wake music activation as the final step in the successful wake sequence
- Wake music starts only **after lights are fully up** (not when they start fading)
- Light fade-in reduced from 30 to 25 minutes to fit entire sequence in 30 minutes from alarm

## Wake Sequence Timeline

```
T+0 (Alarm)           T+5                                        T+30
  │                     │                                          │
  ▼                     ▼                                          ▼
┌─────┐               ┌─────────────────────────────────────────────┐
│ALARM│               │    LIGHTS FADE IN (25 min transition)       │
└──┬──┘               │  1% ────────────────────────────────► 100%  │
   │                  └─────────────────────────────────────────────┤
   ▼                                                                ▼
begin_wake                                                    WAKE MUSIC
• Music fade-out         (silence during light fade)          STARTS HERE
  starts                                                      (lights 100%)
```

**Timeline:**
- **T+0:** Alarm triggers `begin_wake` (music fade-out starts)
- **T+5:** Lights start fading in (1% → 100% over 25 minutes)
- **T+30:** Lights fully up, `musicPlaybackType` set to `"wakeup"`

If user cancels early (turns off lights), wake music won't play.

## Changes

1. **New timing constants** (`manager.go:29-46`)
   - `lightFadeInDuration = 25 * time.Minute`
   - `wakeMusicDelay = lightFadeInDuration`

2. **New `scheduleWakeMusic()` function** (`manager.go:723-751`)
   - Waits for light fade-in to complete
   - Checks `isWakeSequenceActive` before playing (cancellation support)
   - Sets `musicPlaybackType` to `"wakeup"`

3. **Refactored `TriggerWakeForTest()`** to call `handleWake()` directly

## Test plan

- [x] Unit test `TestWake_AllConditionsMet` verifies music activated after delay
- [x] Integration test `TestScenario_WakeSequence_ActivatesWakeMusic` validates full flow
- [x] Integration test `TestScenario_WakeUpLightFadeIn_StartsAtLowBrightness` updated for 25-min transition
- [x] All existing tests pass
- [x] Pre-push hooks pass (unit + integration tests, coverage ≥65%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)