### PR TITLE
Fix #640: Track pending writes to suppress echo-back races

### DIFF
--- a/docs/reference/CONCURRENCY_LESSONS.md
+++ b/docs/reference/CONCURRENCY_LESSONS.md
@@ -1143,7 +1143,74 @@ func (m *Manager) handleStateChange(key string, oldValue, newValue interface{}) 
 
 ---
 
+## Lesson 15: Track Pending Writes to Suppress Echo-Back Races
+
+**Pattern**: When writing state to Home Assistant, record the expected value so echo-backs can be recognized and suppressed.
+
+**Why**: Home Assistant echoes back state changes via WebSocket `state_changed` events. When the Go app sets a value, the echo arrives asynchronously. Two race conditions arise:
+
+1. **Stale echo-back**: HA echoes back the *old* value before processing the write. This overwrites the cache with stale data and fires phantom handler notifications.
+2. **Correct echo-back**: HA echoes back the *new* value after processing the write. Without tracking, this is indistinguishable from a genuine external change and triggers redundant handler notifications.
+
+**Race Scenario (Without Fix)**:
+```
+T+0ms:  SetBool("isAnyoneHome", true)    → cache = true
+T+2ms:  HA echo: false (stale)           → cache = false ← WRONG
+T+3ms:  Subscribers notified: true→false  ← PHANTOM
+T+50ms: HA echo: true (correct)          → cache = true
+T+51ms: Subscribers notified: false→true  ← PHANTOM
+```
+
+**Implementation**:
+```go
+type Manager struct {
+    // ...
+    pendingWrites map[string]interface{}  // Protected by cacheMu
+}
+```
+
+**Write Path** (`SetBool`, `SetString`, `SetNumber`, `SetJSON`):
+1. Update cache with new value
+2. If there's an active HA subscription for this entity, record `pendingWrites[key] = value`
+3. Sync to HA
+4. If HA sync fails, rollback both cache and pending write
+5. Notify subscribers
+
+**Receive Path** (subscription callback):
+1. Check if `pendingWrites[key]` exists
+2. If pending value == echo value: confirmed echo-back → clear pending, return (no notification)
+3. If pending value != echo value: stale echo-back → suppress, return (no cache update)
+4. If no pending: normal flow (compare with cache, update, notify)
+
+**Key Details**:
+- `pendingWrites` is protected by `cacheMu` (same lock as cache) for atomicity
+- Only record pending writes when there's an active HA subscription (`hasActiveHASub`)
+- `SyncFromHA` clears all pending writes (authoritative baseline reset)
+- Rapid writes update the pending value to the latest (last write wins)
+
+**Where Applied**:
+- `internal/state/manager.go` - All Set* methods and subscription callback
+
+**Tests That Validate This**:
+- `TestSetBool_SuppressesEchoBack` - Echo from own write suppressed
+- `TestSetBool_SuppressesStaleEchoBack` - Stale echo doesn't overwrite cache
+- `TestSetBool_EchoBackConfirmsClearsPendingFlag` - Confirmed echo clears flag
+- `TestSetString_SuppressesStaleEchoBack` - String variant
+- `TestSetNumber_SuppressesStaleEchoBack` - Number variant
+- `TestManager_EchoBackSuppression_RapidWrites` - Latest pending value wins
+- `TestManager_EchoBackSuppression_HAFailureRollback` - Failure clears pending
+- `TestManager_SetString_NoPendingWriteWithoutSub` - No pending without subscription
+- `TestManager_SyncFromHA_ClearsPendingWrites` - SyncFromHA resets pending state
+
+---
+
 ## Change Log
+
+### 2026-02-11
+- **Added Lesson 15**: Track Pending Writes to Suppress Echo-Back Races
+  - Documents pending write tracking pattern for HA echo-back suppression (Issue #640)
+  - Replaces timestamp-based filtering with deterministic value-based matching
+  - Applied to all Set* methods and subscription callback in `internal/state/manager.go`
 
 ### 2026-02-09
 - **Added Lesson 14**: Establish Clear Ownership When Multiple Systems React to the Same State Change

--- a/homeautomation-go/internal/state/manager.go
+++ b/homeautomation-go/internal/state/manager.go
@@ -57,6 +57,13 @@ type Manager struct {
 	nextSubID              uint64
 	readOnly               bool
 
+	// pendingWrites tracks values that the app has written to HA but whose
+	// echo-back confirmation hasn't arrived yet. When HA echoes back a state
+	// change that matches a pending write, it's recognized as our own write
+	// and suppressed to avoid phantom transitions that re-trigger handlers.
+	// Protected by cacheMu.
+	pendingWrites map[string]interface{}
+
 	// wakeSequenceLatch is internal state for computed isAnyoneHomeAndAwake.
 	// When the wake sequence activates (isWakeSequenceActive false->true),
 	// this latch is set to keep isAnyoneHomeAndAwake=true even if someone
@@ -95,12 +102,19 @@ func NewManager(client ha.HAClient, logger *zap.Logger, readOnly bool) *Manager 
 		subscribersWithContext: make(map[string]map[uint64]StateChangeHandlerWithContext),
 		haSubs:                 make(map[string]ha.Subscription),
 		readOnly:               readOnly,
+		pendingWrites:          make(map[string]interface{}),
 	}
 }
 
 // SyncFromHA reads all state variables from Home Assistant
 func (m *Manager) SyncFromHA() error {
 	m.logger.Info("Syncing state from Home Assistant...")
+
+	// Clear all pending writes - SyncFromHA establishes HA's state as the
+	// authoritative baseline, so any prior pending writes are now obsolete.
+	m.cacheMu.Lock()
+	m.pendingWrites = make(map[string]interface{})
+	m.cacheMu.Unlock()
 
 	states, err := m.client.GetAllStates()
 	if err != nil {
@@ -196,6 +210,15 @@ func (m *Manager) parseStateValue(stateStr string, varType StateType) (interface
 	}
 }
 
+// hasActiveHASub returns true if there is an active HA subscription for the given entity ID.
+// Must be called without holding haSubsMu.
+func (m *Manager) hasActiveHASub(entityID string) bool {
+	m.haSubsMu.Lock()
+	_, exists := m.haSubs[entityID]
+	m.haSubsMu.Unlock()
+	return exists
+}
+
 // subscribeToEntity subscribes to state changes for an entity
 func (m *Manager) subscribeToEntity(entityID, key string) error {
 	m.haSubsMu.Lock()
@@ -227,6 +250,32 @@ func (m *Manager) subscribeToEntity(entityID, key string) error {
 
 		// Update cache and check if value actually changed
 		m.cacheMu.Lock()
+
+		// Check for pending write echo-back suppression.
+		// If we recently wrote a value to HA, the echo-back should be suppressed
+		// to avoid phantom transitions that re-trigger handlers.
+		if pendingValue, hasPending := m.pendingWrites[key]; hasPending {
+			if reflect.DeepEqual(newValue, pendingValue) {
+				// Echo-back matches our pending write - confirmed.
+				// Clear the pending flag and return without notifying.
+				delete(m.pendingWrites, key)
+				m.cacheMu.Unlock()
+				m.logger.Debug("Echo-back confirmed pending write",
+					zap.String("key", key),
+					zap.Any("value", newValue))
+				return
+			}
+			// Echo-back differs from our pending write - this is a stale
+			// echo from before our write was processed. Suppress it to
+			// prevent the cache from being overwritten with the old value.
+			m.cacheMu.Unlock()
+			m.logger.Debug("Suppressed stale echo-back",
+				zap.String("key", key),
+				zap.Any("pending", pendingValue),
+				zap.Any("stale_echo", newValue))
+			return
+		}
+
 		oldValue := m.cache[key]
 		if reflect.DeepEqual(oldValue, newValue) {
 			// Value hasn't changed, skip notification
@@ -397,6 +446,12 @@ func (m *Manager) SetBool(key string, value bool) error {
 
 	// Update cache
 	m.cache[key] = value
+
+	// Track pending write if there's an active HA subscription that would
+	// deliver an echo-back for this entity.
+	if !variable.LocalOnly && m.hasActiveHASub(variable.EntityID) {
+		m.pendingWrites[key] = value
+	}
 	m.cacheMu.Unlock()
 
 	// Skip HA sync for local-only variables, but still notify subscribers
@@ -414,15 +469,16 @@ func (m *Manager) SetBool(key string, value bool) error {
 	// Sync to HA
 	entityName := extractEntityName(variable.EntityID)
 	if err := m.client.SetInputBoolean(entityName, value); err != nil {
-		// Rollback cache on error
+		// Rollback cache and pending write on error
 		m.cacheMu.Lock()
 		m.cache[key] = oldValue
+		delete(m.pendingWrites, key)
 		m.cacheMu.Unlock()
 		return fmt.Errorf("failed to set HA value: %w", err)
 	}
 
 	// Notify subscribers after successful HA sync
-	// The HA callback will skip notification since cache already has the new value
+	// The HA echo-back will be suppressed by the pending write tracker.
 	m.notifySubscribers(key, oldValue, value)
 
 	return nil
@@ -482,6 +538,11 @@ func (m *Manager) SetString(key string, value string) error {
 
 	// Update cache
 	m.cache[key] = value
+
+	// Track pending write if there's an active HA subscription
+	if !variable.LocalOnly && m.hasActiveHASub(variable.EntityID) {
+		m.pendingWrites[key] = value
+	}
 	m.cacheMu.Unlock()
 
 	// Skip HA sync for local-only variables, but still notify subscribers
@@ -499,15 +560,16 @@ func (m *Manager) SetString(key string, value string) error {
 	// Sync to HA
 	entityName := extractEntityName(variable.EntityID)
 	if err := m.client.SetInputText(entityName, value); err != nil {
-		// Rollback cache on error
+		// Rollback cache and pending write on error
 		m.cacheMu.Lock()
 		m.cache[key] = oldValue
+		delete(m.pendingWrites, key)
 		m.cacheMu.Unlock()
 		return fmt.Errorf("failed to set HA value: %w", err)
 	}
 
 	// Notify subscribers after successful HA sync
-	// The HA callback will skip notification since cache already has the new value
+	// The HA echo-back will be suppressed by the pending write tracker.
 	m.notifySubscribers(key, oldValue, value)
 
 	return nil
@@ -567,6 +629,11 @@ func (m *Manager) SetNumber(key string, value float64) error {
 
 	// Update cache
 	m.cache[key] = value
+
+	// Track pending write if there's an active HA subscription
+	if !variable.LocalOnly && m.hasActiveHASub(variable.EntityID) {
+		m.pendingWrites[key] = value
+	}
 	m.cacheMu.Unlock()
 
 	// Skip HA sync for local-only variables, but still notify subscribers
@@ -584,15 +651,16 @@ func (m *Manager) SetNumber(key string, value float64) error {
 	// Sync to HA
 	entityName := extractEntityName(variable.EntityID)
 	if err := m.client.SetInputNumber(entityName, value); err != nil {
-		// Rollback cache on error
+		// Rollback cache and pending write on error
 		m.cacheMu.Lock()
 		m.cache[key] = oldValue
+		delete(m.pendingWrites, key)
 		m.cacheMu.Unlock()
 		return fmt.Errorf("failed to set HA value: %w", err)
 	}
 
 	// Notify subscribers after successful HA sync
-	// The HA callback will skip notification since cache already has the new value
+	// The HA echo-back will be suppressed by the pending write tracker.
 	m.notifySubscribers(key, oldValue, value)
 
 	return nil
@@ -655,6 +723,11 @@ func (m *Manager) SetJSON(key string, value interface{}) error {
 
 	// Update cache
 	m.cache[key] = value
+
+	// Track pending write if there's an active HA subscription
+	if !variable.LocalOnly && m.hasActiveHASub(variable.EntityID) {
+		m.pendingWrites[key] = value
+	}
 	m.cacheMu.Unlock()
 
 	// Skip HA sync for local-only variables, but still notify subscribers
@@ -672,9 +745,10 @@ func (m *Manager) SetJSON(key string, value interface{}) error {
 	// Convert to JSON string for HA
 	jsonBytes, err := json.Marshal(value)
 	if err != nil {
-		// Rollback cache on error
+		// Rollback cache and pending write on error
 		m.cacheMu.Lock()
 		m.cache[key] = oldValue
+		delete(m.pendingWrites, key)
 		m.cacheMu.Unlock()
 		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
@@ -682,15 +756,16 @@ func (m *Manager) SetJSON(key string, value interface{}) error {
 	// Sync to HA
 	entityName := extractEntityName(variable.EntityID)
 	if err := m.client.SetInputText(entityName, string(jsonBytes)); err != nil {
-		// Rollback cache on error
+		// Rollback cache and pending write on error
 		m.cacheMu.Lock()
 		m.cache[key] = oldValue
+		delete(m.pendingWrites, key)
 		m.cacheMu.Unlock()
 		return fmt.Errorf("failed to set HA value: %w", err)
 	}
 
 	// Notify subscribers after successful HA sync
-	// The HA callback will skip notification since cache already has the new value
+	// The HA echo-back will be suppressed by the pending write tracker.
 	m.notifySubscribers(key, oldValue, value)
 
 	return nil
@@ -731,6 +806,11 @@ func (m *Manager) CompareAndSwapBool(key string, old, new bool) (bool, error) {
 	// Update cache (still holding lock)
 	m.cache[key] = new
 
+	// Track pending write if there's an active HA subscription
+	if !variable.LocalOnly && m.hasActiveHASub(variable.EntityID) {
+		m.pendingWrites[key] = new
+	}
+
 	// Release lock before calling HA client to avoid deadlock
 	m.cacheMu.Unlock()
 
@@ -745,6 +825,7 @@ func (m *Manager) CompareAndSwapBool(key string, old, new bool) (bool, error) {
 		// Rollback on error
 		m.cacheMu.Lock()
 		m.cache[key] = old
+		delete(m.pendingWrites, key)
 		m.cacheMu.Unlock()
 		return false, fmt.Errorf("failed to set HA value: %w", err)
 	}

--- a/homeautomation-go/internal/state/manager_test.go
+++ b/homeautomation-go/internal/state/manager_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1036,4 +1037,335 @@ func TestManager_SyncFromHA_PreservesLocalOnlyVariables(t *testing.T) {
 
 	assert.Equal(t, int32(1), atomic.LoadInt32(&notified),
 		"subscriber must be notified when local-only variable changes from true to false after reconnect")
+}
+
+// Echo-back suppression tests
+// These tests validate that the state manager tracks pending writes and
+// suppresses HA echo-backs to prevent phantom transitions.
+
+func TestSetBool_SuppressesEchoBack(t *testing.T) {
+	t.Parallel()
+	logger := testlogger.New()
+	mockClient := ha.NewMockClient()
+	mockClient.SetState("input_boolean.expecting_someone", "off", map[string]interface{}{})
+	mockClient.Connect()
+
+	manager := NewManager(mockClient, logger, false)
+	manager.SyncFromHA()
+
+	// Subscribe to track notifications
+	var notifyCount int32
+	sub, err := manager.Subscribe("isExpectingSomeone", func(key string, oldValue, newValue interface{}) {
+		atomic.AddInt32(&notifyCount, 1)
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	// SetBool updates cache, records pending write, syncs to HA.
+	// The mock client's echo-back fires synchronously within SetBool.
+	// The pending write tracker should suppress the echo, so subscribers
+	// are only notified once (from SetBool itself, not from the echo).
+	err = manager.SetBool("isExpectingSomeone", true)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&notifyCount),
+		"Subscriber should be notified exactly once (from SetBool), not twice (echo-back should be suppressed)")
+
+	// Verify the value is correct
+	val, err := manager.GetBool("isExpectingSomeone")
+	require.NoError(t, err)
+	assert.True(t, val)
+}
+
+func TestSetBool_SuppressesStaleEchoBack(t *testing.T) {
+	t.Parallel()
+	logger := testlogger.New()
+	mockClient := ha.NewMockClient()
+	mockClient.SetState("input_boolean.expecting_someone", "off", map[string]interface{}{})
+	mockClient.Connect()
+
+	manager := NewManager(mockClient, logger, false)
+	manager.SyncFromHA()
+
+	// Subscribe to track notifications
+	var notifyCount int32
+	sub, err := manager.Subscribe("isExpectingSomeone", func(key string, oldValue, newValue interface{}) {
+		atomic.AddInt32(&notifyCount, 1)
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	// Set value to true
+	err = manager.SetBool("isExpectingSomeone", true)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&notifyCount))
+
+	// Now simulate a stale echo-back with the OLD value (false).
+	// This represents HA echoing back the state from before our write was processed.
+	// The pending write tracker should have already been cleared by the matching
+	// echo-back from SetBool, so this is just a normal state change.
+	// But if we set a NEW pending write first, the stale echo should be suppressed.
+
+	// Set to a new value to create a fresh pending write
+	atomic.StoreInt32(&notifyCount, 0)
+	// Directly set a pending write to simulate the race
+	manager.cacheMu.Lock()
+	manager.cache["isExpectingSomeone"] = true
+	manager.pendingWrites["isExpectingSomeone"] = true
+	manager.cacheMu.Unlock()
+
+	// Now simulate a stale echo-back with "off" (false)
+	mockClient.SimulateStateChange("input_boolean.expecting_someone", "off")
+
+	// The stale echo-back should be suppressed
+	assert.Equal(t, int32(0), atomic.LoadInt32(&notifyCount),
+		"Stale echo-back should be suppressed and not notify subscribers")
+
+	// Cache should still have the pending value (true), not the stale echo (false)
+	val, err := manager.GetBool("isExpectingSomeone")
+	require.NoError(t, err)
+	assert.True(t, val, "Cache should retain pending write value, not stale echo-back")
+}
+
+func TestSetBool_EchoBackConfirmsClearsPendingFlag(t *testing.T) {
+	t.Parallel()
+	logger := testlogger.New()
+	mockClient := ha.NewMockClient()
+	mockClient.SetState("input_boolean.expecting_someone", "off", map[string]interface{}{})
+	mockClient.Connect()
+
+	manager := NewManager(mockClient, logger, false)
+	manager.SyncFromHA()
+
+	// Directly set a pending write to simulate pre-echo state
+	manager.cacheMu.Lock()
+	manager.cache["isExpectingSomeone"] = true
+	manager.pendingWrites["isExpectingSomeone"] = true
+	manager.cacheMu.Unlock()
+
+	// Subscribe to track notifications
+	var notifyCount int32
+	sub, err := manager.Subscribe("isExpectingSomeone", func(key string, oldValue, newValue interface{}) {
+		atomic.AddInt32(&notifyCount, 1)
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	// Simulate the correct echo-back (true) - should confirm and clear the pending flag
+	mockClient.SimulateStateChange("input_boolean.expecting_someone", "on")
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&notifyCount),
+		"Confirming echo-back should not notify subscribers (cache already has the value)")
+
+	// Verify pending flag was cleared
+	manager.cacheMu.RLock()
+	_, hasPending := manager.pendingWrites["isExpectingSomeone"]
+	manager.cacheMu.RUnlock()
+	assert.False(t, hasPending, "Pending flag should be cleared after confirmed echo-back")
+
+	// Now a genuine external change should go through
+	mockClient.SimulateStateChange("input_boolean.expecting_someone", "off")
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&notifyCount),
+		"Genuine external change should notify subscribers after pending flag is cleared")
+}
+
+func TestSetString_SuppressesStaleEchoBack(t *testing.T) {
+	t.Parallel()
+	logger := testlogger.New()
+	mockClient := ha.NewMockClient()
+	mockClient.SetState("input_text.day_phase", "morning", map[string]interface{}{})
+	mockClient.Connect()
+
+	manager := NewManager(mockClient, logger, false)
+	manager.SyncFromHA()
+
+	// Subscribe to track notifications
+	var notifyCount int32
+	sub, err := manager.Subscribe("dayPhase", func(key string, oldValue, newValue interface{}) {
+		atomic.AddInt32(&notifyCount, 1)
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	// Directly set a pending write to simulate pre-echo state
+	manager.cacheMu.Lock()
+	manager.cache["dayPhase"] = "evening"
+	manager.pendingWrites["dayPhase"] = "evening"
+	manager.cacheMu.Unlock()
+
+	// Simulate stale echo-back with old value "morning"
+	mockClient.SimulateStateChange("input_text.day_phase", "morning")
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&notifyCount),
+		"Stale string echo-back should be suppressed")
+
+	// Cache should retain the pending value
+	val, err := manager.GetString("dayPhase")
+	require.NoError(t, err)
+	assert.Equal(t, "evening", val)
+}
+
+func TestSetNumber_SuppressesStaleEchoBack(t *testing.T) {
+	t.Parallel()
+	logger := testlogger.New()
+	mockClient := ha.NewMockClient()
+	mockClient.SetState("input_number.alarm_time", "100", map[string]interface{}{})
+	mockClient.Connect()
+
+	manager := NewManager(mockClient, logger, false)
+	manager.SyncFromHA()
+
+	// Subscribe to track notifications
+	var notifyCount int32
+	sub, err := manager.Subscribe("alarmTime", func(key string, oldValue, newValue interface{}) {
+		atomic.AddInt32(&notifyCount, 1)
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	// Directly set a pending write to simulate pre-echo state
+	manager.cacheMu.Lock()
+	manager.cache["alarmTime"] = 200.0
+	manager.pendingWrites["alarmTime"] = 200.0
+	manager.cacheMu.Unlock()
+
+	// Simulate stale echo-back with old value "100"
+	mockClient.SimulateStateChange("input_number.alarm_time", "100")
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&notifyCount),
+		"Stale number echo-back should be suppressed")
+
+	// Cache should retain the pending value
+	val, err := manager.GetNumber("alarmTime")
+	require.NoError(t, err)
+	assert.Equal(t, 200.0, val)
+}
+
+func TestManager_EchoBackSuppression_RapidWrites(t *testing.T) {
+	t.Parallel()
+	logger := testlogger.New()
+	mockClient := ha.NewMockClient()
+	mockClient.SetState("input_text.day_phase", "morning", map[string]interface{}{})
+	mockClient.Connect()
+
+	manager := NewManager(mockClient, logger, false)
+	manager.SyncFromHA()
+
+	// Subscribe to track notifications
+	var notifyCount int32
+	sub, err := manager.Subscribe("dayPhase", func(key string, oldValue, newValue interface{}) {
+		atomic.AddInt32(&notifyCount, 1)
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	// Simulate rapid writes: write "afternoon" then "evening" before any echo arrives.
+	// The pending write should be updated to "evening" (latest value wins).
+	manager.cacheMu.Lock()
+	manager.cache["dayPhase"] = "afternoon"
+	manager.pendingWrites["dayPhase"] = "afternoon"
+	manager.cacheMu.Unlock()
+
+	// Second write overwrites the pending value
+	manager.cacheMu.Lock()
+	manager.cache["dayPhase"] = "evening"
+	manager.pendingWrites["dayPhase"] = "evening"
+	manager.cacheMu.Unlock()
+
+	// Stale echo from first write arrives ("afternoon") - should be suppressed
+	mockClient.SimulateStateChange("input_text.day_phase", "afternoon")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&notifyCount),
+		"Echo from intermediate write should be suppressed")
+
+	// The correct echo arrives ("evening") - should confirm
+	mockClient.SimulateStateChange("input_text.day_phase", "evening")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&notifyCount),
+		"Confirming echo should not notify (cache already correct)")
+
+	// Verify pending flag was cleared
+	manager.cacheMu.RLock()
+	_, hasPending := manager.pendingWrites["dayPhase"]
+	manager.cacheMu.RUnlock()
+	assert.False(t, hasPending, "Pending flag should be cleared after final echo")
+}
+
+func TestManager_EchoBackSuppression_HAFailureRollback(t *testing.T) {
+	t.Parallel()
+	logger := testlogger.New()
+	mockClient := ha.NewMockClient()
+	mockClient.SetState("input_boolean.expecting_someone", "off", map[string]interface{}{})
+	mockClient.Connect()
+
+	manager := NewManager(mockClient, logger, false)
+	manager.SyncFromHA()
+
+	// Inject error for the HA service call
+	mockClient.SetServiceError("input_boolean", "turn_on", fmt.Errorf("HA unavailable"))
+
+	err := manager.SetBool("isExpectingSomeone", true)
+	assert.Error(t, err)
+
+	// Verify the pending write was cleaned up on failure
+	manager.cacheMu.RLock()
+	_, hasPending := manager.pendingWrites["isExpectingSomeone"]
+	manager.cacheMu.RUnlock()
+	assert.False(t, hasPending, "Pending write should be cleared on HA sync failure")
+
+	// Verify cache was rolled back
+	val, err := manager.GetBool("isExpectingSomeone")
+	require.NoError(t, err)
+	assert.False(t, val, "Cache should be rolled back on HA sync failure")
+}
+
+func TestManager_SetString_NoPendingWriteWithoutSub(t *testing.T) {
+	t.Parallel()
+	logger := testlogger.New()
+	mockClient := ha.NewMockClient()
+	mockClient.SetState("input_text.day_phase", "morning", map[string]interface{}{})
+	mockClient.Connect()
+
+	// Create manager but do NOT call SyncFromHA (no HA subscriptions created)
+	manager := NewManager(mockClient, logger, false)
+
+	// Manually set the cache for testing (bypass SyncFromHA)
+	manager.cacheMu.Lock()
+	manager.cache["dayPhase"] = "morning"
+	manager.cacheMu.Unlock()
+
+	// Set value - should NOT record a pending write since there's no HA subscription
+	err := manager.SetString("dayPhase", "evening")
+	require.NoError(t, err)
+
+	manager.cacheMu.RLock()
+	_, hasPending := manager.pendingWrites["dayPhase"]
+	manager.cacheMu.RUnlock()
+	assert.False(t, hasPending,
+		"Should not record pending write when there's no active HA subscription")
+}
+
+func TestManager_SyncFromHA_ClearsPendingWrites(t *testing.T) {
+	t.Parallel()
+	logger := testlogger.New()
+	mockClient := ha.NewMockClient()
+	mockClient.SetState("input_boolean.expecting_someone", "off", map[string]interface{}{})
+	mockClient.Connect()
+
+	manager := NewManager(mockClient, logger, false)
+	manager.SyncFromHA()
+
+	// Set up a pending write
+	manager.cacheMu.Lock()
+	manager.pendingWrites["isExpectingSomeone"] = true
+	manager.cacheMu.Unlock()
+
+	// SyncFromHA should clear all pending writes
+	err := manager.SyncFromHA()
+	require.NoError(t, err)
+
+	manager.cacheMu.RLock()
+	pendingCount := len(manager.pendingWrites)
+	manager.cacheMu.RUnlock()
+	assert.Equal(t, 0, pendingCount,
+		"SyncFromHA should clear all pending writes")
 }


### PR DESCRIPTION
Resolves #640
Supersedes #637

## Summary
- Added `pendingWrites` map to the state manager that tracks values written to HA before their echo-back arrives
- When HA echoes back a state change, the subscription callback checks `pendingWrites`:
  - **Matching echo**: Confirmed our write, clear pending flag, suppress notification (cache already correct)
  - **Stale echo**: Value differs from pending write, suppress entirely (don't overwrite cache with stale data)
  - **No pending**: Normal flow (genuine external change)
- All `Set*` methods (`SetBool`, `SetString`, `SetNumber`, `SetJSON`) and `CompareAndSwapBool` record pending writes
- `SyncFromHA` clears all pending writes (authoritative baseline reset)
- Pending writes are only tracked when an active HA subscription exists for the entity
- HA sync failures roll back both cache and pending write state
- Added Lesson 15 to `CONCURRENCY_LESSONS.md` documenting the pattern

## Test Plan
- [x] `TestSetBool_SuppressesEchoBack` - Echo from own write suppressed
- [x] `TestSetBool_SuppressesStaleEchoBack` - Stale echo doesn't overwrite cache
- [x] `TestSetBool_EchoBackConfirmsClearsPendingFlag` - Confirmed echo clears flag, then external changes go through
- [x] `TestSetString_SuppressesStaleEchoBack` - String variant
- [x] `TestSetNumber_SuppressesStaleEchoBack` - Number variant
- [x] `TestManager_EchoBackSuppression_RapidWrites` - Latest pending value wins on rapid writes
- [x] `TestManager_EchoBackSuppression_HAFailureRollback` - Failure clears pending write
- [x] `TestManager_SetString_NoPendingWriteWithoutSub` - No pending without HA subscription
- [x] `TestManager_SyncFromHA_ClearsPendingWrites` - SyncFromHA resets pending state
- [x] All existing unit tests pass (74.8% coverage)
- [x] All 11 integration tests pass
- [x] Race detector clean

🤖 Generated with Claude Code