### PR TITLE
fix(tv): Add 60-second debounce before turning off Hue Sync light sync

### DIFF
--- a/homeautomation-go/internal/plugins/tv/manager.go
+++ b/homeautomation-go/internal/plugins/tv/manager.go
@@ -36,6 +36,11 @@ const (
 
 	// Entity ID for sync box light sync control
 	SyncBoxLightSyncEntity = "switch.sync_box_light_sync"
+
+	// LightSyncOffDebounce is how long to wait before turning off light sync
+	// after Apple TV reports "paused". Prevents flapping due to Apple TV
+	// integration briefly reporting "paused" state during active playback.
+	LightSyncOffDebounce = 60 * time.Second
 )
 
 // Manager handles TV monitoring and manipulation
@@ -58,6 +63,12 @@ type Manager struct {
 	rebootCountResetAt time.Time
 	recoveryInProgress bool
 
+	// Light sync debounce state
+	lightSyncOffMu       sync.Mutex
+	lightSyncOffPending  bool          // true if a turn_off is pending
+	lightSyncOffCancel   chan struct{} // signal to cancel pending turn_off
+	lightSyncOffDebounce time.Duration // configurable debounce duration
+
 	// For testing: injectable time and sleep functions
 	timeNow   func() time.Time
 	sleepFunc func(time.Duration)
@@ -75,8 +86,9 @@ func NewManager(haClient ha.HAClient, stateManager *state.Manager, logger *zap.L
 		shadowTracker: shadowTracker,
 		subHelper:     shadowstate.NewSubscriptionHelper(haClient, stateManager, registry, shadowTracker, "tv", logger.Named("tv")),
 		// Initialize time functions with defaults
-		timeNow:   time.Now,
-		sleepFunc: time.Sleep,
+		timeNow:              time.Now,
+		sleepFunc:            time.Sleep,
+		lightSyncOffDebounce: LightSyncOffDebounce,
 	}
 }
 
@@ -378,7 +390,8 @@ func (m *Manager) calculateTVPlaying(hdmiInput string) {
 	m.controlSyncBoxLightSync(isTVPlaying)
 }
 
-// controlSyncBoxLightSync turns the sync box light sync on or off based on TV playing state
+// controlSyncBoxLightSync turns the sync box light sync on or off based on TV playing state.
+// Turn ON happens immediately; turn OFF is debounced to prevent flapping.
 func (m *Manager) controlSyncBoxLightSync(isTVPlaying bool) {
 	if m.readOnly {
 		m.logger.Debug("Skipping sync box light sync control in read-only mode",
@@ -386,27 +399,96 @@ func (m *Manager) controlSyncBoxLightSync(isTVPlaying bool) {
 		return
 	}
 
-	action := "turn_off"
 	if isTVPlaying {
-		action = "turn_on"
+		// Turn ON immediately, and cancel any pending turn-off
+		m.cancelPendingLightSyncOff()
+
+		m.logger.Info("Controlling sync box light sync",
+			zap.String("action", "turn_on"),
+			zap.String("entity_id", SyncBoxLightSyncEntity))
+
+		err := m.haClient.CallService("switch", "turn_on", map[string]interface{}{
+			"entity_id": SyncBoxLightSyncEntity,
+		})
+		if err != nil {
+			m.logger.Error("Failed to turn on sync box light sync", zap.Error(err))
+		}
+	} else {
+		// Turn OFF with debounce to prevent flapping
+		m.scheduleLightSyncOff()
 	}
+}
 
-	m.logger.Info("Controlling sync box light sync",
-		zap.String("action", action),
-		zap.String("entity_id", SyncBoxLightSyncEntity))
+// scheduleLightSyncOff schedules a debounced turn-off for the sync box light sync.
+// If a turn-off is already pending, this is a no-op.
+func (m *Manager) scheduleLightSyncOff() {
+	m.lightSyncOffMu.Lock()
 
-	err := m.haClient.CallService("switch", action, map[string]interface{}{
-		"entity_id": SyncBoxLightSyncEntity,
-	})
-	if err != nil {
-		m.logger.Error("Failed to control sync box light sync",
-			zap.String("action", action),
-			zap.Error(err))
+	// If already pending, do nothing
+	if m.lightSyncOffPending {
+		m.logger.Debug("Light sync turn-off already pending, skipping duplicate")
+		m.lightSyncOffMu.Unlock()
 		return
 	}
 
-	m.logger.Debug("Sync box light sync controlled successfully",
-		zap.String("action", action))
+	m.lightSyncOffPending = true
+	m.lightSyncOffCancel = make(chan struct{})
+	cancelCh := m.lightSyncOffCancel
+	m.lightSyncOffMu.Unlock()
+
+	debounce := m.lightSyncOffDebounce
+	m.logger.Debug("Scheduling light sync turn-off with debounce",
+		zap.Duration("debounce", debounce))
+
+	go func() {
+		// Use a timer so we can cancel it
+		timer := time.NewTimer(debounce)
+		defer timer.Stop()
+
+		select {
+		case <-cancelCh:
+			m.logger.Debug("Light sync turn-off cancelled")
+			return
+		case <-timer.C:
+			// Debounce period elapsed, proceed with turn-off
+		}
+
+		m.lightSyncOffMu.Lock()
+		m.lightSyncOffPending = false
+		m.lightSyncOffMu.Unlock()
+
+		m.logger.Info("Controlling sync box light sync",
+			zap.String("action", "turn_off"),
+			zap.String("entity_id", SyncBoxLightSyncEntity),
+			zap.String("reason", "debounce elapsed"))
+
+		err := m.haClient.CallService("switch", "turn_off", map[string]interface{}{
+			"entity_id": SyncBoxLightSyncEntity,
+		})
+		if err != nil {
+			m.logger.Error("Failed to turn off sync box light sync", zap.Error(err))
+		}
+	}()
+}
+
+// cancelPendingLightSyncOff cancels any pending light sync turn-off.
+func (m *Manager) cancelPendingLightSyncOff() {
+	m.lightSyncOffMu.Lock()
+	defer m.lightSyncOffMu.Unlock()
+
+	if m.lightSyncOffPending && m.lightSyncOffCancel != nil {
+		close(m.lightSyncOffCancel)
+		m.lightSyncOffPending = false
+		m.lightSyncOffCancel = nil
+		m.logger.Debug("Cancelled pending light sync turn-off")
+	}
+}
+
+// IsLightSyncOffPending returns whether a light sync turn-off is pending (for testing)
+func (m *Manager) IsLightSyncOffPending() bool {
+	m.lightSyncOffMu.Lock()
+	defer m.lightSyncOffMu.Unlock()
+	return m.lightSyncOffPending
 }
 
 // checkAndRecoverSyncBox checks if sync box recovery is needed and performs power cycle

--- a/homeautomation-go/internal/plugins/tv/manager_test.go
+++ b/homeautomation-go/internal/plugins/tv/manager_test.go
@@ -1057,3 +1057,269 @@ func TestTVManager_ShadowState_TracksRecovery(t *testing.T) {
 		t.Error("Expected LastSyncBoxReboot to be set")
 	}
 }
+
+func TestTVManager_LightSyncDebounce_TurnOnImmediate(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	manager := NewManager(mockHA, stateMgr, logger, false, nil)
+
+	// Call controlSyncBoxLightSync with isTVPlaying=true
+	manager.controlSyncBoxLightSync(true)
+
+	// Verify turn_on was called immediately (no delay)
+	calls := mockHA.GetServiceCalls()
+	var switchCalls []ha.ServiceCall
+	for _, call := range calls {
+		if call.Domain == "switch" {
+			switchCalls = append(switchCalls, call)
+		}
+	}
+
+	if len(switchCalls) != 1 {
+		t.Errorf("Expected exactly 1 switch service call, got %d", len(switchCalls))
+		return
+	}
+
+	if switchCalls[0].Service != "turn_on" {
+		t.Errorf("Expected turn_on service call, got %s", switchCalls[0].Service)
+	}
+	if switchCalls[0].Data["entity_id"] != SyncBoxLightSyncEntity {
+		t.Errorf("Expected entity_id to be %s, got %v", SyncBoxLightSyncEntity, switchCalls[0].Data["entity_id"])
+	}
+}
+
+func TestTVManager_LightSyncDebounce_TurnOffDelayed(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	manager := NewManager(mockHA, stateMgr, logger, false, nil)
+	// Use a short debounce for testing
+	manager.lightSyncOffDebounce = 50 * time.Millisecond
+
+	// Call controlSyncBoxLightSync with isTVPlaying=false
+	manager.controlSyncBoxLightSync(false)
+
+	// Verify no calls immediately
+	calls := mockHA.GetServiceCalls()
+	var switchCalls []ha.ServiceCall
+	for _, call := range calls {
+		if call.Domain == "switch" {
+			switchCalls = append(switchCalls, call)
+		}
+	}
+
+	if len(switchCalls) != 0 {
+		t.Errorf("Expected 0 switch service calls immediately after turn-off request, got %d", len(switchCalls))
+	}
+
+	// Verify pending state
+	if !manager.IsLightSyncOffPending() {
+		t.Error("Expected light sync turn-off to be pending")
+	}
+
+	// Wait for debounce to elapse
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify turn_off was called after debounce
+	calls = mockHA.GetServiceCalls()
+	switchCalls = nil
+	for _, call := range calls {
+		if call.Domain == "switch" {
+			switchCalls = append(switchCalls, call)
+		}
+	}
+
+	if len(switchCalls) != 1 {
+		t.Errorf("Expected 1 switch service call after debounce, got %d", len(switchCalls))
+		return
+	}
+
+	if switchCalls[0].Service != "turn_off" {
+		t.Errorf("Expected turn_off service call, got %s", switchCalls[0].Service)
+	}
+
+	// Verify no longer pending
+	if manager.IsLightSyncOffPending() {
+		t.Error("Expected light sync turn-off to no longer be pending")
+	}
+}
+
+func TestTVManager_LightSyncDebounce_CancelledByTurnOn(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	manager := NewManager(mockHA, stateMgr, logger, false, nil)
+	// Use a longer debounce to give us time to cancel
+	manager.lightSyncOffDebounce = 200 * time.Millisecond
+
+	// Request turn-off (schedules debounce)
+	manager.controlSyncBoxLightSync(false)
+
+	// Verify pending
+	if !manager.IsLightSyncOffPending() {
+		t.Error("Expected light sync turn-off to be pending")
+	}
+
+	// Wait a bit but not long enough for debounce
+	time.Sleep(50 * time.Millisecond)
+
+	// Request turn-on (should cancel pending turn-off)
+	manager.controlSyncBoxLightSync(true)
+
+	// Verify no longer pending
+	if manager.IsLightSyncOffPending() {
+		t.Error("Expected light sync turn-off to be cancelled")
+	}
+
+	// Wait for original debounce period to elapse
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify only turn_on was called, not turn_off
+	calls := mockHA.GetServiceCalls()
+	var switchCalls []ha.ServiceCall
+	for _, call := range calls {
+		if call.Domain == "switch" {
+			switchCalls = append(switchCalls, call)
+		}
+	}
+
+	if len(switchCalls) != 1 {
+		t.Errorf("Expected exactly 1 switch service call (turn_on only), got %d", len(switchCalls))
+		return
+	}
+
+	if switchCalls[0].Service != "turn_on" {
+		t.Errorf("Expected turn_on service call, got %s", switchCalls[0].Service)
+	}
+}
+
+func TestTVManager_LightSyncDebounce_MultipleOffRequests(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	manager := NewManager(mockHA, stateMgr, logger, false, nil)
+	// Use a short debounce for testing
+	manager.lightSyncOffDebounce = 50 * time.Millisecond
+
+	// Request multiple turn-offs
+	manager.controlSyncBoxLightSync(false)
+	manager.controlSyncBoxLightSync(false)
+	manager.controlSyncBoxLightSync(false)
+
+	// Wait for debounce to elapse
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify only one turn_off was called
+	calls := mockHA.GetServiceCalls()
+	var switchCalls []ha.ServiceCall
+	for _, call := range calls {
+		if call.Domain == "switch" {
+			switchCalls = append(switchCalls, call)
+		}
+	}
+
+	if len(switchCalls) != 1 {
+		t.Errorf("Expected exactly 1 switch service call despite multiple requests, got %d", len(switchCalls))
+		return
+	}
+
+	if switchCalls[0].Service != "turn_off" {
+		t.Errorf("Expected turn_off service call, got %s", switchCalls[0].Service)
+	}
+}
+
+func TestTVManager_LightSyncDebounce_ReadOnlyMode(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, true) // read-only state manager
+
+	manager := NewManager(mockHA, stateMgr, logger, true, nil) // read-only manager
+	manager.lightSyncOffDebounce = 10 * time.Millisecond
+
+	// Request turn-on in read-only mode
+	manager.controlSyncBoxLightSync(true)
+
+	// Request turn-off in read-only mode
+	manager.controlSyncBoxLightSync(false)
+
+	// Wait for potential debounce
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify NO service calls were made
+	calls := mockHA.GetServiceCalls()
+	var switchCalls []ha.ServiceCall
+	for _, call := range calls {
+		if call.Domain == "switch" {
+			switchCalls = append(switchCalls, call)
+		}
+	}
+
+	if len(switchCalls) != 0 {
+		t.Errorf("Expected 0 switch service calls in read-only mode, got %d", len(switchCalls))
+	}
+}
+
+func TestTVManager_LightSyncDebounce_RapidFlapping(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	manager := NewManager(mockHA, stateMgr, logger, false, nil)
+	manager.lightSyncOffDebounce = 100 * time.Millisecond
+
+	// Simulate rapid flapping: playing -> paused -> playing -> paused -> playing
+	manager.controlSyncBoxLightSync(true)  // Turn ON (immediate)
+	manager.controlSyncBoxLightSync(false) // Schedule OFF
+	time.Sleep(10 * time.Millisecond)
+	manager.controlSyncBoxLightSync(true)  // Cancel OFF, turn ON
+	manager.controlSyncBoxLightSync(false) // Schedule OFF
+	time.Sleep(10 * time.Millisecond)
+	manager.controlSyncBoxLightSync(true) // Cancel OFF, turn ON
+
+	// Wait for debounce period to ensure no late turn-off
+	time.Sleep(150 * time.Millisecond)
+
+	// Verify service calls
+	calls := mockHA.GetServiceCalls()
+	var switchCalls []ha.ServiceCall
+	for _, call := range calls {
+		if call.Domain == "switch" {
+			switchCalls = append(switchCalls, call)
+		}
+	}
+
+	// Should see 3 turn_on calls and 0 turn_off calls (all turn-offs were cancelled)
+	turnOnCount := 0
+	turnOffCount := 0
+	for _, call := range switchCalls {
+		if call.Service == "turn_on" {
+			turnOnCount++
+		} else if call.Service == "turn_off" {
+			turnOffCount++
+		}
+	}
+
+	if turnOnCount != 3 {
+		t.Errorf("Expected 3 turn_on calls during rapid flapping, got %d", turnOnCount)
+	}
+	if turnOffCount != 0 {
+		t.Errorf("Expected 0 turn_off calls during rapid flapping (all cancelled), got %d", turnOffCount)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a 60-second debounce before turning off `switch.sync_box_light_sync` to prevent flapping
- Fixes issue where Apple TV integration reports "paused" state every 1-2 minutes during active playback
- Turn ON happens immediately; Turn OFF is delayed and cancelled if playing resumes within 60 seconds

## Problem

The Apple TV integration in Home Assistant flaps between "playing" and "paused" states every 1-2 minutes while content is actively playing. Log evidence:

```
8:20:23: playing -> paused
8:19:56: paused -> playing
8:19:40: playing -> paused
8:18:40: paused -> playing
```

This caused the Go automation to rapidly toggle `switch.sync_box_light_sync` on and off, resulting in Hue Sync not staying activated.

## Test plan

- [x] Unit tests added for debounce behavior (6 new tests)
- [x] All unit tests pass with race detector
- [x] All integration tests pass
- [ ] Deploy to production
- [ ] Watch content on Apple TV and verify Hue Sync stays on during playback
- [ ] Monitor logs: `tag=home-automation json logger==tv`
- [ ] Verify "Light sync turn-off cancelled" messages appear during flapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)