### PR TITLE
feat: Log git commit provenance on application startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,9 +107,20 @@ validate-diagrams:
 # Go Application (homeautomation-go) Targets
 # ============================================================================
 
+# Version info for build-time injection
+GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+GIT_DIRTY := $(shell git diff --quiet 2>/dev/null && echo "false" || echo "true")
+BUILD_TIME := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
+VERSION_PKG := homeautomation/internal/version
+LDFLAGS := -X '$(VERSION_PKG).GitCommit=$(GIT_COMMIT)' \
+           -X '$(VERSION_PKG).GitBranch=$(GIT_BRANCH)' \
+           -X '$(VERSION_PKG).GitDirty=$(GIT_DIRTY)' \
+           -X '$(VERSION_PKG).BuildTime=$(BUILD_TIME)'
+
 #build-go: @ Build the Go application binary
 build-go:
-	cd homeautomation-go && go build -o homeautomation ./cmd/main.go
+	cd homeautomation-go && go build -ldflags "$(LDFLAGS)" -o homeautomation ./cmd/main.go
 
 #dev-ui: @ Run application with mock HA server for local UI development
 dev-ui: build-go

--- a/homeautomation-go/cmd/app/run.go
+++ b/homeautomation-go/cmd/app/run.go
@@ -18,6 +18,7 @@ import (
 	"homeautomation/internal/plugins/reset"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
+	"homeautomation/internal/version"
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
 	pkgstate "homeautomation/pkg/state"
@@ -70,6 +71,13 @@ func Run() {
 	// Combine both cores using zap.NewTee
 	logger := zap.New(zapcore.NewTee(stdoutCore, bufferCore))
 	defer logger.Sync()
+
+	// Log version information immediately on startup for debugging
+	logger.Info("Home Automation starting",
+		zap.String("commit", version.GitCommit),
+		zap.String("branch", version.GitBranch),
+		zap.String("build_time", version.BuildTime),
+		zap.String("dirty", version.GitDirty))
 
 	// Load environment variables from .env file if present
 	if err := godotenv.Load(); err != nil {

--- a/homeautomation-go/internal/version/version.go
+++ b/homeautomation-go/internal/version/version.go
@@ -1,0 +1,27 @@
+// Package version provides build-time version information.
+// These variables are set via ldflags during compilation.
+package version
+
+// Build-time variables - set via ldflags in Makefile
+var (
+	// GitCommit is the git commit hash at build time
+	GitCommit = "unknown"
+
+	// GitBranch is the git branch at build time
+	GitBranch = "unknown"
+
+	// BuildTime is the UTC timestamp when the binary was built
+	BuildTime = "unknown"
+
+	// GitDirty indicates if the working directory had uncommitted changes
+	GitDirty = "false"
+)
+
+// Info returns a formatted version string for logging
+func Info() string {
+	dirty := ""
+	if GitDirty == "true" {
+		dirty = " (dirty)"
+	}
+	return GitCommit + dirty + " (" + GitBranch + ") built " + BuildTime
+}


### PR DESCRIPTION
## Summary
- Add `internal/version` package with build-time variables (commit, branch, build time, dirty flag)
- Update Makefile to inject git info via ldflags during `make build-go`
- Log version info immediately on startup for easy debugging of production issues

## Example log output
```json
{"msg":"Home Automation starting","commit":"7a02127","branch":"main","build_time":"2026-01-12T01:44:46Z","dirty":"true"}
```

## Test plan
- [x] `make build-go` compiles successfully with ldflags
- [x] Application logs version info on startup (verified with `DEV_MODE=true`)
- [x] Unit tests pass (71.1% coverage)
- [x] Integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)