### PR TITLE
Fix #622: Fix flaky TestScenario_OwnerLeavesAndReturns integration test

### DIFF
--- a/homeautomation-go/test/integration/scenario_security_test.go
+++ b/homeautomation-go/test/integration/scenario_security_test.go
@@ -273,36 +273,30 @@ func TestScenario_OwnerLeavesAndReturns(t *testing.T) {
 
 	server.SetState("input_boolean.nick_home", "on", nil)
 	server.SetState("binary_sensor.garage_door_vehicle_detected", "off", nil)
-	time.Sleep(100 * time.Millisecond)
+
+	// Wait for the arrival event to be fully processed before sending the departure.
+	// Without this, under load the "on" event's setOwnerJustReturnedHome() can execute
+	// AFTER the "off" event's clearOwnerJustReturnedHome(), leaving the flag as true.
+	waitForBoolState(t, manager, "didOwnerJustReturnHome", true, "didOwnerJustReturnHome should be true after Nick arrives")
 
 	server.SetState("input_boolean.nick_home", "off", nil)
-	time.Sleep(100 * time.Millisecond)
 
-	didReturn, err := manager.GetBool("didOwnerJustReturnHome")
-	require.NoError(t, err)
-	assert.False(t, didReturn, "didOwnerJustReturnHome should be false when owner leaves")
+	// Use polling helper instead of time.Sleep to wait for the departure to be processed
+	waitForBoolState(t, manager, "didOwnerJustReturnHome", false, "didOwnerJustReturnHome should be false when owner leaves")
 
 	server.ClearServiceCalls()
 
 	t.Log("WHEN: Nick returns 5 minutes later")
 
-	time.Sleep(100 * time.Millisecond) // Simulate some time passing
-
 	server.SetState("input_boolean.nick_home", "on", nil)
-	time.Sleep(100 * time.Millisecond)
 
 	t.Log("THEN: didOwnerJustReturnHome should be set to true again")
 
-	didReturn, err = manager.GetBool("didOwnerJustReturnHome")
-	require.NoError(t, err)
-	assert.True(t, didReturn, "didOwnerJustReturnHome should be true on return")
+	waitForBoolState(t, manager, "didOwnerJustReturnHome", true, "didOwnerJustReturnHome should be true on return")
 
 	t.Log("AND: Garage should open again")
 
-	time.Sleep(50 * time.Millisecond)
-
-	garageOpenCall := server.FindServiceCall("cover", "open_cover", "cover.garage_door_door")
-	assert.NotNil(t, garageOpenCall, "Garage should open on second arrival")
+	waitForServiceCallWithEntity(t, server, "cover", "open_cover", "cover.garage_door_door", "Garage should open on second arrival")
 }
 
 // TestScenario_OnlyOwnersTriggersGarage tests that only owners (Nick/Caroline)


### PR DESCRIPTION
Resolves #622

## Summary

Fixed the flaky `TestScenario_OwnerLeavesAndReturns` integration test by replacing `time.Sleep` calls with polling-based `waitForBoolState` and `waitForServiceCallWithEntity` helpers.

**Root cause:** The test set `nick_home` to `"on"` then immediately (after only 100ms sleep) set it to `"off"`. Under parallel test load, the WebSocket event processing pipeline could reorder the handlers: the arrival event's `setOwnerJustReturnedHome()` would execute *after* the departure event's `clearOwnerJustReturnedHome()`, leaving `didOwnerJustReturnHome` as `true` when the test expected `false`.

**Fix:** 
- Wait for `didOwnerJustReturnHome` to become `true` after the arrival event before sending the departure event (ensures proper sequencing)
- Use `waitForBoolState` polling helpers instead of `time.Sleep` for all state assertions
- Use `waitForServiceCallWithEntity` instead of `time.Sleep` + manual assertion for the garage door check

This follows the same pattern already used by other tests in the file (e.g., `TestScenario_NickReturnsHomeGarageEmpty`).

## Test Plan

- [x] `make unit-tests` passes
- [x] `make integration-tests` passes  
- [x] `make pre-commit` passes (formatting, linting, build)
- [x] `make pre-push` passes (full validation with race detector and coverage)

🤖 Generated with Claude Code