### PR TITLE
Fix #471: Strongly recommend devcontainer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,45 @@ Automation behavior is configured via YAML files in [`configs/`](configs/):
 
 ## Running
 
-### Prerequisites
+### Devcontainer (Recommended)
 
-- Go 1.23+
+**The devcontainer is the strongly recommended way to work with this repository.** It provides a pre-configured development environment with all dependencies, tools, and git hooks already installed. This is also the same environment used by CI pipelines.
+
+**Using VS Code or GitHub Codespaces:**
+1. Open the repository in VS Code
+2. When prompted, click "Reopen in Container" (or use the Command Palette: `Dev Containers: Reopen in Container`)
+3. Wait for the container to build and initialize
+
+The devcontainer automatically:
+- Installs Go 1.25 and all required dependencies
+- Sets up Go modules (`go mod tidy && go mod download`)
+- Installs git hooks (pre-commit and pre-push validation)
+- Installs GitHub CLI, Claude Code CLI, and Playwright
+- Configures VS Code extensions for Go and Mermaid
+
+### Manual Setup (Without Devcontainer)
+
+If you cannot use a devcontainer, you can set up the environment manually by running the same scripts the devcontainer uses:
+
+**Prerequisites:**
+- Go 1.23+ (1.25 recommended)
+- Node.js 20+ (for Claude Code and Playwright)
 - Home Assistant with WebSocket API enabled
 - Long-lived access token from Home Assistant
+
+**Setup steps:**
+```bash
+# 1. Install Go modules
+cd homeautomation-go
+go mod tidy && go mod download
+cd ..
+
+# 2. Install git hooks (IMPORTANT: ensures code quality)
+bash .githooks/install-hooks.sh
+
+# 3. (Optional) Install Claude Code CLI
+npm install -g @anthropic-ai/claude-code
+```
 
 ### Quick Start
 


### PR DESCRIPTION
Resolves #471

## Summary
- Added new "Devcontainer (Recommended)" section as the primary option in the Running section
- Emphasized that the devcontainer provides a pre-configured environment matching CI pipelines
- Documented what the devcontainer automatically sets up (Go, modules, git hooks, GitHub CLI, Claude Code CLI, Playwright, VS Code extensions)
- Renamed "Prerequisites" to "Manual Setup (Without Devcontainer)" for non-devcontainer users
- Added instructions to run the same setup scripts the devcontainer uses (.githooks/install-hooks.sh, go mod tidy/download)

## Test Plan
- [x] Verified README.md markdown syntax is valid
- [x] Pre-commit checks passed (formatting, linting, build)
- [x] Pre-push checks passed (all tests with race detector, coverage ≥65%)
- [ ] Manually review rendered README on GitHub to confirm formatting looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)