### PR TITLE
fix: Add pull_request event handler to Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -49,7 +49,7 @@ on:
 # Uses branch name for concurrency group
 # cancel-in-progress: false ensures we complete the first review rather than restarting
 concurrency:
-  group: claude-review-${{ github.event_name == 'workflow_dispatch' && inputs.head_ref || github.event.workflow_run.head_branch }}
+  group: claude-review-${{ github.event_name == 'workflow_dispatch' && inputs.head_ref || github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.event.workflow_run.head_branch }}
   cancel-in-progress: false
 
 env:
@@ -69,11 +69,12 @@ jobs:
       pr_body_b64: ${{ steps.get-pr.outputs.pr_body_b64 }}
       head_ref: ${{ steps.get-pr.outputs.head_ref }}
       head_repo: ${{ steps.get-pr.outputs.head_repo }}
-      # Handle both workflow_run and workflow_dispatch events
-      tests_passed: ${{ github.event_name == 'workflow_dispatch' && inputs.tests_passed == 'true' || github.event.workflow_run.conclusion == 'success' }}
-      run_id: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.id }}
+      # Handle workflow_run, workflow_dispatch, and pull_request events
+      # For pull_request (reopen), tests haven't run yet so tests_passed is false
+      tests_passed: ${{ github.event_name == 'workflow_dispatch' && inputs.tests_passed == 'true' || github.event_name == 'pull_request' && 'false' || github.event.workflow_run.conclusion == 'success' }}
+      run_id: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event_name == 'pull_request' && github.run_id || github.event.workflow_run.id }}
       # SHA that triggered this workflow - used to detect if author pushed newer commits
-      triggering_sha: ${{ github.event.workflow_run.head_sha }}
+      triggering_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
       issue_number: ${{ steps.get-issue.outputs.issue_number }}
       issue_title: ${{ steps.get-issue.outputs.issue_title }}
       issue_body_b64: ${{ steps.get-issue.outputs.issue_body_b64 }}
@@ -98,6 +99,13 @@ jobs:
               headRepo = '${{ inputs.head_repo }}';
               prNumber = parseInt('${{ inputs.pr_number }}', 10);
               console.log(`Triggered via workflow_dispatch for PR #${prNumber}`);
+            } else if (eventName === 'pull_request') {
+              // Use data from pull_request event (triggered on reopen)
+              const pr = context.payload.pull_request;
+              headBranch = pr.head.ref;
+              headRepo = pr.head.repo.full_name;
+              prNumber = pr.number;
+              console.log(`Triggered via pull_request event for PR #${prNumber}`);
             } else {
               // Use data from workflow_run event
               headBranch = context.payload.workflow_run.head_branch;


### PR DESCRIPTION
## Summary
- Fixes the Claude Code Review workflow failing when triggered by `pull_request: [reopened]` events
- Adds proper handling for `pull_request` event type in the get-pr script
- Updates concurrency group and output variables to handle all three event types

## Root Cause
The workflow is configured to trigger on three event types:
1. `workflow_run` - When PR Tests workflow completes
2. `workflow_dispatch` - Manual trigger with inputs
3. `pull_request: [reopened]` - When a PR is reopened

The JavaScript code in the `get-pr` step only handled `workflow_dispatch` and `workflow_run` events. When triggered by a `pull_request` event, `context.payload.workflow_run` was undefined, causing:

```
TypeError: Cannot read properties of undefined (reading 'head_branch')
```

## Changes Made
1. **Concurrency group** (line 52): Added handling for `github.event.pull_request.head.ref`
2. **get-pr script** (lines 90-106): Added `else if (eventName === 'pull_request')` branch to extract PR details from `context.payload.pull_request`
3. **Output variables** (lines 73-76):
   - `tests_passed`: Set to `false` for pull_request events (tests haven't run yet)
   - `run_id`: Use `github.run_id` for pull_request events
   - `triggering_sha`: Use `github.event.pull_request.head.sha` for pull_request events

## Test plan
- [ ] Verify workflow YAML syntax is valid
- [ ] Reopen a PR and confirm the workflow runs without the TypeError
- [ ] Confirm the `agent-reviews-passed` label is removed on reopen
- [ ] Confirm reviews don't run immediately (since `tests_passed` is false)

Resolves #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)