### PR TITLE
fix(sensorhealth): Debounce Z-Wave dead device notifications

### DIFF
--- a/homeautomation-go/internal/plugins/sensorhealth/manager.go
+++ b/homeautomation-go/internal/plugins/sensorhealth/manager.go
@@ -29,6 +29,12 @@ const (
 	TemperatureLockupCheckInterval = 1 * time.Hour
 	// Rate limiting for lockup notifications (per sensor)
 	TemperatureLockupNotificationRateLimit = 24 * time.Hour
+
+	// Z-Wave dead device debounce delay.
+	// Devices occasionally report transient "dead" status due to network hiccups
+	// before immediately recovering. We delay the dead notification by this amount
+	// and cancel it if the device recovers, to avoid noisy flapping alerts.
+	NodeDeadDebounceDelay = 5 * time.Minute
 )
 
 // BatterySensor represents a discovered battery sensor
@@ -59,12 +65,13 @@ type TemperatureSensor struct {
 
 // NodeStatus represents a discovered Z-Wave node status sensor
 type NodeStatus struct {
-	EntityID         string
-	DeviceID         string
-	DeviceName       string
-	Status           string // alive, asleep, awake, dead
-	LastChanged      time.Time
-	NotificationSent bool // Track if we've sent notification for current dead state
+	EntityID          string
+	DeviceID          string
+	DeviceName        string
+	Status            string // alive, asleep, awake, dead
+	LastChanged       time.Time
+	NotificationSent  bool        // Track if we've sent notification for current dead state
+	deadDebounceTimer clock.Timer // Pending debounce timer for dead notification (nil if none)
 }
 
 // Manager handles sensor health monitoring: low batteries, node status, and temperature lockup
@@ -597,20 +604,47 @@ func (m *Manager) handleNodeStatusChange(entityID string, oldState, newState *ha
 	isNowDead := newState.State == "dead"
 	isNowAlive := newState.State == "alive" || newState.State == "awake" || newState.State == "asleep"
 
-	// If device just became dead, send notification
-	if isNowDead && !wasDeadOrUnknown && !node.NotificationSent {
-		node.NotificationSent = true
-		m.mu.Unlock()
-		m.sendDeviceDeadNotification(node)
-		m.mu.Lock()
+	// If device just became dead, start a debounce timer instead of notifying immediately.
+	// This avoids noisy notifications for transient "dead" reports that recover within seconds.
+	if isNowDead && !wasDeadOrUnknown && !node.NotificationSent && node.deadDebounceTimer == nil {
+		nodeEntityID := node.EntityID
+		node.deadDebounceTimer = m.clock.AfterFunc(NodeDeadDebounceDelay, func() {
+			m.mu.Lock()
+			n, ok := m.nodeStatuses[nodeEntityID]
+			if !ok || n.Status != "dead" || n.NotificationSent {
+				m.mu.Unlock()
+				return
+			}
+			n.NotificationSent = true
+			n.deadDebounceTimer = nil
+			m.mu.Unlock()
+			m.sendDeviceDeadNotification(n)
+			m.evaluateDeadDevices()
+		})
+		m.logger.Debug("Started dead device debounce timer",
+			zap.String("entity_id", entityID),
+			zap.String("device_name", node.DeviceName),
+			zap.Duration("delay", NodeDeadDebounceDelay))
 	}
 
-	// If device recovered from dead state, send recovery notification and reset flag
-	if isNowAlive && wasDeadOrUnknown && node.NotificationSent {
-		node.NotificationSent = false
-		m.mu.Unlock()
-		m.sendDeviceRecoveredNotification(node)
-		m.mu.Lock()
+	// If device recovered from dead/unknown state, handle debounce timer and recovery notification
+	if isNowAlive && wasDeadOrUnknown {
+		// Cancel pending debounce timer if device recovered before it fired
+		if node.deadDebounceTimer != nil {
+			node.deadDebounceTimer.Stop()
+			node.deadDebounceTimer = nil
+			m.logger.Debug("Cancelled dead device debounce timer (device recovered)",
+				zap.String("entity_id", entityID),
+				zap.String("device_name", node.DeviceName))
+		}
+
+		// Only send recovery notification if we actually notified about the dead state
+		if node.NotificationSent {
+			node.NotificationSent = false
+			m.mu.Unlock()
+			m.sendDeviceRecoveredNotification(node)
+			m.mu.Lock()
+		}
 	}
 	m.mu.Unlock()
 

--- a/homeautomation-go/internal/plugins/sensorhealth/manager_test.go
+++ b/homeautomation-go/internal/plugins/sensorhealth/manager_test.go
@@ -885,7 +885,15 @@ func TestSensorHealthManager_NodeStatus_DeadDevice_Notification(t *testing.T) {
 		t.Errorf("Expected status 'dead', got '%s'", nodeStatuses[testNodeStatus1].Status)
 	}
 
-	// Verify notification was sent
+	// Notification should NOT be sent yet (debounce timer is pending)
+	if countNtfyNotifications(mockNtfy) != 0 {
+		t.Errorf("Expected 0 notifications before debounce expires, got %d", countNtfyNotifications(mockNtfy))
+	}
+
+	// Advance clock past the debounce delay to fire the timer
+	mockClock.Advance(NodeDeadDebounceDelay)
+
+	// Verify notification was sent after debounce
 	notificationCount := countNtfyNotifications(mockNtfy)
 	if notificationCount != 1 {
 		t.Errorf("Expected 1 dead device notification, got %d", notificationCount)
@@ -1056,9 +1064,10 @@ func TestSensorHealthManager_NodeStatus_ReadOnlyMode(t *testing.T) {
 	mockNtfy := ntfy.NewMockClient()
 	logger := zap.NewNop()
 	stateMgr := state.NewManager(mockHA, logger, true) // read-only
+	mockClock := clock.NewMockClock(time.Now())
 
 	// Create manager in read-only mode
-	manager := NewManagerWithClock(mockHA, stateMgr, logger, true, nil, mockNtfy, clock.NewMockClock(time.Now()))
+	manager := NewManagerWithClock(mockHA, stateMgr, logger, true, nil, mockNtfy, mockClock)
 
 	// Add a node status sensor
 	manager.AddNodeStatus(&NodeStatus{
@@ -1070,6 +1079,9 @@ func TestSensorHealthManager_NodeStatus_ReadOnlyMode(t *testing.T) {
 
 	// Simulate device becoming dead
 	manager.SimulateNodeStatusChange(testNodeStatus1, "dead")
+
+	// Advance clock past debounce delay to fire the timer
+	mockClock.Advance(NodeDeadDebounceDelay)
 
 	// Verify device is marked as dead
 	nodeStatuses := manager.GetNodeStatuses()
@@ -1378,6 +1390,9 @@ func TestSensorHealthManager_NodeStatus_DeadDeviceNotification_UsesUserFriendlyN
 	// Simulate the device becoming dead
 	manager.SimulateNodeStatusChange("sensor.humidifier_power_control_node_status", "dead")
 
+	// Advance clock past debounce delay to fire the timer
+	mockClock.Advance(NodeDeadDebounceDelay)
+
 	// Verify notification was sent with user-friendly name
 	calls := mockNtfy.GetCalls()
 	if len(calls) != 1 {
@@ -1392,5 +1407,109 @@ func TestSensorHealthManager_NodeStatus_DeadDeviceNotification_UsesUserFriendlyN
 	}
 	if strings.Contains(notification.Body, "Wave Plug US") {
 		t.Errorf("Notification should NOT contain Z-Wave product name 'Wave Plug US', got: %s", notification.Body)
+	}
+}
+
+// ============================================================================
+// Dead Device Debounce Tests
+// ============================================================================
+
+func TestSensorHealthManager_NodeStatus_DeadDevice_DebounceSuppress(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := NewManagerWithClock(mockHA, stateMgr, logger, false, nil, mockNtfy, mockClock)
+
+	// Add a node status sensor
+	manager.AddNodeStatus(&NodeStatus{
+		EntityID:   testNodeStatus1,
+		DeviceID:   "device_zwave_1",
+		DeviceName: "Front Door Lock",
+		Status:     "alive",
+	})
+
+	// Device goes dead (starts debounce timer)
+	manager.SimulateNodeStatusChange(testNodeStatus1, "dead")
+
+	// No notification yet — timer is pending
+	if countNtfyNotifications(mockNtfy) != 0 {
+		t.Errorf("Expected 0 notifications before debounce, got %d", countNtfyNotifications(mockNtfy))
+	}
+
+	// Device recovers before the debounce timer fires (e.g., after 2 minutes)
+	mockClock.Advance(2 * time.Minute)
+	manager.SimulateNodeStatusChange(testNodeStatus1, "alive")
+
+	// Now advance past the original debounce deadline — timer was cancelled, should not fire
+	mockClock.Advance(NodeDeadDebounceDelay)
+
+	// Zero notifications: the transient dead status was suppressed
+	if countNtfyNotifications(mockNtfy) != 0 {
+		t.Errorf("Expected 0 notifications (transient dead suppressed), got %d", countNtfyNotifications(mockNtfy))
+	}
+
+	// Verify device is back to alive
+	nodeStatuses := manager.GetNodeStatuses()
+	if nodeStatuses[testNodeStatus1].Status != "alive" {
+		t.Errorf("Expected status 'alive', got '%s'", nodeStatuses[testNodeStatus1].Status)
+	}
+	if nodeStatuses[testNodeStatus1].NotificationSent {
+		t.Error("Expected NotificationSent to be false (no notification was ever sent)")
+	}
+}
+
+func TestSensorHealthManager_NodeStatus_DeadDevice_DebounceExpires(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := NewManagerWithClock(mockHA, stateMgr, logger, false, nil, mockNtfy, mockClock)
+
+	// Add a node status sensor
+	manager.AddNodeStatus(&NodeStatus{
+		EntityID:   testNodeStatus1,
+		DeviceID:   "device_zwave_1",
+		DeviceName: "Front Door Lock",
+		Status:     "alive",
+	})
+
+	// Device goes dead (starts debounce timer)
+	manager.SimulateNodeStatusChange(testNodeStatus1, "dead")
+
+	// No notification yet
+	if countNtfyNotifications(mockNtfy) != 0 {
+		t.Errorf("Expected 0 notifications before debounce, got %d", countNtfyNotifications(mockNtfy))
+	}
+
+	// Debounce timer fires after 5 minutes — device is still dead
+	mockClock.Advance(NodeDeadDebounceDelay)
+
+	// Dead notification should now be sent
+	if countNtfyNotifications(mockNtfy) != 1 {
+		t.Fatalf("Expected 1 dead notification after debounce, got %d", countNtfyNotifications(mockNtfy))
+	}
+	notification := getLastNtfyNotification(mockNtfy)
+	if notification.Title != "Device Offline" {
+		t.Errorf("Expected title 'Device Offline', got '%s'", notification.Title)
+	}
+
+	// Device recovers — recovery notification should be sent
+	manager.SimulateNodeStatusChange(testNodeStatus1, "alive")
+
+	if countNtfyNotifications(mockNtfy) != 2 {
+		t.Fatalf("Expected 2 notifications (1 dead + 1 recovery), got %d", countNtfyNotifications(mockNtfy))
+	}
+	recoveryNotification := getLastNtfyNotification(mockNtfy)
+	if recoveryNotification.Title != "Device Online" {
+		t.Errorf("Expected title 'Device Online', got '%s'", recoveryNotification.Title)
 	}
 }

--- a/homeautomation-go/test/integration/scenario_sensor_monitoring_test.go
+++ b/homeautomation-go/test/integration/scenario_sensor_monitoring_test.go
@@ -568,6 +568,10 @@ func TestScenario_SensorHealth_NodeStatusMonitoring(t *testing.T) {
 	})
 	time.Sleep(150 * time.Millisecond)
 
+	// Advance mock clock past the debounce delay so the dead notification fires
+	env.mockClock.Advance(sensorhealth.NodeDeadDebounceDelay)
+	time.Sleep(50 * time.Millisecond)
+
 	// Verify notification sent
 	calls := env.mockNtfy.GetCalls()
 	assert.GreaterOrEqual(t, len(calls), 1, "Should send notification for dead device")


### PR DESCRIPTION
## Summary

- Z-Wave devices occasionally report transient "dead" status due to network hiccups before immediately recovering to "alive", causing paired "Device Offline" / "Device Online" notifications within seconds — noisy and unhelpful
- Adds a 5-minute debounce delay (using `clock.AfterFunc`) before sending dead device notifications; if the device recovers before the timer fires, the timer is cancelled silently with zero notifications
- Startup notifications for devices that are already dead remain immediate (no debounce) since those are confirmed problems, not transient blips

## Test plan

- [x] Existing `TestSensorHealthManager_NodeStatus_DeadDevice_Notification` updated to verify notification is delayed until after debounce period
- [x] Existing `TestSensorHealthManager_NodeStatus_DeviceRecovery` passes unchanged (recovery from confirmed dead state)
- [x] New `TestSensorHealthManager_NodeStatus_DeadDevice_DebounceSuppress` — device goes dead then recovers within 5 min, asserts zero notifications
- [x] New `TestSensorHealthManager_NodeStatus_DeadDevice_DebounceExpires` — device stays dead past 5 min, asserts dead notification fires, then recovery sends second notification
- [x] Integration test `TestScenario_SensorHealth_NodeStatusMonitoring` updated to advance mock clock past debounce delay
- [x] `make unit-tests` passes (74.8% coverage)
- [x] `make integration-tests` passes
- [x] Pre-push hook passes (compilation, race detector, coverage >= 65%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)