### PR TITLE
feat(monitoring): Skip devices with monitoring_ignore label

### DIFF
--- a/homeautomation-go/internal/plugins/monitoring/manager.go
+++ b/homeautomation-go/internal/plugins/monitoring/manager.go
@@ -27,6 +27,10 @@ const (
 
 	// How often to check for stale sensors
 	StalenessCheckInterval = 1 * time.Hour
+
+	// MonitoringIgnoreLabel is the Home Assistant label that excludes entities from monitoring
+	// In Home Assistant, this corresponds to a label with display name "Monitoring Ignore"
+	MonitoringIgnoreLabel = "monitoring_ignore"
 )
 
 // WaterLeakSensor represents a discovered water leak sensor
@@ -106,6 +110,16 @@ func NewManagerWithClock(haClient ha.HAClient, stateManager *state.Manager, logg
 	m := NewManager(haClient, stateManager, logger, readOnly, registry, ntfyClient)
 	m.clock = c
 	return m
+}
+
+// hasIgnoreLabel checks if the given labels contain the monitoring ignore label
+func hasIgnoreLabel(labels []string) bool {
+	for _, label := range labels {
+		if label == MonitoringIgnoreLabel {
+			return true
+		}
+	}
+	return false
 }
 
 // GetShadowState returns the current shadow state
@@ -226,10 +240,30 @@ func (m *Manager) discoverWaterLeakSensors() error {
 		entityToDevice[entry.EntityID] = entry.DeviceID
 	}
 
+	// Get device registry for labels
+	devices, err := m.haClient.GetDevices()
+	if err != nil {
+		m.logger.Warn("Failed to get device registry", zap.Error(err))
+		errs = append(errs, err)
+	}
+
+	deviceToLabels := make(map[string][]string)
+	for _, device := range devices {
+		deviceToLabels[device.ID] = device.Labels
+	}
+
 	// Create sensor structs and subscribe
 	m.mu.Lock()
 	for _, state := range waterLeakStates {
 		deviceID := entityToDevice[state.EntityID]
+
+		// Check if device has the monitoring ignore label
+		if hasIgnoreLabel(deviceToLabels[deviceID]) {
+			m.logger.Info("Skipping water leak sensor with monitoring_ignore label on device",
+				zap.String("entity_id", state.EntityID),
+				zap.String("device_id", deviceID))
+			continue
+		}
 
 		friendlyName := state.EntityID
 		if name, ok := state.Attributes["friendly_name"].(string); ok {
@@ -316,10 +350,30 @@ func (m *Manager) discoverBatterySensors() error {
 		entityToDevice[entry.EntityID] = entry.DeviceID
 	}
 
+	// Get device registry for labels
+	devices, err := m.haClient.GetDevices()
+	if err != nil {
+		m.logger.Warn("Failed to get device registry", zap.Error(err))
+		errs = append(errs, err)
+	}
+
+	deviceToLabels := make(map[string][]string)
+	for _, device := range devices {
+		deviceToLabels[device.ID] = device.Labels
+	}
+
 	// Create sensor structs and subscribe
 	m.mu.Lock()
 	for _, state := range batteryStates {
 		deviceID := entityToDevice[state.EntityID]
+
+		// Check if device has the monitoring ignore label
+		if hasIgnoreLabel(deviceToLabels[deviceID]) {
+			m.logger.Info("Skipping battery sensor with monitoring_ignore label on device",
+				zap.String("entity_id", state.EntityID),
+				zap.String("device_id", deviceID))
+			continue
+		}
 
 		friendlyName := state.EntityID
 		if name, ok := state.Attributes["friendly_name"].(string); ok {

--- a/homeautomation-go/internal/plugins/monitoring/manager_test.go
+++ b/homeautomation-go/internal/plugins/monitoring/manager_test.go
@@ -540,3 +540,137 @@ func TestParseBatteryLevel(t *testing.T) {
 		})
 	}
 }
+
+func TestHasIgnoreLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		labels   []string
+		expected bool
+	}{
+		{"nil labels", nil, false},
+		{"empty labels", []string{}, false},
+		{"other labels only", []string{"important", "kitchen"}, false},
+		{"has ignore label", []string{"monitoring_ignore"}, true},
+		{"ignore label among others", []string{"important", "monitoring_ignore", "kitchen"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasIgnoreLabel(tt.labels)
+			if result != tt.expected {
+				t.Errorf("hasIgnoreLabel(%v) = %v, expected %v", tt.labels, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMonitoringManager_IgnoreLabeledDevices(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+
+	// Add devices - one normal, one with monitoring_ignore label
+	mockHA.AddDevice(&ha.Device{
+		ID:     "device_water_leak_normal",
+		Name:   "Normal Water Leak Device",
+		Labels: []string{},
+	})
+	mockHA.AddDevice(&ha.Device{
+		ID:     "device_water_leak_ignored",
+		Name:   "Ignored Water Leak Device",
+		Labels: []string{"monitoring_ignore"},
+	})
+	mockHA.AddDevice(&ha.Device{
+		ID:     "device_battery_normal",
+		Name:   "Normal Battery Device",
+		Labels: []string{},
+	})
+	mockHA.AddDevice(&ha.Device{
+		ID:     "device_battery_ignored",
+		Name:   "Ignored Battery Device",
+		Labels: []string{"monitoring_ignore", "other_label"},
+	})
+
+	// Add entity registry entries with device links
+	mockHA.AddEntityRegistryEntry(&ha.EntityRegistryEntry{
+		EntityID: "binary_sensor.water_leak_normal",
+		DeviceID: "device_water_leak_normal",
+	})
+	mockHA.AddEntityRegistryEntry(&ha.EntityRegistryEntry{
+		EntityID: "binary_sensor.water_leak_ignored",
+		DeviceID: "device_water_leak_ignored",
+	})
+	mockHA.AddEntityRegistryEntry(&ha.EntityRegistryEntry{
+		EntityID: "sensor.battery_normal",
+		DeviceID: "device_battery_normal",
+	})
+	mockHA.AddEntityRegistryEntry(&ha.EntityRegistryEntry{
+		EntityID: "sensor.battery_ignored",
+		DeviceID: "device_battery_ignored",
+	})
+
+	// Add water leak sensor states
+	mockHA.SetState("binary_sensor.water_leak_normal", "off", map[string]interface{}{
+		"device_class":  "moisture",
+		"friendly_name": "Normal Water Leak Sensor",
+	})
+	mockHA.SetState("binary_sensor.water_leak_ignored", "off", map[string]interface{}{
+		"device_class":  "moisture",
+		"friendly_name": "Ignored Water Leak Sensor",
+	})
+
+	// Add battery sensor states
+	mockHA.SetState("sensor.battery_normal", "85.0", map[string]interface{}{
+		"device_class":        "battery",
+		"unit_of_measurement": "%",
+		"friendly_name":       "Normal Battery Sensor",
+	})
+	mockHA.SetState("sensor.battery_ignored", "10.0", map[string]interface{}{
+		"device_class":        "battery",
+		"unit_of_measurement": "%",
+		"friendly_name":       "Ignored Battery Sensor",
+	})
+
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	manager := NewManager(mockHA, stateMgr, logger, false, nil, mockNtfy)
+
+	err := manager.Start()
+	if err != nil {
+		t.Fatalf("Failed to start manager: %v", err)
+	}
+	defer manager.Stop()
+
+	// Verify only non-ignored water leak sensors were discovered
+	waterLeakSensors := manager.GetWaterLeakSensors()
+	if len(waterLeakSensors) != 1 {
+		t.Errorf("Expected 1 water leak sensor (ignored device filtered), got %d", len(waterLeakSensors))
+	}
+	if len(waterLeakSensors) == 1 {
+		if _, ok := waterLeakSensors["binary_sensor.water_leak_normal"]; !ok {
+			t.Error("Expected normal water leak sensor to be discovered")
+		}
+	}
+
+	// Verify only non-ignored battery sensors were discovered
+	batterySensors := manager.GetBatterySensors()
+	if len(batterySensors) != 1 {
+		t.Errorf("Expected 1 battery sensor (ignored device filtered), got %d", len(batterySensors))
+	}
+	if len(batterySensors) == 1 {
+		if _, ok := batterySensors["sensor.battery_normal"]; !ok {
+			t.Error("Expected normal battery sensor to be discovered")
+		}
+	}
+
+	// Verify that no notifications were sent for the ignored low battery sensor
+	// (the ignored device has 10% battery which is below threshold)
+	notificationCount := countNtfyNotifications(mockNtfy)
+	if notificationCount != 0 {
+		t.Errorf("Expected 0 notifications (ignored device should not trigger), got %d", notificationCount)
+	}
+}


### PR DESCRIPTION
## Summary
- Devices tagged with the "Monitoring Ignore" label in Home Assistant will no longer generate notifications from the monitoring plugin
- Applies to both water leak sensors and battery sensors
- The label is checked at the **device** level, not the entity level

## Changes
- Added `MonitoringIgnoreLabel` constant (`monitoring_ignore`) in `manager.go:32`
- Added `hasIgnoreLabel()` helper function to check device labels
- Modified `discoverWaterLeakSensors()` to fetch device registry and skip sensors whose device has the label
- Modified `discoverBatterySensors()` with the same filtering logic
- Added info-level logging when sensors are skipped due to the label
- Added comprehensive tests for label filtering

## Test plan
- [x] Unit tests pass (69.8% coverage)
- [x] Integration tests pass
- [x] New tests added for `hasIgnoreLabel()` helper
- [x] New test `TestMonitoringManager_IgnoreLabeledDevices` verifies both water leak and battery sensors are filtered
- [ ] Manual verification: Deploy and confirm device https://home-assistant.featherback-mermaid.ts.net/config/devices/device/6f9ec8ae48a5b91b4accdf4d4e43610c no longer generates notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)