### PR TITLE
fix(loadshedding): Defer rate-limited actions instead of dropping them

### DIFF
--- a/homeautomation-go/internal/plugins/loadshedding/manager.go
+++ b/homeautomation-go/internal/plugins/loadshedding/manager.go
@@ -34,6 +34,13 @@ const (
 	tempHighRestricted = 80.0
 )
 
+// deferredAction represents a pending action that was rate-limited
+type deferredAction struct {
+	actionType  string // "enable" or "disable"
+	energyLevel string
+	trigger     string
+}
+
 // Manager manages thermostat control based on energy state
 type Manager struct {
 	haClient       ha.HAClient
@@ -49,6 +56,15 @@ type Manager struct {
 
 	// Subscription helper for automatic shadow state input capture
 	subHelper *shadowstate.SubscriptionHelper
+
+	// Configurable rate limit interval (defaults to minActionInterval)
+	rateLimitInterval time.Duration
+
+	// Deferred action mechanism for rate-limited actions
+	deferredAction   *deferredAction
+	deferredTimer    *time.Timer
+	deferredMu       sync.Mutex
+	deferredStopChan chan struct{}
 }
 
 // NewManager creates a new Load Shedding manager
@@ -56,14 +72,28 @@ func NewManager(haClient ha.HAClient, stateManager *state.Manager, logger *zap.L
 	shadowTracker := shadowstate.NewLoadSheddingTracker()
 
 	return &Manager{
-		haClient:      haClient,
-		stateManager:  stateManager,
-		logger:        logger.Named("loadshedding"),
-		readOnly:      readOnly,
-		enabled:       false,
-		shadowTracker: shadowTracker,
-		subHelper:     shadowstate.NewSubscriptionHelper(haClient, stateManager, registry, shadowTracker, "loadshedding", logger.Named("loadshedding")),
+		haClient:          haClient,
+		stateManager:      stateManager,
+		logger:            logger.Named("loadshedding"),
+		readOnly:          readOnly,
+		enabled:           false,
+		shadowTracker:     shadowTracker,
+		subHelper:         shadowstate.NewSubscriptionHelper(haClient, stateManager, registry, shadowTracker, "loadshedding", logger.Named("loadshedding")),
+		rateLimitInterval: minActionInterval,
+		deferredStopChan:  make(chan struct{}),
 	}
+}
+
+// SetRateLimitIntervalForTesting allows tests to use a shorter rate limit interval
+func (m *Manager) SetRateLimitIntervalForTesting(interval time.Duration) {
+	m.rateLimitInterval = interval
+}
+
+// IsLoadSheddingOn returns whether load shedding is currently active (thread-safe)
+func (m *Manager) IsLoadSheddingOn() bool {
+	m.stateMu.Lock()
+	defer m.stateMu.Unlock()
+	return m.loadSheddingOn
 }
 
 // Start begins monitoring energy state and controlling thermostats
@@ -103,6 +133,10 @@ func (m *Manager) Stop() {
 	}
 
 	m.logger.Info("Stopping Load Shedding Manager")
+
+	// Cancel any pending deferred action
+	m.cancelDeferredAction()
+
 	m.subHelper.UnsubscribeAll()
 	m.enabled = false
 	m.logger.Info("Load Shedding Manager stopped")
@@ -160,6 +194,9 @@ func (m *Manager) enableLoadShedding(energyLevel string, trigger string) {
 		zap.String("trigger", trigger),
 		zap.String("reason", "Energy state is "+energyLevel+" (low battery)"))
 
+	// Cancel any pending disable action since we're now enabling
+	m.cancelDeferredAction()
+
 	// Check if load shedding is already enabled
 	m.stateMu.Lock()
 	alreadyEnabled := m.loadSheddingOn
@@ -186,8 +223,26 @@ func (m *Manager) enableLoadShedding(energyLevel string, trigger string) {
 		return
 	}
 
-	// Check rate limiting
-	if !m.checkRateLimit() {
+	// Check rate limiting - if rate limited, schedule deferred action
+	passed, timeRemaining := m.checkRateLimit()
+	if !passed {
+		m.scheduleDeferredAction("enable", energyLevel, trigger, timeRemaining)
+		return
+	}
+
+	m.executeEnableLoadShedding(energyLevel, trigger)
+}
+
+// executeEnableLoadShedding performs the actual enable action (called directly or deferred)
+func (m *Manager) executeEnableLoadShedding(energyLevel string, trigger string) {
+	// Re-check if load shedding is already enabled (state may have changed)
+	m.stateMu.Lock()
+	alreadyEnabled := m.loadSheddingOn
+	m.stateMu.Unlock()
+
+	if alreadyEnabled {
+		m.logger.Info("⏭  Deferred action skipped: Load shedding already enabled",
+			zap.String("reason", "State changed while waiting"))
 		return
 	}
 
@@ -255,6 +310,9 @@ func (m *Manager) disableLoadShedding(energyLevel string, trigger string) {
 		zap.String("trigger", trigger),
 		zap.String("reason", "Energy state is "+energyLevel+" (battery restored)"))
 
+	// Cancel any pending enable action since we're now disabling
+	m.cancelDeferredAction()
+
 	// Check if load shedding is already disabled
 	m.stateMu.Lock()
 	alreadyDisabled := !m.loadSheddingOn
@@ -281,8 +339,26 @@ func (m *Manager) disableLoadShedding(energyLevel string, trigger string) {
 		return
 	}
 
-	// Check rate limiting
-	if !m.checkRateLimit() {
+	// Check rate limiting - if rate limited, schedule deferred action
+	passed, timeRemaining := m.checkRateLimit()
+	if !passed {
+		m.scheduleDeferredAction("disable", energyLevel, trigger, timeRemaining)
+		return
+	}
+
+	m.executeDisableLoadShedding(energyLevel, trigger)
+}
+
+// executeDisableLoadShedding performs the actual disable action (called directly or deferred)
+func (m *Manager) executeDisableLoadShedding(energyLevel string, trigger string) {
+	// Re-check if load shedding is already disabled (state may have changed)
+	m.stateMu.Lock()
+	alreadyDisabled := !m.loadSheddingOn
+	m.stateMu.Unlock()
+
+	if alreadyDisabled {
+		m.logger.Info("⏭  Deferred action skipped: Load shedding already disabled",
+			zap.String("reason", "State changed while waiting"))
 		return
 	}
 
@@ -326,26 +402,98 @@ func (m *Manager) disableLoadShedding(energyLevel string, trigger string) {
 }
 
 // checkRateLimit ensures we don't take actions too frequently
-func (m *Manager) checkRateLimit() bool {
+// Returns (passed, timeRemaining) where timeRemaining is how long until rate limit expires
+func (m *Manager) checkRateLimit() (bool, time.Duration) {
 	m.lastActionMu.Lock()
 	defer m.lastActionMu.Unlock()
 
 	now := time.Now()
 	timeSinceLastAction := now.Sub(m.lastAction)
 
-	if !m.lastAction.IsZero() && timeSinceLastAction < minActionInterval {
-		timeRemaining := minActionInterval - timeSinceLastAction
-		m.logger.Info("⏱  RATE LIMIT: Action skipped",
+	if !m.lastAction.IsZero() && timeSinceLastAction < m.rateLimitInterval {
+		timeRemaining := m.rateLimitInterval - timeSinceLastAction
+		m.logger.Info("⏱  RATE LIMIT: Action will be deferred",
 			zap.Duration("time_since_last_action", timeSinceLastAction),
-			zap.Duration("min_interval", minActionInterval),
+			zap.Duration("min_interval", m.rateLimitInterval),
 			zap.Duration("time_remaining", timeRemaining),
-			zap.String("reason", "Preventing rapid thermostat toggling"))
-		return false
+			zap.String("reason", "Scheduling deferred action after rate limit expires"))
+		return false, timeRemaining
 	}
 
 	m.logger.Info("✓ Rate limit check passed",
 		zap.Duration("time_since_last_action", timeSinceLastAction))
-	return true
+	return true, 0
+}
+
+// scheduleDeferredAction schedules an action to execute after the rate limit expires
+func (m *Manager) scheduleDeferredAction(actionType string, energyLevel string, trigger string, delay time.Duration) {
+	m.deferredMu.Lock()
+	defer m.deferredMu.Unlock()
+
+	// Cancel any existing deferred action
+	if m.deferredTimer != nil {
+		m.deferredTimer.Stop()
+		m.deferredTimer = nil
+	}
+
+	m.deferredAction = &deferredAction{
+		actionType:  actionType,
+		energyLevel: energyLevel,
+		trigger:     trigger,
+	}
+
+	m.logger.Info("📅 Scheduling deferred action",
+		zap.String("action_type", actionType),
+		zap.String("energy_level", energyLevel),
+		zap.Duration("delay", delay))
+
+	m.deferredTimer = time.AfterFunc(delay, func() {
+		m.executeDeferredAction()
+	})
+}
+
+// cancelDeferredAction cancels any pending deferred action
+func (m *Manager) cancelDeferredAction() {
+	m.deferredMu.Lock()
+	defer m.deferredMu.Unlock()
+
+	if m.deferredTimer != nil {
+		m.deferredTimer.Stop()
+		m.deferredTimer = nil
+	}
+
+	if m.deferredAction != nil {
+		m.logger.Info("🚫 Cancelled deferred action",
+			zap.String("action_type", m.deferredAction.actionType),
+			zap.String("energy_level", m.deferredAction.energyLevel))
+		m.deferredAction = nil
+	}
+}
+
+// executeDeferredAction executes the pending deferred action
+func (m *Manager) executeDeferredAction() {
+	m.deferredMu.Lock()
+	action := m.deferredAction
+	m.deferredAction = nil
+	m.deferredTimer = nil
+	m.deferredMu.Unlock()
+
+	if action == nil {
+		return
+	}
+
+	m.logger.Info("⏰ Executing deferred action after rate limit expired",
+		zap.String("action_type", action.actionType),
+		zap.String("energy_level", action.energyLevel),
+		zap.String("trigger", action.trigger))
+
+	// Execute the deferred action
+	switch action.actionType {
+	case "enable":
+		m.executeEnableLoadShedding(action.energyLevel, action.trigger+" (deferred)")
+	case "disable":
+		m.executeDisableLoadShedding(action.energyLevel, action.trigger+" (deferred)")
+	}
 }
 
 // checkThermostatHoldState checks if thermostat holds are currently enabled

--- a/homeautomation-go/internal/plugins/loadshedding/manager_test.go
+++ b/homeautomation-go/internal/plugins/loadshedding/manager_test.go
@@ -380,3 +380,156 @@ func TestManagerReset(t *testing.T) {
 	err = manager.Reset()
 	assert.NoError(t, err)
 }
+
+// TestLoadShedding_DeferredActionAfterRateLimit tests that when an action is
+// rate-limited, it gets automatically retried after the rate limit expires.
+// This is the bug fix for: when energy goes red->white quickly, the disable
+// action was rate-limited and never retried, leaving thermostats in hold mode.
+func TestLoadShedding_DeferredActionAfterRateLimit(t *testing.T) {
+	t.Parallel()
+	logger := testlogger.New()
+	mockClient := ha.NewMockClient()
+
+	// Initialize thermostat hold switches in mock (start with them off)
+	mockClient.SetState(thermostatHoldHouse, "off", nil)
+	mockClient.SetState(thermostatHoldSuite, "off", nil)
+
+	stateManager := state.NewManager(mockClient, logger, false)
+
+	err := stateManager.SyncFromHA()
+	assert.NoError(t, err)
+
+	ls := NewManager(mockClient, stateManager, logger, false, nil)
+
+	// Use a short rate limit interval for testing (100ms instead of 1 hour)
+	ls.SetRateLimitIntervalForTesting(100 * time.Millisecond)
+
+	err = ls.Start()
+	assert.NoError(t, err)
+	defer ls.Stop()
+
+	// Step 1: Set energy state to red (enables load shedding)
+	err = stateManager.SetString("currentEnergyLevel", "red")
+	assert.NoError(t, err)
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify load shedding was enabled
+	calls := mockClient.GetServiceCalls()
+	foundSwitchOn := false
+	for _, call := range calls {
+		if call.Domain == "switch" && call.Service == "turn_on" {
+			foundSwitchOn = true
+		}
+	}
+	assert.True(t, foundSwitchOn, "Load shedding should be enabled (switch.turn_on called)")
+
+	// Simulate thermostats now being in hold mode
+	mockClient.SetState(thermostatHoldHouse, "on", nil)
+	mockClient.SetState(thermostatHoldSuite, "on", nil)
+
+	// Clear service calls for cleaner verification
+	mockClient.ClearServiceCalls()
+
+	// Step 2: Immediately set energy state to white (should be rate-limited)
+	err = stateManager.SetString("currentEnergyLevel", "white")
+	assert.NoError(t, err)
+	time.Sleep(50 * time.Millisecond)
+
+	// At this point, the disable action should be rate-limited (not executed yet)
+	calls = mockClient.GetServiceCalls()
+	foundSwitchOff := false
+	for _, call := range calls {
+		if call.Domain == "switch" && call.Service == "turn_off" {
+			foundSwitchOff = true
+		}
+	}
+	// The action should NOT have been executed yet due to rate limiting
+	// (It will be deferred)
+
+	// Step 3: Wait for the rate limit to expire plus buffer for deferred action
+	time.Sleep(150 * time.Millisecond)
+
+	// Step 4: Verify the deferred disable action was executed
+	calls = mockClient.GetServiceCalls()
+	foundSwitchOff = false
+	for _, call := range calls {
+		if call.Domain == "switch" && call.Service == "turn_off" {
+			foundSwitchOff = true
+			entities, ok := call.Data["entity_id"].([]string)
+			assert.True(t, ok, "entity_id should be []string")
+			assert.Contains(t, entities, thermostatHoldHouse)
+			assert.Contains(t, entities, thermostatHoldSuite)
+		}
+	}
+	assert.True(t, foundSwitchOff,
+		"Deferred action should execute switch.turn_off after rate limit expires")
+
+	// Verify load shedding state is now disabled
+	assert.False(t, ls.IsLoadSheddingOn(), "Load shedding should be disabled after deferred action")
+}
+
+// TestLoadShedding_DeferredActionCancelledByNewAction tests that if a new
+// action comes in that supersedes the deferred action, the deferred action
+// is cancelled appropriately.
+func TestLoadShedding_DeferredActionCancelledByNewAction(t *testing.T) {
+	t.Parallel()
+	logger := testlogger.New()
+	mockClient := ha.NewMockClient()
+
+	// Initialize thermostat hold switches in mock (start with them off)
+	mockClient.SetState(thermostatHoldHouse, "off", nil)
+	mockClient.SetState(thermostatHoldSuite, "off", nil)
+
+	stateManager := state.NewManager(mockClient, logger, false)
+
+	err := stateManager.SyncFromHA()
+	assert.NoError(t, err)
+
+	ls := NewManager(mockClient, stateManager, logger, false, nil)
+
+	// Use a short rate limit interval for testing
+	ls.SetRateLimitIntervalForTesting(200 * time.Millisecond)
+
+	err = ls.Start()
+	assert.NoError(t, err)
+	defer ls.Stop()
+
+	// Step 1: Set energy state to red (enables load shedding)
+	err = stateManager.SetString("currentEnergyLevel", "red")
+	assert.NoError(t, err)
+	time.Sleep(50 * time.Millisecond)
+
+	// Simulate thermostats now being in hold mode
+	mockClient.SetState(thermostatHoldHouse, "on", nil)
+	mockClient.SetState(thermostatHoldSuite, "on", nil)
+
+	mockClient.ClearServiceCalls()
+
+	// Step 2: Set energy state to white (rate-limited, deferred)
+	err = stateManager.SetString("currentEnergyLevel", "white")
+	assert.NoError(t, err)
+	time.Sleep(50 * time.Millisecond)
+
+	// Step 3: Before deferred action fires, go back to red
+	// This should cancel the pending disable and keep load shedding on
+	err = stateManager.SetString("currentEnergyLevel", "red")
+	assert.NoError(t, err)
+	time.Sleep(50 * time.Millisecond)
+
+	// Step 4: Wait for what would have been the deferred action time
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify that switch.turn_off was NOT called (deferred disable was cancelled)
+	calls := mockClient.GetServiceCalls()
+	foundSwitchOff := false
+	for _, call := range calls {
+		if call.Domain == "switch" && call.Service == "turn_off" {
+			foundSwitchOff = true
+		}
+	}
+	assert.False(t, foundSwitchOff,
+		"Deferred disable should be cancelled when energy goes back to red")
+
+	// Load shedding should still be on
+	assert.True(t, ls.IsLoadSheddingOn(), "Load shedding should remain enabled")
+}


### PR DESCRIPTION
## Summary

- Fix bug where rate-limited load shedding actions were silently dropped, leaving thermostats stuck in hold mode
- Add deferred action mechanism that schedules rate-limited actions to execute after the rate limit expires
- Ensure conflicting state changes cancel pending deferred actions appropriately

## Problem

When energy transitioned from red → white quickly (within the 1-hour rate limit window), the disable action was rate-limited and never retried. This left thermostats in hold mode indefinitely, even though energy had recovered. 

Example from production logs:
```
8:21 PM - Load shedding ENABLED (energy=red)
9:00 PM - Energy changed to white, attempted disable...
         ⏱ RATE LIMIT: Action skipped (only 39 min since last action)
         ❌ Disable never retried - thermostats stuck in hold mode
```

## Solution

Instead of dropping rate-limited actions, they are now **deferred**:
- `scheduleDeferredAction()` - schedules the action to run after rate limit expires
- `cancelDeferredAction()` - cancels pending action if state changes (e.g., going back to red cancels pending disable)
- `executeDeferredAction()` - runs the deferred action and re-validates state before executing

## Test plan

- [x] `TestLoadShedding_DeferredActionAfterRateLimit` - verifies deferred action executes after rate limit
- [x] `TestLoadShedding_DeferredActionCancelledByNewAction` - verifies conflicting state changes cancel deferred actions
- [x] All existing load shedding tests pass
- [x] Full test suite passes with race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)