### PR TITLE
fix(tv): Use TV remote entity for isTVOn instead of sync box power

### DIFF
--- a/homeautomation-go/internal/plugins/tv/manager.go
+++ b/homeautomation-go/internal/plugins/tv/manager.go
@@ -38,6 +38,9 @@ const (
 	// Entity ID for sync box light sync control
 	SyncBoxLightSyncEntity = "switch.sync_box_light_sync"
 
+	// Entity ID for the TV remote (actual TV power state)
+	TVRemoteEntity = "remote.big_beautiful_oled"
+
 	// LightSyncOffDebounce is how long to wait before turning off light sync
 	// after Apple TV reports "paused". Prevents flapping due to Apple TV
 	// integration briefly reporting "paused" state during active playback.
@@ -64,6 +67,10 @@ type Manager struct {
 	dailyRebootCount   int
 	rebootCountResetAt time.Time
 	recoveryInProgress bool
+
+	// TV remote (panel power) state — tracked locally to avoid HA GetState races
+	tvRemoteMu sync.RWMutex
+	tvRemoteOn bool // last-known state of remote.big_beautiful_oled
 
 	// Light sync debounce state
 	lightSyncOffMu       sync.Mutex
@@ -107,6 +114,11 @@ func (m *Manager) Start() error {
 	// Subscribe to Apple TV media player state changes (shadow inputs captured automatically)
 	if err := m.subHelper.SubscribeToEntity("media_player.big_beautiful_oled", m.handleAppleTVStateChange); err != nil {
 		return fmt.Errorf("failed to subscribe to media_player.big_beautiful_oled: %w", err)
+	}
+
+	// Subscribe to TV remote entity (actual TV power state)
+	if err := m.subHelper.SubscribeToEntity(TVRemoteEntity, m.handleTVRemoteChange); err != nil {
+		return fmt.Errorf("failed to subscribe to %s: %w", TVRemoteEntity, err)
 	}
 
 	// Subscribe to sync box software power state changes (detects crash/unavailable)
@@ -162,6 +174,14 @@ func (m *Manager) initializeStates() error {
 		m.logger.Warn("Failed to get initial Apple TV state", zap.Error(err))
 	}
 
+	// Get TV remote state (actual TV power)
+	tvRemoteState, err := m.haClient.GetState(TVRemoteEntity)
+	if err == nil && tvRemoteState != nil {
+		m.handleTVRemoteChange(TVRemoteEntity, nil, tvRemoteState)
+	} else if err != nil {
+		m.logger.Warn("Failed to get initial TV remote state", zap.Error(err))
+	}
+
 	// Get sync box power state
 	syncBoxState, err := m.haClient.GetState("switch.sync_box_power")
 	if err == nil && syncBoxState != nil {
@@ -212,6 +232,44 @@ func (m *Manager) handleAppleTVStateChange(entityID string, oldState, newState *
 	m.shadowTracker.UpdateAppleTVState(isPlaying, newState.State)
 }
 
+// handleTVRemoteChange processes remote.big_beautiful_oled state changes (TV panel power).
+// The TV remote acts as a kill switch: when the TV panel turns off, light sync is forced off.
+// TV turning on does NOT trigger light sync — that's driven by sync box state changes.
+func (m *Manager) handleTVRemoteChange(entityID string, oldState, newState *ha.State) {
+	if newState == nil {
+		return
+	}
+
+	isOn := newState.State == "on"
+	m.tvRemoteMu.Lock()
+	m.tvRemoteOn = isOn
+	m.tvRemoteMu.Unlock()
+
+	m.logger.Debug("TV remote state changed",
+		zap.String("entity_id", entityID),
+		zap.String("new_state", newState.State),
+		zap.Bool("is_on", isOn))
+
+	// Only act when TV turns off — force isTVPlaying=false and light sync off.
+	// TV turning on is intentionally ignored: the sync box state drives light sync enablement,
+	// not the TV panel (which may just be showing a screensaver).
+	if newState.State != "on" {
+		m.logger.Info("TV panel turned off, forcing isTVPlaying=false and light sync off",
+			zap.String("tv_state", newState.State))
+
+		if err := m.stateManager.SetBool("isTVPlaying", false); err != nil {
+			if errors.Is(err, state.ErrReadOnlyMode) {
+				m.logger.Debug("Skipping isTVPlaying update in read-only mode",
+					zap.Bool("is_playing", false))
+			} else {
+				m.logger.Error("Failed to set isTVPlaying to false", zap.Error(err))
+			}
+		}
+		m.shadowTracker.UpdateTVPlaying(false)
+		m.controlSyncBoxLightSync(false)
+	}
+}
+
 // handleSyncBoxPowerChange processes switch.sync_box_power state changes
 func (m *Manager) handleSyncBoxPowerChange(entityID string, oldState, newState *ha.State) {
 	if newState == nil {
@@ -256,7 +314,7 @@ func (m *Manager) handleSyncBoxPowerChange(entityID string, oldState, newState *
 	// Update shadow state
 	m.shadowTracker.UpdateTVPower(isTVOn)
 
-	// If TV is off, then it's definitely not playing
+	// If sync box is off, then it's definitely not playing
 	if !isTVOn {
 		if err := m.stateManager.SetBool("isTVPlaying", false); err != nil {
 			if errors.Is(err, state.ErrReadOnlyMode) {
@@ -335,9 +393,33 @@ func (m *Manager) calculateTVPlaying(hdmiInput string) {
 		return
 	}
 
-	// If TV is off, it's definitely not playing
+	// If sync box is off, it's definitely not playing
 	if !isTVOn {
-		m.logger.Debug("TV is off, setting isTVPlaying to false",
+		m.logger.Debug("Sync box is off, setting isTVPlaying to false",
+			zap.String("hdmi_input", hdmiInput))
+
+		if err := m.stateManager.SetBool("isTVPlaying", false); err != nil {
+			if errors.Is(err, state.ErrReadOnlyMode) {
+				m.logger.Debug("Skipping isTVPlaying update in read-only mode",
+					zap.Bool("is_playing", false))
+			} else {
+				m.logger.Error("Failed to set isTVPlaying", zap.Error(err))
+			}
+		}
+		m.shadowTracker.UpdateTVPlaying(false)
+		m.controlSyncBoxLightSync(false)
+		return
+	}
+
+	// Also check if TV panel is actually on (tracked locally from remote entity).
+	// Prevents enabling light sync when sync box is on but TV is off
+	// (e.g., sync box powers on overnight while TV is off).
+	m.tvRemoteMu.RLock()
+	tvPanelOn := m.tvRemoteOn
+	m.tvRemoteMu.RUnlock()
+
+	if !tvPanelOn {
+		m.logger.Debug("TV panel is off, setting isTVPlaying to false",
 			zap.String("hdmi_input", hdmiInput))
 
 		if err := m.stateManager.SetBool("isTVPlaying", false); err != nil {

--- a/homeautomation-go/internal/plugins/tv/manager_test.go
+++ b/homeautomation-go/internal/plugins/tv/manager_test.go
@@ -77,6 +77,112 @@ func TestTVManager_AppleTVStateChange(t *testing.T) {
 	}
 }
 
+func TestTVManager_TVRemoteOff_KillsLightSync(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		remoteState string
+		expectKill  bool
+		description string
+	}{
+		{
+			name:        "TV remote off - kills light sync",
+			remoteState: "off",
+			expectKill:  true,
+			description: "When TV remote turns off, isTVPlaying should be forced false",
+		},
+		{
+			name:        "TV remote standby - kills light sync",
+			remoteState: "standby",
+			expectKill:  true,
+			description: "When TV remote goes to standby, isTVPlaying should be forced false",
+		},
+		{
+			name:        "TV remote on - no effect",
+			remoteState: "on",
+			expectKill:  false,
+			description: "When TV remote turns on, isTVPlaying should not be affected (sync box drives light sync enablement)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockHA := ha.NewMockClient()
+			logger := zap.NewNop()
+			stateMgr := state.NewManager(mockHA, logger, false)
+
+			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil)
+
+			// Initially set isTVPlaying to true
+			if err := stateMgr.SetBool("isTVPlaying", true); err != nil {
+				t.Fatalf("Failed to set initial isTVPlaying: %v", err)
+			}
+
+			// Simulate TV remote state change
+			newState := &ha.State{
+				EntityID: "remote.big_beautiful_oled",
+				State:    tt.remoteState,
+			}
+			manager.handleTVRemoteChange("remote.big_beautiful_oled", nil, newState)
+
+			// Verify isTVPlaying state
+			isTVPlaying, err := stateMgr.GetBool("isTVPlaying")
+			if err != nil {
+				t.Fatalf("Failed to get isTVPlaying: %v", err)
+			}
+
+			if tt.expectKill && isTVPlaying {
+				t.Errorf("Expected isTVPlaying=false when TV remote is %s, got true", tt.remoteState)
+			}
+			if !tt.expectKill && !isTVPlaying {
+				t.Errorf("Expected isTVPlaying to remain true when TV remote is %s, got false", tt.remoteState)
+			}
+		})
+	}
+}
+
+func TestTVManager_TVRemoteOff_SetsTVPlayingFalse(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil)
+
+	// Initially set isTVPlaying to true
+	if err := stateMgr.SetBool("isTVPlaying", true); err != nil {
+		t.Fatalf("Failed to set initial isTVPlaying: %v", err)
+	}
+
+	// Simulate TV remote turning off
+	newState := &ha.State{
+		EntityID: "remote.big_beautiful_oled",
+		State:    "off",
+	}
+	manager.handleTVRemoteChange("remote.big_beautiful_oled", nil, newState)
+
+	// Verify isTVPlaying is now false
+	isTVPlaying, err := stateMgr.GetBool("isTVPlaying")
+	if err != nil {
+		t.Fatalf("Failed to get isTVPlaying: %v", err)
+	}
+
+	if isTVPlaying {
+		t.Errorf("Expected isTVPlaying=false when TV remote turns off, got true")
+	}
+
+	// Verify isTVon is also false
+	isTVOn, err := stateMgr.GetBool("isTVon")
+	if err != nil {
+		t.Fatalf("Failed to get isTVon: %v", err)
+	}
+
+	if isTVOn {
+		t.Errorf("Expected isTVon=false when TV remote turns off, got true")
+	}
+}
+
 func TestTVManager_SyncBoxPowerChange(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -132,9 +238,7 @@ func TestTVManager_SyncBoxPowerChange(t *testing.T) {
 }
 
 func TestTVManager_SyncBoxOff_SetsTVPlayingFalse(t *testing.T) {
-	t.Parallel(
-	// Create mock HA client and state manager
-	)
+	t.Parallel()
 
 	mockHA := ha.NewMockClient()
 	logger := zap.NewNop()
@@ -161,8 +265,8 @@ func TestTVManager_SyncBoxOff_SetsTVPlayingFalse(t *testing.T) {
 		t.Fatalf("Failed to get isTVPlaying: %v", err)
 	}
 
-	if isTVPlaying != false {
-		t.Errorf("Expected isTVPlaying=false when TV turns off, got %v", isTVPlaying)
+	if isTVPlaying {
+		t.Errorf("Expected isTVPlaying=false when sync box turns off, got true")
 	}
 }
 
@@ -224,10 +328,13 @@ func TestTVManager_HDMIInputChange(t *testing.T) {
 			// Create TV manager
 			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil)
 
-			// Set isTVon to true (TV must be on for isTVPlaying calculations to work)
+			// Set isTVon to true (sync box must be on for isTVPlaying calculations)
 			if err := stateMgr.SetBool("isTVon", true); err != nil {
 				t.Fatalf("Failed to set isTVon: %v", err)
 			}
+
+			// Set TV remote to on (TV panel must be on for isTVPlaying to be true)
+			manager.handleTVRemoteChange(TVRemoteEntity, nil, &ha.State{EntityID: TVRemoteEntity, State: "on"})
 
 			// Set isAppleTVPlaying state
 			if err := stateMgr.SetBool("isAppleTVPlaying", tt.isAppleTVPlaying); err != nil {
@@ -368,10 +475,13 @@ func TestTVManager_AppleTVPlayingChange_RecalculatesTVPlaying(t *testing.T) {
 			// Create TV manager
 			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil)
 
-			// Set isTVon to true (TV must be on for isTVPlaying calculations to work)
+			// Set isTVon to true (sync box must be on for isTVPlaying calculations)
 			if err := stateMgr.SetBool("isTVon", true); err != nil {
 				t.Fatalf("Failed to set isTVon: %v", err)
 			}
+
+			// Set TV remote to on (TV panel must be on for isTVPlaying to be true)
+			manager.handleTVRemoteChange(TVRemoteEntity, nil, &ha.State{EntityID: TVRemoteEntity, State: "on"})
 
 			// Set initial HDMI input in mock HA client
 			mockHA.SetState("select.sync_box_hdmi_input", tt.hdmiInput, nil)
@@ -417,6 +527,7 @@ func TestTVManager_Start_InitializesStates(t *testing.T) {
 
 	// Set up initial entity states in mock HA
 	mockHA.SetState("media_player.big_beautiful_oled", "playing", nil)
+	mockHA.SetState("remote.big_beautiful_oled", "on", nil)
 	mockHA.SetState("switch.sync_box_power", "on", nil)
 	mockHA.SetState("select.sync_box_hdmi_input", "AppleTV", nil)
 
@@ -477,9 +588,9 @@ func TestTVManager_Stop_CleansUpSubscriptions(t *testing.T) {
 		t.Fatalf("Failed to start TV manager: %v", err)
 	}
 
-	// Verify subscriptions exist (4 HA subs: AppleTV, sync box software power, physical power, HDMI input)
-	if len(manager.subHelper.GetHASubscriptions()) != 4 {
-		t.Errorf("Expected 4 HA subscriptions after Start(), got %d", len(manager.subHelper.GetHASubscriptions()))
+	// Verify subscriptions exist (5 HA subs: AppleTV, TV remote, sync box software power, physical power, HDMI input)
+	if len(manager.subHelper.GetHASubscriptions()) != 5 {
+		t.Errorf("Expected 5 HA subscriptions after Start(), got %d", len(manager.subHelper.GetHASubscriptions()))
 	}
 	if len(manager.subHelper.GetStateSubscriptions()) != 1 {
 		t.Errorf("Expected 1 state subscription after Start(), got %d", len(manager.subHelper.GetStateSubscriptions()))
@@ -996,9 +1107,9 @@ func TestTVManager_Start_AddsPhysicalPowerSubscription(t *testing.T) {
 		t.Fatalf("Failed to start TV manager: %v", err)
 	}
 
-	// Verify subscriptions exist - now should be 4 (added physical power subscription)
-	if len(manager.subHelper.GetHASubscriptions()) != 4 {
-		t.Errorf("Expected 4 HA subscriptions after Start(), got %d", len(manager.subHelper.GetHASubscriptions()))
+	// Verify subscriptions exist - now should be 5 (AppleTV, TV remote, sync box software power, physical power, HDMI input)
+	if len(manager.subHelper.GetHASubscriptions()) != 5 {
+		t.Errorf("Expected 5 HA subscriptions after Start(), got %d", len(manager.subHelper.GetHASubscriptions()))
 	}
 	if len(manager.subHelper.GetStateSubscriptions()) != 1 {
 		t.Errorf("Expected 1 state subscription after Start(), got %d", len(manager.subHelper.GetStateSubscriptions()))

--- a/homeautomation-go/test/integration/scenario_multi_plugin_test.go
+++ b/homeautomation-go/test/integration/scenario_multi_plugin_test.go
@@ -143,6 +143,7 @@ func TestScenario_TVPlaying_DimsLivingRoomLights(t *testing.T) {
 	env.server.SetState("media_player.big_beautiful_oled", "playing", map[string]interface{}{
 		"friendly_name": "Apple TV",
 	})
+	env.server.SetState("remote.big_beautiful_oled", "on", map[string]interface{}{})
 	env.server.SetState("switch.sync_box_power", "on", map[string]interface{}{})
 	env.server.SetState("select.sync_box_hdmi_input", "Apple TV", map[string]interface{}{})
 

--- a/homeautomation-go/test/integration/scenario_tv_test.go
+++ b/homeautomation-go/test/integration/scenario_tv_test.go
@@ -41,17 +41,18 @@ func TestScenario_AppleTVPlaying(t *testing.T) {
 	server, manager, cleanup := setupTVScenarioTest(t)
 	defer cleanup()
 
-	t.Log("GIVEN: Apple TV is idle, sync box is on, HDMI input is AppleTV")
+	t.Log("GIVEN: Apple TV is idle, TV is on, sync box is on, HDMI input is AppleTV")
 
 	// Set initial states
 	server.SetState("media_player.big_beautiful_oled", "idle", map[string]interface{}{
 		"friendly_name": "Apple TV",
 	})
+	server.SetState("remote.big_beautiful_oled", "on", map[string]interface{}{})
 	server.SetState("switch.sync_box_power", "on", map[string]interface{}{})
 	server.SetState("select.sync_box_hdmi_input", "AppleTV", map[string]interface{}{})
 
 	// Wait for initial state to propagate
-	waitForBoolState(t, manager, "isTVon", true, "isTVon should be true when sync box is on")
+	waitForBoolState(t, manager, "isTVon", true, "isTVon should be true when TV remote is on")
 
 	t.Log("WHEN: Apple TV starts playing")
 
@@ -74,12 +75,13 @@ func TestScenario_HDMIInputSwitch(t *testing.T) {
 	server, manager, cleanup := setupTVScenarioTest(t)
 	defer cleanup()
 
-	t.Log("GIVEN: Apple TV is playing, sync box is on, HDMI input is AppleTV")
+	t.Log("GIVEN: Apple TV is playing, TV is on, sync box is on, HDMI input is AppleTV")
 
 	// Set initial states - Apple TV playing
 	server.SetState("media_player.big_beautiful_oled", "playing", map[string]interface{}{
 		"friendly_name": "Apple TV",
 	})
+	server.SetState("remote.big_beautiful_oled", "on", map[string]interface{}{})
 	server.SetState("switch.sync_box_power", "on", map[string]interface{}{})
 	server.SetState("select.sync_box_hdmi_input", "AppleTV", map[string]interface{}{})
 
@@ -117,53 +119,37 @@ func TestScenario_HDMIInputSwitch(t *testing.T) {
 	waitForBoolState(t, manager, "isTVPlaying", false, "isTVPlaying should be false when AppleTV is idle")
 }
 
-// TestScenario_SyncBoxPower verifies that sync box power changes update isTVon
-// and that turning off the sync box sets isTVPlaying to false
-func TestScenario_SyncBoxPower(t *testing.T) {
+// TestScenario_TVRemoteKillSwitch verifies that the TV remote entity acts as a
+// kill switch: when the TV panel turns off, isTVPlaying is forced false and
+// light sync turns off, even though isTVon (driven by sync box) may still be true.
+func TestScenario_TVRemoteKillSwitch(t *testing.T) {
 	t.Parallel()
 	server, manager, cleanup := setupTVScenarioTest(t)
 	defer cleanup()
 
-	t.Log("GIVEN: Sync box is off, Apple TV is idle")
+	t.Log("GIVEN: Sync box is on, TV is on, Apple TV is playing on AppleTV input")
 
-	// Set initial states
-	server.SetState("switch.sync_box_power", "off", map[string]interface{}{})
-	server.SetState("media_player.big_beautiful_oled", "idle", map[string]interface{}{
+	// Set initial states - everything on and playing
+	server.SetState("remote.big_beautiful_oled", "on", map[string]interface{}{})
+	server.SetState("switch.sync_box_power", "on", map[string]interface{}{})
+	server.SetState("media_player.big_beautiful_oled", "playing", map[string]interface{}{
 		"friendly_name": "Apple TV",
 	})
 	server.SetState("select.sync_box_hdmi_input", "AppleTV", map[string]interface{}{})
 
-	// Wait for initial state
-	waitForBoolState(t, manager, "isTVon", false, "isTVon should be false when sync box is off")
-
-	t.Log("WHEN: Sync box powers on")
-
-	// Power on sync box
-	server.SetState("switch.sync_box_power", "on", map[string]interface{}{})
-
-	t.Log("THEN: Verify isTVon is true")
-
 	waitForBoolState(t, manager, "isTVon", true, "isTVon should be true when sync box is on")
-
-	t.Log("GIVEN: Apple TV starts playing while sync box is on")
-
-	// Start Apple TV playback
-	server.SetState("media_player.big_beautiful_oled", "playing", map[string]interface{}{
-		"friendly_name": "Apple TV",
-	})
-
-	// Verify isTVPlaying is true
 	waitForBoolState(t, manager, "isTVPlaying", true, "isTVPlaying should be true when AppleTV is playing")
 
-	t.Log("WHEN: Sync box powers off")
+	t.Log("WHEN: TV panel turns off (remote entity goes off) but sync box stays on")
 
-	// Power off sync box
-	server.SetState("switch.sync_box_power", "off", map[string]interface{}{})
+	// TV panel turns off - sync box stays on
+	server.SetState("remote.big_beautiful_oled", "off", map[string]interface{}{})
 
-	t.Log("THEN: Verify isTVon is false AND isTVPlaying is false")
+	t.Log("THEN: isTVPlaying should be forced false (kill switch)")
 
-	waitForBoolState(t, manager, "isTVon", false, "isTVon should be false when sync box is off")
-	waitForBoolState(t, manager, "isTVPlaying", false, "isTVPlaying should be false when sync box is off (even if AppleTV is playing)")
+	waitForBoolState(t, manager, "isTVPlaying", false, "isTVPlaying should be false when TV panel turns off")
+	// Note: isTVon remains true because it's driven by sync box power
+	waitForBoolState(t, manager, "isTVon", true, "isTVon should remain true (sync box is still on)")
 }
 
 // TestScenario_MultipleInputs tests behavior when inputs change rapidly
@@ -172,15 +158,16 @@ func TestScenario_MultipleInputs(t *testing.T) {
 	server, manager, cleanup := setupTVScenarioTest(t)
 	defer cleanup()
 
-	t.Log("GIVEN: Sync box is on, Apple TV is idle, HDMI input is AppleTV")
+	t.Log("GIVEN: TV is on, sync box is on, Apple TV is idle, HDMI input is AppleTV")
 
 	// Set initial states
+	server.SetState("remote.big_beautiful_oled", "on", map[string]interface{}{})
 	server.SetState("switch.sync_box_power", "on", map[string]interface{}{})
 	server.SetState("media_player.big_beautiful_oled", "idle", map[string]interface{}{
 		"friendly_name": "Apple TV",
 	})
 	server.SetState("select.sync_box_hdmi_input", "AppleTV", map[string]interface{}{})
-	waitForBoolState(t, manager, "isTVon", true, "isTVon should be true when sync box is on")
+	waitForBoolState(t, manager, "isTVon", true, "isTVon should be true when TV remote is on")
 
 	t.Log("WHEN: Switching between multiple HDMI inputs")
 
@@ -214,6 +201,7 @@ func TestScenario_TVOffState(t *testing.T) {
 	t.Log("GIVEN: TV is initially on with Apple TV playing")
 
 	// Set initial states - everything on and playing
+	server.SetState("remote.big_beautiful_oled", "on", map[string]interface{}{})
 	server.SetState("switch.sync_box_power", "on", map[string]interface{}{})
 	server.SetState("media_player.big_beautiful_oled", "playing", map[string]interface{}{
 		"friendly_name": "Apple TV",
@@ -258,9 +246,10 @@ func TestScenario_RapidInputSwitching(t *testing.T) {
 	server, manager, cleanup := setupTVScenarioTest(t)
 	defer cleanup()
 
-	t.Log("GIVEN: Sync box is on, Apple TV is playing")
+	t.Log("GIVEN: TV is on, sync box is on, Apple TV is playing")
 
 	// Set initial states
+	server.SetState("remote.big_beautiful_oled", "on", map[string]interface{}{})
 	server.SetState("switch.sync_box_power", "on", map[string]interface{}{})
 	server.SetState("media_player.big_beautiful_oled", "playing", map[string]interface{}{
 		"friendly_name": "Apple TV",
@@ -288,15 +277,16 @@ func TestScenario_AppleTVPlaybackStateChanges(t *testing.T) {
 	server, manager, cleanup := setupTVScenarioTest(t)
 	defer cleanup()
 
-	t.Log("GIVEN: Sync box is on, HDMI input is AppleTV")
+	t.Log("GIVEN: TV is on, sync box is on, HDMI input is AppleTV")
 
 	// Set initial states
+	server.SetState("remote.big_beautiful_oled", "on", map[string]interface{}{})
 	server.SetState("switch.sync_box_power", "on", map[string]interface{}{})
 	server.SetState("select.sync_box_hdmi_input", "AppleTV", map[string]interface{}{})
 	server.SetState("media_player.big_beautiful_oled", "idle", map[string]interface{}{
 		"friendly_name": "Apple TV",
 	})
-	waitForBoolState(t, manager, "isTVon", true, "isTVon should be true when sync box is on")
+	waitForBoolState(t, manager, "isTVon", true, "isTVon should be true when TV remote is on")
 
 	testCases := []struct {
 		state           string
@@ -324,4 +314,38 @@ func TestScenario_AppleTVPlaybackStateChanges(t *testing.T) {
 		waitForBoolState(t, manager, "isTVPlaying", tc.expectedPlaying,
 			"isTVPlaying should be %v when Apple TV is %s and input is AppleTV", tc.expectedPlaying, tc.state)
 	}
+}
+
+// TestScenario_TVOffSyncBoxOn verifies that when the TV is off but the sync box
+// powers on independently, isTVPlaying remains false and light sync is not enabled.
+// This prevents the bug where sync box turning on overnight caused 9+ hours of light sync.
+func TestScenario_TVOffSyncBoxOn(t *testing.T) {
+	t.Parallel()
+	server, manager, cleanup := setupTVScenarioTest(t)
+	defer cleanup()
+
+	t.Log("GIVEN: TV is off, sync box is off, HDMI input is on a non-AppleTV input")
+
+	// Set initial states - TV is off
+	server.SetState("remote.big_beautiful_oled", "off", map[string]interface{}{})
+	server.SetState("switch.sync_box_power", "off", map[string]interface{}{})
+	server.SetState("select.sync_box_hdmi_input", "HDMI 1", map[string]interface{}{})
+	server.SetState("media_player.big_beautiful_oled", "off", map[string]interface{}{
+		"friendly_name": "Apple TV",
+	})
+
+	// Wait for initial state
+	waitForBoolState(t, manager, "isTVon", false, "isTVon should be false when TV remote is off")
+
+	t.Log("WHEN: Sync box powers on independently (e.g., after power restore)")
+
+	// Sync box powers on but TV stays off
+	server.SetState("switch.sync_box_power", "on", map[string]interface{}{})
+
+	t.Log("THEN: isTVon becomes true (sync box drives it), but isTVPlaying stays false (TV panel is off)")
+
+	// isTVon is driven by sync box, so it becomes true
+	waitForBoolState(t, manager, "isTVon", true, "isTVon should be true (sync box is on)")
+	// But isTVPlaying stays false because calculateTVPlaying checks TV remote state
+	waitForBoolState(t, manager, "isTVPlaying", false, "isTVPlaying should remain false (TV panel is off)")
 }


### PR DESCRIPTION
## Summary

- **Subscribe to `remote.big_beautiful_oled` (TV panel power) as a kill switch**: when the TV turns off, `isTVPlaying` is forced false and light sync is turned off
- **`isTVOn` remains driven by sync box power** (`switch.sync_box_power`) — this is the "on" path that enables light sync evaluation
- **`calculateTVPlaying` now checks TV remote state** — prevents enabling light sync when sync box is on but TV panel is off (the overnight bug)
- **TV remote turning ON intentionally does nothing** — avoids false light sync activation when the TV is just showing a screensaver

## Context

The sync box turned on independently overnight while the TV was off. The system set `isTVOn = true` (from sync box power), saw a non-AppleTV HDMI input, assumed `isTVPlaying = true`, and left Hue Sync light sync on for 9+ hours.

The fix uses an asymmetric model:
- **Light sync ON** is driven by sync box state (+ HDMI input + AppleTV playing), gated by TV panel being on
- **Light sync OFF** is also triggered by TV panel turning off (kill switch)

## Test plan

- [x] `make unit-tests` passes (74.7% coverage)
- [x] `make integration-tests` passes
- [x] Pre-push hook passes (compilation, race detector, coverage, integration tests)
- [x] New unit test: `TestTVManager_TVRemoteOff_KillsLightSync` (off/standby kill, on is no-op)
- [x] New unit test: `TestTVManager_TVRemoteOff_SetsTVPlayingFalse`
- [x] New integration test: `TestScenario_TVOffSyncBoxOn` — sync box on + TV off = isTVon true but isTVPlaying false
- [x] New integration test: `TestScenario_TVRemoteKillSwitch` — TV off forces isTVPlaying false even with sync box on
- [x] Updated existing integration tests to set `remote.big_beautiful_oled` "on" for correct calculateTVPlaying behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)