### PR TITLE
Fix #578: Use user-assigned device name in Z-Wave notifications

### DIFF
--- a/homeautomation-go/internal/plugins/sensorhealth/manager.go
+++ b/homeautomation-go/internal/plugins/sensorhealth/manager.go
@@ -490,7 +490,12 @@ func (m *Manager) discoverNodeStatusSensors() error {
 
 	deviceNameMap := make(map[string]string)
 	for _, device := range devices {
-		deviceNameMap[device.ID] = device.Name
+		// Prefer user-assigned name over default device name (e.g., Z-Wave product name)
+		if device.NameByUser != "" {
+			deviceNameMap[device.ID] = device.NameByUser
+		} else {
+			deviceNameMap[device.ID] = device.Name
+		}
 	}
 
 	labelChecker := ha.NewDeviceLabelChecker(devices)

--- a/homeautomation-go/internal/plugins/sensorhealth/manager_test.go
+++ b/homeautomation-go/internal/plugins/sensorhealth/manager_test.go
@@ -1268,3 +1268,129 @@ func TestSensorHealthManager_NotifyAlreadyDeadDevices_SkipsAlreadyNotified(t *te
 		t.Errorf("Expected 1 startup notification (skipping already-notified), got %d", len(calls))
 	}
 }
+
+func TestSensorHealthManager_NodeStatus_UsesNameByUserOverDefaultName(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+
+	// Add device with both Name (product name) and NameByUser (user-assigned name)
+	// This simulates a Z-Wave device like "Wave Plug US" renamed to "Humidifier Power Control"
+	mockHA.AddDevice(&ha.Device{
+		ID:         "device_zwave_renamed",
+		Name:       "Wave Plug US",             // Default Z-Wave product name
+		NameByUser: "Humidifier Power Control", // User-assigned name in HA
+		Labels:     []string{},
+	})
+	mockHA.AddEntityRegistryEntry(&ha.EntityRegistryEntry{
+		EntityID: "sensor.humidifier_power_control_node_status",
+		DeviceID: "device_zwave_renamed",
+	})
+	mockHA.SetState("sensor.humidifier_power_control_node_status", "alive", map[string]interface{}{
+		"friendly_name": "Humidifier Power Control Node Status",
+	})
+
+	// Add a device with only Name (no user customization)
+	mockHA.AddDevice(&ha.Device{
+		ID:         "device_zwave_default",
+		Name:       "Z-Wave Thermostat",
+		NameByUser: "", // No user-assigned name
+		Labels:     []string{},
+	})
+	mockHA.AddEntityRegistryEntry(&ha.EntityRegistryEntry{
+		EntityID: "sensor.thermostat_node_status",
+		DeviceID: "device_zwave_default",
+	})
+	mockHA.SetState("sensor.thermostat_node_status", "alive", map[string]interface{}{
+		"friendly_name": "Z-Wave Thermostat Node Status",
+	})
+
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	manager := NewManager(mockHA, stateMgr, logger, false, nil, mockNtfy)
+
+	err := manager.Start()
+	if err != nil {
+		t.Fatalf("Failed to start manager: %v", err)
+	}
+	defer manager.Stop()
+
+	// Verify node status sensors were discovered
+	nodeStatuses := manager.GetNodeStatuses()
+	if len(nodeStatuses) != 2 {
+		t.Errorf("Expected 2 node status sensors, got %d", len(nodeStatuses))
+	}
+
+	// Verify that the renamed device uses NameByUser
+	renamedNode := nodeStatuses["sensor.humidifier_power_control_node_status"]
+	if renamedNode == nil {
+		t.Fatal("Expected to find humidifier power control node status")
+	}
+	if renamedNode.DeviceName != "Humidifier Power Control" {
+		t.Errorf("Expected device name 'Humidifier Power Control' (NameByUser), got '%s'", renamedNode.DeviceName)
+	}
+
+	// Verify that the non-renamed device uses Name
+	defaultNode := nodeStatuses["sensor.thermostat_node_status"]
+	if defaultNode == nil {
+		t.Fatal("Expected to find thermostat node status")
+	}
+	if defaultNode.DeviceName != "Z-Wave Thermostat" {
+		t.Errorf("Expected device name 'Z-Wave Thermostat' (Name fallback), got '%s'", defaultNode.DeviceName)
+	}
+}
+
+func TestSensorHealthManager_NodeStatus_DeadDeviceNotification_UsesUserFriendlyName(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+
+	// Add device with both Name (product name) and NameByUser (user-assigned name)
+	mockHA.AddDevice(&ha.Device{
+		ID:         "device_zwave_renamed",
+		Name:       "Wave Plug US",
+		NameByUser: "Humidifier Power Control",
+		Labels:     []string{},
+	})
+	mockHA.AddEntityRegistryEntry(&ha.EntityRegistryEntry{
+		EntityID: "sensor.humidifier_power_control_node_status",
+		DeviceID: "device_zwave_renamed",
+	})
+	mockHA.SetState("sensor.humidifier_power_control_node_status", "alive", map[string]interface{}{
+		"friendly_name": "Humidifier Power Control Node Status",
+	})
+
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := NewManagerWithClock(mockHA, stateMgr, logger, false, nil, mockNtfy, mockClock)
+
+	err := manager.Start()
+	if err != nil {
+		t.Fatalf("Failed to start manager: %v", err)
+	}
+	defer manager.Stop()
+
+	// Simulate the device becoming dead
+	manager.SimulateNodeStatusChange("sensor.humidifier_power_control_node_status", "dead")
+
+	// Verify notification was sent with user-friendly name
+	calls := mockNtfy.GetCalls()
+	if len(calls) != 1 {
+		t.Fatalf("Expected 1 notification, got %d", len(calls))
+	}
+
+	notification := calls[0]
+
+	// The notification should use the user-assigned name, NOT the Z-Wave product name
+	if !strings.Contains(notification.Body, "Humidifier Power Control") {
+		t.Errorf("Expected notification to contain user-friendly name 'Humidifier Power Control', got: %s", notification.Body)
+	}
+	if strings.Contains(notification.Body, "Wave Plug US") {
+		t.Errorf("Notification should NOT contain Z-Wave product name 'Wave Plug US', got: %s", notification.Body)
+	}
+}


### PR DESCRIPTION
Resolves #578

## Summary

The sensorhealth plugin was using `device.Name` (the Z-Wave product name like "Wave Plug US") instead of `device.NameByUser` (the user-assigned name like "Humidifier Power Control") in node status notifications. This made notifications confusing when users had renamed devices in Home Assistant, as the product name doesn't appear in the HA UI.

**Changes:**
- Modified `discoverNodeStatusSensors()` in `manager.go` to prefer `NameByUser` when available, falling back to `Name`
- Added tests to verify the behavior

**Before:** `Z-Wave device 'Wave Plug US' is not responding (status: dead).`

**After:** `Z-Wave device 'Humidifier Power Control' is not responding (status: dead).`

## Test Plan

- [x] Existing unit tests pass
- [x] Added new unit test `TestSensorHealthManager_NodeStatus_UsesNameByUserOverDefaultName` that verifies NameByUser is preferred over Name
- [x] Added new test `TestSensorHealthManager_NodeStatus_DeadDeviceNotification_UsesUserFriendlyName` that verifies notifications contain the user-friendly name
- [x] Integration tests pass

🤖 Generated with Claude Code