### PR TITLE
fix(ci): Increase test verification timeout from 3min to ~7min

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -716,7 +716,7 @@ jobs:
           echo "Checking test status for commit $HEAD_SHA"
 
           # Retry loop - check run may not be visible immediately after workflow triggers
-          MAX_ATTEMPTS=18
+          MAX_ATTEMPTS=40
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
             STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null | head -1 || echo "")
@@ -913,7 +913,7 @@ jobs:
           echo "Checking test status for commit $HEAD_SHA"
 
           # Retry loop - check run may not be visible immediately after workflow triggers
-          MAX_ATTEMPTS=18
+          MAX_ATTEMPTS=40
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
             STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null | head -1 || echo "")
@@ -1070,7 +1070,7 @@ jobs:
           echo "Checking test status for commit $HEAD_SHA"
 
           # Retry loop - check run may not be visible immediately after workflow triggers
-          MAX_ATTEMPTS=18
+          MAX_ATTEMPTS=40
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
             STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null | head -1 || echo "")
@@ -1206,7 +1206,7 @@ jobs:
           echo "Checking test status for commit $HEAD_SHA"
 
           # Retry loop - check run may not be visible immediately after workflow triggers
-          MAX_ATTEMPTS=18
+          MAX_ATTEMPTS=40
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
             STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null | head -1 || echo "")
@@ -1356,7 +1356,7 @@ jobs:
           echo "Checking test status for commit $HEAD_SHA"
 
           # Retry loop - check run may not be visible immediately after workflow triggers
-          MAX_ATTEMPTS=18
+          MAX_ATTEMPTS=40
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
             STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null | head -1 || echo "")


### PR DESCRIPTION
## Summary

- Increased `MAX_ATTEMPTS` from 18 to 40 in the "Verify tests passed on current commit" step across all 5 review jobs
- This extends the timeout from ~3 minutes to ~6-7 minutes, accommodating PR Tests runs that can take 5+ minutes

## Problem

The `design-review`, `test-review`, `concurrency-review`, `docs-review`, and `merge-decision` jobs all have a "Verify tests passed on current commit" step that polls for the "All Required Tests" check run to complete. This step had a retry loop with `MAX_ATTEMPTS=18` and a 10-second sleep between attempts, giving a total timeout of **3 minutes**.

However, the PR Tests workflow can take **5+ minutes** to complete. As a result, the review jobs were timing out waiting for the test check to appear, causing them to skip their actual work.

## Files Changed

- `.github/workflows/claude-code-review.yml` (lines 719, 916, 1073, 1209, 1359)

Fixes #539

## Test plan

- [ ] Verify YAML syntax is valid
- [ ] Verify all 5 occurrences of MAX_ATTEMPTS were updated
- [ ] PR Tests should complete and Claude Code Review should wait successfully for the check to appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)