### PR TITLE
feat(workflows): Include issue comments in Claude prompts

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -778,6 +778,12 @@ jobs:
             PR_BODY=$(echo "$PR_BODY_B64" | base64 -d 2>/dev/null || echo "")
             ISSUE_BODY=$(echo "$ISSUE_BODY_B64" | base64 -d 2>/dev/null || echo "")
 
+            # Fetch all comments on the linked issue (may contain additional context/requirements)
+            ISSUE_COMMENTS=""
+            if [ -n "$ISSUE_NUMBER" ]; then
+              ISSUE_COMMENTS=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" --jq '.[] | "---\n**\(.user.login)** commented at \(.created_at):\n\(.body)\n"' 2>/dev/null | head -c 50000 || echo "")
+            fi
+
             claude --print \
               --verbose \
               --output-format stream-json \
@@ -797,6 +803,9 @@ jobs:
             Linked Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
             Issue Description:
             ${ISSUE_BODY}
+
+            Issue Comments (additional context/requirements):
+            ${ISSUE_COMMENTS}
 
             **YOUR TASK:**
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -347,6 +347,9 @@ jobs:
             # (see https://github.com/NickBorgers/home-automation/issues/441)
             ISSUE_BODY=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '.body')
 
+            # Fetch all comments on the issue (may contain additional context/requirements)
+            ISSUE_COMMENTS=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" --jq '.[] | "---\n**\(.user.login)** commented at \(.created_at):\n\(.body)\n"' 2>/dev/null | head -c 50000 || echo "")
+
             claude --print \
               --verbose \
               --output-format stream-json \
@@ -359,6 +362,9 @@ jobs:
 
             ISSUE BODY:
             ${ISSUE_BODY}
+
+            ISSUE COMMENTS (if any):
+            ${ISSUE_COMMENTS}
 
             YOUR TASK:
             1. Analyze the issue and understand what needs to be done

--- a/docs/operations/CLAUDE_GHA_PIPELINES.md
+++ b/docs/operations/CLAUDE_GHA_PIPELINES.md
@@ -108,7 +108,7 @@ Automatically resolves newly opened issues.
 
 **Workflow**:
 1. Labels issue with `claude-started`
-2. Analyzes the issue title and body
+2. Analyzes the issue title, body, and **all comments** on the issue
 3. Explores the codebase to understand context
 4. Implements fixes or features
 5. Creates a branch (`claude/issue-{number}`)
@@ -239,7 +239,7 @@ Design validation and critical design review specialist. **Runs first** (before 
 **Pre-Flight Check**: Before running the review, verifies that "All Required Tests" commit status is `success` on the current HEAD. If tests haven't passed, the review is skipped to avoid reviewing broken code that can't be merged anyway.
 
 **Purpose**: This reviewer serves two functions:
-1. **Intent Validation**: Ensures the PR actually implements what was requested in the linked issue and/or PR description
+1. **Intent Validation**: Ensures the PR actually implements what was requested in the linked issue and/or PR description (including **all comments** on the linked issue)
 2. **Design Critique**: Critically reviews the design decisions for quality, trade-offs, and potential issues
 
 **Focus Areas**:


### PR DESCRIPTION
## Summary

- **resolve-issue** (claude.yml) now fetches and includes all comments from the issue
- **design-review** (claude-code-review.yml) now fetches and includes all comments from the linked issue

This ensures both bots have full context including any additional requirements, clarifications, or discussions that occurred after the initial issue was created.

Resolves the gap where bots would miss important context added in issue comments (such as https://github.com/NickBorgers/home-automation/issues/513#issuecomment-3781128818).

## Implementation Details

- Comments are fetched via `gh api repos/${REPO}/issues/${ISSUE_NUMBER}/comments`
- Output is limited to 50KB to prevent prompt overflow
- Formatted as markdown with author, timestamp, and body for each comment

## Test plan

- [ ] Create an issue with initial requirements
- [ ] Add a comment with additional context/requirements
- [ ] Verify the resolve-issue bot sees both the issue body AND the comment
- [ ] Create a PR linked to an issue
- [ ] Add a comment on the issue after PR creation
- [ ] Verify the design-review bot sees the issue comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)