### PR TITLE
fix(devcontainer): Remove expired Yarn GPG key source

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,7 +6,9 @@ FROM mcr.microsoft.com/devcontainers/go:1.24
 
 # Install system packages: Playwright browser dependencies, zsh, and utilities
 # Consolidates what was previously in common-utils feature
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Remove Yarn apt source from base image - its GPG key is expired/missing
+RUN rm -f /etc/apt/sources.list.d/yarn.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
     # Shell and common utilities (from common-utils feature)
     zsh \
     # Core Chromium dependencies


### PR DESCRIPTION
## Summary
- The base Go devcontainer image (`mcr.microsoft.com/devcontainers/go:1.24`) ships with a Yarn apt repository whose GPG key (`FF7CB5667B542092084BBDC562D54FD4003F6525`) is expired/missing
- `apt-get update` fails during the Docker build with: `The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed`
- Fix removes the Yarn apt source before running `apt-get update` — Yarn is not used in this project

## Test plan
- [ ] Rebuild the devcontainer in VS Code and verify it builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)