### PR TITLE
Fix #649: Make recoveryStarted channel buffered to prevent test hang

### DIFF
--- a/homeautomation-go/internal/plugins/tv/manager_test.go
+++ b/homeautomation-go/internal/plugins/tv/manager_test.go
@@ -949,7 +949,7 @@ func TestTVManager_SyncBoxRecoveryInProgress_SkipsDuplicate(t *testing.T) {
 	mockHA.SetState(SyncBoxSoftwarePowerEntity, "unavailable", nil)
 
 	// Use a channel to control when the first recovery completes
-	recoveryStarted := make(chan struct{})
+	recoveryStarted := make(chan struct{}, 1)
 	recoveryComplete := make(chan struct{})
 
 	manager.sleepFunc = func(d time.Duration) {


### PR DESCRIPTION
Resolves #649

## Summary
- Changed `recoveryStarted` channel from unbuffered to buffered (capacity 1) in `TestTVManager_SyncBoxRecoveryInProgress_SkipsDuplicate`
- The unbuffered channel caused a race condition: if the goroutine's non-blocking `select` send executed before the main goroutine's `<-recoveryStarted` receive, the signal was lost to the `default` case, hanging the test forever
- With a buffered channel, the send always succeeds regardless of goroutine scheduling order

## Test Plan
- [x] `make unit-tests` passes (all tests including the fixed test)
- [x] `make pre-push` passes (race detector, coverage, integration tests)
- Verify with repeated runs: `go test -race -run TestTVManager_SyncBoxRecoveryInProgress_SkipsDuplicate -timeout 30s -count=20 ./internal/plugins/tv/`

🤖 Generated with Claude Code