### PR TITLE
fix(tests): Use dynamic ports to prevent integration test port conflicts

### DIFF
--- a/homeautomation-go/pkg/testutil/mock_ha_server.go
+++ b/homeautomation-go/pkg/testutil/mock_ha_server.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -27,7 +28,9 @@ type connWrapper struct {
 // MockHAServer simulates a Home Assistant WebSocket server
 type MockHAServer struct {
 	server       *http.Server
+	listener     net.Listener // Added to support dynamic port allocation
 	addr         string
+	actualAddr   string // The actual address after binding (may differ if port 0 used)
 	states       map[string]*EntityState
 	statesMu     sync.RWMutex
 	connections  []*connWrapper
@@ -118,23 +121,40 @@ func (s *MockHAServer) SetEventDelay(delay time.Duration) {
 
 // Start starts the mock server
 func (s *MockHAServer) Start() error {
+	// First, create a listener to get a port and verify it's available
+	// This catches port conflicts immediately instead of in a goroutine
+	listener, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		return fmt.Errorf("failed to start mock HA server: %w", err)
+	}
+	s.listener = listener
+	s.actualAddr = listener.Addr().String()
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/websocket", s.handleWebSocket)
 
 	s.server = &http.Server{
-		Addr:    s.addr,
 		Handler: mux,
 	}
 
 	go func() {
-		if err := s.server.ListenAndServe(); err != http.ErrServerClosed {
+		if err := s.server.Serve(listener); err != http.ErrServerClosed {
 			log.Printf("Mock HA server error: %v", err)
 		}
 	}()
 
-	// Wait for server to start
-	time.Sleep(100 * time.Millisecond)
+	// Small delay to ensure server is accepting connections
+	time.Sleep(50 * time.Millisecond)
 	return nil
+}
+
+// Addr returns the actual address the server is listening on.
+// This is useful when using port 0 (dynamic port allocation).
+func (s *MockHAServer) Addr() string {
+	if s.actualAddr != "" {
+		return s.actualAddr
+	}
+	return s.addr
 }
 
 // Stop stops the mock server

--- a/homeautomation-go/test/integration/integration_test.go
+++ b/homeautomation-go/test/integration/integration_test.go
@@ -16,22 +16,28 @@ import (
 
 const (
 	testToken = "test_token_12345"
-	testAddr  = "localhost:18123"
+	// Use port 0 to let OS assign a free port, avoiding port conflicts between tests
+	testAddr = "localhost:0"
+	// Fixed port for reconnection tests that require the client to reconnect to the same address
+	reconnectTestAddr = "localhost:18199"
 )
 
 func setupTest(t *testing.T) (*MockHAServer, *ha.Client, *state.Manager, func()) {
 	// Create logger
 	logger := testlogger.New()
 
-	// Start mock HA server
+	// Start mock HA server with dynamic port allocation
 	server := NewMockHAServer(testAddr, testToken)
 	server.InitializeStates()
 
 	err := server.Start()
 	require.NoError(t, err)
 
-	// Create and connect client
-	client := ha.NewClient(fmt.Sprintf("ws://%s/api/websocket", testAddr), testToken, logger)
+	// Get the actual address the server is listening on
+	actualAddr := server.Addr()
+
+	// Create and connect client using the actual server address
+	client := ha.NewClient(fmt.Sprintf("ws://%s/api/websocket", actualAddr), testToken, logger)
 	err = client.Connect()
 	require.NoError(t, err)
 
@@ -417,14 +423,14 @@ func TestCompareAndSwapRaceCondition(t *testing.T) {
 func TestReconnection(t *testing.T) {
 	logger := testlogger.New()
 
-	// Start server
-	server := NewMockHAServer(testAddr, testToken)
+	// Start server (use fixed port for reconnection tests)
+	server := NewMockHAServer(reconnectTestAddr, testToken)
 	server.InitializeStates()
 	err := server.Start()
 	require.NoError(t, err)
 
 	// Connect client
-	client := ha.NewClient(fmt.Sprintf("ws://%s/api/websocket", testAddr), testToken, logger)
+	client := ha.NewClient(fmt.Sprintf("ws://%s/api/websocket", reconnectTestAddr), testToken, logger)
 	err = client.Connect()
 	require.NoError(t, err)
 
@@ -439,7 +445,7 @@ func TestReconnection(t *testing.T) {
 
 	// Restart server
 	t.Log("Restarting server...")
-	server = NewMockHAServer(testAddr, testToken)
+	server = NewMockHAServer(reconnectTestAddr, testToken)
 	server.InitializeStates()
 	err = server.Start()
 	require.NoError(t, err)
@@ -466,14 +472,14 @@ func TestReconnection(t *testing.T) {
 func TestReconnectionMessageIDReset(t *testing.T) {
 	logger := testlogger.New()
 
-	// Start server
-	server := NewMockHAServer(testAddr, testToken)
+	// Start server (use fixed port for reconnection tests)
+	server := NewMockHAServer(reconnectTestAddr, testToken)
 	server.InitializeStates()
 	err := server.Start()
 	require.NoError(t, err)
 
 	// Connect client
-	client := ha.NewClient(fmt.Sprintf("ws://%s/api/websocket", testAddr), testToken, logger)
+	client := ha.NewClient(fmt.Sprintf("ws://%s/api/websocket", reconnectTestAddr), testToken, logger)
 	err = client.Connect()
 	require.NoError(t, err)
 	require.True(t, client.IsConnected())
@@ -494,7 +500,7 @@ func TestReconnectionMessageIDReset(t *testing.T) {
 
 	// Restart server (this simulates a new HA session that expects message IDs from 1)
 	t.Log("Restarting server (new session)...")
-	server = NewMockHAServer(testAddr, testToken)
+	server = NewMockHAServer(reconnectTestAddr, testToken)
 	server.InitializeStates()
 	err = server.Start()
 	require.NoError(t, err)
@@ -640,14 +646,14 @@ func TestAllStateTypes(t *testing.T) {
 func TestReconnectStateSync(t *testing.T) {
 	logger := testlogger.New()
 
-	// Start server
-	server := NewMockHAServer(testAddr, testToken)
+	// Start server (use fixed port for reconnection tests)
+	server := NewMockHAServer(reconnectTestAddr, testToken)
 	server.InitializeStates()
 	err := server.Start()
 	require.NoError(t, err)
 
 	// Connect client and create state manager
-	client := ha.NewClient(fmt.Sprintf("ws://%s/api/websocket", testAddr), testToken, logger)
+	client := ha.NewClient(fmt.Sprintf("ws://%s/api/websocket", reconnectTestAddr), testToken, logger)
 	err = client.Connect()
 	require.NoError(t, err)
 
@@ -689,7 +695,7 @@ func TestReconnectStateSync(t *testing.T) {
 	// Restart server with CHANGED state
 	// This simulates state changing while disconnected
 	t.Log("Restarting server with changed state...")
-	server = NewMockHAServer(testAddr, testToken)
+	server = NewMockHAServer(reconnectTestAddr, testToken)
 	server.InitializeStates()
 
 	// Change state while client is disconnected - Nick comes home!
@@ -738,14 +744,14 @@ func TestReconnectStateSync(t *testing.T) {
 func TestReconnectCountIncrementsOnMultipleReconnects(t *testing.T) {
 	logger := testlogger.New()
 
-	// Start server
-	server := NewMockHAServer(testAddr, testToken)
+	// Start server (use fixed port for reconnection tests)
+	server := NewMockHAServer(reconnectTestAddr, testToken)
 	server.InitializeStates()
 	err := server.Start()
 	require.NoError(t, err)
 
 	// Connect client
-	client := ha.NewClient(fmt.Sprintf("ws://%s/api/websocket", testAddr), testToken, logger)
+	client := ha.NewClient(fmt.Sprintf("ws://%s/api/websocket", reconnectTestAddr), testToken, logger)
 	err = client.Connect()
 	require.NoError(t, err)
 
@@ -760,7 +766,7 @@ func TestReconnectCountIncrementsOnMultipleReconnects(t *testing.T) {
 		time.Sleep(1 * time.Second)
 
 		// Restart server
-		server = NewMockHAServer(testAddr, testToken)
+		server = NewMockHAServer(reconnectTestAddr, testToken)
 		server.InitializeStates()
 		err = server.Start()
 		require.NoError(t, err)

--- a/homeautomation-go/test/integration/scenario_computed_state_test.go
+++ b/homeautomation-go/test/integration/scenario_computed_state_test.go
@@ -30,15 +30,18 @@ import (
 func setupComputedStateTest(t *testing.T) (*MockHAServer, *ha.Client, *state.Manager, func()) {
 	logger := testlogger.New()
 
-	// Start mock HA server
+	// Start mock HA server with dynamic port
 	server := NewMockHAServer(testAddr, testToken)
 	server.InitializeStates()
 
 	err := server.Start()
 	require.NoError(t, err)
 
-	// Create and connect client
-	client := ha.NewClient(fmt.Sprintf("ws://%s/api/websocket", testAddr), testToken, logger)
+	// Get the actual address the server is listening on
+	actualAddr := server.Addr()
+
+	// Create and connect client using the actual server address
+	client := ha.NewClient(fmt.Sprintf("ws://%s/api/websocket", actualAddr), testToken, logger)
 	err = client.Connect()
 	require.NoError(t, err)
 
@@ -121,7 +124,7 @@ func TestScenario_ComputedState_IsAnyoneHomeAndAwake_InitialComputation(t *testi
 		t.Run(tc.name, func(t *testing.T) {
 			logger := testlogger.New()
 
-			// Start mock HA server with specific initial state
+			// Start mock HA server with specific initial state (using dynamic port)
 			server := NewMockHAServer(testAddr, testToken)
 			server.InitializeStates()
 
@@ -135,8 +138,11 @@ func TestScenario_ComputedState_IsAnyoneHomeAndAwake_InitialComputation(t *testi
 			require.NoError(t, err)
 			defer server.Stop()
 
-			// Create and connect client
-			client := ha.NewClient(fmt.Sprintf("ws://%s/api/websocket", testAddr), testToken, logger)
+			// Get the actual address the server is listening on
+			actualAddr := server.Addr()
+
+			// Create and connect client using the actual server address
+			client := ha.NewClient(fmt.Sprintf("ws://%s/api/websocket", actualAddr), testToken, logger)
 			err = client.Connect()
 			require.NoError(t, err)
 			defer client.Disconnect()


### PR DESCRIPTION
## Summary
- Fixed flaky integration tests caused by port conflicts when tests run in quick succession
- MockHAServer.Start() now properly detects and reports port binding failures instead of silently failing
- Most tests now use dynamic port allocation (port 0) to avoid conflicts
- Reconnection tests use a dedicated fixed port since they need to restart the server on the same address

## Problem
The integration tests were using a hardcoded port (18123) for the mock Home Assistant server. When tests ran in quick succession (especially in CI), the previous test's server might not have fully released the port, causing "bind: address already in use" errors.

More critically, the Start() method always returned nil even when the port was unavailable, allowing tests to continue with a broken setup. This could cause tests to connect to stale servers from previous tests, leading to flaky behavior like the CI failure in [run 21811689722](https://github.com/NickBorgers/home-automation/actions/runs/21811689722/job/62924879650).

## Test plan
- [x] All unit tests pass
- [x] All integration tests pass locally
- [x] CI will verify tests pass in the GitHub Actions environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)