### PR TITLE
fix(ci): Increase test verification timeout to prevent race condition

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -708,7 +708,7 @@ jobs:
           echo "Checking test status for commit $HEAD_SHA"
 
           # Retry loop - check run may not be visible immediately after workflow triggers
-          MAX_ATTEMPTS=6
+          MAX_ATTEMPTS=18
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
             STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null | head -1 || echo "")
@@ -896,7 +896,7 @@ jobs:
           echo "Checking test status for commit $HEAD_SHA"
 
           # Retry loop - check run may not be visible immediately after workflow triggers
-          MAX_ATTEMPTS=6
+          MAX_ATTEMPTS=18
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
             STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null | head -1 || echo "")
@@ -1030,7 +1030,7 @@ jobs:
           echo "Checking test status for commit $HEAD_SHA"
 
           # Retry loop - check run may not be visible immediately after workflow triggers
-          MAX_ATTEMPTS=6
+          MAX_ATTEMPTS=18
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
             STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null | head -1 || echo "")
@@ -1166,7 +1166,7 @@ jobs:
           echo "Checking test status for commit $HEAD_SHA"
 
           # Retry loop - check run may not be visible immediately after workflow triggers
-          MAX_ATTEMPTS=6
+          MAX_ATTEMPTS=18
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
             STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null | head -1 || echo "")
@@ -1316,7 +1316,7 @@ jobs:
           echo "Checking test status for commit $HEAD_SHA"
 
           # Retry loop - check run may not be visible immediately after workflow triggers
-          MAX_ATTEMPTS=6
+          MAX_ATTEMPTS=18
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
             STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null | head -1 || echo "")


### PR DESCRIPTION
## Summary
- Fix race condition in claude-code-review.yml where review jobs timed out waiting for test results
- Increase MAX_ATTEMPTS from 6 to 18 (60s → 3 minutes wait time)

## Problem
The agent review workflow was failing with "Could not determine merge decision" because the merge-decision job gave up looking for the "All Required Tests" check run before it was created.

**Timeline from failed run [#21098819506](https://github.com/NickBorgers/home-automation/actions/runs/21098819506):**
| Event | Time |
|-------|------|
| merge-decision last retry | 18:37:39Z |
| "All Required Tests" check started | 18:37:43Z |
| "All Required Tests" check completed | 18:37:47Z |

The job gave up **4 seconds** before the check run even started.

## Fix
Increase `MAX_ATTEMPTS` from 6 to 18 across all 5 review jobs, providing 3 minutes of wait time (vs ~2.5 minutes for tests to complete).

## Why not use `needs` dependencies?
Considered adding hard workflow dependencies but decided against it because:
- Reviews would be blocked entirely if tests fail (lose code quality feedback)
- If test workflow gets stuck, reviews blocked indefinitely
- Removes parallelism, increasing total pipeline time
- The timeout approach maintains current architecture while fixing the race

## Test plan
- [ ] Verify next PR triggers both workflows and reviews complete successfully
- [ ] Confirm review jobs wait appropriately for test completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)