### PR TITLE
fix(ntfy): POST JSON to base URL with topic in payload

### DIFF
--- a/homeautomation-go/internal/ntfy/client.go
+++ b/homeautomation-go/internal/ntfy/client.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -37,7 +39,8 @@ const (
 
 // Client is an ntfy.sh notification client
 type Client struct {
-	topicURL   string
+	baseURL    string // e.g., "https://ntfy.sh"
+	topic      string // e.g., "my-secret-topic"
 	httpClient *http.Client
 	logger     *zap.Logger
 	readOnly   bool
@@ -54,6 +57,7 @@ type ntfyPayload struct {
 }
 
 // NewClient creates a new ntfy client.
+// topicURL should be the full URL including topic, e.g., "https://ntfy.sh/my-topic"
 // Returns nil if topicURL is empty, logging an error.
 func NewClient(topicURL string, logger *zap.Logger, readOnly bool) *Client {
 	if topicURL == "" {
@@ -62,8 +66,30 @@ func NewClient(topicURL string, logger *zap.Logger, readOnly bool) *Client {
 		return nil
 	}
 
+	// Parse the topic URL to extract base URL and topic
+	parsed, err := url.Parse(topicURL)
+	if err != nil {
+		logger.Error("Invalid NTFY_TOPIC_URL - notifications will be disabled",
+			zap.String("url", topicURL),
+			zap.Error(err))
+		return nil
+	}
+
+	// Extract topic from path (e.g., "/my-topic" -> "my-topic")
+	topic := strings.TrimPrefix(parsed.Path, "/")
+	if topic == "" {
+		logger.Error("NTFY_TOPIC_URL missing topic - notifications will be disabled",
+			zap.String("url", topicURL),
+			zap.String("action", "URL should be like https://ntfy.sh/your-topic"))
+		return nil
+	}
+
+	// Construct base URL (scheme + host)
+	baseURL := fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host)
+
 	return &Client{
-		topicURL: topicURL,
+		baseURL: baseURL,
+		topic:   topic,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
@@ -88,6 +114,7 @@ func (c *Client) Send(msg *Message) error {
 	}
 
 	payload := ntfyPayload{
+		Topic:    c.topic, // Required when POSTing JSON to base URL
 		Title:    msg.Title,
 		Message:  msg.Body,
 		Priority: priority,
@@ -110,7 +137,8 @@ func (c *Client) Send(msg *Message) error {
 		return nil
 	}
 
-	req, err := http.NewRequest(http.MethodPost, c.topicURL, bytes.NewBuffer(jsonData))
+	// POST JSON to base URL (not topic URL) per ntfy.sh API requirements
+	req, err := http.NewRequest(http.MethodPost, c.baseURL, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}

--- a/homeautomation-go/internal/ntfy/client_test.go
+++ b/homeautomation-go/internal/ntfy/client_test.go
@@ -18,12 +18,23 @@ func TestNewClient(t *testing.T) {
 	t.Run("returns client when URL provided", func(t *testing.T) {
 		client := NewClient("https://ntfy.sh/test-topic", logger, false)
 		assert.NotNil(t, client)
-		assert.Equal(t, "https://ntfy.sh/test-topic", client.topicURL)
+		assert.Equal(t, "https://ntfy.sh", client.baseURL)
+		assert.Equal(t, "test-topic", client.topic)
 		assert.False(t, client.readOnly)
 	})
 
 	t.Run("returns nil when URL empty", func(t *testing.T) {
 		client := NewClient("", logger, false)
+		assert.Nil(t, client)
+	})
+
+	t.Run("returns nil when URL has no topic", func(t *testing.T) {
+		client := NewClient("https://ntfy.sh", logger, false)
+		assert.Nil(t, client)
+	})
+
+	t.Run("returns nil when URL has only slash", func(t *testing.T) {
+		client := NewClient("https://ntfy.sh/", logger, false)
 		assert.Nil(t, client)
 	})
 
@@ -54,7 +65,7 @@ func TestClient_Send(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client := NewClient(server.URL, logger, false)
+		client := NewClient(server.URL+"/test-topic", logger, false)
 
 		msg := &Message{
 			Title:    "Test Title",
@@ -67,6 +78,7 @@ func TestClient_Send(t *testing.T) {
 		err := client.Send(msg)
 		require.NoError(t, err)
 
+		assert.Equal(t, "test-topic", receivedPayload.Topic)
 		assert.Equal(t, "Test Title", receivedPayload.Title)
 		assert.Equal(t, "Test body message", receivedPayload.Message)
 		assert.Equal(t, PriorityHigh, receivedPayload.Priority)
@@ -84,7 +96,7 @@ func TestClient_Send(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client := NewClient(server.URL, logger, false)
+		client := NewClient(server.URL+"/my-topic", logger, false)
 
 		msg := &Message{
 			Body: "Just the message",
@@ -93,6 +105,7 @@ func TestClient_Send(t *testing.T) {
 		err := client.Send(msg)
 		require.NoError(t, err)
 
+		assert.Equal(t, "my-topic", receivedPayload.Topic)
 		assert.Equal(t, "", receivedPayload.Title)
 		assert.Equal(t, "Just the message", receivedPayload.Message)
 		assert.Equal(t, PriorityDefault, receivedPayload.Priority)
@@ -108,7 +121,7 @@ func TestClient_Send(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client := NewClient(server.URL, logger, false)
+		client := NewClient(server.URL+"/test-topic", logger, false)
 
 		// Test priority too high
 		msg := &Message{Body: "test", Priority: 10}
@@ -143,7 +156,7 @@ func TestClient_Send(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client := NewClient(server.URL, logger, false)
+		client := NewClient(server.URL+"/test-topic", logger, false)
 
 		err := client.Send(&Message{Body: "test"})
 		assert.Error(t, err)
@@ -151,7 +164,7 @@ func TestClient_Send(t *testing.T) {
 	})
 
 	t.Run("returns error on network failure", func(t *testing.T) {
-		client := NewClient("http://localhost:1", logger, false)
+		client := NewClient("http://localhost:1/test-topic", logger, false)
 
 		err := client.Send(&Message{Body: "test"})
 		assert.Error(t, err)
@@ -166,7 +179,7 @@ func TestClient_Send(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client := NewClient(server.URL, logger, true) // readOnly = true
+		client := NewClient(server.URL+"/test-topic", logger, true) // readOnly = true
 
 		err := client.Send(&Message{
 			Title: "Test",


### PR DESCRIPTION
## Summary
- Fixes ntfy.sh notifications showing raw JSON instead of rendered notifications
- The ntfy.sh API requires JSON payloads to be POSTed to the base URL with topic in the body, not to the topic-specific URL
- Parses topic URL into components and includes topic field in JSON payload

## Root Cause
When POSTing JSON to `https://ntfy.sh/topic`, ntfy treats the entire body as a plain text message. The API requires JSON to be POSTed to `https://ntfy.sh` with the `topic` field in the JSON payload.

## Test plan
- [x] Unit tests pass (93.9% coverage on ntfy package)
- [x] Integration tests pass
- [ ] Deploy and verify water leak notification renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)