### PR TITLE
Fix #642: Reduce test suite overhead by pruning redundant tests

### DIFF
--- a/homeautomation-go/internal/plugins/energy/manager_test.go
+++ b/homeautomation-go/internal/plugins/energy/manager_test.go
@@ -390,36 +390,6 @@ func TestEnergyManager_Stop(t *testing.T) {
 	assert.Equal(t, 0, len(manager.subHelper.GetStateSubscriptions()), "State subscriptions should be empty after Stop")
 }
 
-func TestEnergyManager_ReadOnlyMode(t *testing.T) {
-	t.Parallel()
-	logger := zap.NewNop()
-	mockClient := ha.NewMockClient()
-	// Create state manager in read-only mode
-	stateManager := state.NewManager(mockClient, logger, true)
-
-	config := createTestConfig()
-	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, true, nil, nil)
-
-	// Test battery change handler - should handle read-only gracefully
-	manager.handleBatteryChange(50.0)
-	// No error should be thrown, just logged at debug level
-
-	// Test solar generation handlers
-	manager.handleThisHourSolarChange(5.0)
-	manager.handleRemainingSolarChange(15.0)
-
-	// Test free energy check
-	_ = stateManager.SetBool("isGridAvailable", true)
-	manager.checkFreeEnergy()
-
-	// Test energy level change handlers (observing computed state)
-	_ = stateManager.SetString("currentEnergyLevel", "green")
-	manager.handleCurrentEnergyLevelChange("currentEnergyLevel", "black", "green")
-
-	// If we get here without panicking, the read-only mode handling worked correctly
-	// The actual verification is that no errors are thrown, just debug logs
-}
-
 // TestTimezoneHandling tests that timezone configuration works correctly
 func TestTimezoneHandling(t *testing.T) {
 	t.Parallel()
@@ -803,46 +773,6 @@ func TestIndicatorLightsReadOnlyMode(t *testing.T) {
 	assert.Equal(t, "black", shadowState.Outputs.IndicatorLightsAction.EnergyLevel)
 }
 
-func TestIndicatorLightsNoEntitiesDiscovered(t *testing.T) {
-	t.Parallel()
-	logger := testlogger.New()
-	mockClient := ha.NewMockClient()
-	stateManager := state.NewManager(mockClient, logger, false)
-	config := createTestConfig()
-
-	// Set up mock states with NO "Radar" entities
-	mockClient.SetState("light.living_room_lamp", "on", map[string]interface{}{
-		"friendly_name": "Living Room Lamp",
-	})
-
-	mockClient.Connect()
-
-	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, nil, nil)
-
-	err := manager.Start()
-	assert.NoError(t, err)
-	defer manager.Stop()
-
-	// Verify no entities were discovered
-	assert.Len(t, manager.indicatorLightEntities, 0)
-
-	// Clear any service calls
-	mockClient.ClearServiceCalls()
-
-	// Calling updateIndicatorLights should not panic and should not make light.turn_on calls
-	manager.updateIndicatorLights("black")
-
-	// Verify NO light.turn_on service was called when no entities discovered
-	calls := mockClient.GetServiceCalls()
-	var lightCalls []ha.ServiceCall
-	for _, c := range calls {
-		if c.Domain == "light" && c.Service == "turn_on" {
-			lightCalls = append(lightCalls, c)
-		}
-	}
-	assert.Len(t, lightCalls, 0, "Expected no light.turn_on service calls when no entities discovered")
-}
-
 func TestIndicatorLightsDiscoveryCaseInsensitive(t *testing.T) {
 	t.Parallel()
 	logger := testlogger.New()
@@ -877,33 +807,6 @@ func TestIndicatorLightsDiscoveryCaseInsensitive(t *testing.T) {
 	assert.Contains(t, manager.indicatorLightEntities, "light.apollo_lower_case")
 	assert.Contains(t, manager.indicatorLightEntities, "light.apollo_upper_case")
 	assert.Contains(t, manager.indicatorLightEntities, "light.apollo_mixed_case")
-}
-
-func TestIndicatorLightsDiscoveryInvalidPattern(t *testing.T) {
-	t.Parallel()
-	logger := testlogger.New()
-	mockClient := ha.NewMockClient()
-	stateManager := state.NewManager(mockClient, logger, false)
-	config := createTestConfig()
-
-	// Set an invalid regex pattern (unclosed bracket)
-	config.Energy.IndicatorLights.FriendlyNamePattern = "[invalid"
-
-	mockClient.SetState("light.test_light", "on", map[string]interface{}{
-		"friendly_name": "Test Radar Light",
-	})
-
-	mockClient.Connect()
-
-	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, nil, nil)
-
-	// Start should not fail - invalid pattern is handled gracefully
-	err := manager.Start()
-	assert.NoError(t, err)
-	defer manager.Stop()
-
-	// No entities should be discovered when pattern is invalid
-	assert.Len(t, manager.indicatorLightEntities, 0)
 }
 
 func TestIndicatorLightsDiscoveryCustomPattern(t *testing.T) {

--- a/homeautomation-go/internal/plugins/music/manager_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_test.go
@@ -704,39 +704,6 @@ func TestStopDoesNotTriggerRateLimiting(t *testing.T) {
 	}
 }
 
-// TestDoubleActivationPrevention tests prevention of re-activating already playing music
-func TestDoubleActivationPrevention(t *testing.T) {
-	t.Parallel()
-	logger := zap.NewNop()
-	mockClient := ha.NewMockClient()
-	stateManager := state.NewManager(mockClient, logger, false)
-
-	config := &MusicConfig{
-		Music: map[string]MusicMode{
-			"day": {
-				Participants: []Participant{
-					{PlayerName: "Kitchen", BaseVolume: 9, LeaveMutedIf: []MuteCondition{}},
-				},
-				PlaybackOptions: []PlaybackOption{
-					{URI: "spotify:playlist:test", MediaType: "playlist", VolumeMultiplier: 1.0},
-				},
-			},
-		},
-	}
-
-	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, true, nil, nil)
-
-	// First playback
-	manager.handleMusicPlaybackTypeChange("musicPlaybackType", "", "day")
-	firstURI := manager.currentlyPlaying.URI
-
-	// Second activation of same type should be blocked
-	manager.handleMusicPlaybackTypeChange("musicPlaybackType", "day", "day")
-	if manager.currentlyPlaying.URI != firstURI {
-		t.Error("Double activation should not have changed the playlist")
-	}
-}
-
 // TestMuteConditionEvaluation tests mute condition logic
 func TestMuteConditionEvaluation(t *testing.T) {
 	t.Parallel()
@@ -933,43 +900,6 @@ func TestStopPlayback_OnlyAffectsActiveSpeakers(t *testing.T) {
 	}
 }
 
-// TestStopPlayback_NoCurrentPlayback verifies that stopPlayback handles
-// the case where there is no active playback gracefully.
-func TestStopPlayback_NoCurrentPlayback(t *testing.T) {
-	t.Parallel()
-	logger := zap.NewNop()
-	mockClient := ha.NewMockClient()
-	stateManager := state.NewManager(mockClient, logger, false)
-
-	config := &MusicConfig{
-		Music: map[string]MusicMode{
-			"morning": {
-				Participants: []Participant{
-					{PlayerName: "Kitchen", BaseVolume: 9},
-					{PlayerName: "Soundbar", BaseVolume: 10},
-				},
-				PlaybackOptions: []PlaybackOption{},
-			},
-		},
-	}
-
-	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, nil, nil)
-
-	// No currently playing music
-	manager.currentlyPlaying = nil
-
-	// Stop playback - should not panic and should not call any volume_set
-	manager.stopPlayback()
-
-	// Should NOT have any volume_set calls since nothing was playing
-	calls := mockClient.GetServiceCalls()
-	for _, call := range calls {
-		if call.Domain == "media_player" && call.Service == "volume_set" {
-			t.Errorf("Unexpected volume_set call when nothing was playing: %v", call.Data)
-		}
-	}
-}
-
 // TestOrchestratePlayback tests the main orchestration flow
 func TestOrchestratePlayback(t *testing.T) {
 	t.Parallel()
@@ -1024,142 +954,6 @@ func TestOrchestratePlayback(t *testing.T) {
 	}
 }
 
-// TestToLower tests the toLower helper function
-func TestToLower(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"Kitchen", "kitchen"},
-		{"Kids Bathroom", "kids bathroom"},
-		{"DINING ROOM", "dining room"},
-		{"soundbar", "soundbar"},
-		{"", ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-
-			result := toLower(tt.input)
-			if result != tt.expected {
-				t.Errorf("toLower(%q) = %q, want %q", tt.input, result, tt.expected)
-			}
-		})
-	}
-}
-
-// TestValuesMatch tests value matching logic
-func TestValuesMatch(t *testing.T) {
-	t.Parallel()
-	logger := zap.NewNop()
-	mockClient := ha.NewMockClient()
-	stateManager := state.NewManager(mockClient, logger, false)
-	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, nil, nil)
-
-	tests := []struct {
-		name     string
-		a        interface{}
-		b        interface{}
-		expected bool
-	}{
-		{"Matching bools", true, true, true},
-		{"Non-matching bools", true, false, false},
-		{"Matching strings", "test", "test", true},
-		{"Non-matching strings", "test", "other", false},
-		{"Matching numbers", 42, 42, true},
-		{"Non-matching numbers", 42, 43, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-
-			result := manager.valuesMatch(tt.a, tt.b)
-			if result != tt.expected {
-				t.Errorf("valuesMatch(%v, %v) = %v, want %v",
-					tt.a, tt.b, result, tt.expected)
-			}
-		})
-	}
-}
-
-// TestGetStateValue tests state value retrieval
-func TestGetStateValue(t *testing.T) {
-	t.Parallel()
-	logger := zap.NewNop()
-	mockClient := ha.NewMockClient()
-	stateManager := state.NewManager(mockClient, logger, false)
-
-	// Set up various state variables
-	_ = stateManager.SetBool("isTVPlaying", true)
-	_ = stateManager.SetString("dayPhase", "evening")
-	_ = stateManager.SetNumber("alarmTime", 7.5)
-
-	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, nil, nil)
-
-	// Test getting boolean
-	val, err := manager.getStateValue("isTVPlaying")
-	if err != nil {
-		t.Errorf("getStateValue(isTVPlaying) failed: %v", err)
-	}
-	if val != true {
-		t.Errorf("getStateValue(isTVPlaying) = %v, want true", val)
-	}
-
-	// Test getting string
-	val, err = manager.getStateValue("dayPhase")
-	if err != nil {
-		t.Errorf("getStateValue(dayPhase) failed: %v", err)
-	}
-	if val != "evening" {
-		t.Errorf("getStateValue(dayPhase) = %v, want 'evening'", val)
-	}
-
-	// Test getting number
-	val, err = manager.getStateValue("alarmTime")
-	if err != nil {
-		t.Errorf("getStateValue(alarmTime) failed: %v", err)
-	}
-	if val != 7.5 {
-		t.Errorf("getStateValue(alarmTime) = %v, want 7.5", val)
-	}
-
-	// Test non-existent variable
-	_, err = manager.getStateValue("nonExistent")
-	if err == nil {
-		t.Error("getStateValue(nonExistent) should return error")
-	}
-}
-
-// TestCallService tests service calling
-func TestCallService(t *testing.T) {
-	t.Parallel()
-	logger := zap.NewNop()
-	mockClient := ha.NewMockClient()
-	stateManager := state.NewManager(mockClient, logger, false)
-	config := &MusicConfig{Music: map[string]MusicMode{}}
-
-	// Test in normal mode
-	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, nil, nil)
-	err := manager.callService("media_player", "play_media", map[string]interface{}{
-		"entity_id": "media_player.kitchen",
-	})
-	if err != nil {
-		t.Errorf("callService() in normal mode failed: %v", err)
-	}
-
-	// Test in read-only mode
-	managerRO := NewManager(context.Background(), mockClient, stateManager, config, logger, true, nil, nil)
-	err = managerRO.callService("media_player", "play_media", map[string]interface{}{
-		"entity_id": "media_player.kitchen",
-	})
-	if err != nil {
-		t.Errorf("callService() in read-only mode failed: %v", err)
-	}
-}
-
 // TestHandleMusicPlaybackTypeChange_EmptyString tests stopping playback
 func TestHandleMusicPlaybackTypeChange_EmptyString(t *testing.T) {
 	t.Parallel()
@@ -1193,21 +987,6 @@ func TestHandleMusicPlaybackTypeChange_EmptyString(t *testing.T) {
 	if manager.currentlyPlaying != nil {
 		t.Error("handleMusicPlaybackTypeChange with empty string should stop playback")
 	}
-}
-
-// TestHandleMusicPlaybackTypeChange_InvalidType tests handling of invalid type values
-func TestHandleMusicPlaybackTypeChange_InvalidType(t *testing.T) {
-	t.Parallel()
-	logger := zap.NewNop()
-	mockClient := ha.NewMockClient()
-	stateManager := state.NewManager(mockClient, logger, false)
-	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, nil, nil)
-
-	// Pass non-string value (should log error and return)
-	manager.handleMusicPlaybackTypeChange("musicPlaybackType", "", 123)
-
-	// If we reach here without panic, the invalid type handling worked
 }
 
 // TestExecutePlayback tests the complete execution flow
@@ -1475,39 +1254,6 @@ func TestBuildSpeakerGroupAllFail(t *testing.T) {
 	}
 	if result.Results[1].Active {
 		t.Error("Expected Living Room to be marked as failed")
-	}
-}
-
-// TestBuildSpeakerGroupRetryOnSecondAttempt tests successful retry on second attempt
-func TestBuildSpeakerGroupRetryOnSecondAttempt(t *testing.T) {
-	t.Parallel()
-	logger := zap.NewNop()
-	mockClient := ha.NewMockClient()
-	stateManager := state.NewManager(mockClient, logger, false)
-	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, nil, nil)
-
-	// Use no-op sleep to make test fast
-	manager.SetSleepFunc(func(d time.Duration) {})
-
-	// Configure mock to fail once, then succeed
-	mockClient.SetServiceFailCount("media_player", "join", 1, fmt.Errorf("service call failed: timeout waiting for response"))
-
-	participants := []ParticipantWithVolume{
-		{PlayerName: "Kitchen", Volume: 9},
-		{PlayerName: "Living Room", Volume: 10},
-	}
-
-	// Should succeed on second attempt
-	result, err := manager.buildSpeakerGroup(participants, "media_player.kitchen")
-	if err != nil {
-		t.Errorf("buildSpeakerGroup() should have succeeded on retry, got: %v", err)
-	}
-	if result == nil {
-		t.Fatal("buildSpeakerGroup() returned nil result")
-	}
-	if result.ActiveCount != 2 {
-		t.Errorf("Expected 2 active speakers, got %d", result.ActiveCount)
 	}
 }
 
@@ -3346,140 +3092,11 @@ func TestPlaybackVerification_RecoveryAfterNudge(t *testing.T) {
 	}
 }
 
-// TestPlaybackVerification_RecoveryOnSecondAttempt tests that playback verification
-// succeeds when the speaker requires a full retry (not just a nudge) to start playing.
-// This simulates when the first play_media and nudge both fail, but retrying works.
-func TestPlaybackVerification_RecoveryOnSecondAttempt(t *testing.T) {
-	t.Parallel()
-	logger := zap.NewNop()
-	mockClient := ha.NewMockClient()
-	stateManager := state.NewManager(mockClient, logger, false)
-
-	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, nil, nil)
-
-	// Use no-op sleep to make test fast
-	manager.SetSleepFunc(func(d time.Duration) {})
-
-	// Set up state sequence for recovery on second attempt:
-	// Attempt 1: check 1 = "idle", check 2 (after nudge) = "idle" -> fails, retry
-	// Attempt 2: check 3 = "playing" -> SUCCESS
-	mockClient.SetStateSequence("media_player.kitchen", []string{"idle", "idle", "playing"})
-
-	option := PlaybackOption{
-		URI:              "spotify:playlist:test",
-		MediaType:        "playlist",
-		VolumeMultiplier: 1.0,
-	}
-
-	attempts, err := manager.startPlaybackWithVerification("media_player.kitchen", option)
-
-	if err != nil {
-		t.Errorf("Expected success on second attempt, got error: %v", err)
-	}
-	if attempts != 2 {
-		t.Errorf("Expected 2 attempts, got %d", attempts)
-	}
-
-	// Verify play_media was called twice (once per attempt)
-	calls := mockClient.GetServiceCalls()
-	playMediaCount := 0
-	for _, call := range calls {
-		if call.Domain == "media_player" && call.Service == "play_media" {
-			playMediaCount++
-		}
-	}
-
-	if playMediaCount != 2 {
-		t.Errorf("Expected 2 play_media calls, got %d", playMediaCount)
-	}
-}
-
 // ============================================================================
 // Phase 1: Zone Assignment Policy Tests
 // ============================================================================
 
-// TestShouldIncludeInZone_NoConditions tests that speakers without exclude_if conditions are always included
-func TestShouldIncludeInZone_NoConditions(t *testing.T) {
-	t.Parallel()
-	logger := zap.NewNop()
-	mockClient := ha.NewMockClient()
-	stateManager := state.NewManager(mockClient, logger, false)
-	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, nil, nil)
-
-	participant := Participant{
-		PlayerName:   "Kitchen",
-		BaseVolume:   9,
-		LeaveMutedIf: []MuteCondition{},
-		ExcludeIf:    []MuteCondition{}, // No exclude conditions
-	}
-
-	if !manager.shouldIncludeInZone(participant) {
-		t.Error("Speaker with no exclude_if conditions should be included in zone")
-	}
-}
-
-// TestShouldIncludeInZone_ConditionNotMatched tests that speakers are included when exclude_if condition doesn't match
-func TestShouldIncludeInZone_ConditionNotMatched(t *testing.T) {
-	t.Parallel()
-	logger := zap.NewNop()
-	mockClient := ha.NewMockClient()
-	stateManager := state.NewManager(mockClient, logger, false)
-	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, nil, nil)
-
-	// Set up state: isMasterAsleep = false
-	if err := stateManager.SetBool("isMasterAsleep", false); err != nil {
-		t.Fatalf("Failed to set isMasterAsleep: %v", err)
-	}
-
-	participant := Participant{
-		PlayerName:   "Bedroom",
-		BaseVolume:   9,
-		LeaveMutedIf: []MuteCondition{},
-		ExcludeIf: []MuteCondition{
-			{Variable: "isMasterAsleep", Value: true}, // Exclude if asleep
-		},
-	}
-
-	// Condition is isMasterAsleep=true, but actual value is false
-	// So the condition does NOT match, speaker should be INCLUDED
-	if !manager.shouldIncludeInZone(participant) {
-		t.Error("Speaker should be included when exclude_if condition (isMasterAsleep=true) doesn't match (value is false)")
-	}
-}
-
-// TestShouldIncludeInZone_ConditionMatched tests that speakers are excluded when exclude_if condition matches
-func TestShouldIncludeInZone_ConditionMatched(t *testing.T) {
-	t.Parallel()
-	logger := zap.NewNop()
-	mockClient := ha.NewMockClient()
-	stateManager := state.NewManager(mockClient, logger, false)
-	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, nil, nil)
-
-	// Set up state: isMasterAsleep = true
-	if err := stateManager.SetBool("isMasterAsleep", true); err != nil {
-		t.Fatalf("Failed to set isMasterAsleep: %v", err)
-	}
-
-	participant := Participant{
-		PlayerName:   "Bedroom",
-		BaseVolume:   9,
-		LeaveMutedIf: []MuteCondition{},
-		ExcludeIf: []MuteCondition{
-			{Variable: "isMasterAsleep", Value: true}, // Exclude if asleep
-		},
-	}
-
-	// Condition matches, speaker should be EXCLUDED
-	if manager.shouldIncludeInZone(participant) {
-		t.Error("Speaker should be excluded when exclude_if condition (isMasterAsleep=true) matches (value is true)")
-	}
-}
-
-// TestShouldIncludeInZone_MultipleConditions tests that any matching condition excludes the speaker
+// TestShouldIncludeInZone_MultipleConditions tests zone inclusion with various condition combinations
 func TestShouldIncludeInZone_MultipleConditions(t *testing.T) {
 	t.Parallel()
 	logger := zap.NewNop()
@@ -3855,30 +3472,6 @@ func TestExcludeIf_ParticipantWithVolumePreservesExcludeIf(t *testing.T) {
 	}
 }
 
-// TestRandomJitter tests that randomJitter returns values within expected bounds
-func TestRandomJitter(t *testing.T) {
-	t.Parallel()
-	logger := zap.NewNop()
-	mockClient := ha.NewMockClient()
-	stateManager := state.NewManager(mockClient, logger, false)
-	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, nil, nil)
-
-	// Run multiple iterations to test the distribution
-	const iterations = 1000
-	for i := 0; i < iterations; i++ {
-		jitter := manager.randomJitter()
-
-		// Jitter should be >= 0 and < asyncJoinJitterMax (15s)
-		if jitter < 0 {
-			t.Errorf("randomJitter() returned negative value: %v", jitter)
-		}
-		if jitter >= asyncJoinJitterMax {
-			t.Errorf("randomJitter() returned value >= max: %v >= %v", jitter, asyncJoinJitterMax)
-		}
-	}
-}
-
 // TestBuildSpeakerGroupAsync_StaggeredDelays verifies that speakers launch with staggered delays
 func TestBuildSpeakerGroupAsync_StaggeredDelays(t *testing.T) {
 	t.Parallel()
@@ -3987,38 +3580,6 @@ func TestBuildSpeakerGroupAsync_ParallelExecution(t *testing.T) {
 		if !expectedSpeakers[speaker] {
 			t.Errorf("Unexpected speaker joined: %s", speaker)
 		}
-	}
-}
-
-// TestBuildSpeakerGroupAsync_SingleFollower tests with just one follower
-func TestBuildSpeakerGroupAsync_SingleFollower(t *testing.T) {
-	t.Parallel()
-	logger := zap.NewNop()
-	mockClient := ha.NewMockClient()
-	stateManager := state.NewManager(mockClient, logger, false)
-	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, nil, nil)
-
-	manager.SetSleepFunc(func(d time.Duration) {})
-
-	participants := []ParticipantWithVolume{
-		{PlayerName: "Kitchen", Volume: 9},      // Lead
-		{PlayerName: "Living Room", Volume: 10}, // Only follower
-	}
-
-	mockClient.ClearServiceCalls()
-	manager.buildSpeakerGroupAsync(participants, "media_player.kitchen", "day")
-
-	calls := mockClient.GetServiceCalls()
-	joinCalls := 0
-	for _, call := range calls {
-		if call.Domain == "media_player" && call.Service == "join" {
-			joinCalls++
-		}
-	}
-
-	if joinCalls != 1 {
-		t.Errorf("Expected 1 join call for single follower, got %d", joinCalls)
 	}
 }
 
@@ -4231,53 +3792,6 @@ func TestJoinSpeakerWithRetry_PermanentError(t *testing.T) {
 	}
 }
 
-// TestJoinSpeakerWithRetry_MaxRetriesExhausted tests behavior when all retries are exhausted
-func TestJoinSpeakerWithRetry_MaxRetriesExhausted(t *testing.T) {
-	t.Parallel()
-	logger := zap.NewNop()
-	mockClient := ha.NewMockClient()
-	stateManager := state.NewManager(mockClient, logger, false)
-	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, nil, nil)
-
-	// Track retry delays to verify we retry maxAsyncSpeakerRetries-1 times
-	// (the last attempt doesn't sleep after failure)
-	var sleepMu sync.Mutex
-	var sleepCount int
-
-	manager.SetSleepFunc(func(d time.Duration) {
-		sleepMu.Lock()
-		sleepCount++
-		sleepMu.Unlock()
-	})
-
-	// Fail all attempts (more than maxAsyncSpeakerRetries * 2 for callServiceWithRetry internal retries)
-	// Using transient error (timeout) that won't trigger permanent error detection
-	mockClient.SetServiceFailCount("media_player", "join", 100, fmt.Errorf("service call failed: timeout waiting for response"))
-
-	participant := ParticipantWithVolume{
-		PlayerName:   "Living Room",
-		Volume:       10,
-		LeaveMutedIf: []MuteCondition{},
-	}
-
-	mockClient.ClearServiceCalls()
-	manager.joinSpeakerWithRetry(participant, "media_player.kitchen", "day")
-
-	sleepMu.Lock()
-	actualSleepCount := sleepCount
-	sleepMu.Unlock()
-
-	// Since mock only records successful calls and all calls fail,
-	// we verify retry count via sleepCount.
-	// joinSpeakerWithRetry calls sleep after each failed attempt except the last.
-	// With maxAsyncSpeakerRetries=6, we expect 5 retry delays (sleep after attempts 1-5, not after 6)
-	expectedSleepCount := maxAsyncSpeakerRetries - 1
-	if actualSleepCount != expectedSleepCount {
-		t.Errorf("Expected %d retry delays (max retries - 1), got %d", expectedSleepCount, actualSleepCount)
-	}
-}
-
 // TestBuildSpeakerGroupAsync_WaitGroupCompletion verifies WaitGroup waits for all goroutines
 func TestBuildSpeakerGroupAsync_WaitGroupCompletion(t *testing.T) {
 	t.Parallel()
@@ -4326,101 +3840,5 @@ func TestBuildSpeakerGroupAsync_WaitGroupCompletion(t *testing.T) {
 	// All 3 followers should have completed their join attempts
 	if originalCalls != 3 {
 		t.Errorf("Expected 3 completed join calls after WaitGroup.Wait(), got %d", originalCalls)
-	}
-}
-
-// TestBuildSpeakerGroupAsync_NoFollowers tests with only lead speaker (no followers)
-func TestBuildSpeakerGroupAsync_NoFollowers(t *testing.T) {
-	t.Parallel()
-	logger := zap.NewNop()
-	mockClient := ha.NewMockClient()
-	stateManager := state.NewManager(mockClient, logger, false)
-	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, nil, nil)
-
-	manager.SetSleepFunc(func(d time.Duration) {})
-
-	// Only lead speaker, no followers
-	participants := []ParticipantWithVolume{
-		{PlayerName: "Kitchen", Volume: 9}, // Lead only
-	}
-
-	mockClient.ClearServiceCalls()
-
-	// Should complete immediately without any join calls
-	manager.buildSpeakerGroupAsync(participants, "media_player.kitchen", "day")
-
-	calls := mockClient.GetServiceCalls()
-
-	// Should have 0 join calls (no followers to join)
-	joinCalls := 0
-	for _, call := range calls {
-		if call.Domain == "media_player" && call.Service == "join" {
-			joinCalls++
-		}
-	}
-
-	if joinCalls != 0 {
-		t.Errorf("Expected 0 join calls with no followers, got %d", joinCalls)
-	}
-}
-
-// TestBuildSpeakerGroupAsync_IndependentFailures verifies one speaker failure doesn't block others
-func TestBuildSpeakerGroupAsync_IndependentFailures(t *testing.T) {
-	t.Parallel()
-	logger := zap.NewNop()
-	mockClient := ha.NewMockClient()
-	stateManager := state.NewManager(mockClient, logger, false)
-	config := &MusicConfig{Music: map[string]MusicMode{}}
-	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, nil, nil)
-
-	manager.SetSleepFunc(func(d time.Duration) {})
-
-	// Since goroutines run in parallel and the mock uses a global fail counter,
-	// we can't easily isolate failures to specific speakers.
-	// Instead, we test that both goroutines complete (function returns) even when
-	// some calls fail, proving they don't block each other.
-
-	// Fail first 10 calls, then succeed. With 2 followers running in parallel:
-	// - Each follower makes multiple calls (due to callServiceWithRetry internal retry)
-	// - Eventually calls succeed after the fail count is exhausted
-	mockClient.SetServiceFailCount("media_player", "join", 10, fmt.Errorf("service call failed: timeout"))
-
-	participants := []ParticipantWithVolume{
-		{PlayerName: "Kitchen", Volume: 9},      // Lead
-		{PlayerName: "Living Room", Volume: 10}, // Follower 1
-		{PlayerName: "Bedroom", Volume: 8},      // Follower 2
-	}
-
-	mockClient.ClearServiceCalls()
-
-	// Key test: buildSpeakerGroupAsync should complete (not hang) even with failures
-	// This proves goroutines don't block each other
-	done := make(chan bool)
-	go func() {
-		manager.buildSpeakerGroupAsync(participants, "media_player.kitchen", "day")
-		done <- true
-	}()
-
-	select {
-	case <-done:
-		// Success - function completed
-	case <-time.After(5 * time.Second):
-		t.Fatal("buildSpeakerGroupAsync timed out - goroutines may be blocking each other")
-	}
-
-	// Verify at least one successful call was made (after failures exhausted)
-	calls := mockClient.GetServiceCalls()
-	joinCalls := 0
-	for _, call := range calls {
-		if call.Domain == "media_player" && call.Service == "join" {
-			joinCalls++
-		}
-	}
-
-	// After 10 failures, subsequent calls should succeed. With 2 parallel goroutines
-	// retrying, we expect at least some successful calls (from both followers)
-	if joinCalls < 1 {
-		t.Errorf("Expected at least 1 successful join call after failures exhausted, got %d", joinCalls)
 	}
 }

--- a/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
@@ -124,72 +124,36 @@ func TestBeginWake_AllConditionsMet(t *testing.T) {
 	}
 }
 
-func TestBeginWake_NoOneHome(t *testing.T) {
+func TestBeginWake_ConditionsRequired(t *testing.T) {
 	t.Parallel()
-	now := time.Date(2024, 1, 15, 9, 5, 0, 0, time.UTC)
-	manager, mockHA, stateManager, _ := setupTest(t, now)
-
-	// Set no one home
-	stateManager.SetBool("isAnyoneHome", false)
-	stateManager.SetBool("isMasterAsleep", true)
-	stateManager.SetString("musicPlaybackType", "sleep")
-
-	// Clear mock calls
-	mockHA.ClearServiceCalls()
-
-	// Trigger begin_wake
-	manager.handleBeginWake()
-
-	// Verify that isFadeOutInProgress was NOT changed
-	fadeOut, _ := stateManager.GetBool("isFadeOutInProgress")
-	if fadeOut {
-		t.Error("isFadeOutInProgress should not be set when no one is home")
+	tests := []struct {
+		name           string
+		isAnyoneHome   bool
+		isMasterAsleep bool
+		musicType      string
+	}{
+		{"No one home", false, true, "sleep"},
+		{"Master not asleep", true, false, "sleep"},
+		{"Not playing sleep music", true, true, "day"},
 	}
-}
 
-func TestBeginWake_MasterNotAsleep(t *testing.T) {
-	t.Parallel()
-	now := time.Date(2024, 1, 15, 9, 5, 0, 0, time.UTC)
-	manager, mockHA, stateManager, _ := setupTest(t, now)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2024, 1, 15, 9, 5, 0, 0, time.UTC)
+			manager, mockHA, stateManager, _ := setupTest(t, now)
 
-	// Set master not asleep
-	stateManager.SetBool("isAnyoneHome", true)
-	stateManager.SetBool("isMasterAsleep", false)
-	stateManager.SetString("musicPlaybackType", "sleep")
+			stateManager.SetBool("isAnyoneHome", tt.isAnyoneHome)
+			stateManager.SetBool("isMasterAsleep", tt.isMasterAsleep)
+			stateManager.SetString("musicPlaybackType", tt.musicType)
+			mockHA.ClearServiceCalls()
 
-	// Clear mock calls
-	mockHA.ClearServiceCalls()
+			manager.handleBeginWake()
 
-	// Trigger begin_wake
-	manager.handleBeginWake()
-
-	// Verify that isFadeOutInProgress was NOT changed
-	fadeOut, _ := stateManager.GetBool("isFadeOutInProgress")
-	if fadeOut {
-		t.Error("isFadeOutInProgress should not be set when master is not asleep")
-	}
-}
-
-func TestBeginWake_NotPlayingSleepMusic(t *testing.T) {
-	t.Parallel()
-	now := time.Date(2024, 1, 15, 9, 5, 0, 0, time.UTC)
-	manager, mockHA, stateManager, _ := setupTest(t, now)
-
-	// Set music playback to something other than "sleep"
-	stateManager.SetBool("isAnyoneHome", true)
-	stateManager.SetBool("isMasterAsleep", true)
-	stateManager.SetString("musicPlaybackType", "day")
-
-	// Clear mock calls
-	mockHA.ClearServiceCalls()
-
-	// Trigger begin_wake
-	manager.handleBeginWake()
-
-	// Verify that isFadeOutInProgress was NOT changed
-	fadeOut, _ := stateManager.GetBool("isFadeOutInProgress")
-	if fadeOut {
-		t.Error("isFadeOutInProgress should not be set when not playing sleep music")
+			fadeOut, _ := stateManager.GetBool("isFadeOutInProgress")
+			if fadeOut {
+				t.Errorf("isFadeOutInProgress should not be set when %s", tt.name)
+			}
+		})
 	}
 }
 
@@ -344,21 +308,6 @@ func TestReadOnlyMode(t *testing.T) {
 	// But we can verify the manager respects read-only flag
 	if !manager.readOnly {
 		t.Error("Manager should be in read-only mode")
-	}
-}
-
-func TestIsSameDay(t *testing.T) {
-	t.Parallel()
-	t1 := time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC)
-	t2 := time.Date(2024, 1, 15, 23, 59, 0, 0, time.UTC)
-	t3 := time.Date(2024, 1, 16, 0, 1, 0, 0, time.UTC)
-
-	if !isSameDay(t1, t2) {
-		t.Error("t1 and t2 should be on the same day")
-	}
-
-	if isSameDay(t1, t3) {
-		t.Error("t1 and t3 should not be on the same day")
 	}
 }
 
@@ -578,29 +527,6 @@ func TestHandleGoToBed_ReadOnly(t *testing.T) {
 	}
 }
 
-// TestRealTimeProvider tests the plugin.RealTimeProvider
-func TestRealTimeProvider(t *testing.T) {
-	t.Parallel()
-	provider := plugin.RealTimeProvider{}
-	now := provider.Now()
-
-	// Verify it returns a reasonable time (within last minute)
-	if time.Since(now) > time.Minute {
-		t.Errorf("RealTimeProvider returned time too far in the past: %v", now)
-	}
-}
-
-// TestFixedTimeProvider tests the plugin.FixedTimeProvider
-func TestFixedTimeProvider(t *testing.T) {
-	t.Parallel()
-	fixedTime := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
-	provider := plugin.FixedTimeProvider{FixedTime: fixedTime}
-
-	if provider.Now() != fixedTime {
-		t.Errorf("FixedTimeProvider did not return fixed time")
-	}
-}
-
 // TestCheckTimeTriggers_ErrorGettingSchedule tests error handling when schedule config is not available
 func TestCheckTimeTriggers_ErrorGettingSchedule(t *testing.T) {
 	t.Parallel()
@@ -648,184 +574,116 @@ func TestHandleWake_ErrorGettingState(t *testing.T) {
 	}
 }
 
-// TestHandleBeginWake_ReadOnly tests read-only mode for begin_wake
-func TestHandleBeginWake_ReadOnly(t *testing.T) {
+// TestReadOnlyModeBlocksServiceCalls tests that all handlers block service calls in read-only mode
+func TestReadOnlyModeBlocksServiceCalls(t *testing.T) {
 	t.Parallel()
-	now := time.Date(2024, 1, 15, 9, 5, 0, 0, time.UTC)
-	logger := zap.NewNop()
-	mockHA := ha.NewMockClient()
-	stateManager := state.NewManager(mockHA, logger, false)
+	tests := []struct {
+		name    string
+		handler string
+		setup   func(*state.Manager)
+	}{
+		{
+			name:    "begin_wake",
+			handler: "beginWake",
+			setup: func(sm *state.Manager) {
+				sm.SetBool("isAnyoneHome", true)
+				sm.SetBool("isMasterAsleep", true)
+				sm.SetString("musicPlaybackType", "sleep")
+			},
+		},
+		{
+			name:    "wake",
+			handler: "wake",
+			setup: func(sm *state.Manager) {
+				sm.SetBool("isAnyoneHome", true)
+				sm.SetBool("isMasterAsleep", true)
+				sm.SetBool("isFadeOutInProgress", true)
+				sm.SetBool("isNickHome", true)
+				sm.SetBool("isCarolineHome", true)
+			},
+		},
+		{
+			name:    "stop_screens",
+			handler: "stopScreens",
+			setup: func(sm *state.Manager) {
+				sm.SetBool("isAnyoneHome", true)
+				sm.SetBool("isEveryoneAsleep", false)
+			},
+		},
+	}
 
-	// Set all conditions
-	stateManager.SetBool("isAnyoneHome", true)
-	stateManager.SetBool("isMasterAsleep", true)
-	stateManager.SetString("musicPlaybackType", "sleep")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2024, 1, 15, 9, 30, 0, 0, time.UTC)
+			logger := zap.NewNop()
+			mockHA := ha.NewMockClient()
+			stateManager := state.NewManager(mockHA, logger, false)
 
-	configLoader := config.NewLoader("../../../configs", logger)
-	timeProvider := plugin.FixedTimeProvider{FixedTime: now}
-	manager := NewManager(context.Background(), mockHA, stateManager, configLoader, logger, true, timeProvider, nil) // READ-ONLY
+			// Initialize default state
+			stateManager.SetBool("isAnyoneHome", true)
+			stateManager.SetBool("isMasterAsleep", true)
+			stateManager.SetBool("isGuestAsleep", false)
+			stateManager.SetBool("isEveryoneAsleep", true)
+			stateManager.SetBool("isFadeOutInProgress", false)
+			stateManager.SetBool("isNickHome", true)
+			stateManager.SetBool("isCarolineHome", true)
+			stateManager.SetString("musicPlaybackType", "sleep")
 
-	mockHA.ClearServiceCalls()
+			tt.setup(stateManager)
 
-	// Trigger begin_wake
-	manager.handleBeginWake()
+			configLoader := config.NewLoader("../../../configs", logger)
+			timeProvider := plugin.FixedTimeProvider{FixedTime: now}
+			manager := NewManager(context.Background(), mockHA, stateManager, configLoader, logger, true, timeProvider, nil)
 
-	// In read-only mode, no state changes should be made to HA
-	// State manager itself is not read-only, so local state may change
-	// But no HA service calls should be made
-	calls := mockHA.GetServiceCalls()
-	if len(calls) > 0 {
-		t.Errorf("Expected no service calls in read-only mode, got %d", len(calls))
+			mockHA.ClearServiceCalls()
+
+			switch tt.handler {
+			case "beginWake":
+				manager.handleBeginWake()
+			case "wake":
+				manager.handleWake()
+			case "stopScreens":
+				manager.handleStopScreens()
+			}
+
+			calls := mockHA.GetServiceCalls()
+			if len(calls) > 0 {
+				t.Errorf("Expected no service calls in read-only mode for %s, got %d", tt.name, len(calls))
+			}
+		})
 	}
 }
 
-// TestHandleWake_ReadOnly tests read-only mode for wake
-func TestHandleWake_ReadOnly(t *testing.T) {
+func TestHandleWake_ConditionsRequired(t *testing.T) {
 	t.Parallel()
-	now := time.Date(2024, 1, 15, 9, 30, 0, 0, time.UTC)
-	logger := zap.NewNop()
-	mockHA := ha.NewMockClient()
-	stateManager := state.NewManager(mockHA, logger, false)
-
-	// Set all conditions
-	stateManager.SetBool("isAnyoneHome", true)
-	stateManager.SetBool("isMasterAsleep", true)
-	stateManager.SetBool("isFadeOutInProgress", true)
-	stateManager.SetBool("isNickHome", true)
-	stateManager.SetBool("isCarolineHome", true)
-
-	configLoader := config.NewLoader("../../../configs", logger)
-	timeProvider := plugin.FixedTimeProvider{FixedTime: now}
-	manager := NewManager(context.Background(), mockHA, stateManager, configLoader, logger, true, timeProvider, nil) // READ-ONLY
-
-	mockHA.ClearServiceCalls()
-
-	// Trigger wake
-	manager.handleWake()
-
-	// In read-only mode, no service calls should be made
-	calls := mockHA.GetServiceCalls()
-	if len(calls) > 0 {
-		t.Errorf("Expected no service calls in read-only mode, got %d", len(calls))
+	tests := []struct {
+		name                string
+		isAnyoneHome        bool
+		isMasterAsleep      bool
+		isFadeOutInProgress bool
+	}{
+		{"No one home", false, true, true},
+		{"Master not asleep", true, false, true},
+		{"Fade out not in progress", true, true, false},
 	}
-}
 
-// TestHandleStopScreens_ReadOnly tests read-only mode for stop_screens
-func TestHandleStopScreens_ReadOnly(t *testing.T) {
-	t.Parallel()
-	now := time.Date(2024, 1, 15, 22, 30, 0, 0, time.UTC)
-	logger := zap.NewNop()
-	mockHA := ha.NewMockClient()
-	stateManager := state.NewManager(mockHA, logger, false)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2024, 1, 15, 9, 30, 0, 0, time.UTC)
+			manager, mockHA, stateManager, _ := setupTest(t, now)
 
-	// Set conditions
-	stateManager.SetBool("isAnyoneHome", true)
-	stateManager.SetBool("isEveryoneAsleep", false)
+			stateManager.SetBool("isAnyoneHome", tt.isAnyoneHome)
+			stateManager.SetBool("isMasterAsleep", tt.isMasterAsleep)
+			stateManager.SetBool("isFadeOutInProgress", tt.isFadeOutInProgress)
+			mockHA.ClearServiceCalls()
 
-	configLoader := config.NewLoader("../../../configs", logger)
-	timeProvider := plugin.FixedTimeProvider{FixedTime: now}
-	manager := NewManager(context.Background(), mockHA, stateManager, configLoader, logger, true, timeProvider, nil) // READ-ONLY
+			manager.handleWake()
 
-	mockHA.ClearServiceCalls()
-
-	// Trigger stop_screens
-	manager.handleStopScreens()
-
-	// In read-only mode, no service calls should be made
-	calls := mockHA.GetServiceCalls()
-	if len(calls) > 0 {
-		t.Errorf("Expected no service calls in read-only mode, got %d", len(calls))
-	}
-}
-
-// TestHandleWake_NoOneHome tests wake trigger when no one is home
-func TestHandleWake_NoOneHome(t *testing.T) {
-	t.Parallel()
-	now := time.Date(2024, 1, 15, 9, 30, 0, 0, time.UTC)
-	manager, mockHA, stateManager, _ := setupTest(t, now)
-
-	// Set no one home
-	stateManager.SetBool("isAnyoneHome", false)
-	stateManager.SetBool("isMasterAsleep", true)
-	stateManager.SetBool("isFadeOutInProgress", true)
-
-	mockHA.ClearServiceCalls()
-
-	// Trigger wake
-	manager.handleWake()
-
-	// Should not make service calls when no one is home
-	calls := mockHA.GetServiceCalls()
-	if len(calls) > 0 {
-		t.Error("Should not execute wake sequence when no one is home")
-	}
-}
-
-// TestHandleWake_MasterNotAsleep tests wake trigger when master is not asleep
-func TestHandleWake_MasterNotAsleep(t *testing.T) {
-	t.Parallel()
-	now := time.Date(2024, 1, 15, 9, 30, 0, 0, time.UTC)
-	manager, mockHA, stateManager, _ := setupTest(t, now)
-
-	// Set master not asleep
-	stateManager.SetBool("isAnyoneHome", true)
-	stateManager.SetBool("isMasterAsleep", false)
-	stateManager.SetBool("isFadeOutInProgress", true)
-
-	mockHA.ClearServiceCalls()
-
-	// Trigger wake
-	manager.handleWake()
-
-	// Should not make service calls when master is not asleep
-	calls := mockHA.GetServiceCalls()
-	if len(calls) > 0 {
-		t.Error("Should not execute wake sequence when master is not asleep")
-	}
-}
-
-// TestHandleWake_FadeOutNotInProgress tests wake trigger when fade out is not in progress
-func TestHandleWake_FadeOutNotInProgress(t *testing.T) {
-	t.Parallel()
-	now := time.Date(2024, 1, 15, 9, 30, 0, 0, time.UTC)
-	manager, mockHA, stateManager, _ := setupTest(t, now)
-
-	// Set fade out not in progress
-	stateManager.SetBool("isAnyoneHome", true)
-	stateManager.SetBool("isMasterAsleep", true)
-	stateManager.SetBool("isFadeOutInProgress", false)
-
-	mockHA.ClearServiceCalls()
-
-	// Trigger wake
-	manager.handleWake()
-
-	// Should not make service calls when fade out is not in progress
-	calls := mockHA.GetServiceCalls()
-	if len(calls) > 0 {
-		t.Error("Should not execute wake sequence when fade out is not in progress")
-	}
-}
-
-// TestHandleStopScreens_NoOneHome tests stop_screens when no one is home
-func TestHandleStopScreens_NoOneHome(t *testing.T) {
-	t.Parallel()
-	now := time.Date(2024, 1, 15, 22, 30, 0, 0, time.UTC)
-	manager, mockHA, stateManager, _ := setupTest(t, now)
-
-	// Set no one home
-	stateManager.SetBool("isAnyoneHome", false)
-	stateManager.SetBool("isEveryoneAsleep", false)
-
-	mockHA.ClearServiceCalls()
-
-	// Trigger stop_screens
-	manager.handleStopScreens()
-
-	// Should not flash lights when no one is home
-	calls := mockHA.GetServiceCalls()
-	if len(calls) > 0 {
-		t.Error("Should not flash lights when no one is home")
+			calls := mockHA.GetServiceCalls()
+			if len(calls) > 0 {
+				t.Errorf("Should not execute wake sequence when %s", tt.name)
+			}
+		})
 	}
 }
 
@@ -1971,85 +1829,39 @@ func TestStart_SubscribesToEightSleepSensors(t *testing.T) {
 
 // Eight Sleep Availability Tests
 
-func TestIsEightSleepUnavailable_BothSensorsAvailable(t *testing.T) {
+func TestIsEightSleepUnavailable_SensorCombinations(t *testing.T) {
 	t.Parallel()
-	now := time.Date(2024, 1, 15, 8, 0, 0, 0, time.UTC)
-	manager, mockHA, _, _ := setupTest(t, now)
-
-	// Set both sensors to available states (not "unavailable")
-	mockHA.SetState("sensor.nick_s_eight_sleep_side_sleep_stage", "awake", nil)
-	mockHA.SetState("sensor.caroline_s_eight_sleep_side_sleep_stage", "light", nil)
-
-	if manager.isEightSleepUnavailable() {
-		t.Error("isEightSleepUnavailable should return false when both sensors are available")
+	tests := []struct {
+		name              string
+		nickState         string // empty = sensor not set (error)
+		carolineState     string // empty = sensor not set (error)
+		expectUnavailable bool
+	}{
+		{"Both available", "awake", "light", false},
+		{"Only Nick available", "deep", "unavailable", false},
+		{"Only Caroline available", "unavailable", "rem", false},
+		{"Both unavailable", "unavailable", "unavailable", true},
+		{"Both not found", "", "", true},
+		{"Nick error, Caroline available", "", "awake", false},
 	}
-}
 
-func TestIsEightSleepUnavailable_OnlyNickAvailable(t *testing.T) {
-	t.Parallel()
-	now := time.Date(2024, 1, 15, 8, 0, 0, 0, time.UTC)
-	manager, mockHA, _, _ := setupTest(t, now)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2024, 1, 15, 8, 0, 0, 0, time.UTC)
+			manager, mockHA, _, _ := setupTest(t, now)
 
-	// Nick's sensor available, Caroline's unavailable
-	mockHA.SetState("sensor.nick_s_eight_sleep_side_sleep_stage", "deep", nil)
-	mockHA.SetState("sensor.caroline_s_eight_sleep_side_sleep_stage", "unavailable", nil)
+			if tt.nickState != "" {
+				mockHA.SetState("sensor.nick_s_eight_sleep_side_sleep_stage", tt.nickState, nil)
+			}
+			if tt.carolineState != "" {
+				mockHA.SetState("sensor.caroline_s_eight_sleep_side_sleep_stage", tt.carolineState, nil)
+			}
 
-	if manager.isEightSleepUnavailable() {
-		t.Error("isEightSleepUnavailable should return false when at least one sensor is available (Nick)")
-	}
-}
-
-func TestIsEightSleepUnavailable_OnlyCarolineAvailable(t *testing.T) {
-	t.Parallel()
-	now := time.Date(2024, 1, 15, 8, 0, 0, 0, time.UTC)
-	manager, mockHA, _, _ := setupTest(t, now)
-
-	// Nick's sensor unavailable, Caroline's available
-	mockHA.SetState("sensor.nick_s_eight_sleep_side_sleep_stage", "unavailable", nil)
-	mockHA.SetState("sensor.caroline_s_eight_sleep_side_sleep_stage", "rem", nil)
-
-	if manager.isEightSleepUnavailable() {
-		t.Error("isEightSleepUnavailable should return false when at least one sensor is available (Caroline)")
-	}
-}
-
-func TestIsEightSleepUnavailable_BothSensorsUnavailable(t *testing.T) {
-	t.Parallel()
-	now := time.Date(2024, 1, 15, 8, 0, 0, 0, time.UTC)
-	manager, mockHA, _, _ := setupTest(t, now)
-
-	// Both sensors report "unavailable"
-	mockHA.SetState("sensor.nick_s_eight_sleep_side_sleep_stage", "unavailable", nil)
-	mockHA.SetState("sensor.caroline_s_eight_sleep_side_sleep_stage", "unavailable", nil)
-
-	if !manager.isEightSleepUnavailable() {
-		t.Error("isEightSleepUnavailable should return true when both sensors are unavailable")
-	}
-}
-
-func TestIsEightSleepUnavailable_BothSensorsNotFound(t *testing.T) {
-	t.Parallel()
-	now := time.Date(2024, 1, 15, 8, 0, 0, 0, time.UTC)
-	manager, _, _, _ := setupTest(t, now)
-
-	// Don't set any state - sensors don't exist in mock
-	// This simulates GetState returning an error
-
-	if !manager.isEightSleepUnavailable() {
-		t.Error("isEightSleepUnavailable should return true when both sensors return errors")
-	}
-}
-
-func TestIsEightSleepUnavailable_NickErrorCarolineAvailable(t *testing.T) {
-	t.Parallel()
-	now := time.Date(2024, 1, 15, 8, 0, 0, 0, time.UTC)
-	manager, mockHA, _, _ := setupTest(t, now)
-
-	// Nick's sensor doesn't exist (error), Caroline's is available
-	mockHA.SetState("sensor.caroline_s_eight_sleep_side_sleep_stage", "awake", nil)
-
-	if manager.isEightSleepUnavailable() {
-		t.Error("isEightSleepUnavailable should return false when at least one sensor is available")
+			result := manager.isEightSleepUnavailable()
+			if result != tt.expectUnavailable {
+				t.Errorf("isEightSleepUnavailable() = %v, want %v", result, tt.expectUnavailable)
+			}
+		})
 	}
 }
 

--- a/homeautomation-go/internal/plugins/statetracking/manager_test.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager_test.go
@@ -1407,39 +1407,3 @@ func TestStateTrackingManager_CarolineNearHome_IgnoresWhenAlreadyHome(t *testing
 		t.Error("Expected didOwnerJustReturnHome=false when caroline_near_home triggers while Caroline IS home (leaving)")
 	}
 }
-
-func TestStateTrackingManager_NearHome_IgnoresNilStates(t *testing.T) {
-	t.Parallel()
-	// Test that near_home handlers gracefully handle nil states (no panic)
-
-	mockHA := ha.NewMockClient()
-	logger := zap.NewNop()
-	stateMgr := state.NewManager(mockHA, logger, false)
-
-	// Setup: Nick is NOT home
-	if err := stateMgr.SetBool("isNickHome", false); err != nil {
-		t.Fatalf("Failed to set isNickHome: %v", err)
-	}
-	if err := stateMgr.SetBool("didOwnerJustReturnHome", false); err != nil {
-		t.Fatalf("Failed to set didOwnerJustReturnHome: %v", err)
-	}
-
-	// Create and start manager
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil)
-	if err := manager.Start(); err != nil {
-		t.Fatalf("Failed to start manager: %v", err)
-	}
-	defer manager.Stop()
-
-	// Simulate state change from unknown (nil oldState) - should not trigger or panic
-	mockHA.SetState("input_boolean.nick_near_home", "on", nil)
-
-	// Verify didOwnerJustReturnHome was NOT set (oldState was nil)
-	didOwnerReturn, err := stateMgr.GetBool("didOwnerJustReturnHome")
-	if err != nil {
-		t.Fatalf("Failed to get didOwnerJustReturnHome: %v", err)
-	}
-	if didOwnerReturn {
-		t.Error("Expected didOwnerJustReturnHome=false when oldState is nil (initial state, not a transition)")
-	}
-}

--- a/homeautomation-go/internal/plugins/tv/manager_test.go
+++ b/homeautomation-go/internal/plugins/tv/manager_test.go
@@ -141,48 +141,6 @@ func TestTVManager_TVRemoteOff_KillsLightSync(t *testing.T) {
 	}
 }
 
-func TestTVManager_TVRemoteOff_SetsTVPlayingFalse(t *testing.T) {
-	t.Parallel()
-
-	mockHA := ha.NewMockClient()
-	logger := zap.NewNop()
-	stateMgr := state.NewManager(mockHA, logger, false)
-
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil)
-
-	// Initially set isTVPlaying to true
-	if err := stateMgr.SetBool("isTVPlaying", true); err != nil {
-		t.Fatalf("Failed to set initial isTVPlaying: %v", err)
-	}
-
-	// Simulate TV remote turning off
-	newState := &ha.State{
-		EntityID: "remote.big_beautiful_oled",
-		State:    "off",
-	}
-	manager.handleTVRemoteChange("remote.big_beautiful_oled", nil, newState)
-
-	// Verify isTVPlaying is now false
-	isTVPlaying, err := stateMgr.GetBool("isTVPlaying")
-	if err != nil {
-		t.Fatalf("Failed to get isTVPlaying: %v", err)
-	}
-
-	if isTVPlaying {
-		t.Errorf("Expected isTVPlaying=false when TV remote turns off, got true")
-	}
-
-	// Verify isTVon is also false
-	isTVOn, err := stateMgr.GetBool("isTVon")
-	if err != nil {
-		t.Fatalf("Failed to get isTVon: %v", err)
-	}
-
-	if isTVOn {
-		t.Errorf("Expected isTVon=false when TV remote turns off, got true")
-	}
-}
-
 func TestTVManager_SyncBoxPowerChange(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -606,46 +564,6 @@ func TestTVManager_Stop_CleansUpSubscriptions(t *testing.T) {
 	if len(manager.subHelper.GetStateSubscriptions()) != 0 {
 		t.Error("Expected stateSubscriptions to be empty after Stop()")
 	}
-}
-
-func TestTVManager_ReadOnlyMode(t *testing.T) {
-	t.Parallel(
-	// Create mock HA client
-	)
-
-	mockHA := ha.NewMockClient()
-	logger := zap.NewNop()
-
-	// Create state manager in read-only mode
-	stateMgr := state.NewManager(mockHA, logger, true)
-
-	// Initialize state from HA (this populates the cache)
-	mockHA.SetState("input_boolean.apple_tv_playing", "off", nil)
-	if err := stateMgr.SyncFromHA(); err != nil {
-		t.Fatalf("Failed to sync from HA: %v", err)
-	}
-
-	// Create TV manager in read-only mode
-	_ = NewManager(context.Background(), mockHA, stateMgr, logger, true, nil)
-
-	// Simulate HA state change (this should update local cache)
-	mockHA.SimulateStateChange("input_boolean.apple_tv_playing", "on")
-
-	// Small delay to allow state propagation
-	time.Sleep(10 * time.Millisecond)
-
-	// In read-only mode, local cache should still be updated when HA sends changes
-	isPlaying, err := stateMgr.GetBool("isAppleTVPlaying")
-	if err != nil {
-		t.Fatalf("Failed to get isAppleTVPlaying: %v", err)
-	}
-	if !isPlaying {
-		t.Error("Expected isAppleTVPlaying=true (local cache should update from HA changes even in read-only mode)")
-	}
-
-	// Verify that the manager doesn't try to write back to HA (this is implicit -
-	// if it tried, it would error, but the state manager only prevents writes,
-	// not reads or cache updates from HA)
 }
 
 func TestTVManager_SyncBoxUnavailable_TriggersRecovery(t *testing.T) {

--- a/homeautomation-go/internal/shadowstate/tracker_test.go
+++ b/homeautomation-go/internal/shadowstate/tracker_test.go
@@ -395,11 +395,6 @@ func TestLightingTrackerMetadataUpdates(t *testing.T) {
 	}
 }
 
-func TestLightingShadowStateImplementsInterface(t *testing.T) {
-	t.Parallel()
-	var _ PluginShadowState = (*LightingShadowState)(nil)
-}
-
 // Security Tracker Tests
 
 func TestNewSecurityTracker(t *testing.T) {
@@ -707,11 +702,6 @@ func TestSecurityTrackerMetadataUpdates(t *testing.T) {
 	}
 }
 
-func TestSecurityShadowStateImplementsInterface(t *testing.T) {
-	t.Parallel()
-	var _ PluginShadowState = (*SecurityShadowState)(nil)
-}
-
 func TestSecurityTrackerLastActionTime(t *testing.T) {
 	t.Parallel()
 	st := NewSecurityTracker()
@@ -992,11 +982,6 @@ func TestSleepHygieneTrackerConcurrentAccess(t *testing.T) {
 	wg.Wait()
 }
 
-func TestSleepHygieneShadowStateImplementsInterface(t *testing.T) {
-	t.Parallel()
-	var _ PluginShadowState = (*SleepHygieneShadowState)(nil)
-}
-
 // ============================================================================
 // Phase 6: Read-Heavy Plugin Tracker Tests
 // ============================================================================
@@ -1125,11 +1110,6 @@ func TestLoadSheddingTrackerGetStateReturnsDeepCopy(t *testing.T) {
 	}
 }
 
-func TestLoadSheddingShadowStateImplementsInterface(t *testing.T) {
-	t.Parallel()
-	var _ PluginShadowState = (*LoadSheddingShadowState)(nil)
-}
-
 // EnergyTracker tests
 
 func TestNewEnergyTracker(t *testing.T) {
@@ -1185,51 +1165,6 @@ func TestEnergyTrackerUpdateSensorReadings(t *testing.T) {
 	}
 	if state.Outputs.SensorReadings.LastUpdate.IsZero() {
 		t.Error("Expected LastUpdate to be set")
-	}
-}
-
-func TestEnergyTrackerUpdateBatteryLevel(t *testing.T) {
-	t.Parallel()
-	et := NewEnergyTracker()
-
-	et.UpdateBatteryLevel("high")
-
-	state := et.GetState()
-	if state.Outputs.BatteryEnergyLevel != "high" {
-		t.Errorf("Expected BatteryEnergyLevel 'high', got %s", state.Outputs.BatteryEnergyLevel)
-	}
-	if state.Outputs.LastComputations.LastBatteryLevelCalc.IsZero() {
-		t.Error("Expected LastBatteryLevelCalc to be set")
-	}
-}
-
-func TestEnergyTrackerUpdateSolarLevel(t *testing.T) {
-	t.Parallel()
-	et := NewEnergyTracker()
-
-	et.UpdateSolarLevel("medium")
-
-	state := et.GetState()
-	if state.Outputs.SolarProductionEnergyLevel != "medium" {
-		t.Errorf("Expected SolarProductionEnergyLevel 'medium', got %s", state.Outputs.SolarProductionEnergyLevel)
-	}
-	if state.Outputs.LastComputations.LastSolarLevelCalc.IsZero() {
-		t.Error("Expected LastSolarLevelCalc to be set")
-	}
-}
-
-func TestEnergyTrackerUpdateOverallLevel(t *testing.T) {
-	t.Parallel()
-	et := NewEnergyTracker()
-
-	et.UpdateOverallLevel("low")
-
-	state := et.GetState()
-	if state.Outputs.CurrentEnergyLevel != "low" {
-		t.Errorf("Expected CurrentEnergyLevel 'low', got %s", state.Outputs.CurrentEnergyLevel)
-	}
-	if state.Outputs.LastComputations.LastOverallLevelCalc.IsZero() {
-		t.Error("Expected LastOverallLevelCalc to be set")
 	}
 }
 
@@ -1306,11 +1241,6 @@ func TestEnergyTrackerConcurrentAccess(t *testing.T) {
 	}
 
 	wg.Wait()
-}
-
-func TestEnergyShadowStateImplementsInterface(t *testing.T) {
-	t.Parallel()
-	var _ PluginShadowState = (*EnergyShadowState)(nil)
 }
 
 // StateTrackingTracker tests
@@ -1401,60 +1331,6 @@ func TestStateTrackingTrackerUpdateSleepDetectionTimer(t *testing.T) {
 	}
 }
 
-func TestStateTrackingTrackerUpdateWakeDetectionTimer(t *testing.T) {
-	t.Parallel()
-	stt := NewStateTrackingTracker()
-
-	// Activate timer
-	stt.UpdateWakeDetectionTimer(true)
-
-	state := stt.GetState()
-	if !state.Outputs.TimerStates.WakeDetectionActive {
-		t.Error("Expected WakeDetectionActive to be true")
-	}
-	if state.Outputs.TimerStates.WakeDetectionStarted.IsZero() {
-		t.Error("Expected WakeDetectionStarted to be set")
-	}
-
-	// Deactivate timer
-	stt.UpdateWakeDetectionTimer(false)
-
-	state = stt.GetState()
-	if state.Outputs.TimerStates.WakeDetectionActive {
-		t.Error("Expected WakeDetectionActive to be false")
-	}
-	if !state.Outputs.TimerStates.WakeDetectionStarted.IsZero() {
-		t.Error("Expected WakeDetectionStarted to be cleared")
-	}
-}
-
-func TestStateTrackingTrackerUpdateOwnerReturnTimer(t *testing.T) {
-	t.Parallel()
-	stt := NewStateTrackingTracker()
-
-	// Activate timer
-	stt.UpdateOwnerReturnTimer(true)
-
-	state := stt.GetState()
-	if !state.Outputs.TimerStates.OwnerReturnResetActive {
-		t.Error("Expected OwnerReturnResetActive to be true")
-	}
-	if state.Outputs.TimerStates.OwnerReturnResetStarted.IsZero() {
-		t.Error("Expected OwnerReturnResetStarted to be set")
-	}
-
-	// Deactivate timer
-	stt.UpdateOwnerReturnTimer(false)
-
-	state = stt.GetState()
-	if state.Outputs.TimerStates.OwnerReturnResetActive {
-		t.Error("Expected OwnerReturnResetActive to be false")
-	}
-	if !state.Outputs.TimerStates.OwnerReturnResetStarted.IsZero() {
-		t.Error("Expected OwnerReturnResetStarted to be cleared")
-	}
-}
-
 func TestStateTrackingTrackerRecordArrivalAnnouncement(t *testing.T) {
 	t.Parallel()
 	stt := NewStateTrackingTracker()
@@ -1529,11 +1405,6 @@ func TestStateTrackingTrackerConcurrentAccess(t *testing.T) {
 	wg.Wait()
 }
 
-func TestStateTrackingShadowStateImplementsInterface(t *testing.T) {
-	t.Parallel()
-	var _ PluginShadowState = (*StateTrackingShadowState)(nil)
-}
-
 // DayPhaseTracker tests
 
 func TestNewDayPhaseTracker(t *testing.T) {
@@ -1565,52 +1436,6 @@ func TestDayPhaseTrackerUpdateCurrentInputs(t *testing.T) {
 	}
 	if state.Inputs.Current["sunAzimuth"] != 180.0 {
 		t.Errorf("Expected sunAzimuth to be 180.0, got %v", state.Inputs.Current["sunAzimuth"])
-	}
-}
-
-func TestDayPhaseTrackerUpdateSunEvent(t *testing.T) {
-	t.Parallel()
-	dpt := NewDayPhaseTracker()
-
-	dpt.UpdateSunEvent("sunset")
-
-	state := dpt.GetState()
-	if state.Outputs.SunEvent != "sunset" {
-		t.Errorf("Expected SunEvent 'sunset', got %s", state.Outputs.SunEvent)
-	}
-	if state.Outputs.LastSunEventCalc.IsZero() {
-		t.Error("Expected LastSunEventCalc to be set")
-	}
-}
-
-func TestDayPhaseTrackerUpdateDayPhase(t *testing.T) {
-	t.Parallel()
-	dpt := NewDayPhaseTracker()
-
-	dpt.UpdateDayPhase("evening")
-
-	state := dpt.GetState()
-	if state.Outputs.DayPhase != "evening" {
-		t.Errorf("Expected DayPhase 'evening', got %s", state.Outputs.DayPhase)
-	}
-	if state.Outputs.LastDayPhaseCalc.IsZero() {
-		t.Error("Expected LastDayPhaseCalc to be set")
-	}
-}
-
-func TestDayPhaseTrackerUpdateNextTransition(t *testing.T) {
-	t.Parallel()
-	dpt := NewDayPhaseTracker()
-
-	transitionTime := time.Now().Add(2 * time.Hour)
-	dpt.UpdateNextTransition(transitionTime, "night")
-
-	state := dpt.GetState()
-	if !state.Outputs.NextTransitionTime.Equal(transitionTime) {
-		t.Errorf("Expected NextTransitionTime to match, got %v", state.Outputs.NextTransitionTime)
-	}
-	if state.Outputs.NextTransitionPhase != "night" {
-		t.Errorf("Expected NextTransitionPhase 'night', got %s", state.Outputs.NextTransitionPhase)
 	}
 }
 
@@ -1663,11 +1488,6 @@ func TestDayPhaseTrackerConcurrentAccess(t *testing.T) {
 	}
 
 	wg.Wait()
-}
-
-func TestDayPhaseShadowStateImplementsInterface(t *testing.T) {
-	t.Parallel()
-	var _ PluginShadowState = (*DayPhaseShadowState)(nil)
 }
 
 // TVTracker tests
@@ -1757,21 +1577,6 @@ func TestTVTrackerUpdateTVPower(t *testing.T) {
 	}
 }
 
-func TestTVTrackerUpdateHDMIInput(t *testing.T) {
-	t.Parallel()
-	tvt := NewTVTracker()
-
-	tvt.UpdateHDMIInput("HDMI2")
-
-	state := tvt.GetState()
-	if state.Outputs.CurrentHDMIInput != "HDMI2" {
-		t.Errorf("Expected CurrentHDMIInput 'HDMI2', got %s", state.Outputs.CurrentHDMIInput)
-	}
-	if state.Outputs.LastUpdate.IsZero() {
-		t.Error("Expected LastUpdate to be set")
-	}
-}
-
 func TestTVTrackerUpdateTVPlaying(t *testing.T) {
 	t.Parallel()
 	tvt := NewTVTracker()
@@ -1844,11 +1649,6 @@ func TestTVTrackerConcurrentAccess(t *testing.T) {
 	}
 
 	wg.Wait()
-}
-
-func TestTVShadowStateImplementsInterface(t *testing.T) {
-	t.Parallel()
-	var _ PluginShadowState = (*TVShadowState)(nil)
 }
 
 // ============================================================================
@@ -2126,11 +1926,6 @@ func TestSexModeTrackerConcurrentAccess(t *testing.T) {
 	wg.Wait()
 }
 
-func TestSexModeShadowStateImplementsInterface(t *testing.T) {
-	t.Parallel()
-	var _ PluginShadowState = (*SexModeShadowState)(nil)
-}
-
 // ============================================================================
 // Christmas Tracker Tests
 // ============================================================================
@@ -2268,11 +2063,6 @@ func TestChristmasTrackerConcurrentAccess(t *testing.T) {
 	wg.Wait()
 }
 
-func TestChristmasShadowStateImplementsInterface(t *testing.T) {
-	t.Parallel()
-	var _ PluginShadowState = (*ChristmasShadowState)(nil)
-}
-
 // ============================================================================
 // Environmental Tracker Tests
 // ============================================================================
@@ -2328,25 +2118,6 @@ func TestEnvironmentalTrackerUpdateHumiditySensors(t *testing.T) {
 	}
 }
 
-func TestEnvironmentalTrackerUpdateAlertLevel(t *testing.T) {
-	t.Parallel()
-	et := NewEnvironmentalTracker()
-
-	conditionStart := time.Now().Add(-35 * time.Minute)
-	et.UpdateAlertLevel("warning", conditionStart, true)
-
-	state := et.GetState()
-	if state.Outputs.AlertLevel != "warning" {
-		t.Errorf("Expected AlertLevel 'warning', got %s", state.Outputs.AlertLevel)
-	}
-	if !state.Outputs.ConditionStartTime.Equal(conditionStart) {
-		t.Error("Expected ConditionStartTime to match")
-	}
-	if !state.Outputs.IsSustained {
-		t.Error("Expected IsSustained to be true")
-	}
-}
-
 func TestEnvironmentalTrackerRecordNotification(t *testing.T) {
 	t.Parallel()
 	et := NewEnvironmentalTracker()
@@ -2366,57 +2137,6 @@ func TestEnvironmentalTrackerRecordNotification(t *testing.T) {
 	}
 	if len(state.Outputs.LastNotification.SensorLocations) != 2 {
 		t.Errorf("Expected 2 sensor locations, got %d", len(state.Outputs.LastNotification.SensorLocations))
-	}
-}
-
-func TestEnvironmentalTrackerRecordResolutionNotice(t *testing.T) {
-	t.Parallel()
-	et := NewEnvironmentalTracker()
-
-	et.RecordResolutionNotice("Humidity levels have returned to normal")
-
-	state := et.GetState()
-	if state.Outputs.LastResolutionNotice == nil {
-		t.Fatal("Expected LastResolutionNotice to be set")
-	}
-	if state.Outputs.LastResolutionNotice.Level != "resolved" {
-		t.Errorf("Expected level 'resolved', got %s", state.Outputs.LastResolutionNotice.Level)
-	}
-	if state.Outputs.LastResolutionNotice.Message != "Humidity levels have returned to normal" {
-		t.Errorf("Unexpected message: %s", state.Outputs.LastResolutionNotice.Message)
-	}
-}
-
-func TestEnvironmentalTrackerUpdateWaterLeakSensors(t *testing.T) {
-	t.Parallel()
-	et := NewEnvironmentalTracker()
-
-	sensors := []WaterLeakSensorData{
-		{EntityID: "binary_sensor.water_leak_1", FriendlyName: "Under Sink", State: "off"},
-		{EntityID: "binary_sensor.water_leak_2", FriendlyName: "Near Washer", State: "on"},
-	}
-
-	et.UpdateWaterLeakSensors(sensors)
-
-	state := et.GetState()
-	if len(state.Outputs.WaterLeakSensors) != 2 {
-		t.Errorf("Expected 2 water leak sensors, got %d", len(state.Outputs.WaterLeakSensors))
-	}
-}
-
-func TestEnvironmentalTrackerUpdateActiveWaterLeaks(t *testing.T) {
-	t.Parallel()
-	et := NewEnvironmentalTracker()
-
-	alerts := []WaterLeakAlert{
-		{EntityID: "binary_sensor.water_leak_2", FriendlyName: "Near Washer", DetectedAt: time.Now(), NotificationSent: true},
-	}
-
-	et.UpdateActiveWaterLeaks(alerts)
-
-	state := et.GetState()
-	if len(state.Outputs.ActiveWaterLeaks) != 1 {
-		t.Errorf("Expected 1 active water leak, got %d", len(state.Outputs.ActiveWaterLeaks))
 	}
 }
 
@@ -2487,11 +2207,6 @@ func TestEnvironmentalTrackerConcurrentAccess(t *testing.T) {
 	}
 
 	wg.Wait()
-}
-
-func TestEnvironmentalShadowStateImplementsInterface(t *testing.T) {
-	t.Parallel()
-	var _ PluginShadowState = (*EnvironmentalShadowState)(nil)
 }
 
 // ============================================================================
@@ -2568,22 +2283,6 @@ func TestSensorHealthTrackerUpdateTemperatureSensors(t *testing.T) {
 	}
 }
 
-func TestSensorHealthTrackerUpdateLowBatteryAlerts(t *testing.T) {
-	t.Parallel()
-	st := NewSensorHealthTracker()
-
-	alerts := []LowBatteryAlert{
-		{EntityID: "sensor.battery_2", FriendlyName: "Door Sensor", BatteryLevel: 15, DetectedAt: time.Now(), NotificationSent: true},
-	}
-
-	st.UpdateLowBatteryAlerts(alerts)
-
-	state := st.GetState()
-	if len(state.Outputs.LowBatteryAlerts) != 1 {
-		t.Errorf("Expected 1 low battery alert, got %d", len(state.Outputs.LowBatteryAlerts))
-	}
-}
-
 func TestSensorHealthTrackerRecordNotification(t *testing.T) {
 	t.Parallel()
 	st := NewSensorHealthTracker()
@@ -2599,52 +2298,6 @@ func TestSensorHealthTrackerRecordNotification(t *testing.T) {
 	}
 	if state.Outputs.LastNotification.EntityID != "sensor.battery_2" {
 		t.Errorf("Expected EntityID 'sensor.battery_2', got %s", state.Outputs.LastNotification.EntityID)
-	}
-}
-
-func TestSensorHealthTrackerRecordTemperatureLockupNotification(t *testing.T) {
-	t.Parallel()
-	st := NewSensorHealthTracker()
-
-	st.RecordTemperatureLockupNotification("sensor.temp_garage", "Garage Temperature", "Temperature sensor appears locked up")
-
-	state := st.GetState()
-	if state.Outputs.LastTemperatureLockupNotice == nil {
-		t.Fatal("Expected LastTemperatureLockupNotice to be set")
-	}
-	if state.Outputs.LastTemperatureLockupNotice.EntityID != "sensor.temp_garage" {
-		t.Errorf("Expected EntityID 'sensor.temp_garage', got %s", state.Outputs.LastTemperatureLockupNotice.EntityID)
-	}
-	if state.Outputs.LastTemperatureLockupNotice.FriendlyName != "Garage Temperature" {
-		t.Errorf("Expected FriendlyName 'Garage Temperature', got %s", state.Outputs.LastTemperatureLockupNotice.FriendlyName)
-	}
-}
-
-func TestSensorHealthTrackerRecordTemperatureRecoveryNotification(t *testing.T) {
-	t.Parallel()
-	st := NewSensorHealthTracker()
-
-	st.RecordTemperatureRecoveryNotification("sensor.temp_garage", "Garage Temperature", "Temperature sensor recovered")
-
-	state := st.GetState()
-	if state.Outputs.LastTemperatureRecoveryNotice == nil {
-		t.Fatal("Expected LastTemperatureRecoveryNotice to be set")
-	}
-	if state.Outputs.LastTemperatureRecoveryNotice.EntityID != "sensor.temp_garage" {
-		t.Errorf("Expected EntityID 'sensor.temp_garage', got %s", state.Outputs.LastTemperatureRecoveryNotice.EntityID)
-	}
-}
-
-func TestSensorHealthTrackerSetLastDiscoveryRefresh(t *testing.T) {
-	t.Parallel()
-	st := NewSensorHealthTracker()
-
-	refreshTime := time.Now()
-	st.SetLastDiscoveryRefresh(refreshTime)
-
-	state := st.GetState()
-	if !state.Outputs.LastDiscoveryRefresh.Equal(refreshTime) {
-		t.Errorf("Expected LastDiscoveryRefresh to be %v, got %v", refreshTime, state.Outputs.LastDiscoveryRefresh)
 	}
 }
 
@@ -2696,11 +2349,6 @@ func TestSensorHealthTrackerConcurrentAccess(t *testing.T) {
 	}
 
 	wg.Wait()
-}
-
-func TestSensorHealthShadowStateImplementsInterface(t *testing.T) {
-	t.Parallel()
-	var _ PluginShadowState = (*SensorHealthShadowState)(nil)
 }
 
 // ============================================================================
@@ -2834,11 +2482,6 @@ func TestSensorConfigTrackerConcurrentAccess(t *testing.T) {
 	wg.Wait()
 }
 
-func TestSensorConfigShadowStateImplementsInterface(t *testing.T) {
-	t.Parallel()
-	var _ PluginShadowState = (*SensorConfigShadowState)(nil)
-}
-
 // ============================================================================
 // Infrastructure Tracker Tests
 // ============================================================================
@@ -2867,91 +2510,6 @@ func TestInfrastructureTrackerUpdateCurrentInputs(t *testing.T) {
 	state := it.GetState()
 	if state.Inputs.Current["septicPower"] != 85.0 {
 		t.Errorf("Expected septicPower to be 85.0, got %v", state.Inputs.Current["septicPower"])
-	}
-}
-
-func TestInfrastructureTrackerUpdateSepticPower(t *testing.T) {
-	t.Parallel()
-	it := NewInfrastructureTracker()
-
-	it.UpdateSepticPower(87.5)
-
-	state := it.GetState()
-	if state.Outputs.SepticSystemStatus.CurrentPowerW != 87.5 {
-		t.Errorf("Expected CurrentPowerW 87.5, got %f", state.Outputs.SepticSystemStatus.CurrentPowerW)
-	}
-	if state.Outputs.LastUpdate.IsZero() {
-		t.Error("Expected LastUpdate to be set")
-	}
-}
-
-func TestInfrastructureTrackerUpdateSystemState(t *testing.T) {
-	t.Parallel()
-	it := NewInfrastructureTracker()
-
-	it.UpdateSystemState("normal")
-
-	state := it.GetState()
-	if state.Outputs.SepticSystemStatus.SystemState != "normal" {
-		t.Errorf("Expected SystemState 'normal', got %s", state.Outputs.SepticSystemStatus.SystemState)
-	}
-}
-
-func TestInfrastructureTrackerUpdateAeratorFailureStart(t *testing.T) {
-	t.Parallel()
-	it := NewInfrastructureTracker()
-
-	startTime := time.Now()
-	it.UpdateAeratorFailureStart(startTime)
-
-	state := it.GetState()
-	if !state.Outputs.SepticSystemStatus.AeratorFailureStart.Equal(startTime) {
-		t.Error("Expected AeratorFailureStart to match")
-	}
-}
-
-func TestInfrastructureTrackerUpdatePumpRunningStart(t *testing.T) {
-	t.Parallel()
-	it := NewInfrastructureTracker()
-
-	startTime := time.Now()
-	it.UpdatePumpRunningStart(startTime)
-
-	state := it.GetState()
-	if !state.Outputs.SepticSystemStatus.PumpRunningStart.Equal(startTime) {
-		t.Error("Expected PumpRunningStart to match")
-	}
-}
-
-func TestInfrastructureTrackerUpdateLastNormalPowerTime(t *testing.T) {
-	t.Parallel()
-	it := NewInfrastructureTracker()
-
-	normalTime := time.Now()
-	it.UpdateLastNormalPowerTime(normalTime)
-
-	state := it.GetState()
-	if !state.Outputs.SepticSystemStatus.LastNormalPowerTime.Equal(normalTime) {
-		t.Error("Expected LastNormalPowerTime to match")
-	}
-}
-
-func TestInfrastructureTrackerUpdateIsAlerting(t *testing.T) {
-	t.Parallel()
-	it := NewInfrastructureTracker()
-
-	it.UpdateIsAlerting(true)
-
-	state := it.GetState()
-	if !state.Outputs.SepticSystemStatus.IsAlerting {
-		t.Error("Expected IsAlerting to be true")
-	}
-
-	it.UpdateIsAlerting(false)
-
-	state = it.GetState()
-	if state.Outputs.SepticSystemStatus.IsAlerting {
-		t.Error("Expected IsAlerting to be false")
 	}
 }
 
@@ -3091,11 +2649,6 @@ func TestInfrastructureTrackerConcurrentAccess(t *testing.T) {
 	}
 
 	wg.Wait()
-}
-
-func TestInfrastructureShadowStateImplementsInterface(t *testing.T) {
-	t.Parallel()
-	var _ PluginShadowState = (*InfrastructureShadowState)(nil)
 }
 
 // ============================================================================


### PR DESCRIPTION
Resolves #642

## Summary
- **Removed ~1,432 lines** of test code (145 insertions, 1,577 deletions) across 6 test files
- **music/manager_test.go** (-582 lines): Removed 16 trivial/redundant tests including stdlib wrapper tests (`TestToLower`), basic equality checks (`TestValuesMatch`), and duplicate retry/async tests
- **shadowstate/tracker_test.go** (-447 lines): Removed 14 `ImplementsInterface` tests (compile-time checks with no runtime value) and 23 trivial single-field setter tests
- **sleephygiene/manager_test.go** (-188 lines): Consolidated condition-guard tests into table-driven subtests (`TestBeginWake_ConditionsRequired`, `TestHandleWake_ConditionsRequired`, `TestIsEightSleepUnavailable_SensorCombinations`, `TestReadOnlyModeBlocksServiceCalls`)
- **energy/manager_test.go** (-97 lines): Removed generic smoke tests and trivial error-path tests
- **tv/manager_test.go** (-82 lines): Removed redundant tests covered by existing table-driven tests
- **statetracking/manager_test.go** (-36 lines): Removed trivial nil-state guard test
- Mock HA server "consolidation": Investigated and determined the two implementations (WebSocket `MockHAServer` vs in-process `MockClient`) serve different purposes and should remain separate. The `test/integration/mock_ha_server.go` wrapper is just 20 lines of type aliases.
- **Coverage maintained at 74.1%** (above 65% minimum), all unit and integration tests pass

## Test Plan
- [x] `make unit-tests` passes (74.1% coverage)
- [x] `make integration-tests` passes (all 11 scenarios)
- [x] `make pre-commit` passes (formatting, linting, build)
- [x] Pre-push hook passes (full validation with race detector)

🤖 Generated with [Claude Code](https://claude.com/claude-code)