### PR TITLE
Fix #641: Fix documentation drift and contradictions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,12 +103,14 @@ grep -n "isNickHome" docs/archive/flows.json                     # Find state va
 
 ## Development Standards
 
-### Shadow State Pattern (CRITICAL)
+### Shadow State Pattern
 
-**Every plugin MUST implement shadow state tracking.** See [SHADOW_STATE.md](./docs/reference/SHADOW_STATE.md).
+**Plugins should implement shadow state tracking for observability.** See [SHADOW_STATE.md](./docs/reference/SHADOW_STATE.md).
+
+All plugins register a shadow tracker and track outputs. Implementing `updateShadowInputs()` to capture raw inputs is recommended but currently only done in `dayphase` and `sleephygiene`.
 
 ```go
-// EVERY handler must update shadow inputs at the start
+// Recommended: update shadow inputs at the start of handlers
 func (m *Manager) handleSomeChange(entityID string, oldState, newState *ha.State) {
     if newState == nil {
         return
@@ -122,9 +124,9 @@ func (m *Manager) handleSomeChange(entityID string, oldState, newState *ha.State
 
 **Checklist for new plugins:**
 - [ ] Add `shadowTracker` field to Manager struct
-- [ ] Implement `updateShadowInputs()` method
-- [ ] Call `updateShadowInputs()` at START of every handler
-- [ ] Test that `/api/shadow/{plugin}` shows populated inputs
+- [ ] Register with `/api/shadow/{plugin}` endpoint
+- [ ] Recommended: Implement `updateShadowInputs()` method
+- [ ] Recommended: Call `updateShadowInputs()` at START of every handler
 
 ### Go Code Standards
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -70,8 +70,8 @@
 ### Test Coverage
 
 **Unit Tests:** All passing ✅
-- HA Client: >70% coverage
-- State Manager: >70% coverage
+- HA Client: >65% coverage
+- State Manager: >65% coverage
 - No race conditions detected
 
 **Integration Tests:** 11/11 passing ✅
@@ -699,7 +699,7 @@ homeautomation-go/
 2. ✅ State changes in HA reflected in Golang cache within 1 second
 3. ✅ State changes in Golang written to HA successfully
 4. ✅ WebSocket reconnection works with exponential backoff
-5. ✅ All unit tests pass with >70% coverage
+5. ✅ All unit tests pass with >65% coverage
 6. ✅ Thread-safe concurrent access verified (5,000+ operations tested)
 7. ✅ Integration test suite validates correctness
 8. ✅ Critical concurrency bugs fixed

--- a/docs/operations/BRANCH_PROTECTION.md
+++ b/docs/operations/BRANCH_PROTECTION.md
@@ -15,7 +15,7 @@ The following CI workflows must pass before a PR can be merged:
    - **File**: `.github/workflows/pr-tests.yml`
    - **Checks**:
      - ✅ Go unit tests with race detector
-     - ✅ Test coverage ≥70%
+     - ✅ Test coverage ≥65%
      - ✅ Integration tests (11/11 passing)
      - ✅ Config validation (YAML, Spotify URIs)
 
@@ -71,14 +71,11 @@ After configuring branch protection:
 
 #### Go Tests (`homeautomation-go/`)
 ```bash
-# Unit tests with race detector
-go test ./... -race
-
-# Coverage check (minimum 70%)
-go test ./... -race -coverprofile=coverage.out
+# Unit tests with race detector and coverage check (minimum 65%)
+make unit-tests
 
 # Integration tests (concurrent load, deadlocks, race conditions)
-go test -v -race ./test/integration/...
+make integration-tests
 ```
 
 #### Config Tests
@@ -98,28 +95,17 @@ make run-spotify-validation-music
 Run the same checks locally that CI will run:
 
 ```bash
-cd homeautomation-go
+# Run all checks (formatting, linting, build)
+make pre-commit
 
-# 1. Ensure everything compiles
-go build ./...
+# Run unit tests with race detector and coverage (uses caching)
+make unit-tests
 
-# 2. Run all tests
-go test ./...
+# Run integration tests (uses caching)
+make integration-tests
 
-# 3. Run with race detector
-go test -race ./...
-
-# 4. Check coverage
-go test -coverprofile=coverage.out ./...
-go tool cover -func=coverage.out
-
-# 5. Run integration tests
-go test -v -race ./test/integration/...
-```
-
-Or use the one-liner from `../../AGENTS.md`:
-```bash
-cd homeautomation-go && go build ./... && go test ./... && echo "✅ Ready to push"
+# Or run full CI validation (no cache)
+make pre-push
 ```
 
 ### What Happens on PR Creation
@@ -178,10 +164,11 @@ cd homeautomation-go && go build ./... && go test ./... && echo "✅ Ready to pu
 go version
 
 # Update dependencies
-go mod tidy
+cd homeautomation-go && go mod tidy
 
 # Run with race detector (CI does this)
-go test -race ./...
+make unit-tests
+make integration-tests
 
 # Check CI logs for specific error messages
 ```
@@ -200,7 +187,7 @@ go test -race ./...
 - Catches issues before they reach main branch
 
 ✅ **Enforces code quality standards**
-- Minimum 70% test coverage
+- Minimum 65% test coverage
 - Race condition detection
 - Integration test validation
 

--- a/docs/operations/DOCKER.md
+++ b/docs/operations/DOCKER.md
@@ -273,9 +273,8 @@ docker exec -it homeautomation /bin/sh
 The GitHub Actions workflow (`.github/workflows/docker-build-push.yml`) performs:
 
 1. **Test Stage**:
-   - Runs `go test ./... -race -v`
-   - Generates coverage report
-   - Fails if coverage < 70%
+   - Runs `make ci-unit-tests` (includes race detector and coverage)
+   - Fails if coverage < 65%
 
 2. **Build and Push Stage**:
    - Builds multi-platform Docker image

--- a/docs/reference/CONCURRENCY_LESSONS.md
+++ b/docs/reference/CONCURRENCY_LESSONS.md
@@ -220,7 +220,7 @@ func (c *Client) handleEvent(msg *Message) {
 
 ## Lesson 6: Always Test with Race Detector
 
-**Command**: `go test -race ./...`
+**Command**: `make unit-tests` and `make integration-tests` (both include `-race`)
 
 **Why**: Race conditions are timing-dependent and may not manifest in normal runs.
 
@@ -850,8 +850,12 @@ When concurrency bugs occur, use these techniques to diagnose them:
 
 ### 1. Race Detector
 ```bash
-go test -race ./...
-go build -race ./cmd/main.go && ./main
+# Run tests with race detection (preferred - uses caching)
+make unit-tests
+make integration-tests
+
+# Build binary with race detection for manual testing
+cd homeautomation-go && go build -race ./cmd/main.go && ./main
 ```
 The race detector instruments memory accesses and reports concurrent access without synchronization. It catches ~95% of data races but has ~10x performance overhead.
 

--- a/docs/reference/PLUGIN_SYSTEM.md
+++ b/docs/reference/PLUGIN_SYSTEM.md
@@ -846,19 +846,12 @@ assert.Eventually(t, func() bool {
 ### Running Tests
 
 ```bash
-# Run all plugin tests
-cd homeautomation-go
-go test ./internal/plugins/... -v
+# Run all tests (preferred - uses caching)
+make unit-tests
+make integration-tests
 
-# Run with race detector
-go test ./internal/plugins/... -race
-
-# Run specific plugin tests
-go test ./internal/plugins/energy/... -v
-
-# Generate coverage report
-go test ./internal/plugins/... -coverprofile=coverage.out
-go tool cover -html=coverage.out
+# Run full validation (same as CI)
+make pre-push
 ```
 
 ---

--- a/docs/reference/SHADOW_STATE.md
+++ b/docs/reference/SHADOW_STATE.md
@@ -58,13 +58,15 @@ type ShadowMetadata struct {
 
 ## Implementation Requirements
 
-### CRITICAL: Track Raw Inputs
+### Track Raw Inputs
 
-**Every plugin handler MUST update shadow state inputs when receiving data from Home Assistant or state changes.**
+**Plugins SHOULD update shadow state inputs when receiving data from Home Assistant or state changes.** Currently, `dayphase` and `sleephygiene` implement full `updateShadowInputs()` tracking. Other plugins track outputs via their shadow trackers but do not yet capture raw inputs.
 
-This is the most common bug: plugins update outputs but forget to track the raw inputs that triggered the computation.
+When adding or modifying a plugin, implementing `updateShadowInputs()` is recommended for debugging and observability. It is not currently enforced across all plugins.
 
-### Required Pattern
+A common bug when implementing shadow state: plugins update outputs but forget to track the raw inputs that triggered the computation.
+
+### Recommended Pattern
 
 ```go
 // CORRECT: Update shadow inputs at start of every handler

--- a/homeautomation-go/STATE_TRACKING_README.md
+++ b/homeautomation-go/STATE_TRACKING_README.md
@@ -289,6 +289,6 @@ Potential improvements for future iterations:
 
 ## See Also
 
-- [Node-RED Analysis](../docs/NODE_RED_TABS_ANALYSIS.md) - Detailed analysis of original Node-RED implementation
-- [Implementation Plan](../docs/architecture/IMPLEMENTATION_PLAN.md) - Overall migration strategy
+- [Node-RED Analysis](../docs/archive/NODE_RED_TABS_ANALYSIS.md) - Detailed analysis of original Node-RED implementation (archived)
+- [Architecture](../docs/architecture/ARCHITECTURE.md) - System design and implementation status
 - [Main README](./README.md) - Golang project overview


### PR DESCRIPTION
Resolves #641

## Summary
- **Shadow state spec drift**: Updated SHADOW_STATE.md and AGENTS.md to reconcile the `updateShadowInputs()` mandate with reality. Only `dayphase` and `sleephygiene` implement it (2 of 18 plugins). Changed language from MUST/CRITICAL to SHOULD/recommended.
- **Coverage threshold alignment**: Standardized all docs to 65% minimum coverage (matching the Makefile enforcement). Fixed in BRANCH_PROTECTION.md, DOCKER.md, and ARCHITECTURE.md which incorrectly stated 70%.
- **Bare `go test` commands**: Replaced bare `go test` examples with `make unit-tests` / `make integration-tests` in PLUGIN_SYSTEM.md, CONCURRENCY_LESSONS.md, BRANCH_PROTECTION.md, and DOCKER.md.
- **Dead/broken references**: Fixed broken link to `NODE_RED_TABS_ANALYSIS.md` in `STATE_TRACKING_README.md` (wrong path). Fixed dead link to non-existent `IMPLEMENTATION_PLAN.md`, pointed to `ARCHITECTURE.md` instead. Archive files themselves are retained as they are properly organized and some are still referenced.

## Test Plan
- [x] `make unit-tests` passes (74.7% coverage)
- [x] `make integration-tests` passes (11/11)
- [x] `make pre-push` full validation passes
- [ ] Review that documentation is internally consistent
- [ ] Verify no remaining bare `go test` commands in actionable contexts

🤖 Generated with Claude Code