### PR TITLE
fix(workflow): select most recent check run when multiple exist

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -719,7 +719,7 @@ jobs:
           MAX_ATTEMPTS=40
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null | head -1 || echo "")
+            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '[.check_runs[] | select(.name == "All Required Tests")] | sort_by(.completed_at) | last | .conclusion' 2>/dev/null || echo "")
 
             if [ "$STATUS" = "success" ]; then
               echo "✅ All Required Tests passed on current commit"
@@ -916,7 +916,7 @@ jobs:
           MAX_ATTEMPTS=40
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null | head -1 || echo "")
+            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '[.check_runs[] | select(.name == "All Required Tests")] | sort_by(.completed_at) | last | .conclusion' 2>/dev/null || echo "")
 
             if [ "$STATUS" = "success" ]; then
               echo "✅ All Required Tests passed on current commit"
@@ -1073,7 +1073,7 @@ jobs:
           MAX_ATTEMPTS=40
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null | head -1 || echo "")
+            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '[.check_runs[] | select(.name == "All Required Tests")] | sort_by(.completed_at) | last | .conclusion' 2>/dev/null || echo "")
 
             if [ "$STATUS" = "success" ]; then
               echo "✅ All Required Tests passed on current commit"
@@ -1209,7 +1209,7 @@ jobs:
           MAX_ATTEMPTS=40
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null | head -1 || echo "")
+            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '[.check_runs[] | select(.name == "All Required Tests")] | sort_by(.completed_at) | last | .conclusion' 2>/dev/null || echo "")
 
             if [ "$STATUS" = "success" ]; then
               echo "✅ All Required Tests passed on current commit"
@@ -1359,7 +1359,7 @@ jobs:
           MAX_ATTEMPTS=40
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "All Required Tests") | .conclusion' 2>/dev/null | head -1 || echo "")
+            STATUS=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '[.check_runs[] | select(.name == "All Required Tests")] | sort_by(.completed_at) | last | .conclusion' 2>/dev/null || echo "")
 
             if [ "$STATUS" = "success" ]; then
               echo "✅ All Required Tests passed on current commit"


### PR DESCRIPTION
## Summary
- Fixes a bug where the workflow used `| head -1` to select check runs, which incorrectly picked the first (potentially older/failed) run instead of the most recent one
- When multiple check runs exist for "All Required Tests" on the same commit (e.g., after a retry or manual re-run), the workflow now correctly uses jq to sort by `completed_at` and select the last (most recent) entry

## Test plan
- [ ] Verify the jq query works correctly when there's only one check run
- [ ] Verify the jq query correctly selects the most recent check run when multiple exist
- [ ] CI tests pass

Resolves #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)