### PR TITLE
feat(loadshedding): Add EV charger to load shedding control

### DIFF
--- a/docs/flows/LOAD_SHEDDING.md
+++ b/docs/flows/LOAD_SHEDDING.md
@@ -1,12 +1,12 @@
 # Load Shedding Flow
 
-This document describes the load shedding automation flow, which manages HVAC thermostat control based on energy availability.
+This document describes the load shedding automation flow, which manages HVAC thermostat control and EV charger based on energy availability.
 
 ## Overview
 
-The load shedding plugin controls thermostats based on energy levels to:
-1. Restrict HVAC when battery is low (red/black)
-2. Return to normal schedules when energy is available (green/white)
+The load shedding plugin controls thermostats and EV charger based on energy levels to:
+1. Restrict HVAC and disable EV charger when battery is low (red/black)
+2. Return to normal schedules and re-enable EV charger when energy is available (green/white)
 3. Maintain hysteresis to prevent rapid toggling (yellow)
 
 ## Energy Level Response
@@ -55,6 +55,7 @@ flowchart TD
     subgraph Actions["Enable Actions"]
         turnOnHold["Turn on thermostat hold<br/>(both zones)"]
         setTemp["Set temperature range<br/>65°F - 80°F"]
+        turnOffEV["Turn off EV charger"]
     end
 
     alreadyOn -->|Yes| skipOn
@@ -64,11 +65,13 @@ flowchart TD
     rateLimit -->|Yes| skipRate
     rateLimit -->|No| turnOnHold
     turnOnHold --> setTemp
+    setTemp --> turnOffEV
 
     style skipOn fill:#95a5a6,color:#fff
     style skipHold fill:#95a5a6,color:#fff
     style skipRate fill:#f39c12,color:#fff
     style setTemp fill:#e74c3c,color:#fff
+    style turnOffEV fill:#e74c3c,color:#fff
 ```
 
 ### Disable Load Shedding (Energy Restored)
@@ -89,6 +92,7 @@ flowchart TD
 
     subgraph Actions["Disable Actions"]
         turnOffHold["Turn off thermostat hold<br/>(both zones)"]
+        turnOnEV["Turn on EV charger"]
     end
 
     alreadyOff -->|Yes| skipOff
@@ -97,11 +101,13 @@ flowchart TD
     checkHold -->|No| rateLimit
     rateLimit -->|Yes| skipRate
     rateLimit -->|No| turnOffHold
+    turnOffHold --> turnOnEV
 
     style skipOff fill:#95a5a6,color:#fff
     style skipHold fill:#95a5a6,color:#fff
     style skipRate fill:#f39c12,color:#fff
     style turnOffHold fill:#27ae60,color:#fff
+    style turnOnEV fill:#27ae60,color:#fff
 ```
 
 ## Yellow State Hysteresis
@@ -136,14 +142,15 @@ sequenceDiagram
 
 Without hysteresis, the system would rapidly toggle at threshold boundaries (e.g., 29%↔31% repeatedly enabling/disabling).
 
-## Thermostat Entities
+## Controlled Entities
 
-| Entity | Zone | Description |
+| Entity | Type | Description |
 |--------|------|-------------|
-| `switch.most_of_house_thermostat_hold` | House | Main zone hold mode |
-| `switch.primary_suite_thermostat_hold` | Suite | Primary suite hold mode |
-| `climate.most_of_house_thermostat` | House | Main zone climate control |
-| `climate.primary_suite_thermostat` | Suite | Primary suite climate control |
+| `switch.most_of_house_thermostat_hold` | Thermostat | Main zone hold mode |
+| `switch.primary_suite_thermostat_hold` | Thermostat | Primary suite hold mode |
+| `climate.most_of_house_thermostat` | Thermostat | Main zone climate control |
+| `climate.primary_suite_thermostat` | Thermostat | Primary suite climate control |
+| `switch.leaf_charger` | EV Charger | Nissan Leaf charger plug |
 
 ## Temperature Range
 

--- a/homeautomation-go/internal/plugins/loadshedding/manager.go
+++ b/homeautomation-go/internal/plugins/loadshedding/manager.go
@@ -30,6 +30,9 @@ const (
 	climateHouse        = "climate.most_of_house_thermostat"
 	climateSuite        = "climate.primary_suite_thermostat"
 
+	// EV Charger entity
+	evChargerSwitch = "switch.leaf_charger"
+
 	// Temperature ranges
 	tempLowRestricted  = 65.0
 	tempHighRestricted = 80.0
@@ -250,10 +253,11 @@ func (m *Manager) executeEnableLoadShedding(energyLevel string, trigger string) 
 	}
 
 	if m.readOnly {
-		m.logger.Info("READ-ONLY: Would enable thermostat hold mode",
-			zap.Strings("entities", []string{thermostatHoldHouse, thermostatHoldSuite}))
+		m.logger.Info("READ-ONLY: Would enable thermostat hold mode and turn off EV charger",
+			zap.Strings("thermostat_entities", []string{thermostatHoldHouse, thermostatHoldSuite}),
+			zap.String("ev_charger_entity", evChargerSwitch))
 		// Record shadow state even in read-only mode for consistency
-		reason := fmt.Sprintf("Energy state is %s (low battery) - would restrict HVAC", energyLevel)
+		reason := fmt.Sprintf("Energy state is %s (low battery) - would restrict HVAC and disable EV charger", energyLevel)
 		m.recordAction(true, "enable", reason, true, tempLowRestricted, tempHighRestricted, trigger)
 		return
 	}
@@ -289,8 +293,22 @@ func (m *Manager) executeEnableLoadShedding(energyLevel string, trigger string) 
 	}
 
 	m.logger.Info("✓ Successfully set wider temperature range")
+
+	// Turn off EV charger to reduce load
+	m.logger.Info("Executing: Turn off EV charger",
+		zap.String("entity", evChargerSwitch))
+
+	if err := m.haClient.CallService(m.ctx, "switch", "turn_off", map[string]interface{}{
+		"entity_id": evChargerSwitch,
+	}); err != nil {
+		m.logger.Error("Failed to turn off EV charger", zap.Error(err))
+		// Continue - thermostat control already succeeded
+	} else {
+		m.logger.Info("✓ Successfully turned off EV charger")
+	}
+
 	m.logger.Info("=== LOAD SHEDDING ACTIVATED ===",
-		zap.String("action", "HVAC restricted to conserve battery"))
+		zap.String("action", "HVAC restricted and EV charger disabled to conserve battery"))
 
 	// Update state tracking and last action time
 	m.stateMu.Lock()
@@ -366,10 +384,11 @@ func (m *Manager) executeDisableLoadShedding(energyLevel string, trigger string)
 	}
 
 	if m.readOnly {
-		m.logger.Info("READ-ONLY: Would disable thermostat hold mode (restore schedule)",
-			zap.Strings("entities", []string{thermostatHoldHouse, thermostatHoldSuite}))
+		m.logger.Info("READ-ONLY: Would disable thermostat hold mode and turn on EV charger (restore schedule)",
+			zap.Strings("thermostat_entities", []string{thermostatHoldHouse, thermostatHoldSuite}),
+			zap.String("ev_charger_entity", evChargerSwitch))
 		// Record shadow state even in read-only mode for consistency
-		reason := fmt.Sprintf("Energy state is %s (battery restored) - would return to normal HVAC", energyLevel)
+		reason := fmt.Sprintf("Energy state is %s (battery restored) - would return to normal HVAC and re-enable EV charger", energyLevel)
 		m.recordAction(false, "disable", reason, false, 0, 0, trigger)
 		return
 	}
@@ -387,8 +406,22 @@ func (m *Manager) executeDisableLoadShedding(energyLevel string, trigger string)
 	}
 
 	m.logger.Info("✓ Successfully disabled thermostat hold mode")
+
+	// Turn on EV charger (restore normal operation)
+	m.logger.Info("Executing: Turn on EV charger",
+		zap.String("entity", evChargerSwitch))
+
+	if err := m.haClient.CallService(m.ctx, "switch", "turn_on", map[string]interface{}{
+		"entity_id": evChargerSwitch,
+	}); err != nil {
+		m.logger.Error("Failed to turn on EV charger", zap.Error(err))
+		// Continue - thermostat control already succeeded
+	} else {
+		m.logger.Info("✓ Successfully turned on EV charger")
+	}
+
 	m.logger.Info("=== LOAD SHEDDING DEACTIVATED ===",
-		zap.String("action", "HVAC returned to normal schedule"))
+		zap.String("action", "HVAC returned to normal schedule and EV charger re-enabled"))
 
 	// Update state tracking and last action time
 	m.stateMu.Lock()

--- a/homeautomation-go/internal/plugins/loadshedding/manager_test.go
+++ b/homeautomation-go/internal/plugins/loadshedding/manager_test.go
@@ -41,9 +41,9 @@ func TestLoadShedding_EnergyStateRed(t *testing.T) {
 
 	// Verify service calls
 	calls := mockClient.GetServiceCalls()
-	assert.GreaterOrEqual(t, len(calls), 2, "Expected at least 2 service calls")
+	assert.GreaterOrEqual(t, len(calls), 3, "Expected at least 3 service calls (thermostat hold, temp range, EV charger)")
 
-	// Check for switch.turn_on call
+	// Check for switch.turn_on call (thermostat holds)
 	foundSwitchOn := false
 	for _, call := range calls {
 		if call.Domain == "switch" && call.Service == "turn_on" {
@@ -54,7 +54,7 @@ func TestLoadShedding_EnergyStateRed(t *testing.T) {
 			assert.Contains(t, entities, thermostatHoldSuite)
 		}
 	}
-	assert.True(t, foundSwitchOn, "Expected switch.turn_on service call")
+	assert.True(t, foundSwitchOn, "Expected switch.turn_on service call for thermostat holds")
 
 	// Check for climate.set_temperature call
 	foundSetTemp := false
@@ -70,6 +70,18 @@ func TestLoadShedding_EnergyStateRed(t *testing.T) {
 		}
 	}
 	assert.True(t, foundSetTemp, "Expected climate.set_temperature service call")
+
+	// Check for switch.turn_off call (EV charger)
+	foundEVChargerOff := false
+	for _, call := range calls {
+		if call.Domain == "switch" && call.Service == "turn_off" {
+			entityID, ok := call.Data["entity_id"].(string)
+			if ok && entityID == evChargerSwitch {
+				foundEVChargerOff = true
+			}
+		}
+	}
+	assert.True(t, foundEVChargerOff, "Expected switch.turn_off service call for EV charger")
 }
 
 func TestLoadShedding_EnergyStateBlack(t *testing.T) {
@@ -99,7 +111,7 @@ func TestLoadShedding_EnergyStateBlack(t *testing.T) {
 
 	// Verify service calls (should be same as red)
 	calls := mockClient.GetServiceCalls()
-	assert.GreaterOrEqual(t, len(calls), 2)
+	assert.GreaterOrEqual(t, len(calls), 3, "Expected at least 3 service calls (thermostat hold, temp range, EV charger)")
 
 	foundSwitchOn := false
 	for _, call := range calls {
@@ -107,7 +119,19 @@ func TestLoadShedding_EnergyStateBlack(t *testing.T) {
 			foundSwitchOn = true
 		}
 	}
-	assert.True(t, foundSwitchOn)
+	assert.True(t, foundSwitchOn, "Expected switch.turn_on for thermostat holds")
+
+	// Check for switch.turn_off call (EV charger)
+	foundEVChargerOff := false
+	for _, call := range calls {
+		if call.Domain == "switch" && call.Service == "turn_off" {
+			entityID, ok := call.Data["entity_id"].(string)
+			if ok && entityID == evChargerSwitch {
+				foundEVChargerOff = true
+			}
+		}
+	}
+	assert.True(t, foundEVChargerOff, "Expected switch.turn_off service call for EV charger")
 }
 
 func TestLoadShedding_EnergyStateGreen(t *testing.T) {
@@ -140,20 +164,33 @@ func TestLoadShedding_EnergyStateGreen(t *testing.T) {
 
 	// Verify service calls
 	calls := mockClient.GetServiceCalls()
-	assert.GreaterOrEqual(t, len(calls), 1)
+	assert.GreaterOrEqual(t, len(calls), 2, "Expected at least 2 service calls (thermostat hold off, EV charger on)")
 
-	// Check for switch.turn_off call
-	foundSwitchOff := false
+	// Check for switch.turn_off call (thermostat holds)
+	foundThermostatOff := false
 	for _, call := range calls {
 		if call.Domain == "switch" && call.Service == "turn_off" {
-			foundSwitchOff = true
 			entities, ok := call.Data["entity_id"].([]string)
-			assert.True(t, ok, "entity_id should be []string")
-			assert.Contains(t, entities, thermostatHoldHouse)
-			assert.Contains(t, entities, thermostatHoldSuite)
+			if ok {
+				foundThermostatOff = true
+				assert.Contains(t, entities, thermostatHoldHouse)
+				assert.Contains(t, entities, thermostatHoldSuite)
+			}
 		}
 	}
-	assert.True(t, foundSwitchOff, "Expected switch.turn_off service call")
+	assert.True(t, foundThermostatOff, "Expected switch.turn_off service call for thermostat holds")
+
+	// Check for switch.turn_on call (EV charger)
+	foundEVChargerOn := false
+	for _, call := range calls {
+		if call.Domain == "switch" && call.Service == "turn_on" {
+			entityID, ok := call.Data["entity_id"].(string)
+			if ok && entityID == evChargerSwitch {
+				foundEVChargerOn = true
+			}
+		}
+	}
+	assert.True(t, foundEVChargerOn, "Expected switch.turn_on service call for EV charger")
 }
 
 func TestLoadShedding_EnergyStateWhite(t *testing.T) {
@@ -186,15 +223,30 @@ func TestLoadShedding_EnergyStateWhite(t *testing.T) {
 
 	// Verify service calls (should be same as green)
 	calls := mockClient.GetServiceCalls()
-	assert.GreaterOrEqual(t, len(calls), 1)
+	assert.GreaterOrEqual(t, len(calls), 2, "Expected at least 2 service calls (thermostat hold off, EV charger on)")
 
-	foundSwitchOff := false
+	foundThermostatOff := false
 	for _, call := range calls {
 		if call.Domain == "switch" && call.Service == "turn_off" {
-			foundSwitchOff = true
+			_, ok := call.Data["entity_id"].([]string)
+			if ok {
+				foundThermostatOff = true
+			}
 		}
 	}
-	assert.True(t, foundSwitchOff)
+	assert.True(t, foundThermostatOff, "Expected switch.turn_off for thermostat holds")
+
+	// Check for switch.turn_on call (EV charger)
+	foundEVChargerOn := false
+	for _, call := range calls {
+		if call.Domain == "switch" && call.Service == "turn_on" {
+			entityID, ok := call.Data["entity_id"].(string)
+			if ok && entityID == evChargerSwitch {
+				foundEVChargerOn = true
+			}
+		}
+	}
+	assert.True(t, foundEVChargerOn, "Expected switch.turn_on service call for EV charger")
 }
 
 func TestLoadShedding_RateLimiting(t *testing.T) {
@@ -437,33 +489,39 @@ func TestLoadShedding_DeferredActionAfterRateLimit(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// At this point, the disable action should be rate-limited (not executed yet)
-	calls = mockClient.GetServiceCalls()
-	foundSwitchOff := false
-	for _, call := range calls {
-		if call.Domain == "switch" && call.Service == "turn_off" {
-			foundSwitchOff = true
-		}
-	}
-	// The action should NOT have been executed yet due to rate limiting
-	// (It will be deferred)
+	// We don't assert on this because the deferred action mechanism is tested below
 
 	// Step 3: Wait for the rate limit to expire plus buffer for deferred action
 	time.Sleep(150 * time.Millisecond)
 
 	// Step 4: Verify the deferred disable action was executed
 	calls = mockClient.GetServiceCalls()
-	foundSwitchOff = false
+	foundThermostatOff := false
 	for _, call := range calls {
 		if call.Domain == "switch" && call.Service == "turn_off" {
-			foundSwitchOff = true
 			entities, ok := call.Data["entity_id"].([]string)
-			assert.True(t, ok, "entity_id should be []string")
-			assert.Contains(t, entities, thermostatHoldHouse)
-			assert.Contains(t, entities, thermostatHoldSuite)
+			if ok {
+				foundThermostatOff = true
+				assert.Contains(t, entities, thermostatHoldHouse)
+				assert.Contains(t, entities, thermostatHoldSuite)
+			}
 		}
 	}
-	assert.True(t, foundSwitchOff,
-		"Deferred action should execute switch.turn_off after rate limit expires")
+	assert.True(t, foundThermostatOff,
+		"Deferred action should execute switch.turn_off for thermostat holds after rate limit expires")
+
+	// Verify EV charger was turned on in deferred action
+	foundEVChargerOn := false
+	for _, call := range calls {
+		if call.Domain == "switch" && call.Service == "turn_on" {
+			entityID, ok := call.Data["entity_id"].(string)
+			if ok && entityID == evChargerSwitch {
+				foundEVChargerOn = true
+			}
+		}
+	}
+	assert.True(t, foundEVChargerOn,
+		"Deferred action should execute switch.turn_on for EV charger after rate limit expires")
 
 	// Verify load shedding state is now disabled
 	assert.False(t, ls.IsLoadSheddingOn(), "Load shedding should be disabled after deferred action")


### PR DESCRIPTION
## Summary

- Add `switch.leaf_charger` (EV charger plug) to the load shedding plugin
- EV charger is turned **off** when energy state is red/black (low battery)
- EV charger is turned **on** when energy recovers to green/white

This helps reduce battery drain during low energy periods by stopping EV charging alongside the existing HVAC thermostat restrictions.

## Test plan

- [x] Unit tests updated to verify EV charger control for all energy states
- [x] Integration tests pass
- [x] Mermaid diagrams validated
- [x] Pre-push validation passed (race detector, coverage ≥65%)

🤖 Generated with [Claude Code](https://claude.ai/code)