### PR TITLE
fix(sleephygiene): Clear stale isWakeSequenceActive on startup

### DIFF
--- a/homeautomation-go/internal/plugins/sleephygiene/manager.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager.go
@@ -155,6 +155,20 @@ func (m *Manager) Start() error {
 	}
 	m.subscriptions = append(m.subscriptions, masterAsleepSub)
 
+	// Clear any stale isWakeSequenceActive from previous run/crash.
+	// Wake sequences can't persist across app restarts - if we're starting fresh,
+	// no wake sequence is in progress. This prevents the bug where stale state
+	// blocks the music plugin from being notified on the next begin_wake.
+	if !m.readOnly {
+		isWakeActive, _ := m.stateManager.GetBool("isWakeSequenceActive")
+		if isWakeActive {
+			m.logger.Info("Clearing stale isWakeSequenceActive from previous run")
+			if err := m.stateManager.SetBool("isWakeSequenceActive", false); err != nil {
+				m.logger.Error("Failed to clear stale isWakeSequenceActive", zap.Error(err))
+			}
+		}
+	}
+
 	// Start ticker to check time triggers every minute
 	m.ticker = time.NewTicker(1 * time.Minute)
 	go m.runTimerLoop()

--- a/homeautomation-go/internal/state/manager_test.go
+++ b/homeautomation-go/internal/state/manager_test.go
@@ -442,6 +442,57 @@ func TestManager_Subscribe(t *testing.T) {
 	})
 }
 
+// TestSetBool_SameValue_DoesNotNotify verifies that SetBool does NOT notify subscribers
+// when setting a variable to its current value. This is intentional behavior to avoid
+// unnecessary Home Assistant updates and subscriber notifications.
+//
+// IMPORTANT: This means plugins relying on edge-triggered behavior must ensure
+// state is properly cleaned up. For example, sleephygiene clears isWakeSequenceActive
+// on startup to prevent stale state from blocking notifications.
+//
+// See: scenario_sleephygiene_test.go TestScenario_StaleWakeSequenceActive_ClearedOnStartup
+func TestSetBool_SameValue_DoesNotNotify(t *testing.T) {
+	t.Parallel()
+	logger := testlogger.New()
+	mockClient := ha.NewMockClient()
+
+	// Set up HA state for isWakeSequenceActive
+	mockClient.SetState("input_boolean.wake_sequence_active", "on", map[string]interface{}{})
+	mockClient.Connect()
+
+	manager := NewManager(mockClient, logger, false)
+	manager.SyncFromHA()
+
+	// Verify initial state is true
+	initialValue, err := manager.GetBool("isWakeSequenceActive")
+	require.NoError(t, err)
+	require.True(t, initialValue, "Initial state should be true")
+
+	// Subscribe to changes
+	var notificationCount int32
+
+	sub, err := manager.Subscribe("isWakeSequenceActive", func(key string, oldValue, newValue interface{}) {
+		atomic.AddInt32(&notificationCount, 1)
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	// Set same value - should NOT notify
+	err = manager.SetBool("isWakeSequenceActive", true)
+	require.NoError(t, err)
+
+	// Verify no notification was sent (this is the expected behavior)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&notificationCount),
+		"SetBool should NOT notify subscribers when value hasn't changed")
+
+	// Now verify that changing the value DOES notify
+	err = manager.SetBool("isWakeSequenceActive", false)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&notificationCount),
+		"SetBool should notify subscribers when value changes")
+}
+
 func TestManagerNotifySubscribersIsSynchronous(t *testing.T) {
 	t.Parallel()
 	manager := &Manager{

--- a/homeautomation-go/test/integration/scenario_sleephygiene_test.go
+++ b/homeautomation-go/test/integration/scenario_sleephygiene_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1056,5 +1057,108 @@ func TestScenario_WakeSequence_ActivatesWakeMusic(t *testing.T) {
 	t.Log("  - Lights began fading in (25-minute transition)")
 	t.Log("  - After light fade-in, musicPlaybackType set to 'wakeup'")
 	t.Log("  - Music plugin will receive state change and play wake music")
+	t.Log("========================================")
+}
+
+// ============================================================================
+// Stale isWakeSequenceActive cleanup on startup
+// ============================================================================
+
+// TestScenario_StaleWakeSequenceActive_ClearedOnStartup verifies that the sleephygiene
+// plugin clears stale isWakeSequenceActive on startup, preventing the bug where
+// morning music doesn't start because SetBool short-circuits on same value.
+//
+// USER STORY:
+// As a user, when my Eight Sleep alarm fires, I expect morning music to start
+// playing in the rest of the house even if the system had a stale isWakeSequenceActive=true
+// from a previous interrupted wake sequence.
+//
+// FIX:
+// The sleephygiene plugin clears isWakeSequenceActive to false on startup.
+// This ensures that when begin_wake fires and sets it to true, it's a change
+// from false→true, which properly notifies subscribers (like the music plugin).
+//
+// SCENARIO:
+//  1. Previous wake sequence left isWakeSequenceActive=true (e.g., app crashed mid-wake)
+//  2. App restarts, sleephygiene.Start() clears stale isWakeSequenceActive to false
+//  3. Eight Sleep alarm fires, begin_wake calls SetBool("isWakeSequenceActive", true)
+//  4. SetBool sees value changed (false→true), notifies subscribers
+//  5. Music plugin learns wake started
+//  6. Morning music plays in rest of house
+func TestScenario_StaleWakeSequenceActive_ClearedOnStartup(t *testing.T) {
+	// Use a fixed time during morning phase
+	fixedTime := time.Date(2025, 1, 15, 8, 0, 0, 0, time.UTC)
+
+	server, client, stateManager, baseCleanup := setupTest(t)
+	defer baseCleanup()
+
+	t.Log("========== TEST: Stale isWakeSequenceActive cleared on startup ==========")
+
+	// GIVEN: isWakeSequenceActive is stale true from previous run
+	t.Log("GIVEN: isWakeSequenceActive is stale true from previous run/crash")
+	server.SetState("input_boolean.wake_sequence_active", "on", map[string]interface{}{})
+	server.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
+	server.SetState("input_boolean.master_asleep", "on", map[string]interface{}{})
+	server.SetState("input_text.day_phase", "morning", map[string]interface{}{})
+
+	// Sync state from HA (this loads the stale isWakeSequenceActive=true)
+	err := stateManager.SyncFromHA()
+	require.NoError(t, err)
+
+	// Verify stale state is loaded before plugin starts
+	isWakeActive, err := stateManager.GetBool("isWakeSequenceActive")
+	require.NoError(t, err)
+	require.True(t, isWakeActive, "Stale isWakeSequenceActive should be true before plugin starts")
+
+	// WHEN: Sleephygiene plugin starts
+	t.Log("WHEN: Sleephygiene plugin starts")
+
+	logger := testlogger.New()
+	configLoader := config.NewLoader("../../configs", logger)
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
+
+	sleepMgr := sleephygiene.NewManager(context.Background(), client, stateManager, configLoader, logger, false, timeProvider, nil)
+	err = sleepMgr.Start()
+	require.NoError(t, err)
+	defer sleepMgr.Stop()
+
+	// Give startup cleanup time to run
+	time.Sleep(50 * time.Millisecond)
+
+	// THEN: isWakeSequenceActive should be cleared to false
+	t.Log("THEN: Verify stale isWakeSequenceActive was cleared")
+
+	isWakeActive, err = stateManager.GetBool("isWakeSequenceActive")
+	require.NoError(t, err)
+
+	assert.False(t, isWakeActive,
+		"Sleephygiene should clear stale isWakeSequenceActive on startup")
+
+	// Now verify that subsequent begin_wake will properly notify subscribers
+	t.Log("AND: Verify subsequent begin_wake properly notifies subscribers")
+
+	var notificationCount int32
+	sub, err := stateManager.Subscribe("isWakeSequenceActive", func(key string, oldValue, newValue interface{}) {
+		atomic.AddInt32(&notificationCount, 1)
+		t.Logf("NOTIFICATION: isWakeSequenceActive changed from %v to %v", oldValue, newValue)
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	// Simulate begin_wake setting isWakeSequenceActive to true
+	err = stateManager.SetBool("isWakeSequenceActive", true)
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&notificationCount),
+		"Subscriber should be notified when isWakeSequenceActive changes from false to true")
+
+	t.Log("========================================")
+	t.Log("SUCCESS:")
+	t.Log("  - Stale isWakeSequenceActive was cleared on startup")
+	t.Log("  - Subsequent begin_wake properly notified subscribers")
+	t.Log("  - Music plugin will learn wake started")
+	t.Log("  - Morning music will play in rest of house")
 	t.Log("========================================")
 }


### PR DESCRIPTION
## Summary

- Clears stale `isWakeSequenceActive` state on sleephygiene plugin startup
- Prevents bug where `SetBool("isWakeSequenceActive", true)` short-circuits without notifying subscribers when value is already `true` from a previous run/crash
- Adds unit test documenting `SetBool` same-value behavior
- Adds integration test verifying startup cleanup works end-to-end

## Problem

When the app restarts while `isWakeSequenceActive=true` (e.g., after a crash during wake sequence), the stale value persists in Home Assistant. On the next wake sequence:

1. `begin_wake` calls `SetBool("isWakeSequenceActive", true)`
2. State manager sees value is already `true`, returns early without notifying subscribers
3. Music plugin never receives notification that wake started
4. Wake music never plays, morning music never starts in rest of house

## Root Cause

`state/manager.go` lines 337-342 intentionally short-circuit when setting the same value:
```go
if oldBool, isBool := oldValue.(bool); isBool && oldBool == value {
    m.cacheMu.Unlock()
    return nil  // No notification to subscribers
}
```

This is correct behavior for edge-triggered state - we don't want spurious notifications. The bug is that wake sequences can't persist across app restarts, so we need to clear stale state.

## Solution

Clear `isWakeSequenceActive` to `false` on sleephygiene startup when it's found to be `true`. Wake sequences by definition cannot survive app restarts, so any `true` value at startup is stale.

## Test plan

- [x] Unit test: `TestSetBool_SameValue_DoesNotNotify` documents expected behavior
- [x] Integration test: `TestScenario_StaleWakeSequenceActive_ClearedOnStartup` verifies fix
- [x] All existing tests pass
- [ ] Manual: Restart app while `isWakeSequenceActive=true`, verify it gets cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)