### PR TITLE
Fix #660: Restore removed defensive tests as compact table-driven variants

### DIFF
--- a/homeautomation-go/internal/plugins/energy/manager_test.go
+++ b/homeautomation-go/internal/plugins/energy/manager_test.go
@@ -656,6 +656,30 @@ func TestIndicatorLightsDiscovery(t *testing.T) {
 	assert.Contains(t, manager.indicatorLightEntities, "light.apollo_kitchen_rgb")
 }
 
+// TestIndicatorLightsDiscovery_InvalidPattern verifies that an invalid regex in
+// FriendlyNamePattern config doesn't crash the system — it degrades gracefully.
+func TestIndicatorLightsDiscovery_InvalidPattern(t *testing.T) {
+	t.Parallel()
+	logger := testlogger.New()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	config := createTestConfig()
+	config.Energy.IndicatorLights.FriendlyNamePattern = "[invalid" // unclosed bracket
+
+	mockClient.SetState("light.apollo_bedroom_rgb", "on", map[string]interface{}{
+		"friendly_name": "Apollo Bedroom Radar Light",
+	})
+	mockClient.Connect()
+
+	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, nil, nil)
+	err := manager.Start()
+	assert.NoError(t, err)
+	defer manager.Stop()
+
+	// Invalid regex → no panic, no entities discovered
+	assert.Empty(t, manager.indicatorLightEntities)
+}
+
 func TestIndicatorLightsServiceCall(t *testing.T) {
 	t.Parallel()
 	logger := testlogger.New()

--- a/homeautomation-go/internal/plugins/music/manager_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_test.go
@@ -3863,6 +3863,92 @@ func TestJoinSpeakerWithRetry_PermanentError(t *testing.T) {
 	}
 }
 
+// TestJoinSpeakerWithRetry_MaxRetriesExhausted verifies that when ALL retry attempts fail
+// with transient errors, the speaker is gracefully skipped and an error is returned.
+func TestJoinSpeakerWithRetry_MaxRetriesExhausted(t *testing.T) {
+	t.Parallel()
+	logger := zap.NewNop()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	config := &MusicConfig{Music: map[string]MusicMode{}}
+	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, nil, nil)
+
+	var sleepCount int
+	manager.SetSleepFunc(func(d time.Duration) { sleepCount++ })
+
+	// Fail all attempts with transient error (not in permanentErrors list)
+	mockClient.SetServiceFailCount("media_player", "join", 100, fmt.Errorf("service call failed: timeout"))
+
+	participant := ParticipantWithVolume{PlayerName: "Living Room", Volume: 10}
+	err := manager.joinSpeakerWithRetry(participant, "media_player.kitchen", "day")
+
+	if err == nil {
+		t.Fatal("Expected error after exhausting all retries")
+	}
+	// maxAsyncSpeakerRetries=6, sleep happens for attempts 1..5 (not after last attempt)
+	if sleepCount != maxAsyncSpeakerRetries-1 {
+		t.Errorf("Expected %d retry delays, got %d", maxAsyncSpeakerRetries-1, sleepCount)
+	}
+}
+
+// TestCallServiceWithRetry_ErrorPaths verifies error propagation through callServiceWithRetry.
+func TestCallServiceWithRetry_ErrorPaths(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		domain      string
+		service     string
+		serviceData map[string]interface{}
+		setupFunc   func(*ha.MockClient)
+		wantErr     bool
+	}{
+		{
+			name:        "no_entity_id_returns_original_error",
+			domain:      "media_player",
+			service:     "play_media",
+			serviceData: map[string]interface{}{"media_content_id": "http://example.com"},
+			setupFunc: func(mc *ha.MockClient) {
+				mc.SetServiceFailCount("media_player", "play_media", 1, fmt.Errorf("service call failed"))
+			},
+			wantErr: true,
+		},
+		{
+			name:    "entity_removed_after_refresh",
+			domain:  "media_player",
+			service: "join",
+			serviceData: map[string]interface{}{
+				"entity_id":     "media_player.kitchen",
+				"group_members": []string{"media_player.living_room"},
+			},
+			setupFunc: func(mc *ha.MockClient) {
+				// Fail all calls; no media_player states → isSpeakerAvailable returns false after refresh
+				mc.SetServiceFailCount("media_player", "join", 2, fmt.Errorf("speaker unavailable"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mockClient := ha.NewMockClient()
+			stateManager := state.NewManager(mockClient, zap.NewNop(), false)
+			config := &MusicConfig{Music: map[string]MusicMode{}}
+			manager := NewManager(context.Background(), mockClient, stateManager, config, zap.NewNop(), false, nil, nil)
+
+			tc.setupFunc(mockClient)
+			err := manager.callServiceWithRetry(tc.domain, tc.service, tc.serviceData)
+
+			if tc.wantErr && err == nil {
+				t.Error("Expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("Expected no error, got %v", err)
+			}
+		})
+	}
+}
+
 // TestBuildSpeakerGroupAsync_WaitGroupCompletion verifies WaitGroup waits for all goroutines
 func TestBuildSpeakerGroupAsync_WaitGroupCompletion(t *testing.T) {
 	t.Parallel()

--- a/homeautomation-go/internal/shadowstate/tracker_test.go
+++ b/homeautomation-go/internal/shadowstate/tracker_test.go
@@ -1331,6 +1331,47 @@ func TestStateTrackingTrackerUpdateSleepDetectionTimer(t *testing.T) {
 	}
 }
 
+// TestStateTrackingTrackerTimerActivateDeactivate covers activate/deactivate for wake and owner-return timers.
+func TestStateTrackingTrackerTimerActivateDeactivate(t *testing.T) {
+	t.Parallel()
+	type timerAccessor struct {
+		active  func(*StateTrackingShadowState) bool
+		started func(*StateTrackingShadowState) time.Time
+	}
+	cases := []struct {
+		name string
+		set  func(*StateTrackingTracker, bool)
+		get  timerAccessor
+	}{
+		{"wake_detection", func(s *StateTrackingTracker, v bool) { s.UpdateWakeDetectionTimer(v) },
+			timerAccessor{
+				func(s *StateTrackingShadowState) bool { return s.Outputs.TimerStates.WakeDetectionActive },
+				func(s *StateTrackingShadowState) time.Time { return s.Outputs.TimerStates.WakeDetectionStarted },
+			}},
+		{"owner_return", func(s *StateTrackingTracker, v bool) { s.UpdateOwnerReturnTimer(v) },
+			timerAccessor{
+				func(s *StateTrackingShadowState) bool { return s.Outputs.TimerStates.OwnerReturnResetActive },
+				func(s *StateTrackingShadowState) time.Time { return s.Outputs.TimerStates.OwnerReturnResetStarted },
+			}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			stt := NewStateTrackingTracker()
+			tc.set(stt, true)
+			s := stt.GetState()
+			if !tc.get.active(s) || tc.get.started(s).IsZero() {
+				t.Error("Expected timer active with non-zero start time")
+			}
+			tc.set(stt, false)
+			s = stt.GetState()
+			if tc.get.active(s) || !tc.get.started(s).IsZero() {
+				t.Error("Expected timer inactive with zero start time")
+			}
+		})
+	}
+}
+
 func TestStateTrackingTrackerRecordArrivalAnnouncement(t *testing.T) {
 	t.Parallel()
 	stt := NewStateTrackingTracker()


### PR DESCRIPTION
Resolves #660

## Summary
- **TestJoinSpeakerWithRetry_MaxRetriesExhausted** (music plugin): Verifies that when all 6 retry attempts fail with transient errors, the speaker is gracefully skipped and the correct number of backoff delays occurred
- **TestCallServiceWithRetry_ErrorPaths** (music plugin): Table-driven tests covering error propagation when entity_id is absent (returns original error) and when entity disappears after speaker refresh
- **TestIndicatorLightsDiscovery_InvalidPattern** (energy plugin): Verifies that an invalid regex in FriendlyNamePattern config doesn't crash — degrades gracefully with no entities discovered
- **TestStateTrackingTrackerTimerActivateDeactivate** (shadowstate): Table-driven test covering wake detection and owner return timer activate/deactivate cycles, filling the gap left by the existing SleepDetectionTimer test

## Test Plan
- [x] `make unit-tests` passes (74.6% coverage)
- [x] `make integration-tests` passes
- [x] `make pre-commit` passes (formatting, linting, build)
- [x] Pre-push hook passes (race detector, coverage check)
- [x] All 4 acceptance criteria tests added
- [x] Total: 151 lines added across 3 files

🤖 Generated with Claude Code