### PR TITLE
Fix #669: Add standard plugin constructor dependency types

### DIFF
--- a/docs/reference/PLUGIN_SYSTEM.md
+++ b/docs/reference/PLUGIN_SYSTEM.md
@@ -386,6 +386,81 @@ defer stateTrackingManager.Stop()  // Stops first (registered first)
 
 ## Creating New Plugins
 
+### Constructor Standard (2026+)
+
+**All new plugins should use `StandardDeps` and `OptionalDeps`** from `homeautomation/internal/plugin` for consistent constructor signatures. This eliminates the inconsistent parameter ordering across existing plugins.
+
+> **Note:** Existing plugins (18 total) will NOT be migrated — this standard applies to new plugins only.
+
+```go
+import intplugin "homeautomation/internal/plugin"
+
+func NewManager(deps intplugin.StandardDeps, opts intplugin.OptionalDeps, config *MyConfig) *Manager {
+    return &Manager{
+        ctx:          deps.Ctx,
+        haClient:     deps.HAClient,
+        stateManager: deps.StateManager,
+        logger:       deps.Logger.Named("myplugin"),
+        readOnly:     deps.ReadOnly,
+        registry:     deps.Registry,
+        timeProvider: opts.TimeProviderOrDefault(),
+        timezone:     opts.TimezoneOrDefault(),
+        ntfyClient:   opts.NtfyClient,
+        config:       config,
+    }
+}
+```
+
+**`StandardDeps`** contains dependencies every plugin needs:
+- `Ctx` — shutdown context for graceful cancellation
+- `HAClient` — Home Assistant client (`ha.HAClient`)
+- `StateManager` — state variable system (`*state.Manager`)
+- `Logger` — structured logger (`*zap.Logger`)
+- `ReadOnly` — read-only mode flag
+- `Registry` — shadow state subscription registry
+
+**`OptionalDeps`** contains dependencies not all plugins need:
+- `TimeProvider` — testable time (use `opts.TimeProviderOrDefault()` for safe nil handling)
+- `Timezone` — timezone for schedule calculations (use `opts.TimezoneOrDefault()`)
+- `NtfyClient` — push notifications (may be nil)
+- `Latitude`, `Longitude` — geographic coordinates for sun calculations
+
+**Benefits:**
+- Consistent parameter order across all new plugins
+- Adding a new standard dependency requires updating one struct, not every constructor
+- Self-documenting which dependencies are required vs optional
+- Helper methods (`TimeProviderOrDefault()`, `TimezoneOrDefault()`) handle nil safely
+
+**In `register.go`**, construct the deps from the plugin context:
+
+```go
+func createPlugin(ctx *plugin.Context) (plugin.Plugin, error) {
+    haClient := pkgha.UnwrapClient(ctx.HAClient)
+    stateManager := pkgstate.UnwrapManager(ctx.StateManager)
+
+    deps := intplugin.StandardDeps{
+        Ctx:          ctx.ShutdownCtx,
+        HAClient:     haClient,
+        StateManager: stateManager,
+        Logger:       ctx.Logger,
+        ReadOnly:     ctx.ReadOnly,
+        Registry:     ctx.Registry,
+    }
+    opts := intplugin.OptionalDeps{
+        TimeProvider: ctx.TimeProvider,
+        Timezone:     ctx.Timezone,
+        NtfyClient:   ctx.NtfyClient,
+    }
+
+    manager := NewManager(deps, opts, config)
+    return &pluginAdapter{manager: manager}, nil
+}
+```
+
+### Legacy Pattern (Pre-2026)
+
+The following pattern is used by existing plugins and is documented here for reference. **New plugins should use the [Constructor Standard](#constructor-standard-2026) above.**
+
 ### Step 1: Create Package Structure
 
 ```bash
@@ -1067,5 +1142,5 @@ import (
 
 ---
 
-**Last Updated:** 2025-11-29
+**Last Updated:** 2026-02-12
 **Go Version:** 1.24

--- a/homeautomation-go/internal/plugin/deps.go
+++ b/homeautomation-go/internal/plugin/deps.go
@@ -1,0 +1,114 @@
+// Package plugin provides standard dependency types for internal plugin constructors.
+//
+// This package defines StandardDeps and OptionalDeps structs that standardize
+// how dependencies are passed to plugin NewManager() constructors. These types
+// use internal types (ha.HAClient, *state.Manager) and are intended for use
+// within internal/plugins/ packages only.
+//
+// For the public plugin system (registry, factory, lifecycle), see pkg/plugin/.
+//
+// # Background
+//
+// Historically, each plugin's NewManager() had a different parameter order and
+// set of parameters, making it error-prone to add new dependencies or create
+// new plugins. This package establishes a standard pattern for new plugins
+// (2026+). Existing plugins are NOT migrated to avoid churn.
+//
+// # Usage
+//
+//	func NewManager(deps plugin.StandardDeps, opts plugin.OptionalDeps, config *MyConfig) *Manager {
+//	    return &Manager{
+//	        ctx:          deps.Ctx,
+//	        haClient:     deps.HAClient,
+//	        stateManager: deps.StateManager,
+//	        logger:       deps.Logger.Named("myplugin"),
+//	        readOnly:     deps.ReadOnly,
+//	        registry:     deps.Registry,
+//	        timeProvider: opts.TimeProviderOrDefault(),
+//	        timezone:     opts.TimezoneOrDefault(),
+//	    }
+//	}
+package plugin
+
+import (
+	"context"
+	"time"
+
+	"homeautomation/internal/ha"
+	"homeautomation/internal/ntfy"
+	"homeautomation/internal/shadowstate"
+	"homeautomation/internal/state"
+	pkgplugin "homeautomation/pkg/plugin"
+
+	"go.uber.org/zap"
+)
+
+// StandardDeps contains the common dependencies required by all plugins.
+// Every plugin needs these to function. Pass this as the first parameter
+// to NewManager().
+type StandardDeps struct {
+	// Ctx is the shutdown context for graceful cancellation.
+	// Cancelled during application shutdown to abort retry loops.
+	Ctx context.Context
+
+	// HAClient provides access to Home Assistant for service calls
+	// and entity state subscriptions.
+	HAClient ha.HAClient
+
+	// StateManager provides access to the state variable system
+	// for reading/writing state and subscribing to changes.
+	StateManager *state.Manager
+
+	// Logger is a structured logger. Plugins should call
+	// Logger.Named("pluginname") for namespaced logging.
+	Logger *zap.Logger
+
+	// ReadOnly indicates whether the application is in read-only mode.
+	// When true, plugins should log intended actions without executing them.
+	ReadOnly bool
+
+	// Registry is the subscription registry for automatic shadow state
+	// input tracking. Plugins use this to register HA and state subscriptions.
+	Registry *shadowstate.SubscriptionRegistry
+}
+
+// OptionalDeps contains optional or plugin-specific dependencies.
+// Not all plugins need these. Pass this as the second parameter to
+// NewManager(). Zero-value fields indicate the dependency is not needed;
+// use the helper methods to get safe defaults.
+type OptionalDeps struct {
+	// TimeProvider provides testable time. When nil, defaults to
+	// pkg/plugin.RealTimeProvider via TimeProviderOrDefault().
+	TimeProvider pkgplugin.TimeProvider
+
+	// Timezone is the configured timezone for time-based calculations.
+	// When nil, defaults to time.Local via TimezoneOrDefault().
+	Timezone *time.Location
+
+	// NtfyClient provides push notifications via ntfy.sh.
+	// May be nil if notifications are not configured or not needed.
+	NtfyClient ntfy.Notifier
+
+	// Latitude is the geographic latitude for sun event calculations.
+	Latitude float64
+
+	// Longitude is the geographic longitude for sun event calculations.
+	Longitude float64
+}
+
+// TimeProviderOrDefault returns the TimeProvider if set, or
+// pkg/plugin.RealTimeProvider{} as a safe default.
+func (o OptionalDeps) TimeProviderOrDefault() pkgplugin.TimeProvider {
+	if o.TimeProvider != nil {
+		return o.TimeProvider
+	}
+	return pkgplugin.RealTimeProvider{}
+}
+
+// TimezoneOrDefault returns the Timezone if set, or time.Local as a safe default.
+func (o OptionalDeps) TimezoneOrDefault() *time.Location {
+	if o.Timezone != nil {
+		return o.Timezone
+	}
+	return time.Local
+}

--- a/homeautomation-go/internal/plugin/deps_test.go
+++ b/homeautomation-go/internal/plugin/deps_test.go
@@ -1,0 +1,40 @@
+package plugin
+
+import (
+	"testing"
+	"time"
+
+	pkgplugin "homeautomation/pkg/plugin"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptionalDeps_TimeProviderOrDefault(t *testing.T) {
+	t.Run("returns RealTimeProvider when nil", func(t *testing.T) {
+		opts := OptionalDeps{}
+		tp := opts.TimeProviderOrDefault()
+		assert.IsType(t, pkgplugin.RealTimeProvider{}, tp)
+	})
+
+	t.Run("returns provided TimeProvider when set", func(t *testing.T) {
+		fixed := pkgplugin.FixedTimeProvider{FixedTime: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+		opts := OptionalDeps{TimeProvider: fixed}
+		tp := opts.TimeProviderOrDefault()
+		assert.Equal(t, fixed, tp)
+	})
+}
+
+func TestOptionalDeps_TimezoneOrDefault(t *testing.T) {
+	t.Run("returns time.Local when nil", func(t *testing.T) {
+		opts := OptionalDeps{}
+		tz := opts.TimezoneOrDefault()
+		assert.Equal(t, time.Local, tz)
+	})
+
+	t.Run("returns provided timezone when set", func(t *testing.T) {
+		chicago, _ := time.LoadLocation("America/Chicago")
+		opts := OptionalDeps{Timezone: chicago}
+		tz := opts.TimezoneOrDefault()
+		assert.Equal(t, chicago, tz)
+	})
+}


### PR DESCRIPTION
Resolves #669

## Summary
- Created `homeautomation-go/internal/plugin/deps.go` with `StandardDeps` and `OptionalDeps` structs that standardize how dependencies are passed to plugin `NewManager()` constructors
- `StandardDeps` bundles the 6 dependencies every plugin needs (Ctx, HAClient, StateManager, Logger, ReadOnly, Registry)
- `OptionalDeps` bundles plugin-specific dependencies (TimeProvider, Timezone, NtfyClient, Latitude/Longitude) with helper methods for safe nil defaults
- Added unit tests with 100% coverage for the new package
- Documented the 2026+ constructor standard in `PLUGIN_SYSTEM.md` with examples for both `NewManager()` usage and `register.go` factory wiring
- Existing 18 plugins are NOT migrated — pattern is for new plugins only

## Test Plan
- [x] `make pre-commit` passes (formatting, linting, vet, staticcheck, build)
- [x] `make unit-tests` passes (74.9% total coverage, 100% on new package)
- [x] `make integration-tests` passes (all 11 integration tests)
- [x] Pre-push hook passes (race detector, coverage ≥65%)
- [ ] Next new plugin should use `StandardDeps`/`OptionalDeps` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)