### PR TITLE
fix(dayphase): Use scheduled winddown time for dusk→winddown transition

### DIFF
--- a/docs/flows/DAY_PHASE_MODES.md
+++ b/docs/flows/DAY_PHASE_MODES.md
@@ -66,8 +66,8 @@ flowchart LR
     morning["morning<br/>(dawn-noon)"]
     day["day<br/>(noon-goldenHour)"]
     sunset["sunset<br/>(goldenHour-schedule.dusk)"]
-    dusk["dusk<br/>(schedule.dusk-schedule.night)"]
-    winddown["winddown<br/>(astronomical night<br/>before schedule.night)"]
+    dusk["dusk<br/>(schedule.dusk-schedule.winddown)"]
+    winddown["winddown<br/>(schedule.winddown-schedule.night)"]
 
     night --> morning
     morning --> day
@@ -249,13 +249,19 @@ The schedule config (`configs/schedule_config.yaml`) defines when phase transiti
 
 | Field | Purpose | Weekday Default | Weekend Default |
 |-------|---------|-----------------|-----------------|
-| `dusk` | Override sunset→dusk transition | 20:00 | 20:00 |
-| `winddown` | Time when winddown begins | 22:15 | 22:00 |
+| `dusk` | Override sunset→dusk transition | 19:30 | 19:30 |
+| `winddown` | Override dusk→winddown transition | 22:15 | 22:00 |
 | `night` | Force night phase | 23:00 | 23:59 |
 | `stop_screens` | Reminder to stop screen time | 22:30 | 22:30 |
-| `go_to_bed` | Start sleep music (rain sounds) | 23:00 | 23:00 |
+| `go_to_bed` | Start sleep music (rain sounds) | 23:30 | 23:59 |
 | `begin_backup_wake` | **BACKUP** start wake sequence (if Eight Sleep unavailable) | 08:50 | 09:50 |
 | `backup_wake_time` | **BACKUP** target wake time (if Eight Sleep unavailable) | 09:15 | 10:15 |
+
+**Phase Transition Logic:**
+- Before `dusk` time: Stay at sunset phase (even if astronomical dusk/night has occurred)
+- After `dusk`, before `winddown`: Stay at dusk phase (even if astronomical night has occurred)
+- After `winddown`, before `night`: Transition to winddown phase
+- After `night`: Force night phase
 
 > **Wake-up behavior**: The primary wake trigger is the Eight Sleep Pod alarm. The `begin_backup_wake` and `backup_wake_time` values are **fallback only** and activate only when the Eight Sleep integration is unavailable (sensor shows `"unavailable"`). This ensures reliable wake-up even during Internet outages.
 

--- a/homeautomation-go/internal/dayphase/calculator.go
+++ b/homeautomation-go/internal/dayphase/calculator.go
@@ -280,7 +280,25 @@ func (c *Calculator) CalculateDayPhase(schedule *config.ParsedSchedule) DayPhase
 			}
 		}
 
-		// After scheduled dusk, before scheduled night
+		// After scheduled dusk, before scheduled winddown: stay at dusk phase
+		// This ensures dusk phase isn't skipped when astronomical night occurs before scheduled winddown
+		if now.Before(schedule.Winddown) {
+			switch sunEvent {
+			case SunEventMorning:
+				return DayPhaseMorning
+			case SunEventDay:
+				return DayPhaseDay
+			case SunEventSunset:
+				return DayPhaseSunset
+			case SunEventDusk, SunEventNight:
+				// Even if astronomical night has occurred, stay at dusk until scheduled winddown
+				return DayPhaseDusk
+			default:
+				return DayPhaseDay
+			}
+		}
+
+		// After scheduled winddown, before scheduled night: winddown phase
 		if now.Before(schedule.Night) {
 			switch sunEvent {
 			case SunEventMorning:
@@ -289,10 +307,8 @@ func (c *Calculator) CalculateDayPhase(schedule *config.ParsedSchedule) DayPhase
 				return DayPhaseDay
 			case SunEventSunset:
 				return DayPhaseSunset
-			case SunEventDusk:
-				return DayPhaseDusk
-			case SunEventNight:
-				// Astronomical night but before scheduled night time
+			case SunEventDusk, SunEventNight:
+				// After scheduled winddown time, transition to winddown phase
 				return DayPhaseWinddown
 			default:
 				return DayPhaseDay

--- a/homeautomation-go/internal/dayphase/calculator_test.go
+++ b/homeautomation-go/internal/dayphase/calculator_test.go
@@ -580,10 +580,11 @@ func TestCalculator_CalculateDayPhaseAllCases(t *testing.T) {
 			expected: DayPhaseNight,
 		},
 		{
-			name:     "winddown with schedule - before schedule.Night",
-			testTime: eveningTime,
+			name:     "dusk phase - astronomical night but before scheduled winddown",
+			testTime: eveningTime, // 7pm
 			setupSunTimes: func(c *Calculator, now time.Time) {
-				// Set sun times so current time falls in night period
+				// Set sun times so current time is in astronomical night (sun event = night)
+				// This happens in winter when astronomical night occurs before the scheduled winddown time
 				setSunTimesForTest(c, now,
 					now.Add(8*time.Hour),                 // dawn
 					now.Add(9*time.Hour),                 // sunrise
@@ -594,16 +595,46 @@ func TestCalculator_CalculateDayPhaseAllCases(t *testing.T) {
 					now.Add(19*time.Hour),                // sunset
 					now.Add(19*time.Hour+30*time.Minute), // dusk
 					now.Add(20*time.Hour),                // nauticalDusk
-					now.Add(-1*time.Hour),                // night (past - we're in night sun event)
+					now.Add(-1*time.Hour),                // night (past - sun event is night)
+				)
+			},
+			schedule: &config.ParsedSchedule{
+				BeginBackupWake: time.Date(2024, 1, 15, 5, 0, 0, 0, time.UTC),
+				BackupWakeTime:  time.Date(2024, 1, 15, 7, 0, 0, 0, time.UTC),
+				Dusk:            time.Date(2024, 1, 15, 17, 0, 0, 0, time.UTC),  // Before 7pm - we're after this
+				Winddown:        time.Date(2024, 1, 15, 22, 15, 0, 0, time.UTC), // 10:15pm - we're before this
+				Night:           time.Date(2024, 1, 15, 23, 0, 0, 0, time.UTC),  // 11pm
+			},
+			// At 7pm, after schedule.Dusk but BEFORE schedule.Winddown -> stay at dusk
+			// This fixes the bug where astronomical night caused immediate jump to winddown
+			expected: DayPhaseDusk,
+		},
+		{
+			name:     "winddown phase - after scheduled winddown time",
+			testTime: eveningTime, // 7pm - we'll use a later winddown time to test the logic
+			setupSunTimes: func(c *Calculator, now time.Time) {
+				// Set sun times so current time is in astronomical night
+				setSunTimesForTest(c, now,
+					now.Add(8*time.Hour),                 // dawn
+					now.Add(9*time.Hour),                 // sunrise
+					now.Add(9*time.Hour+30*time.Minute),  // sunriseEnd
+					now.Add(10*time.Hour),                // goldenHourEnd
+					now.Add(18*time.Hour),                // goldenHour
+					now.Add(18*time.Hour+30*time.Minute), // sunsetStart
+					now.Add(19*time.Hour),                // sunset
+					now.Add(19*time.Hour+30*time.Minute), // dusk
+					now.Add(20*time.Hour),                // nauticalDusk
+					now.Add(-1*time.Hour),                // night (past - sun event is night)
 				)
 			},
 			schedule: &config.ParsedSchedule{
 				BeginBackupWake: time.Date(2024, 1, 15, 5, 0, 0, 0, time.UTC),
 				BackupWakeTime:  time.Date(2024, 1, 15, 7, 0, 0, 0, time.UTC),
 				Dusk:            time.Date(2024, 1, 15, 17, 0, 0, 0, time.UTC), // Before 7pm
-				Night:           time.Date(2024, 1, 15, 21, 0, 0, 0, time.UTC), // After 7pm - schedule night in future
+				Winddown:        time.Date(2024, 1, 15, 18, 0, 0, 0, time.UTC), // 6pm - we're AFTER this
+				Night:           time.Date(2024, 1, 15, 21, 0, 0, 0, time.UTC), // 9pm - we're before this
 			},
-			// At 7pm (evening), after schedule.Dusk but before schedule.Night, sun says night -> winddown
+			// At 7pm, after schedule.Winddown (6pm), before schedule.Night (9pm) -> winddown
 			expected: DayPhaseWinddown,
 		},
 		{


### PR DESCRIPTION
## Summary

- Fixes dusk phase being skipped in winter when astronomical night occurs before scheduled winddown time
- Now uses `schedule.Winddown` config value (e.g., 22:15) to gate the dusk→winddown transition
- Ensures all day phases (sunset → dusk → winddown → night) occur in sequence based on schedule

## Problem

In winter months, astronomical night (sun 18° below horizon) can occur as early as 6:00-6:30pm. With `schedule.Dusk` set to 19:30, the day phase would jump directly from "sunset" to "winddown", skipping "dusk" entirely.

This happened because the old logic used astronomical night to trigger winddown, but the `schedule.Winddown` config value (22:15) was never being used.

## Solution

Added `schedule.Winddown` as a gate for the dusk→winddown transition:
- After `schedule.Dusk`, before `schedule.Winddown`: stay at dusk phase
- After `schedule.Winddown`, before `schedule.Night`: transition to winddown

## Test plan

- [x] Unit tests updated with new test cases for the winddown transition behavior
- [x] All existing unit tests pass
- [x] Integration tests pass
- [x] Documentation updated in `docs/flows/DAY_PHASE_MODES.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)