### PR TITLE
Fix #505: Add retry logic for initial HA connection instead of exiting

### DIFF
--- a/homeautomation-go/cmd/app/run.go
+++ b/homeautomation-go/cmd/app/run.go
@@ -185,9 +185,25 @@ func Run() {
 	// Create HA client
 	client := ha.NewClient(haURL, haToken, logger)
 
-	// Connect to Home Assistant
-	if err := client.Connect(); err != nil {
-		logger.Fatal("Failed to connect to Home Assistant", zap.Error(err))
+	// Connect to Home Assistant with retry logic.
+	// Unlike the runtime reconnection logic which triggers automatically on disconnect,
+	// this provides resilience for initial connection failures (e.g., HA not yet started).
+	// Uses the same exponential backoff pattern as the client's attemptReconnect().
+	initialConnectBackoff := time.Second
+	maxBackoff := 30 * time.Second
+	for {
+		if err := client.Connect(); err != nil {
+			logger.Warn("Failed to connect to Home Assistant, will retry",
+				zap.Error(err),
+				zap.Duration("backoff", initialConnectBackoff))
+			time.Sleep(initialConnectBackoff)
+			initialConnectBackoff *= 2
+			if initialConnectBackoff > maxBackoff {
+				initialConnectBackoff = maxBackoff
+			}
+			continue
+		}
+		break
 	}
 	defer client.Disconnect()
 
@@ -196,9 +212,33 @@ func Run() {
 	// Create State Manager
 	stateManager := state.NewManager(client, logger, readOnly)
 
-	// Sync all state from HA
-	if err := stateManager.SyncFromHA(); err != nil {
-		logger.Fatal("Failed to sync state from HA", zap.Error(err))
+	// Sync all state from HA with retry logic.
+	// This handles transient failures during initial state synchronization.
+	syncMaxRetries := 5
+	syncBackoff := time.Second
+	for attempt := 1; attempt <= syncMaxRetries; attempt++ {
+		if err := stateManager.SyncFromHA(); err != nil {
+			logger.Warn("Failed to sync state from HA",
+				zap.Error(err),
+				zap.Int("attempt", attempt),
+				zap.Int("maxRetries", syncMaxRetries))
+
+			if attempt < syncMaxRetries {
+				logger.Info("Retrying state sync after backoff",
+					zap.Duration("backoff", syncBackoff))
+				time.Sleep(syncBackoff)
+				syncBackoff *= 2
+				if syncBackoff > maxBackoff {
+					syncBackoff = maxBackoff
+				}
+				continue
+			}
+			logger.Fatal("Failed to sync state from HA after all retries", zap.Error(err))
+		}
+		if attempt > 1 {
+			logger.Info("State sync succeeded after retry", zap.Int("attempts", attempt))
+		}
+		break
 	}
 
 	// Set up reconnect callback to resync state after connection recovery.


### PR DESCRIPTION
Resolves #505

## Summary
- Added infinite retry with exponential backoff (1s to 30s) for initial Home Assistant connection, matching the existing runtime reconnection behavior in `attemptReconnect()`
- Added retry with exponential backoff (up to 5 attempts) for initial state synchronization
- The application now waits patiently for Home Assistant to become available rather than immediately exiting with `logger.Fatal()`

## Why This Change
As noted in the issue, the application is increasingly relying on in-memory state for automations that operate over long time horizons (hours). Previously, a brief communication interruption at startup would cause the entire process to exit and reset all that state. 

The runtime reconnection logic already handles disconnects gracefully with exponential backoff - this change applies the same pattern to initial connection failures.

## Test Plan
- [ ] Unit tests pass (verified locally)
- [ ] Integration tests pass (verified locally)
- [ ] Code compiles and passes linting (verified via pre-commit hook)
- [ ] Manual verification: Start the application when Home Assistant is unavailable, then start HA - the app should connect when HA becomes available

🤖 Generated with Claude Code