### PR TITLE
Fix #477: Add post-push smoke test to verify registry-pulled images

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -110,7 +110,9 @@ jobs:
       - name: Pull and test pushed image
         run: |
           # Use the SHA-based tag for exact image verification
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${GITHUB_SHA::7}"
+          # The metadata-action uses prefix={{branch}}- so tag is main-<sha7> or master-<sha7>
+          BRANCH="${GITHUB_REF_NAME}"
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${BRANCH}-${GITHUB_SHA::7}"
           echo "🔍 Testing image: $IMAGE"
 
           # Pull the image we just pushed


### PR DESCRIPTION
Resolves #477

## Summary

This PR adds a post-push verification step to the `docker-build-push.yml` workflow that catches issues specific to the deployed artifact - addressing the "1000 commits problem" where tests pass on source code but the deployed artifact is broken.

### What's New

A new `verify-pushed-image` job that:
1. **Pulls** the just-pushed image from ghcr.io using the SHA tag for exactness
2. **Runs** the container in DEV_MODE (mock Home Assistant)
3. **Waits** up to 30 seconds for health endpoint to respond
4. **Verifies** dashboard and shadow API endpoints are working

### Issues This Catches

| Issue Type | Caught by PR tests? | Caught by this test? |
|------------|---------------------|---------------------|
| Code bugs | ✅ | ✅ |
| Build issues | ✅ | ✅ |
| Registry push failures | ❌ | ✅ |
| Multi-platform build issues | ❌ | ✅ |
| Image manifest problems | ❌ | ✅ |
| Layer corruption | ❌ | ✅ |
| Authentication/permission issues | ❌ | ✅ |

### Workflow Changes

- Added new job `verify-pushed-image` that depends on `build-and-push`
- Uses minimal permissions (packages: read)
- Reuses the same smoke test pattern from PR validation
- Adds ~30-60 seconds to production deploy workflow

## Test Plan

- [ ] YAML syntax validated locally with Python yaml parser
- [ ] Workflow runs successfully on push to main
- [ ] Verify job correctly pulls from ghcr.io and tests the image
- [ ] Verify job fails if container doesn't start (can test by temporarily breaking Dockerfile)

🤖 Generated with Claude Code