### PR TITLE
Fix #566: Add TDD guidance for cross-plugin features

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -241,6 +241,14 @@ jobs:
             - Follow shadow state pattern (docs/reference/SHADOW_STATE.md)
             - Never use \`git push --no-verify\`
 
+            TDD FOR CROSS-PLUGIN FEATURES:
+            - If implementing a feature that spans multiple plugins, write the user story test FIRST
+            - User story tests go in test/integration/scenario_*_test.go
+            - Tests should verify behavior from the user's perspective using GIVEN/WHEN/THEN
+            - Document invariants: rules that should ALWAYS hold (e.g., 'isWakeSequenceActive=true blocks sleep music')
+            - Test the full timeline, not just end states (T+0, T+2min, T+5min)
+            - Reference: scenario_sleephygiene_test.go for TDD-style cross-plugin tests
+
             You are on branch ${PR_HEAD_REF}. Make the changes, commit, and push them."
             else
               PROMPT="You are responding to a request in ${REPO} issue #${ISSUE_NUMBER}.
@@ -253,6 +261,14 @@ jobs:
             - Use \`make pre-commit\` for linting/formatting
             - Follow shadow state pattern (docs/reference/SHADOW_STATE.md)
             - Never use \`git push --no-verify\`
+
+            TDD FOR CROSS-PLUGIN FEATURES:
+            - If implementing a feature that spans multiple plugins, write the user story test FIRST
+            - User story tests go in test/integration/scenario_*_test.go
+            - Tests should verify behavior from the user's perspective using GIVEN/WHEN/THEN
+            - Document invariants: rules that should ALWAYS hold (e.g., 'isWakeSequenceActive=true blocks sleep music')
+            - Test the full timeline, not just end states (T+0, T+2min, T+5min)
+            - Reference: scenario_sleephygiene_test.go for TDD-style cross-plugin tests
 
             Complete the user's request. If you make changes, create a branch, commit them, and open a PR.
             Reply to the user using: gh issue comment ${ISSUE_NUMBER} --body 'YOUR_RESPONSE'"
@@ -379,6 +395,14 @@ jobs:
             - Use \`make pre-commit\` for linting/formatting
             - Follow shadow state pattern (docs/reference/SHADOW_STATE.md)
             - Never use \`git push --no-verify\`
+
+            TDD FOR CROSS-PLUGIN FEATURES:
+            - If implementing a feature that spans multiple plugins, write the user story test FIRST
+            - User story tests go in test/integration/scenario_*_test.go
+            - Tests should verify behavior from the user's perspective using GIVEN/WHEN/THEN
+            - Document invariants: rules that should ALWAYS hold (e.g., 'isWakeSequenceActive=true blocks sleep music')
+            - Test the full timeline, not just end states (T+0, T+2min, T+5min)
+            - Reference: scenario_sleephygiene_test.go for TDD-style cross-plugin tests
 
             BRANCH NAMING: Use \`claude/issue-${ISSUE_NUMBER}\` as the branch name.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,53 @@ func (m *Manager) handleSomeChange(entityID string, oldState, newState *ha.State
 
 **Concurrency:** Protect shared state with mutexes, use `sync.RWMutex` for read-heavy ops, **serialize WebSocket writes with `writeMu`**.
 
+### TDD for Cross-Plugin Features
+
+**When implementing features that span multiple plugins, write user story tests FIRST.**
+
+Cross-plugin bugs often slip through unit tests because unit tests set up state atomically and don't test timing windows between state changes. User story tests validate behavior from the user's perspective.
+
+**When to write user story tests:**
+- Features involving 2+ plugins (e.g., sleephygiene + music, lighting + presence)
+- Features with timing dependencies (e.g., "when alarm triggers, music fades out over 5 minutes")
+- Features with invariants that must ALWAYS hold (e.g., "sleep music never restarts during wake sequence")
+
+**TDD workflow for cross-plugin features:**
+
+```
+1. Write the user story: "When my alarm goes off, I want gentle wake-up music"
+2. Identify invariants: "sleep music must NOT restart while isWakeSequenceActive=true"
+3. Write a test in test/integration/scenario_*_test.go that will FAIL (it will)
+4. Implement the feature across plugins
+5. Test passes when user expectation is met
+```
+
+**Test structure (GIVEN/WHEN/THEN):**
+
+```go
+func TestScenario_UserStory_WakeSequenceDoesNotRestartSleepMusic(t *testing.T) {
+    // GIVEN: Master is asleep, playing sleep music, alarm time reached
+    t.Log("GIVEN: Someone is asleep with sleep music playing")
+    server.SetState("input_boolean.master_asleep", "on", nil)
+    server.SetState("input_text.music_playback_type", "sleep", nil)
+
+    // WHEN: Wake sequence begins
+    t.Log("WHEN: Wake sequence starts (isWakeSequenceActive=true)")
+    server.SetState("input_boolean.wake_sequence_active", "on", nil)
+
+    // THEN: Music plugin must NOT restart sleep music
+    t.Log("THEN: Sleep music is NOT restarted")
+    // ... assertions validating the invariant holds
+}
+```
+
+**Key patterns for user story tests:**
+- **Timeline testing**: Simulate T+0, T+2min, T+5min states to catch timing bugs
+- **Invariant assertions**: Document rules that should ALWAYS hold in comments
+- **Intermediate state testing**: Don't just test end states—test what happens during transitions
+
+**Reference:** See `test/integration/scenario_sleephygiene_test.go` for examples of TDD-style cross-plugin tests with GIVEN/WHEN/THEN structure.
+
 ### API Change Protocol
 
 When modifying function signatures:


### PR DESCRIPTION
Resolves #566

## Summary

This PR adds TDD (Test-Driven Development) guidance to help future Claude runs and developers naturally think in test-first terms when implementing features that span multiple plugins.

### Changes made:

1. **AGENTS.md - New "TDD for Cross-Plugin Features" section**
   - Explains when to write user story tests (2+ plugins, timing dependencies, invariants)
   - Documents the TDD workflow: Write story → Identify invariants → Write failing test → Implement → Pass
   - Provides example test structure using GIVEN/WHEN/THEN format
   - Lists key patterns: timeline testing, invariant assertions, intermediate state testing
   - References `scenario_sleephygiene_test.go` as the canonical example

2. **GHA Claude prompts (.github/workflows/claude.yml)**
   - Added TDD guidance to all three prompt locations:
     - PR comment handler
     - Issue comment handler (non-PR)
     - New issue resolver
   - Prompts now include:
     - Instruction to write user story test FIRST for cross-plugin features
     - Reference to test location (`test/integration/scenario_*_test.go`)
     - Emphasis on GIVEN/WHEN/THEN structure
     - Guidance on documenting invariants
     - Reminder to test the full timeline, not just end states

## Test Plan

- [x] `make pre-commit` passes
- [x] `make pre-push` passes (unit tests + integration tests)
- [ ] Review that guidance is clear and actionable
- [ ] Verify GHA prompts are correctly formatted in YAML

## Context

This addresses the learning from PR #564 where a timing bug (isWakeSequenceActive set at T+5min instead of T+0) wasn't caught because:
1. Unit tests set up state atomically
2. Multi-plugin tests didn't include the affected plugins together
3. No tests captured the user story invariants

The new guidance encourages test-first thinking that would catch such bugs.

🤖 Generated with Claude Code