### PR TITLE
fix(sensorhealth): Add per-device cooldown to Z-Wave dead notifications

### DIFF
--- a/homeautomation-go/internal/plugins/sensorhealth/manager.go
+++ b/homeautomation-go/internal/plugins/sensorhealth/manager.go
@@ -35,6 +35,12 @@ const (
 	// before immediately recovering. We delay the dead notification by this amount
 	// and cancel it if the device recovers, to avoid noisy flapping alerts.
 	NodeDeadDebounceDelay = 5 * time.Minute
+
+	// Per-device cooldown for dead device notifications.
+	// After sending a dead notification for a device, subsequent dead notifications
+	// for the same device are suppressed for this duration. This prevents notification
+	// floods from devices that flap dead/alive on 10-60 minute cycles.
+	NodeDeadNotificationCooldown = 48 * time.Hour
 )
 
 // BatterySensor represents a discovered battery sensor
@@ -65,13 +71,14 @@ type TemperatureSensor struct {
 
 // NodeStatus represents a discovered Z-Wave node status sensor
 type NodeStatus struct {
-	EntityID          string
-	DeviceID          string
-	DeviceName        string
-	Status            string // alive, asleep, awake, dead
-	LastChanged       time.Time
-	NotificationSent  bool        // Track if we've sent notification for current dead state
-	deadDebounceTimer clock.Timer // Pending debounce timer for dead notification (nil if none)
+	EntityID             string
+	DeviceID             string
+	DeviceName           string
+	Status               string // alive, asleep, awake, dead
+	LastChanged          time.Time
+	NotificationSent     bool        // Track if we've sent notification for current dead state
+	LastDeadNotification time.Time   // When we last sent a dead notification (for cooldown)
+	deadDebounceTimer    clock.Timer // Pending debounce timer for dead notification (nil if none)
 }
 
 // Manager handles sensor health monitoring: low batteries, node status, and temperature lockup
@@ -615,7 +622,20 @@ func (m *Manager) handleNodeStatusChange(entityID string, oldState, newState *ha
 				m.mu.Unlock()
 				return
 			}
+			// Check cooldown — suppress if we notified about this device recently
+			if !n.LastDeadNotification.IsZero() &&
+				m.clock.Since(n.LastDeadNotification) < NodeDeadNotificationCooldown {
+				n.deadDebounceTimer = nil
+				m.mu.Unlock()
+				m.logger.Info("Suppressed dead device notification (cooldown active)",
+					zap.String("entity_id", nodeEntityID),
+					zap.String("device_name", n.DeviceName),
+					zap.Duration("since_last", m.clock.Since(n.LastDeadNotification)),
+					zap.Duration("cooldown", NodeDeadNotificationCooldown))
+				return
+			}
 			n.NotificationSent = true
+			n.LastDeadNotification = m.clock.Now()
 			n.deadDebounceTimer = nil
 			m.mu.Unlock()
 			m.sendDeviceDeadNotification(n)

--- a/homeautomation-go/internal/plugins/sensorhealth/manager_test.go
+++ b/homeautomation-go/internal/plugins/sensorhealth/manager_test.go
@@ -1513,3 +1513,124 @@ func TestSensorHealthManager_NodeStatus_DeadDevice_DebounceExpires(t *testing.T)
 		t.Errorf("Expected title 'Device Online', got '%s'", recoveryNotification.Title)
 	}
 }
+
+func TestSensorHealthManager_NodeStatus_DeadDevice_CooldownSuppresses(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := NewManagerWithClock(mockHA, stateMgr, logger, false, nil, mockNtfy, mockClock)
+
+	// Add a node status sensor (simulates a flapping device like Leaf Charger)
+	manager.AddNodeStatus(&NodeStatus{
+		EntityID:   testNodeStatus1,
+		DeviceID:   "device_zwave_1",
+		DeviceName: "Leaf Charger",
+		Status:     "alive",
+	})
+
+	// First cycle: device goes dead → debounce fires → notification sent
+	manager.SimulateNodeStatusChange(testNodeStatus1, "dead")
+	mockClock.Advance(NodeDeadDebounceDelay)
+
+	if countNtfyNotifications(mockNtfy) != 1 {
+		t.Fatalf("Expected 1 dead notification after first debounce, got %d", countNtfyNotifications(mockNtfy))
+	}
+	notification := getLastNtfyNotification(mockNtfy)
+	if notification.Title != "Device Offline" {
+		t.Errorf("Expected title 'Device Offline', got '%s'", notification.Title)
+	}
+
+	// Device recovers → recovery notification sent
+	manager.SimulateNodeStatusChange(testNodeStatus1, "alive")
+
+	if countNtfyNotifications(mockNtfy) != 2 {
+		t.Fatalf("Expected 2 notifications (1 dead + 1 recovery), got %d", countNtfyNotifications(mockNtfy))
+	}
+
+	// Advance 30 minutes (well within the 48h cooldown)
+	mockClock.Advance(30 * time.Minute)
+
+	// Second cycle: device goes dead again within cooldown window
+	manager.SimulateNodeStatusChange(testNodeStatus1, "dead")
+	mockClock.Advance(NodeDeadDebounceDelay)
+
+	// Notification should be suppressed by cooldown
+	if countNtfyNotifications(mockNtfy) != 2 {
+		t.Errorf("Expected 2 notifications (cooldown should suppress), got %d", countNtfyNotifications(mockNtfy))
+	}
+
+	// Device recovers — no recovery notification since dead notification was suppressed
+	// (NotificationSent was never set to true for this cycle)
+	manager.SimulateNodeStatusChange(testNodeStatus1, "alive")
+
+	if countNtfyNotifications(mockNtfy) != 2 {
+		t.Errorf("Expected 2 notifications (no recovery for suppressed dead), got %d", countNtfyNotifications(mockNtfy))
+	}
+}
+
+func TestSensorHealthManager_NodeStatus_DeadDevice_CooldownExpires(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := NewManagerWithClock(mockHA, stateMgr, logger, false, nil, mockNtfy, mockClock)
+
+	// Add a node status sensor
+	manager.AddNodeStatus(&NodeStatus{
+		EntityID:   testNodeStatus1,
+		DeviceID:   "device_zwave_1",
+		DeviceName: "Leaf Charger",
+		Status:     "alive",
+	})
+
+	// First cycle: device goes dead → debounce fires → notification sent
+	manager.SimulateNodeStatusChange(testNodeStatus1, "dead")
+	mockClock.Advance(NodeDeadDebounceDelay)
+
+	if countNtfyNotifications(mockNtfy) != 1 {
+		t.Fatalf("Expected 1 dead notification, got %d", countNtfyNotifications(mockNtfy))
+	}
+
+	// Device recovers
+	manager.SimulateNodeStatusChange(testNodeStatus1, "alive")
+
+	if countNtfyNotifications(mockNtfy) != 2 {
+		t.Fatalf("Expected 2 notifications (dead + recovery), got %d", countNtfyNotifications(mockNtfy))
+	}
+
+	// Advance past the 48h cooldown
+	mockClock.Advance(NodeDeadNotificationCooldown + 1*time.Hour)
+
+	// Second cycle: device goes dead again after cooldown expired
+	manager.SimulateNodeStatusChange(testNodeStatus1, "dead")
+	mockClock.Advance(NodeDeadDebounceDelay)
+
+	// Notification should be sent (cooldown expired)
+	if countNtfyNotifications(mockNtfy) != 3 {
+		t.Fatalf("Expected 3 notifications (cooldown expired, new dead notification), got %d", countNtfyNotifications(mockNtfy))
+	}
+	notification := getLastNtfyNotification(mockNtfy)
+	if notification.Title != "Device Offline" {
+		t.Errorf("Expected title 'Device Offline', got '%s'", notification.Title)
+	}
+
+	// Device recovers — recovery notification should be sent
+	manager.SimulateNodeStatusChange(testNodeStatus1, "alive")
+
+	if countNtfyNotifications(mockNtfy) != 4 {
+		t.Fatalf("Expected 4 notifications (dead + recovery x2), got %d", countNtfyNotifications(mockNtfy))
+	}
+	recoveryNotification := getLastNtfyNotification(mockNtfy)
+	if recoveryNotification.Title != "Device Online" {
+		t.Errorf("Expected title 'Device Online', got '%s'", recoveryNotification.Title)
+	}
+}


### PR DESCRIPTION
## Summary

- Add 48-hour per-device cooldown for Z-Wave dead device notifications to suppress notification floods from flapping devices (Leaf Charger, Dehumidifier Power Control)
- After sending a dead notification, subsequent dead notifications for the same device are suppressed until the cooldown expires
- When a dead notification is suppressed, recovery notifications are automatically suppressed too (NotificationSent stays false)
- Suppressed events are logged at INFO level for Gravwell visibility

## Test plan

- [x] New test: `TestSensorHealthManager_NodeStatus_DeadDevice_CooldownSuppresses` — verifies dead+recovery notifications are suppressed within cooldown window
- [x] New test: `TestSensorHealthManager_NodeStatus_DeadDevice_CooldownExpires` — verifies notifications resume after cooldown expires
- [x] All existing sensorhealth tests pass (no regressions)
- [x] `make unit-tests` passes with race detector
- [x] `make integration-tests` passes
- [x] Coverage at 79.0% for sensorhealth package
- [ ] Monitor Gravwell logs after deployment for "Suppressed dead device notification (cooldown active)" messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)