### PR TITLE
fix(music): Log group_members in join service call failures

### DIFF
--- a/homeautomation-go/internal/plugins/music/manager.go
+++ b/homeautomation-go/internal/plugins/music/manager.go
@@ -2292,9 +2292,16 @@ func (m *Manager) callServiceWithRetry(domain, service string, serviceData map[s
 	}
 
 	// Refresh available speakers
-	m.logger.Info("Service call failed, refreshing available speakers",
+	// For join operations, also log which speakers we're trying to join
+	logFields := []zap.Field{
 		zap.String("entity_id", entityID),
-		zap.Error(err))
+		zap.String("service", domain+"."+service),
+		zap.Error(err),
+	}
+	if groupMembers, ok := serviceData["group_members"].([]string); ok && len(groupMembers) > 0 {
+		logFields = append(logFields, zap.Strings("group_members", groupMembers))
+	}
+	m.logger.Info("Service call failed, refreshing available speakers", logFields...)
 
 	if refreshErr := m.refreshAvailableSpeakers(); refreshErr != nil {
 		m.logger.Warn("Failed to refresh speakers", zap.Error(refreshErr))
@@ -2307,7 +2314,9 @@ func (m *Manager) callServiceWithRetry(domain, service string, serviceData map[s
 	}
 
 	// Retry once
-	m.logger.Info("Retrying service call after refresh", zap.String("entity_id", entityID))
+	m.logger.Info("Retrying service call after refresh",
+		zap.String("entity_id", entityID),
+		zap.String("service", domain+"."+service))
 	return m.callService(domain, service, serviceData)
 }
 


### PR DESCRIPTION
## Summary
- When a `media_player.join` service call fails, the log now includes the `group_members` array showing which speakers were being joined
- Also includes the service name (`media_player.join`) in both failure and retry log messages

## Problem
Previously, when a speaker failed to join a group, the log only showed the `entity_id` (the lead speaker), not the follower that actually failed:

```json
{"entity_id":"media_player.kitchen","error":"Error calling SonosSpeaker.join on Kitchen: HTTPConnectionPool(host='10.212.100.236', port=1400): Read timed out."}
```

The IP address `10.212.100.236` is actually Front Room, but you'd have to know your speaker IPs to debug this.

## Solution
Now the log includes the full context:

```json
{"entity_id":"media_player.kitchen","service":"media_player.join","group_members":["media_player.front_room"],"error":"..."}
```

This makes it immediately clear which speaker failed to join.

## Test plan
- [x] Unit tests pass
- [x] Integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)