### PR TITLE
fix(ci): Fix bash syntax error in merge-decision job

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1478,6 +1478,16 @@ jobs:
             DOCS_REVIEW_RESULT=${{ needs.docs-review.result }}
             CONFIG_ONLY=${{ needs.get-context.outputs.config_only }}
           runCmd: |
+            # Pre-compute conditional values to avoid $() inside double-quoted claude argument
+            # (bash -c wrapping by devcontainers/ci breaks $() inside escaped quotes)
+            if [ "${CONFIG_ONLY}" = "true" ]; then
+              PR_TYPE_DESC="Config-only (reviews were streamlined)"
+              CONFIG_NOTE="NOTE: This is a config-only PR. Most reviews were skipped as they don't apply to configuration changes. Focus on validating the config changes are correct and safe."
+            else
+              PR_TYPE_DESC="Standard"
+              CONFIG_NOTE=""
+            fi
+
             # Using Sonnet: Summarization task - synthesizes existing review results
             claude --print \
               --verbose \
@@ -1489,7 +1499,7 @@ jobs:
 
             You have personal responsibility to approve or reject this PR for merge to main and deployment to production.
 
-            **PR TYPE:** $([ \"${CONFIG_ONLY}\" = \"true\" ] && echo \"Config-only (reviews were streamlined)\" || echo \"Standard\")
+            **PR TYPE:** ${PR_TYPE_DESC}
 
             **REVIEW STATUS:**
             - Code Review: ${CLAUDE_REVIEW_RESULT}
@@ -1498,7 +1508,7 @@ jobs:
             - Concurrency Review: ${CONCURRENCY_REVIEW_RESULT}
             - Docs Review: ${DOCS_REVIEW_RESULT}
 
-            $([ \"${CONFIG_ONLY}\" = \"true\" ] && echo \"NOTE: This is a config-only PR. Most reviews were skipped as they don't apply to configuration changes. Focus on validating the config changes are correct and safe.\")
+            ${CONFIG_NOTE}
 
             **YOUR TASK:**
             1. Read the review comments on this PR: \`gh pr view ${PR_NUMBER} --comments\`


### PR DESCRIPTION
## Summary
- Pre-compute `CONFIG_ONLY` conditional values as shell variables before the `claude` command in the merge-decision job
- Replaces `$(...)` command substitutions that broke when `devcontainers/ci@v0.3` wrapped `runCmd` in `bash -c "..."`, causing exit code 127
- Unblocks PRs #602, #603, and #604 which are all stuck on merge-decision failures

## Root Cause
The merge-decision job's `runCmd` contained two `$([ \"${CONFIG_ONLY}\" = \"true\" ] && echo ...)` command substitutions inside the double-quoted `claude` argument string. When `devcontainers/ci` wraps the entire `runCmd` in `bash -c "..."`, the `\"` escaping collides with the `$(` boundary, producing:

```
bash: -c: line 12: syntax error near unexpected token `('
```

All other review jobs (design, code, test, concurrency, docs) pass because they only use `${VAR}` expansion inside the claude argument string—not `$(...)` command substitution.

## Fix
Pre-compute the two conditional values as shell variables before calling `claude`, then reference them with `${VAR}` expansion. This matches the pattern already used by other review jobs.

## Test plan
- [ ] Verify this PR's own merge-decision job passes (self-validating fix)
- [ ] After merge, close and reopen PRs #602, #603, #604 to re-trigger reviews
- [ ] Confirm merge-decision passes on re-triggered PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)