### PR TITLE
Fix #655: Replace integration test time.Sleep with polling helpers

### DIFF
--- a/homeautomation-go/test/integration/helpers_test.go
+++ b/homeautomation-go/test/integration/helpers_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -134,5 +135,24 @@ func waitForNtfyNotification(t *testing.T, mockNtfy *ntfy.MockClient, title stri
 			}
 		}
 		return false
+	}, stateWaitTimeout, statePollInterval, msgAndArgs...)
+}
+
+// waitForServerState polls until the mock server has the expected state for the given entity.
+// Use this instead of time.Sleep when waiting for server-side state propagation.
+func waitForServerState(t *testing.T, server *MockHAServer, entityID, expectedState string, msgAndArgs ...interface{}) {
+	t.Helper()
+	assert.Eventually(t, func() bool {
+		state := server.GetState(entityID)
+		return state != nil && state.State == expectedState
+	}, stateWaitTimeout, statePollInterval, msgAndArgs...)
+}
+
+// waitForSubscriberNotification polls until the provided counter reaches the expected value.
+// Use this instead of time.Sleep when waiting for subscriber callbacks to complete.
+func waitForSubscriberNotification(t *testing.T, counter *int32, expected int32, msgAndArgs ...interface{}) {
+	t.Helper()
+	assert.Eventually(t, func() bool {
+		return atomic.LoadInt32(counter) >= expected
 	}, stateWaitTimeout, statePollInterval, msgAndArgs...)
 }

--- a/homeautomation-go/test/integration/integration_test.go
+++ b/homeautomation-go/test/integration/integration_test.go
@@ -89,13 +89,8 @@ func TestBasicConnection(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, value)
 
-		// Wait for propagation
-		time.Sleep(100 * time.Millisecond)
-
-		// Verify in server
-		serverState := server.GetState("input_boolean.expecting_someone")
-		assert.NotNil(t, serverState)
-		assert.Equal(t, "on", serverState.State)
+		// Wait for propagation to server
+		waitForServerState(t, server, "input_boolean.expecting_someone", "on", "state should propagate to server")
 	})
 }
 
@@ -122,8 +117,8 @@ func TestStateChangeSubscription(t *testing.T) {
 	// Trigger change from server
 	server.SetState("input_boolean.nick_home", "on", map[string]interface{}{})
 
-	// Wait for event propagation
-	time.Sleep(50 * time.Millisecond)
+	// Wait for state to propagate
+	waitForBoolState(t, manager, "isNickHome", true, "isNickHome should become true")
 
 	mu.Lock()
 	assert.Equal(t, 1, changeCount)
@@ -343,7 +338,17 @@ func TestMultipleSubscribersOnSameEntity(t *testing.T) {
 
 	// Trigger change
 	server.SetState("input_boolean.nick_home", "on", map[string]interface{}{})
-	time.Sleep(50 * time.Millisecond)
+
+	// Wait for all three subscribers to be notified
+	waitForCondition(t, func() bool {
+		mu1.Lock()
+		defer mu1.Unlock()
+		mu2.Lock()
+		defer mu2.Unlock()
+		mu3.Lock()
+		defer mu3.Unlock()
+		return count1 >= 1 && count2 >= 1 && count3 >= 1
+	}, "all 3 subscribers should be called")
 
 	mu1.Lock()
 	mu2.Lock()
@@ -361,7 +366,15 @@ func TestMultipleSubscribersOnSameEntity(t *testing.T) {
 	sub2.Unsubscribe()
 
 	server.SetState("input_boolean.nick_home", "off", map[string]interface{}{})
-	time.Sleep(50 * time.Millisecond)
+
+	// Wait for subscribers 1 and 3 to receive second notification (sub2 is unsubscribed)
+	waitForCondition(t, func() bool {
+		mu1.Lock()
+		defer mu1.Unlock()
+		mu3.Lock()
+		defer mu3.Unlock()
+		return count1 >= 2 && count3 >= 2
+	}, "subscribers 1 and 3 should receive second notification")
 
 	mu1.Lock()
 	mu2.Lock()
@@ -594,8 +607,12 @@ func TestHighFrequencyStateChanges(t *testing.T) {
 	}
 	duration := time.Since(start)
 
-	// Wait for all events to propagate
-	time.Sleep(100 * time.Millisecond)
+	// Wait for most events to propagate
+	waitForCondition(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return changeCount >= numChanges*8/10
+	}, "should receive at least 80%% of changes")
 
 	mu.Lock()
 	finalCount := changeCount
@@ -737,8 +754,12 @@ func TestReconnectStateSync(t *testing.T) {
 	}
 	require.True(t, reconnected, "Client should reconnect automatically")
 
-	// Wait for callback to be invoked and complete
-	time.Sleep(2 * time.Second)
+	// Wait for callback to be invoked
+	waitForCondition(t, func() bool {
+		callbackMu.Lock()
+		defer callbackMu.Unlock()
+		return callbackInvoked
+	}, "reconnect callback should be invoked")
 
 	// Verify callback was invoked
 	callbackMu.Lock()
@@ -806,8 +827,10 @@ func TestReconnectCountIncrementsOnMultipleReconnects(t *testing.T) {
 		}
 		require.True(t, reconnected, "Client should reconnect on cycle %d", i)
 
-		// Give time for reconnect count to update
-		time.Sleep(500 * time.Millisecond)
+		// Wait for reconnect count to update
+		waitForCondition(t, func() bool {
+			return client.GetReconnectCount() >= i
+		}, "reconnect count should reach %d", i)
 
 		// Verify reconnect count
 		assert.Equal(t, i, client.GetReconnectCount(), "Reconnect count should be %d after %d cycles", i, i)

--- a/homeautomation-go/test/integration/scenario_48hr_simulation_test.go
+++ b/homeautomation-go/test/integration/scenario_48hr_simulation_test.go
@@ -259,7 +259,9 @@ func TestScenario_TimezoneOffset_ET(t *testing.T) {
 	defer cleanup()
 
 	// Get initial phase
-	time.Sleep(50 * time.Millisecond)
+	waitForCondition(t, func() bool {
+		return server.GetState("input_text.day_phase") != nil
+	}, "initial day phase should be set")
 	etPhase := server.GetState("input_text.day_phase")
 	t.Logf("Initial phase at %s: %s", etStart.Format("15:04 MST"), etPhase.State)
 
@@ -292,7 +294,9 @@ func TestScenario_TimezoneOffset_PT(t *testing.T) {
 	server, _, mockClock, cleanup := setupDayPhaseSimulation(t, pt, ptStart)
 	defer cleanup()
 
-	time.Sleep(50 * time.Millisecond)
+	waitForCondition(t, func() bool {
+		return server.GetState("input_text.day_phase") != nil
+	}, "initial day phase should be set")
 	ptPhase := server.GetState("input_text.day_phase")
 	t.Logf("Initial phase at %s: %s", ptStart.Format("15:04 MST"), ptPhase.State)
 
@@ -519,7 +523,9 @@ func TestScenario_WeekdayVsWeekend_NightTime(t *testing.T) {
 	defer cleanup2()
 
 	// At 23:00 on Friday, should NOT be night yet (night=23:59)
-	time.Sleep(20 * time.Millisecond)
+	waitForCondition(t, func() bool {
+		return server2.GetState("input_text.day_phase") != nil
+	}, "initial day phase should be set")
 	friPhaseAt2300 := server2.GetState("input_text.day_phase")
 	t.Logf("Friday at 23:00: phase=%s (should NOT be night, weekend schedule)", friPhaseAt2300.State)
 

--- a/homeautomation-go/test/integration/scenario_computed_state_test.go
+++ b/homeautomation-go/test/integration/scenario_computed_state_test.go
@@ -158,7 +158,10 @@ func TestScenario_ComputedState_IsAnyoneHomeAndAwake_InitialComputation(t *testi
 			require.NoError(t, err)
 
 			// Allow computed state to be calculated
-			time.Sleep(50 * time.Millisecond)
+			waitForCondition(t, func() bool {
+				value, err := manager.GetBool("isAnyoneHomeAndAwake")
+				return err == nil && value == tc.expected
+			}, "computed state should be calculated")
 
 			// THEN: isAnyoneHomeAndAwake should be computed correctly
 			value, err := manager.GetBool("isAnyoneHomeAndAwake")
@@ -298,7 +301,7 @@ func TestScenario_ComputedState_RapidChanges(t *testing.T) {
 	server.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
 	server.SetState("input_boolean.tori_here", "off", map[string]interface{}{})
 	// Allow computed state to settle
-	time.Sleep(50 * time.Millisecond)
+	waitForBoolState(t, manager, "isAnyoneHomeAndAwake", true, "computed state should settle to true")
 
 	// WHEN: Rapid state changes occur
 	t.Log("WHEN: Rapid state changes occur")
@@ -312,7 +315,7 @@ func TestScenario_ComputedState_RapidChanges(t *testing.T) {
 	}
 
 	// Allow final state to settle
-	time.Sleep(50 * time.Millisecond)
+	waitForBoolState(t, manager, "isAnyoneHomeAndAwake", true, "final computed state should settle to true (owner home and awake)")
 
 	// THEN: Final computed state should be correct
 	t.Log("THEN: Final computed state should be correct")

--- a/homeautomation-go/test/integration/scenario_lighting_test.go
+++ b/homeautomation-go/test/integration/scenario_lighting_test.go
@@ -394,16 +394,25 @@ func TestScenario_MultipleStateChanges_HandlesCorrectly(t *testing.T) {
 	t.Logf("Service calls before rapid changes: %d", initialCalls)
 
 	// WHEN: Multiple rapid state changes occur
-	// Brief delays between rapid state changes to test that system handles them correctly
-	// without race conditions - we intentionally test overlapping state changes
+	// Wait for each change to be processed before triggering the next, using polling
+	// to verify the system processed each change without race conditions
 	t.Log("WHEN: Multiple rapid state changes occur")
 	server.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	server.SetState("input_boolean.anyone_home_and_awake", "on", map[string]interface{}{})
-	time.Sleep(50 * time.Millisecond) // Brief delay to simulate rapid but not instant changes
+	callsBeforeAfternoon := len(server.GetServiceCalls())
+	waitForCondition(t, func() bool {
+		return len(server.GetServiceCalls()) > callsBeforeAfternoon
+	}, "should process anyone_home state change before next change")
 	server.SetState("input_text.day_phase", "afternoon", map[string]interface{}{})
-	time.Sleep(50 * time.Millisecond) // Brief delay to simulate rapid but not instant changes
+	callsBeforeEvening := len(server.GetServiceCalls())
+	waitForCondition(t, func() bool {
+		return len(server.GetServiceCalls()) > callsBeforeEvening
+	}, "should process afternoon day phase change before next change")
 	server.SetState("input_text.day_phase", "evening", map[string]interface{}{})
-	time.Sleep(50 * time.Millisecond) // Brief delay to simulate rapid but not instant changes
+	callsBeforeTV := len(server.GetServiceCalls())
+	waitForCondition(t, func() bool {
+		return len(server.GetServiceCalls()) > callsBeforeTV
+	}, "should process evening day phase change before next change")
 	server.SetState("input_boolean.tv_playing", "on", map[string]interface{}{})
 
 	// Wait for final scene activation after all rapid changes

--- a/homeautomation-go/test/integration/scenario_nighttime_safety_test.go
+++ b/homeautomation-go/test/integration/scenario_nighttime_safety_test.go
@@ -458,18 +458,25 @@ func TestScenario_WakeCancellation_RevertsToSleepMusicDuringNight(t *testing.T) 
 	t.Log("WHEN: User turns off bedroom lights (wants to sleep more)")
 
 	env.server.SetState("light.primary_suite", "off", map[string]interface{}{})
-	// Brief delay to allow sleephygiene to process the light-off event
-	time.Sleep(150 * time.Millisecond)
 
 	// ========== THEN ==========
 	t.Log("THEN: Music should revert to sleep, wake sequence should cancel")
 
-	// Check if musicPlaybackType changed to sleep
-	// Note: This requires the sleephygiene plugin to detect the light change
-	// and trigger the reversion. In this test, we verify the state change
-	// was detected.
+	// Poll for sleephygiene to process the light-off event and revert music/wake state.
 	// TODO(MULTI_ZONE_MUSIC): Strengthen assertions once wake cancellation flow
 	// is fully implemented. Currently this documents expected behavior.
+	waitForCondition(t, func() bool {
+		musicType, err := env.stateManager.GetString("musicPlaybackType")
+		if err != nil {
+			return false
+		}
+		isWakeActive, err := env.stateManager.GetBool("isWakeSequenceActive")
+		if err != nil {
+			return false
+		}
+		return musicType == "sleep" || !isWakeActive
+	}, "Sleephygiene should process light-off event (revert music to sleep or deactivate wake sequence)")
+
 	musicType, err := env.stateManager.GetString("musicPlaybackType")
 	require.NoError(t, err)
 
@@ -699,17 +706,13 @@ func TestScenario_MultipleMuteConditions_WorkIndependently(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, isTVPlaying, "isTVPlaying should be true")
 
-	// Brief delay to allow playback setup to complete
-	time.Sleep(100 * time.Millisecond)
+	// Wait for playback setup to complete by polling for service calls
+	waitForCondition(t, func() bool {
+		return len(env.server.GetServiceCalls()) > 0
+	}, "Day zone playback should produce service calls")
 
 	calls := env.server.GetServiceCalls()
-
-	// Verify that playback occurred (zone resolution should start day music)
-	if len(calls) > 0 {
-		t.Logf("  ℹ️ %d service calls observed during day zone playback", len(calls))
-	} else {
-		t.Log("  ℹ️ No playback calls - mute condition logic verified in unit tests")
-	}
+	t.Logf("  %d service calls observed during day zone playback", len(calls))
 
 	t.Log("✓ Multiple mute conditions work independently")
 }

--- a/homeautomation-go/test/integration/scenario_security_test.go
+++ b/homeautomation-go/test/integration/scenario_security_test.go
@@ -180,10 +180,10 @@ func TestScenario_DidOwnerJustReturnHomeAutoReset(t *testing.T) {
 	t.Log("GIVEN: Nick arrives home")
 
 	server.SetState("input_boolean.nick_home", "off", nil)
-	time.Sleep(100 * time.Millisecond) // Real sleep for event processing
+	waitForBoolState(t, manager, "isNickHome", false, "isNickHome should be false initially")
 
 	server.SetState("input_boolean.nick_home", "on", nil)
-	time.Sleep(100 * time.Millisecond) // Real sleep for event processing
+	waitForBoolState(t, manager, "didOwnerJustReturnHome", true, "didOwnerJustReturnHome should be true after arrival")
 
 	t.Log("THEN: didOwnerJustReturnHome should be true initially")
 
@@ -192,6 +192,11 @@ func TestScenario_DidOwnerJustReturnHomeAutoReset(t *testing.T) {
 	assert.True(t, didReturn, "didOwnerJustReturnHome should be true after arrival")
 
 	t.Log("WHEN: 10 minutes pass (simulated via mock clock)")
+
+	// Brief real sleep to ensure the mock clock timer from setOwnerJustReturnedHome()
+	// is fully registered. The waitForBoolState above confirms the state was set, but
+	// the timer registration happens after SetBool in the handler goroutine.
+	time.Sleep(50 * time.Millisecond)
 
 	// Use mock clock to advance time instantly; AdvanceAndProcess fires callbacks
 	// and yields to the scheduler so any woken goroutines can complete
@@ -215,10 +220,10 @@ func TestScenario_MultipleArrivalsWithin10Minutes(t *testing.T) {
 
 	server.SetState("input_boolean.nick_home", "off", nil)
 	server.SetState("input_boolean.caroline_home", "off", nil)
-	time.Sleep(100 * time.Millisecond) // Real sleep for event processing
+	waitForBoolState(t, manager, "isNickHome", false, "initial states should propagate")
 
 	server.SetState("input_boolean.nick_home", "on", nil)
-	time.Sleep(100 * time.Millisecond) // Real sleep for event processing
+	waitForBoolState(t, manager, "didOwnerJustReturnHome", true, "didOwnerJustReturnHome should be true after Nick arrives")
 
 	didReturn, err := manager.GetBool("didOwnerJustReturnHome")
 	require.NoError(t, err)
@@ -226,11 +231,15 @@ func TestScenario_MultipleArrivalsWithin10Minutes(t *testing.T) {
 
 	t.Log("WHEN: Caroline arrives 2 minutes later (simulated)")
 
+	// Brief real sleep to ensure Nick's mock clock timer is fully registered
+	// before advancing the clock.
+	time.Sleep(50 * time.Millisecond)
+
 	// Use mock clock to advance time instantly
 	mockClock.AdvanceAndProcess(2 * time.Minute)
 
 	server.SetState("input_boolean.caroline_home", "on", nil)
-	time.Sleep(100 * time.Millisecond) // Real sleep for event processing
+	waitForBoolState(t, manager, "isCarolineHome", true, "isCarolineHome should be true")
 
 	t.Log("THEN: didOwnerJustReturnHome should still be true")
 
@@ -239,6 +248,10 @@ func TestScenario_MultipleArrivalsWithin10Minutes(t *testing.T) {
 	assert.True(t, didReturn, "didOwnerJustReturnHome should still be true")
 
 	t.Log("AND: Timer should have been extended (10 minutes from Caroline's arrival)")
+
+	// Brief real sleep to ensure Caroline's mock clock timer is fully registered
+	// before advancing the clock.
+	time.Sleep(50 * time.Millisecond)
 
 	// Advance 9 minutes - should still be true (timer was reset by Caroline's arrival)
 	mockClock.AdvanceAndProcess(9 * time.Minute)
@@ -312,7 +325,7 @@ func TestScenario_OnlyOwnersTriggersGarage(t *testing.T) {
 	t.Log("WHEN: Tori arrives (isToriHere changes to true)")
 
 	server.SetState("input_boolean.tori_here", "on", nil)
-	time.Sleep(100 * time.Millisecond)
+	waitForBoolState(t, manager, "isToriHere", true, "isToriHere should become true")
 
 	t.Log("THEN: didOwnerJustReturnHome should remain false (Tori is not an owner)")
 

--- a/homeautomation-go/test/integration/scenario_sensor_monitoring_test.go
+++ b/homeautomation-go/test/integration/scenario_sensor_monitoring_test.go
@@ -148,8 +148,10 @@ func TestScenario_SensorMonitoring_CompleteSurfaceArea(t *testing.T) {
 	err = env.environmental.Start()
 	require.NoError(t, err, "Failed to start environmental plugin")
 
-	// Brief setup delay: Allow plugins to complete initialization before assertions
-	time.Sleep(100 * time.Millisecond)
+	// Wait for plugins to complete initialization before assertions
+	waitForCondition(t, func() bool {
+		return len(env.sensorHealth.GetBatterySensors()) >= 1
+	}, "sensorhealth should discover battery sensors")
 
 	// ========== VERIFY: SensorHealth Plugin ==========
 
@@ -581,8 +583,15 @@ func TestScenario_SensorHealth_NodeStatusMonitoring(t *testing.T) {
 	env.server.SetState("sensor.front_door_lock_node_status", "dead", map[string]interface{}{
 		"friendly_name": "Front Door Lock Node Status",
 	})
-	// Brief delay: Allow entity state change to propagate through event processing
-	time.Sleep(50 * time.Millisecond)
+	// Wait for entity state change to propagate through event processing
+	waitForCondition(t, func() bool {
+		for _, ns := range env.sensorHealth.GetShadowState().Outputs.NodeStatuses {
+			if ns.EntityID == "sensor.front_door_lock_node_status" {
+				return ns.Status == "dead"
+			}
+		}
+		return false
+	}, "node status should update to dead")
 
 	// Advance mock clock past the debounce delay and process timer callbacks
 	env.mockClock.AdvanceAndProcess(sensorhealth.NodeDeadDebounceDelay + 1*time.Second)

--- a/homeautomation-go/test/integration/scenario_sexmode_test.go
+++ b/homeautomation-go/test/integration/scenario_sexmode_test.go
@@ -411,8 +411,8 @@ func TestScenario_SexModeDuplicateActivation_Ignored(t *testing.T) {
 	// Activate sex mode
 	server.SetState("input_boolean.sex", "on", nil)
 	waitForStringState(t, stateManager, "musicPlaybackType", "sex", "sex mode should activate")
-	// Allow full handler completion (isActive is set after musicPlaybackType in handleSexModeOn)
-	time.Sleep(100 * time.Millisecond)
+	// Wait for full handler completion (isActive is set after musicPlaybackType in handleSexModeOn)
+	waitForCondition(t, func() bool { return sexModeManager.GetShadowState().Outputs.IsActive }, "sex mode should become active")
 
 	// Count initial service calls
 	initialCalls := len(server.GetServiceCalls())
@@ -603,8 +603,8 @@ func TestScenario_SexModeShadowState_TracksCorrectly(t *testing.T) {
 
 	server.SetState("input_boolean.sex", "on", nil)
 	waitForStringState(t, stateManager, "musicPlaybackType", "sex", "music should switch to sex")
-	// Brief delay for shadow state to update after state change
-	time.Sleep(50 * time.Millisecond)
+	// Wait for shadow state to update after state change
+	waitForCondition(t, func() bool { return sexModeManager.GetShadowState().Outputs.IsActive }, "shadow state should reflect activation")
 
 	t.Log("THEN: Shadow state should reflect activation")
 
@@ -620,8 +620,8 @@ func TestScenario_SexModeShadowState_TracksCorrectly(t *testing.T) {
 
 	server.SetState("input_boolean.sex", "off", nil)
 	waitForStringState(t, stateManager, "musicPlaybackType", "day", "music should be restored")
-	// Brief delay for shadow state to update after state change
-	time.Sleep(50 * time.Millisecond)
+	// Wait for shadow state to update after state change
+	waitForCondition(t, func() bool { return !sexModeManager.GetShadowState().Outputs.IsActive }, "shadow state should reflect deactivation")
 
 	t.Log("THEN: Shadow state should reflect deactivation")
 

--- a/homeautomation-go/test/integration/scenario_sleephygiene_test.go
+++ b/homeautomation-go/test/integration/scenario_sleephygiene_test.go
@@ -125,7 +125,8 @@ func TestScenario_AlarmTimeReached_TriggersBeginWakeSequence(t *testing.T) {
 	// Since it's not exported, we'll trigger it via alarm time change
 	server.SetState("input_number.alarm_time", fmt.Sprintf("%.0f", alarmTimeMs), map[string]interface{}{})
 
-	// Wait for fade out state or volume calls
+	// Allow async handlers to process (fade out may or may not start
+	// since FixedTimeProvider doesn't advance the timer tick)
 	time.Sleep(100 * time.Millisecond)
 
 	// THEN: Verify begin_wake sequence started
@@ -293,8 +294,8 @@ func TestScenario_MidnightReset_ResetsTriggers(t *testing.T) {
 	tomorrowAlarmMs := float64(tomorrowAlarm.Unix() * 1000)
 	server.SetState("input_number.alarm_time", fmt.Sprintf("%.0f", tomorrowAlarmMs), map[string]interface{}{})
 
-	// Allow async handlers to process state
-	time.Sleep(50 * time.Millisecond)
+	// Poll until server state reflects the new alarm time
+	waitForServerState(t, server, "input_number.alarm_time", fmt.Sprintf("%.0f", tomorrowAlarmMs), "alarm time should update for tomorrow")
 
 	// The manager should accept this and be ready to trigger tomorrow
 	alarmTimeState := server.GetState("input_number.alarm_time")
@@ -389,8 +390,11 @@ func TestScenario_WakeCancellation_RevertsToSleepMusic(t *testing.T) {
 	t.Log("WHEN: Bedroom lights are turned off")
 	server.SetState("light.primary_suite", "off", map[string]interface{}{})
 
-	// Wait for music state to change
-	time.Sleep(100 * time.Millisecond)
+	// Poll until music reverts to sleep mode
+	waitForServerState(t, server, "input_text.music_playback_type", "sleep", "music should revert to sleep")
+
+	// Poll until bathroom light turn_off call is recorded
+	waitForServiceCallWithEntity(t, server, "light", "turn_off", "light.primary_bathroom_main_lights", "bathroom lights should be turned off")
 
 	// THEN: Music should revert to sleep mode, bathroom lights turn off
 	t.Log("THEN: Verify music reverts to sleep mode and bathroom lights turn off")
@@ -445,8 +449,8 @@ func TestScenario_MultipleAlarms_UpdatesCorrectly(t *testing.T) {
 	newAlarmMs := float64(newAlarm.Unix() * 1000)
 	server.SetState("input_number.alarm_time", fmt.Sprintf("%.0f", newAlarmMs), map[string]interface{}{})
 
-	// Allow async handlers to process state
-	time.Sleep(50 * time.Millisecond)
+	// Poll until server state reflects the new alarm time
+	waitForServerState(t, server, "input_number.alarm_time", fmt.Sprintf("%.0f", newAlarmMs), "alarm time should update")
 
 	// THEN: New alarm time is accepted and triggers reset
 	t.Log("THEN: Verify new alarm time is accepted")
@@ -517,8 +521,11 @@ func TestScenario_WakeSequence_VolumeFadesOutMonotonically(t *testing.T) {
 		t.Fatal("Fade-out did not complete within timeout")
 	}
 
-	// Allow final service calls to be recorded
-	time.Sleep(50 * time.Millisecond)
+	// Poll until volume_set calls are recorded
+	waitForCondition(t, func() bool {
+		calls := server.GetServiceCalls()
+		return len(filterServiceCalls(calls, "media_player", "volume_set")) >= 2
+	}, "volume_set calls should be recorded")
 
 	// THEN: Verify all volume_set calls show monotonically DECREASING volume
 	t.Log("THEN: Verify all volume_set calls show monotonically decreasing volume")
@@ -1050,8 +1057,8 @@ func TestScenario_WakeSequence_ActivatesWakeMusic(t *testing.T) {
 
 	sleepMgr.TriggerWakeForTest()
 
-	// Wait for service calls and goroutine to complete
-	time.Sleep(150 * time.Millisecond)
+	// Poll until musicPlaybackType changes to "wakeup"
+	waitForServerState(t, server, "input_text.music_playback_type", "wakeup", "music playback type should change to wakeup")
 
 	// THEN: Verify musicPlaybackType was set to "wakeup"
 	t.Log("THEN: Verify musicPlaybackType is set to 'wakeup'")
@@ -1153,8 +1160,8 @@ func TestScenario_StaleWakeSequenceActive_ClearedOnStartup(t *testing.T) {
 	require.NoError(t, err)
 	defer sleepMgr.Stop()
 
-	// Allow startup cleanup to run
-	time.Sleep(50 * time.Millisecond)
+	// Poll until startup cleanup clears the stale isWakeSequenceActive
+	waitForBoolState(t, stateManager, "isWakeSequenceActive", false, "stale isWakeSequenceActive should be cleared on startup")
 
 	// THEN: isWakeSequenceActive should be cleared to false
 	t.Log("THEN: Verify stale isWakeSequenceActive was cleared")
@@ -1180,8 +1187,8 @@ func TestScenario_StaleWakeSequenceActive_ClearedOnStartup(t *testing.T) {
 	err = stateManager.SetBool("isWakeSequenceActive", true)
 	require.NoError(t, err)
 
-	// Allow subscriber notification to complete
-	time.Sleep(50 * time.Millisecond)
+	// Poll until subscriber is notified
+	waitForSubscriberNotification(t, &notificationCount, 1, "subscriber should be notified")
 
 	assert.Equal(t, int32(1), atomic.LoadInt32(&notificationCount),
 		"Subscriber should be notified when isWakeSequenceActive changes from false to true")


### PR DESCRIPTION
Resolves #655

## Summary

Replaced ~30 `time.Sleep` calls across 9 integration test files with deterministic polling helpers that already existed in `helpers_test.go`. Added 2 new helpers (`waitForServerState`, `waitForSubscriberNotification`) to cover additional patterns.

### Files changed (10)

| File | Sleeps replaced | Sleeps kept | Notes |
|------|----------------|-------------|-------|
| `helpers_test.go` | — | — | Added `waitForServerState` and `waitForSubscriberNotification` helpers |
| `integration_test.go` | 6 | ~15 | Reconnection/stress test sleeps kept |
| `scenario_sleephygiene_test.go` | 7 | ~20 | Setup delays and negative tests kept |
| `scenario_sexmode_test.go` | 3 | ~10 | Setup delays kept |
| `scenario_lighting_test.go` | 3 | ~9 | Setup delays and indeterminate tests kept |
| `scenario_nighttime_safety_test.go` | 2 | ~7 | Rapid sensor simulation sleeps kept |
| `scenario_computed_state_test.go` | 3 | ~5 | Rapid toggle and near-simultaneous change sleeps kept |
| `scenario_security_test.go` | 6 | ~3 | Negative tests and mock clock setup kept |
| `scenario_sensor_monitoring_test.go` | 2 | ~5 | Pre-plugin-start setup delays kept |
| `scenario_48hr_simulation_test.go` | 3 | 0 | All sleeps replaced |
| `scenario_multi_plugin_test.go` | 0 | 7 | All are setup delays — no changes needed |

### Categories of replacements
- **State propagation waits** → `waitForBoolState` / `waitForStringState`
- **Service call assertions** → `waitForServiceCall` / `waitForServiceCallWithEntity`
- **Server state checks** → `waitForServerState` (new)
- **Subscriber callbacks** → `waitForSubscriberNotification` (new)
- **General async completion** → `waitForCondition`

### Intentionally kept `time.Sleep` calls (~40)
- Setup delays before `ClearServiceCalls()` (no observable condition to poll)
- Negative tests verifying absence of service calls
- Intentional timing simulation (rapid sensor changes, near-simultaneous events)
- Reconnection test intervals
- Rate-limiting in concurrency stress tests

## Test Plan
- [x] `go vet ./test/integration/...` passes
- [x] `make pre-commit` passes (formatting, linting, build)
- [x] `make integration-tests` passes
- [x] `go test -race -count=1 ./test/integration/...` passes (101s, no race conditions)
- [x] `make pre-push` passes (unit tests + integration tests + coverage ≥65%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)