### PR TITLE
fix(ci): Add concurrency block to claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,15 @@ on:
   pull_request_review:
     types: [submitted]
 
+concurrency:
+  group: >-
+    claude-interactive-${{
+      github.event_name == 'pull_request_review_comment' && github.event.pull_request.number ||
+      github.event_name == 'pull_request_review' && github.event.pull_request.number ||
+      github.event.issue.number
+    }}
+  cancel-in-progress: false
+
 # SECURITY NOTE: This workflow grants Claude Code access to secrets and write permissions.
 # Authorization checks are implemented to prevent prompt injection from untrusted users.
 # Only repository collaborators, members, and owners can trigger Claude.

--- a/docs/operations/CLAUDE_GHA_PIPELINES.md
+++ b/docs/operations/CLAUDE_GHA_PIPELINES.md
@@ -68,6 +68,20 @@ The main workflow that enables Claude to respond to requests and automatically r
 - **PR Review**: When a review body contains `@claude`
 - **New Issue**: When an issue is opened
 
+### Concurrency Control
+
+```yaml
+concurrency:
+  group: claude-interactive-${{ issue_or_pr_number }}
+  cancel-in-progress: false  # Complete first request, queue the second
+```
+
+Scoped by issue/PR number so that:
+- Two rapid `@claude` mentions on the **same** PR/issue are serialized (second queues until first completes)
+- `@claude` on **different** PRs/issues runs in parallel (separate concurrency groups)
+
+`cancel-in-progress: false` ensures the first request completes (it may already be mid-commit). The second request runs after the first finishes and sees its changes.
+
 ### Jobs
 
 #### 1.1 `build-devcontainer`


### PR DESCRIPTION
## Summary
- Adds a `concurrency` block to `claude.yml` scoped by issue/PR number to prevent parallel pushes when `@claude` is mentioned twice rapidly on the same PR/issue
- Uses `cancel-in-progress: false` so the first request completes and the second queues
- Different PRs/issues get separate concurrency groups and run in parallel
- Documents the new concurrency control in `CLAUDE_GHA_PIPELINES.md`

## Test plan
- [ ] After merge, mention `@claude` twice rapidly on the same PR — verify the first run completes and the second queues (visible as "queued" in Actions tab)
- [ ] Verify `@claude` on a different PR runs immediately (not blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)