### PR TITLE
fix: Add monitoring_ignore label support to temperature lockup detection

### DIFF
--- a/homeautomation-go/internal/ha/labels.go
+++ b/homeautomation-go/internal/ha/labels.go
@@ -1,0 +1,76 @@
+package ha
+
+import "strings"
+
+// Label constants used for device filtering across plugins
+const (
+	// MonitoringIgnoreLabel is the Home Assistant label that excludes devices from monitoring.
+	// In Home Assistant, this corresponds to a label with display name "Monitoring Ignore".
+	// Devices with this label will be excluded from:
+	// - Water leak monitoring
+	// - Battery monitoring
+	// - Stale sensor detection
+	// - Temperature lockup detection
+	MonitoringIgnoreLabel = "monitoring_ignore"
+
+	// IndoorLabel is used to identify indoor devices for humidity alerting
+	IndoorLabel = "indoor"
+)
+
+// DeviceLabelChecker provides centralized device label checking functionality.
+// It caches device labels to avoid repeated API calls during sensor discovery.
+type DeviceLabelChecker struct {
+	deviceLabels map[string][]string // deviceID -> labels
+}
+
+// NewDeviceLabelChecker creates a DeviceLabelChecker from a list of devices.
+// This is typically called once during plugin startup after fetching devices from HA.
+func NewDeviceLabelChecker(devices []*Device) *DeviceLabelChecker {
+	checker := &DeviceLabelChecker{
+		deviceLabels: make(map[string][]string),
+	}
+	for _, device := range devices {
+		checker.deviceLabels[device.ID] = device.Labels
+	}
+	return checker
+}
+
+// HasLabel checks if a device has a specific label (case-sensitive).
+func (c *DeviceLabelChecker) HasLabel(deviceID, label string) bool {
+	labels, ok := c.deviceLabels[deviceID]
+	if !ok {
+		return false
+	}
+	for _, l := range labels {
+		if l == label {
+			return true
+		}
+	}
+	return false
+}
+
+// HasLabelIgnoreCase checks if a device has a specific label (case-insensitive).
+// This is useful for labels like "indoor" which may be entered as "Indoor", "INDOOR", etc.
+func (c *DeviceLabelChecker) HasLabelIgnoreCase(deviceID, label string) bool {
+	labels, ok := c.deviceLabels[deviceID]
+	if !ok {
+		return false
+	}
+	for _, l := range labels {
+		if strings.EqualFold(l, label) {
+			return true
+		}
+	}
+	return false
+}
+
+// ShouldIgnoreForMonitoring checks if a device has the monitoring_ignore label.
+// Returns true if the device should be excluded from all monitoring features.
+func (c *DeviceLabelChecker) ShouldIgnoreForMonitoring(deviceID string) bool {
+	return c.HasLabel(deviceID, MonitoringIgnoreLabel)
+}
+
+// GetLabels returns all labels for a device, or nil if device not found.
+func (c *DeviceLabelChecker) GetLabels(deviceID string) []string {
+	return c.deviceLabels[deviceID]
+}

--- a/homeautomation-go/internal/ha/labels_test.go
+++ b/homeautomation-go/internal/ha/labels_test.go
@@ -1,0 +1,170 @@
+package ha
+
+import (
+	"testing"
+)
+
+func TestNewDeviceLabelChecker(t *testing.T) {
+	devices := []*Device{
+		{ID: "device1", Labels: []string{"indoor", "monitoring_ignore"}},
+		{ID: "device2", Labels: []string{"outdoor"}},
+		{ID: "device3", Labels: []string{}},
+		{ID: "device4", Labels: nil},
+	}
+
+	checker := NewDeviceLabelChecker(devices)
+
+	if checker == nil {
+		t.Fatal("expected non-nil checker")
+	}
+	if len(checker.deviceLabels) != 4 {
+		t.Errorf("expected 4 devices, got %d", len(checker.deviceLabels))
+	}
+}
+
+func TestNewDeviceLabelChecker_NilDevices(t *testing.T) {
+	checker := NewDeviceLabelChecker(nil)
+
+	if checker == nil {
+		t.Fatal("expected non-nil checker")
+	}
+	if len(checker.deviceLabels) != 0 {
+		t.Errorf("expected empty map, got %d entries", len(checker.deviceLabels))
+	}
+}
+
+func TestDeviceLabelChecker_HasLabel(t *testing.T) {
+	devices := []*Device{
+		{ID: "device1", Labels: []string{"indoor", "monitoring_ignore"}},
+		{ID: "device2", Labels: []string{"outdoor"}},
+		{ID: "device3", Labels: []string{}},
+	}
+
+	checker := NewDeviceLabelChecker(devices)
+
+	tests := []struct {
+		name     string
+		deviceID string
+		label    string
+		expected bool
+	}{
+		{"device has label", "device1", "indoor", true},
+		{"device has monitoring_ignore", "device1", "monitoring_ignore", true},
+		{"device does not have label", "device1", "outdoor", false},
+		{"different device has label", "device2", "outdoor", true},
+		{"device with empty labels", "device3", "indoor", false},
+		{"unknown device", "unknown", "indoor", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checker.HasLabel(tt.deviceID, tt.label)
+			if result != tt.expected {
+				t.Errorf("HasLabel(%q, %q) = %v, want %v", tt.deviceID, tt.label, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDeviceLabelChecker_ShouldIgnoreForMonitoring(t *testing.T) {
+	devices := []*Device{
+		{ID: "ignored_device", Labels: []string{"monitoring_ignore"}},
+		{ID: "monitored_device", Labels: []string{"indoor"}},
+		{ID: "both_labels", Labels: []string{"indoor", "monitoring_ignore"}},
+		{ID: "no_labels", Labels: []string{}},
+	}
+
+	checker := NewDeviceLabelChecker(devices)
+
+	tests := []struct {
+		name     string
+		deviceID string
+		expected bool
+	}{
+		{"device with only monitoring_ignore", "ignored_device", true},
+		{"device without monitoring_ignore", "monitored_device", false},
+		{"device with multiple labels including monitoring_ignore", "both_labels", true},
+		{"device with no labels", "no_labels", false},
+		{"unknown device", "unknown", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checker.ShouldIgnoreForMonitoring(tt.deviceID)
+			if result != tt.expected {
+				t.Errorf("ShouldIgnoreForMonitoring(%q) = %v, want %v", tt.deviceID, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDeviceLabelChecker_HasLabelIgnoreCase(t *testing.T) {
+	devices := []*Device{
+		{ID: "device1", Labels: []string{"Indoor", "monitoring_ignore"}},
+		{ID: "device2", Labels: []string{"OUTDOOR"}},
+		{ID: "device3", Labels: []string{"indoor"}},
+	}
+
+	checker := NewDeviceLabelChecker(devices)
+
+	tests := []struct {
+		name     string
+		deviceID string
+		label    string
+		expected bool
+	}{
+		{"exact match lowercase", "device3", "indoor", true},
+		{"case mismatch - label uppercase in device", "device1", "indoor", true},
+		{"case mismatch - search uppercase", "device3", "INDOOR", true},
+		{"case mismatch - mixed case search", "device1", "InDoOr", true},
+		{"all uppercase in device", "device2", "outdoor", true},
+		{"label not present", "device1", "outdoor", false},
+		{"unknown device", "unknown", "indoor", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checker.HasLabelIgnoreCase(tt.deviceID, tt.label)
+			if result != tt.expected {
+				t.Errorf("HasLabelIgnoreCase(%q, %q) = %v, want %v", tt.deviceID, tt.label, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDeviceLabelChecker_GetLabels(t *testing.T) {
+	devices := []*Device{
+		{ID: "device1", Labels: []string{"indoor", "monitoring_ignore"}},
+		{ID: "device2", Labels: []string{}},
+	}
+
+	checker := NewDeviceLabelChecker(devices)
+
+	// Device with labels
+	labels := checker.GetLabels("device1")
+	if len(labels) != 2 {
+		t.Errorf("expected 2 labels, got %d", len(labels))
+	}
+
+	// Device with empty labels
+	labels = checker.GetLabels("device2")
+	if len(labels) != 0 {
+		t.Errorf("expected 0 labels, got %d", len(labels))
+	}
+
+	// Unknown device
+	labels = checker.GetLabels("unknown")
+	if labels != nil {
+		t.Errorf("expected nil for unknown device, got %v", labels)
+	}
+}
+
+func TestLabelConstants(t *testing.T) {
+	// Verify constants are defined correctly
+	if MonitoringIgnoreLabel != "monitoring_ignore" {
+		t.Errorf("MonitoringIgnoreLabel = %q, want %q", MonitoringIgnoreLabel, "monitoring_ignore")
+	}
+	if IndoorLabel != "indoor" {
+		t.Errorf("IndoorLabel = %q, want %q", IndoorLabel, "indoor")
+	}
+}

--- a/homeautomation-go/internal/plugins/environmental/manager.go
+++ b/homeautomation-go/internal/plugins/environmental/manager.go
@@ -35,9 +35,6 @@ const (
 	WarningNotificationRateLimit  = 4 * time.Hour
 	CriticalNotificationRateLimit = 1 * time.Hour
 
-	// Label used to identify indoor devices
-	IndoorLabel = "indoor"
-
 	// Temperature sensor lockup detection
 	// A sensor is considered locked up if it has the same reading for this long
 	TemperatureLockupThreshold = 12 * time.Hour
@@ -254,14 +251,13 @@ func (m *Manager) discoverHumiditySensors() error {
 		errs = append(errs, err)
 	}
 
+	labelChecker := ha.NewDeviceLabelChecker(devices)
+
 	indoorDevices := make(map[string]bool)
 	for _, device := range devices {
-		for _, label := range device.Labels {
-			// Case-insensitive comparison to handle "Indoor", "indoor", "INDOOR", etc.
-			if strings.EqualFold(label, IndoorLabel) {
-				indoorDevices[device.ID] = true
-				break
-			}
+		// Use case-insensitive matching to handle "Indoor", "indoor", "INDOOR", etc.
+		if labelChecker.HasLabelIgnoreCase(device.ID, ha.IndoorLabel) {
+			indoorDevices[device.ID] = true
 		}
 	}
 
@@ -774,12 +770,30 @@ func (m *Manager) discoverTemperatureSensors() error {
 		entityToDevice[entry.EntityID] = entry.DeviceID
 	}
 
+	// Step 4: Get device registry for label checking
+	devices, err := m.haClient.GetDevices()
+	if err != nil {
+		m.logger.Warn("Failed to get device registry for temperature sensors",
+			zap.Error(err))
+		errs = append(errs, err)
+	}
+
+	labelChecker := ha.NewDeviceLabelChecker(devices)
+
 	now := m.clock.Now()
 
-	// Step 4: Create TemperatureSensor structs and subscribe to each
+	// Step 5: Create TemperatureSensor structs and subscribe to each
 	m.mu.Lock()
 	for _, state := range tempSensors {
 		deviceID := entityToDevice[state.EntityID]
+
+		// Check if device has the monitoring ignore label
+		if labelChecker.ShouldIgnoreForMonitoring(deviceID) {
+			m.logger.Info("Skipping temperature sensor with monitoring_ignore label on device",
+				zap.String("entity_id", state.EntityID),
+				zap.String("device_id", deviceID))
+			continue
+		}
 
 		friendlyName := state.EntityID
 		if name, ok := state.Attributes["friendly_name"].(string); ok {

--- a/homeautomation-go/internal/plugins/monitoring/manager.go
+++ b/homeautomation-go/internal/plugins/monitoring/manager.go
@@ -27,10 +27,6 @@ const (
 
 	// How often to check for stale sensors
 	StalenessCheckInterval = 1 * time.Hour
-
-	// MonitoringIgnoreLabel is the Home Assistant label that excludes entities from monitoring
-	// In Home Assistant, this corresponds to a label with display name "Monitoring Ignore"
-	MonitoringIgnoreLabel = "monitoring_ignore"
 )
 
 // WaterLeakSensor represents a discovered water leak sensor
@@ -110,16 +106,6 @@ func NewManagerWithClock(haClient ha.HAClient, stateManager *state.Manager, logg
 	m := NewManager(haClient, stateManager, logger, readOnly, registry, ntfyClient)
 	m.clock = c
 	return m
-}
-
-// hasIgnoreLabel checks if the given labels contain the monitoring ignore label
-func hasIgnoreLabel(labels []string) bool {
-	for _, label := range labels {
-		if label == MonitoringIgnoreLabel {
-			return true
-		}
-	}
-	return false
 }
 
 // GetShadowState returns the current shadow state
@@ -240,17 +226,14 @@ func (m *Manager) discoverWaterLeakSensors() error {
 		entityToDevice[entry.EntityID] = entry.DeviceID
 	}
 
-	// Get device registry for labels
+	// Get device registry for label checking
 	devices, err := m.haClient.GetDevices()
 	if err != nil {
 		m.logger.Warn("Failed to get device registry", zap.Error(err))
 		errs = append(errs, err)
 	}
 
-	deviceToLabels := make(map[string][]string)
-	for _, device := range devices {
-		deviceToLabels[device.ID] = device.Labels
-	}
+	labelChecker := ha.NewDeviceLabelChecker(devices)
 
 	// Create sensor structs and subscribe
 	m.mu.Lock()
@@ -258,7 +241,7 @@ func (m *Manager) discoverWaterLeakSensors() error {
 		deviceID := entityToDevice[state.EntityID]
 
 		// Check if device has the monitoring ignore label
-		if hasIgnoreLabel(deviceToLabels[deviceID]) {
+		if labelChecker.ShouldIgnoreForMonitoring(deviceID) {
 			m.logger.Info("Skipping water leak sensor with monitoring_ignore label on device",
 				zap.String("entity_id", state.EntityID),
 				zap.String("device_id", deviceID))
@@ -350,17 +333,14 @@ func (m *Manager) discoverBatterySensors() error {
 		entityToDevice[entry.EntityID] = entry.DeviceID
 	}
 
-	// Get device registry for labels
+	// Get device registry for label checking
 	devices, err := m.haClient.GetDevices()
 	if err != nil {
 		m.logger.Warn("Failed to get device registry", zap.Error(err))
 		errs = append(errs, err)
 	}
 
-	deviceToLabels := make(map[string][]string)
-	for _, device := range devices {
-		deviceToLabels[device.ID] = device.Labels
-	}
+	labelChecker := ha.NewDeviceLabelChecker(devices)
 
 	// Create sensor structs and subscribe
 	m.mu.Lock()
@@ -368,7 +348,7 @@ func (m *Manager) discoverBatterySensors() error {
 		deviceID := entityToDevice[state.EntityID]
 
 		// Check if device has the monitoring ignore label
-		if hasIgnoreLabel(deviceToLabels[deviceID]) {
+		if labelChecker.ShouldIgnoreForMonitoring(deviceID) {
 			m.logger.Info("Skipping battery sensor with monitoring_ignore label on device",
 				zap.String("entity_id", state.EntityID),
 				zap.String("device_id", deviceID))

--- a/homeautomation-go/internal/plugins/monitoring/manager_test.go
+++ b/homeautomation-go/internal/plugins/monitoring/manager_test.go
@@ -541,31 +541,6 @@ func TestParseBatteryLevel(t *testing.T) {
 	}
 }
 
-func TestHasIgnoreLabel(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		labels   []string
-		expected bool
-	}{
-		{"nil labels", nil, false},
-		{"empty labels", []string{}, false},
-		{"other labels only", []string{"important", "kitchen"}, false},
-		{"has ignore label", []string{"monitoring_ignore"}, true},
-		{"ignore label among others", []string{"important", "monitoring_ignore", "kitchen"}, true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := hasIgnoreLabel(tt.labels)
-			if result != tt.expected {
-				t.Errorf("hasIgnoreLabel(%v) = %v, expected %v", tt.labels, result, tt.expected)
-			}
-		})
-	}
-}
-
 func TestMonitoringManager_IgnoreLabeledDevices(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- **Root cause:** Temperature lockup detection in the environmental plugin was not checking for the `monitoring_ignore` label, causing notifications for sensors that should be excluded
- Created centralized `DeviceLabelChecker` in `ha` package to share label-checking logic between plugins
- Updated environmental plugin to skip temperature sensors on devices with `monitoring_ignore` label
- Refactored monitoring plugin to use the centralized helper (no behavior change, just code reuse)

## Test plan

- [x] Unit tests pass for new `DeviceLabelChecker` helper
- [x] Existing environmental plugin tests pass (including case-insensitive indoor label matching)
- [x] Existing monitoring plugin tests pass
- [x] Integration tests pass
- [ ] After deployment, verify temperature sensors on devices with `monitoring_ignore` label no longer trigger lockup notifications

🤖 Generated with [Claude Code](https://claude.ai/code)