### PR TITLE
fix(music): Only set global FadeState to idle when all fade-ins complete

### DIFF
--- a/homeautomation-go/internal/plugins/music/shadow.go
+++ b/homeautomation-go/internal/plugins/music/shadow.go
@@ -271,6 +271,7 @@ func (m *Manager) updateFadeInProgress(entityID string, currentVolume int) {
 }
 
 // recordFadeInHumanOverride records that a human override was detected during fade-in
+// Only sets global FadeState to "idle" when ALL fade-ins are inactive
 func (m *Manager) recordFadeInHumanOverride(entityID string, expectedVolume, actualVolume int) {
 	m.shadowMu.Lock()
 	defer m.shadowMu.Unlock()
@@ -283,11 +284,24 @@ func (m *Manager) recordFadeInHumanOverride(entityID string, expectedVolume, act
 		fadeIn.LastUpdate = m.timeProvider.Now()
 		m.shadowState.Outputs.FadeInProgress[entityID] = fadeIn
 	}
-	m.shadowState.Outputs.FadeState = "idle"
+
+	// Only set global state to idle if NO fade-ins are still active
+	anyActive := false
+	for _, fadeIn := range m.shadowState.Outputs.FadeInProgress {
+		if fadeIn.IsActive {
+			anyActive = true
+			break
+		}
+	}
+	if !anyActive {
+		m.shadowState.Outputs.FadeState = "idle"
+	}
+
 	m.shadowState.Metadata.LastUpdated = m.timeProvider.Now()
 }
 
-// clearFadeInProgress marks fade-in as complete (idle)
+// clearFadeInProgress marks a speaker's fade-in as complete
+// Only sets global FadeState to "idle" when ALL fade-ins are inactive
 func (m *Manager) clearFadeInProgress(entityID string) {
 	m.shadowMu.Lock()
 	defer m.shadowMu.Unlock()
@@ -297,7 +311,19 @@ func (m *Manager) clearFadeInProgress(entityID string) {
 		fadeIn.LastUpdate = m.timeProvider.Now()
 		m.shadowState.Outputs.FadeInProgress[entityID] = fadeIn
 	}
-	m.shadowState.Outputs.FadeState = "idle"
+
+	// Only set global state to idle if NO fade-ins are still active
+	anyActive := false
+	for _, fadeIn := range m.shadowState.Outputs.FadeInProgress {
+		if fadeIn.IsActive {
+			anyActive = true
+			break
+		}
+	}
+	if !anyActive {
+		m.shadowState.Outputs.FadeState = "idle"
+	}
+
 	m.shadowState.Metadata.LastUpdated = m.timeProvider.Now()
 }
 


### PR DESCRIPTION
## Summary
- Fixes bug where dashboard incorrectly showed fade-ins as "not in progress" while speakers were still actively fading in
- When multiple speakers fade in concurrently (async speaker joins), the first speaker to complete would prematurely set global `FadeState` to "idle"
- Both `clearFadeInProgress()` and `recordFadeInHumanOverride()` now check if any fade-ins are still active before setting global state to idle

## Root Cause
The `clearFadeInProgress()` and `recordFadeInHumanOverride()` functions unconditionally set `FadeState = "idle"` whenever a single speaker's fade-in ended. With concurrent fade-ins from async speaker joins, this caused incorrect state reporting.

## Test plan
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Coverage maintained at 74.8%

🤖 Generated with [Claude Code](https://claude.com/claude-code)