### PR TITLE
Exclude soundbar from day music

### DIFF
--- a/configs/music_config.yaml
+++ b/configs/music_config.yaml
@@ -7,11 +7,6 @@ music:
         leave_muted_if:
           - variable: isTVPlaying
             value: true
-      - player_name: "Soundbar"
-        base_volume: 10
-        leave_muted_if:
-          - variable: isGuestAsleep
-            value: true
       - player_name: "Kids Bathroom"
         base_volume: 7
         leave_muted_if:
@@ -58,11 +53,6 @@ music:
         base_volume: 9
         leave_muted_if:
           - variable: isTVPlaying
-            value: true
-      - player_name: "Soundbar"
-        base_volume: 10
-        leave_muted_if:
-          - variable: isGuestAsleep
             value: true
       - player_name: "Kids Bathroom"
         base_volume: 7


### PR DESCRIPTION
We don't have full multi-zone audio output so right now soundbar just keeps playing daytime music and it's annoying. This PR excludes it from day and morning music so that it is not left playing that music when sunset begins.