### PR TITLE
fix: Lowercase image name in verify-pushed-image job

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -111,8 +111,10 @@ jobs:
         run: |
           # Use the SHA-based tag for exact image verification
           # The metadata-action uses prefix={{branch}}- so tag is main-<sha7> or master-<sha7>
+          # Note: Docker requires lowercase image names; github.repository preserves case
           BRANCH="${GITHUB_REF_NAME}"
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${BRANCH}-${GITHUB_SHA::7}"
+          IMAGE_NAME_LOWER=$(echo "${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')
+          IMAGE="${{ env.REGISTRY }}/${IMAGE_NAME_LOWER}:${BRANCH}-${GITHUB_SHA::7}"
           echo "🔍 Testing image: $IMAGE"
 
           # Pull the image we just pushed


### PR DESCRIPTION
## Summary

Fixes the verify-pushed-image job that was failing with:
```
invalid reference format: repository name (NickBorgers/home-automation) must be lowercase
```

**Root cause:** Docker requires lowercase repository names. The `docker/metadata-action` automatically lowercases image names when generating tags, but our manual image construction in the verify job used `${{ env.IMAGE_NAME }}` directly, which preserves the original case from `github.repository`.

**Fix:** Convert the image name to lowercase using `tr '[:upper:]' '[:lower:]'` before constructing the full image reference.

## Test plan

- [ ] Workflow runs successfully and verify job pulls the image correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)