### PR TITLE
Fix sync box recovery: retry power-on and clear stale TV states

### DIFF
--- a/homeautomation-go/internal/plugins/tv/manager.go
+++ b/homeautomation-go/internal/plugins/tv/manager.go
@@ -27,6 +27,12 @@ const (
 	// SyncBoxPowerCycleDelay is the time to wait between turning off and on
 	SyncBoxPowerCycleDelay = 5 * time.Second
 
+	// SyncBoxPowerOnMaxRetries is the number of attempts to turn on physical power
+	SyncBoxPowerOnMaxRetries = 3
+
+	// SyncBoxPowerOnRetryBaseDelay is the base delay between power-on retries (exponential backoff: 5s, 10s, 20s)
+	SyncBoxPowerOnRetryBaseDelay = 5 * time.Second
+
 	// SyncBoxMaxDailyReboots is the maximum number of reboots allowed per day
 	SyncBoxMaxDailyReboots = 10
 
@@ -284,6 +290,26 @@ func (m *Manager) handleSyncBoxPowerChange(entityID string, oldState, newState *
 		m.logger.Warn("Sync box software power is unavailable - may indicate crash",
 			zap.String("entity_id", entityID))
 		m.shadowTracker.UpdateSyncBoxAvailable(false)
+
+		// Clear TV states immediately — the sync box is down, so nothing is playing
+		if err := m.stateManager.SetBool("isTVon", false); err != nil {
+			if errors.Is(err, state.ErrReadOnlyMode) {
+				m.logger.Debug("Skipping isTVon update in read-only mode")
+			} else {
+				m.logger.Error("Failed to set isTVon to false", zap.Error(err))
+			}
+		}
+		m.shadowTracker.UpdateTVPower(false)
+
+		if err := m.stateManager.SetBool("isTVPlaying", false); err != nil {
+			if errors.Is(err, state.ErrReadOnlyMode) {
+				m.logger.Debug("Skipping isTVPlaying update in read-only mode")
+			} else {
+				m.logger.Error("Failed to set isTVPlaying to false", zap.Error(err))
+			}
+		}
+		m.shadowTracker.UpdateTVPlaying(false)
+		m.controlSyncBoxLightSync(false)
 
 		// Trigger recovery check asynchronously
 		go m.checkAndRecoverSyncBox()
@@ -629,8 +655,9 @@ func (m *Manager) checkAndRecoverSyncBox() {
 		return
 	}
 	if physicalPowerState.State != "on" {
-		m.logger.Info("Physical power is off, sync box intentionally unpowered - no recovery needed",
+		m.logger.Warn("Physical power is off - turning it back on",
 			zap.String("physical_power_state", physicalPowerState.State))
+		m.ensurePhysicalPowerOn()
 		return
 	}
 
@@ -710,18 +737,77 @@ func (m *Manager) performPowerCycleRecovery() {
 		zap.Duration("delay", SyncBoxPowerCycleDelay))
 	m.sleepFunc(SyncBoxPowerCycleDelay)
 
-	// Step 3: Turn on physical power
-	m.logger.Info("Turning on sync box physical power")
-	err = m.haClient.CallService(m.ctx, "switch", "turn_on", map[string]interface{}{
-		"entity_id": SyncBoxPhysicalPowerEntity,
-	})
-	if err != nil {
-		m.logger.Error("Failed to turn on sync box physical power", zap.Error(err))
+	// Step 3: Turn on physical power with retries
+	for attempt := 1; attempt <= SyncBoxPowerOnMaxRetries; attempt++ {
+		m.logger.Info("Turning on sync box physical power",
+			zap.Int("attempt", attempt),
+			zap.Int("max_attempts", SyncBoxPowerOnMaxRetries))
+
+		err = m.haClient.CallService(m.ctx, "switch", "turn_on", map[string]interface{}{
+			"entity_id": SyncBoxPhysicalPowerEntity,
+		})
+		if err == nil {
+			m.logger.Info("Sync box power cycle recovery completed",
+				zap.Int("daily_reboot_count", rebootCount),
+				zap.Int("attempt", attempt))
+			return
+		}
+
+		m.logger.Error("Failed to turn on sync box physical power (will retry)",
+			zap.Int("attempt", attempt),
+			zap.Int("max_attempts", SyncBoxPowerOnMaxRetries),
+			zap.Error(err))
+
+		if attempt < SyncBoxPowerOnMaxRetries {
+			retryDelay := SyncBoxPowerOnRetryBaseDelay * time.Duration(1<<(attempt-1))
+			m.logger.Info("Waiting before retry",
+				zap.Duration("delay", retryDelay))
+			m.sleepFunc(retryDelay)
+		}
+	}
+
+	m.logger.Error("CRITICAL: All attempts to turn on sync box physical power failed during power cycle",
+		zap.Int("attempts", SyncBoxPowerOnMaxRetries),
+		zap.Int("daily_reboot_count", rebootCount))
+}
+
+// ensurePhysicalPowerOn turns on the Z-Wave switch with retries (no turn-off step).
+// Used when physical power is found off during recovery — just needs to be turned back on.
+func (m *Manager) ensurePhysicalPowerOn() {
+	if m.readOnly {
+		m.logger.Info("Skipping physical power-on in read-only mode")
 		return
 	}
 
-	m.logger.Info("Sync box power cycle recovery completed",
-		zap.Int("daily_reboot_count", rebootCount))
+	for attempt := 1; attempt <= SyncBoxPowerOnMaxRetries; attempt++ {
+		m.logger.Info("Turning on sync box physical power",
+			zap.Int("attempt", attempt),
+			zap.Int("max_attempts", SyncBoxPowerOnMaxRetries))
+
+		err := m.haClient.CallService(m.ctx, "switch", "turn_on", map[string]interface{}{
+			"entity_id": SyncBoxPhysicalPowerEntity,
+		})
+		if err == nil {
+			m.logger.Info("Sync box physical power turned on successfully",
+				zap.Int("attempt", attempt))
+			return
+		}
+
+		m.logger.Error("Failed to turn on sync box physical power (will retry)",
+			zap.Int("attempt", attempt),
+			zap.Int("max_attempts", SyncBoxPowerOnMaxRetries),
+			zap.Error(err))
+
+		if attempt < SyncBoxPowerOnMaxRetries {
+			retryDelay := SyncBoxPowerOnRetryBaseDelay * time.Duration(1<<(attempt-1))
+			m.logger.Info("Waiting before retry",
+				zap.Duration("delay", retryDelay))
+			m.sleepFunc(retryDelay)
+		}
+	}
+
+	m.logger.Error("CRITICAL: All attempts to turn on sync box physical power failed",
+		zap.Int("attempts", SyncBoxPowerOnMaxRetries))
 }
 
 // GetRecoveryState returns the current recovery state for testing

--- a/homeautomation-go/internal/plugins/tv/manager_test.go
+++ b/homeautomation-go/internal/plugins/tv/manager_test.go
@@ -2,6 +2,8 @@ package tv
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -691,10 +693,8 @@ func TestTVManager_SyncBoxRecoversOnItsOwn_NoRecovery(t *testing.T) {
 	}
 }
 
-func TestTVManager_SyncBoxPhysicalPowerOff_NoRecovery(t *testing.T) {
-	t.Parallel(
-	// Create mock HA client and state manager
-	)
+func TestTVManager_SyncBoxPhysicalPowerOff_TurnsItOn(t *testing.T) {
+	t.Parallel()
 
 	mockHA := ha.NewMockClient()
 	logger := zap.NewNop()
@@ -703,7 +703,7 @@ func TestTVManager_SyncBoxPhysicalPowerOff_NoRecovery(t *testing.T) {
 	// Create TV manager
 	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil)
 
-	// Physical power is OFF - no recovery should happen
+	// Physical power is OFF - should attempt to turn it back on (not a full power cycle)
 	mockHA.SetState(SyncBoxPhysicalPowerEntity, "off", nil)
 	mockHA.SetState(SyncBoxSoftwarePowerEntity, "unavailable", nil)
 
@@ -720,17 +720,26 @@ func TestTVManager_SyncBoxPhysicalPowerOff_NoRecovery(t *testing.T) {
 	// Wait for async recovery to complete
 	time.Sleep(50 * time.Millisecond)
 
-	// Verify NO service calls were made (physical power is off intentionally)
+	// Verify only turn_on was called (not a full power cycle — no turn_off)
 	calls := mockHA.GetServiceCalls()
-	var switchCalls []ha.ServiceCall
+	var turnOnCalls, turnOffCalls []ha.ServiceCall
 	for _, call := range calls {
-		if call.Domain == "switch" {
-			switchCalls = append(switchCalls, call)
+		if call.Domain == "switch" && call.Service == "turn_on" {
+			turnOnCalls = append(turnOnCalls, call)
+		}
+		if call.Domain == "switch" && call.Service == "turn_off" {
+			turnOffCalls = append(turnOffCalls, call)
 		}
 	}
 
-	if len(switchCalls) != 0 {
-		t.Errorf("Expected 0 switch service calls since physical power is off, got %d", len(switchCalls))
+	if len(turnOnCalls) != 1 {
+		t.Errorf("Expected 1 turn_on call to restore physical power, got %d", len(turnOnCalls))
+	}
+	if len(turnOffCalls) != 0 {
+		t.Errorf("Expected 0 turn_off calls (not a full power cycle), got %d", len(turnOffCalls))
+	}
+	if len(turnOnCalls) > 0 && turnOnCalls[0].Data["entity_id"] != SyncBoxPhysicalPowerEntity {
+		t.Errorf("Expected turn_on for %s, got %v", SyncBoxPhysicalPowerEntity, turnOnCalls[0].Data["entity_id"])
 	}
 }
 
@@ -1351,5 +1360,191 @@ func TestTVManager_LightSyncDebounce_RapidFlapping(t *testing.T) {
 	}
 	if turnOffCount != 0 {
 		t.Errorf("Expected 0 turn_off calls during rapid flapping (all cancelled), got %d", turnOffCount)
+	}
+}
+
+func TestTVManager_SyncBoxUnavailable_ClearsTVStates(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil)
+
+	// Set initial states: TV is on and playing
+	if err := stateMgr.SetBool("isTVon", true); err != nil {
+		t.Fatalf("Failed to set isTVon: %v", err)
+	}
+	if err := stateMgr.SetBool("isTVPlaying", true); err != nil {
+		t.Fatalf("Failed to set isTVPlaying: %v", err)
+	}
+
+	// Set up mock so recovery goroutine doesn't panic
+	mockHA.SetState(SyncBoxPhysicalPowerEntity, "on", nil)
+	mockHA.SetState(SyncBoxSoftwarePowerEntity, "unavailable", nil)
+	manager.sleepFunc = func(d time.Duration) {}
+	manager.timeNow = time.Now
+
+	// Trigger unavailable state
+	newState := &ha.State{
+		EntityID: SyncBoxSoftwarePowerEntity,
+		State:    "unavailable",
+	}
+	manager.handleSyncBoxPowerChange(SyncBoxSoftwarePowerEntity, nil, newState)
+
+	// States should be cleared synchronously (before recovery goroutine)
+	isTVon, err := stateMgr.GetBool("isTVon")
+	if err != nil {
+		t.Fatalf("Failed to get isTVon: %v", err)
+	}
+	if isTVon {
+		t.Error("Expected isTVon=false after sync box goes unavailable")
+	}
+
+	isTVPlaying, err := stateMgr.GetBool("isTVPlaying")
+	if err != nil {
+		t.Fatalf("Failed to get isTVPlaying: %v", err)
+	}
+	if isTVPlaying {
+		t.Error("Expected isTVPlaying=false after sync box goes unavailable")
+	}
+
+	// Verify shadow state
+	shadowState := manager.GetShadowState()
+	if shadowState.Outputs.IsTVOn {
+		t.Error("Expected shadow IsTVOn=false after sync box goes unavailable")
+	}
+	if shadowState.Outputs.IsTVPlaying {
+		t.Error("Expected shadow IsTVPlaying=false after sync box goes unavailable")
+	}
+}
+
+func TestTVManager_PowerCycleRecovery_RetryOnTurnOnFailure(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil)
+
+	// Physical power is on, software is unavailable
+	mockHA.SetState(SyncBoxPhysicalPowerEntity, "on", nil)
+	mockHA.SetState(SyncBoxSoftwarePowerEntity, "unavailable", nil)
+
+	// Simulate 2 transient turn_on failures, then success on 3rd attempt
+	mockHA.SetServiceFailCount("switch", "turn_on", 2, fmt.Errorf("Z-Wave error 1405: transient decoding error"))
+
+	sleepDone := make(chan struct{})
+	var sleepDurations []time.Duration
+	var sleepMu sync.Mutex
+	manager.sleepFunc = func(d time.Duration) {
+		sleepMu.Lock()
+		sleepDurations = append(sleepDurations, d)
+		sleepMu.Unlock()
+	}
+	manager.timeNow = time.Now
+
+	go func() {
+		manager.checkAndRecoverSyncBox()
+		close(sleepDone)
+	}()
+
+	// Wait for recovery to complete
+	<-sleepDone
+
+	// Verify service calls: only successful calls are recorded by the mock
+	// 1 turn_off (succeeds) + 1 turn_on (the 3rd attempt that succeeds)
+	calls := mockHA.GetServiceCalls()
+	var turnOnCalls, turnOffCalls []ha.ServiceCall
+	for _, call := range calls {
+		if call.Domain == "switch" && call.Service == "turn_on" {
+			turnOnCalls = append(turnOnCalls, call)
+		}
+		if call.Domain == "switch" && call.Service == "turn_off" {
+			turnOffCalls = append(turnOffCalls, call)
+		}
+	}
+
+	if len(turnOffCalls) != 1 {
+		t.Errorf("Expected 1 turn_off call, got %d", len(turnOffCalls))
+	}
+	if len(turnOnCalls) != 1 {
+		t.Errorf("Expected 1 successful turn_on call (3rd attempt), got %d", len(turnOnCalls))
+	}
+
+	// Verify sleep was called for: debounce + power cycle delay + 2 retry delays
+	// Debounce (30s) + PowerCycleDelay (5s) + retry1 (5s) + retry2 (10s) = 4 sleeps
+	sleepMu.Lock()
+	sleepCount := len(sleepDurations)
+	sleepMu.Unlock()
+	if sleepCount != 4 {
+		t.Errorf("Expected 4 sleep calls (debounce + power cycle delay + 2 retries), got %d: %v",
+			sleepCount, sleepDurations)
+	}
+}
+
+func TestTVManager_PowerCycleRecovery_AllRetriesExhausted(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil)
+
+	// Physical power is on, software is unavailable
+	mockHA.SetState(SyncBoxPhysicalPowerEntity, "on", nil)
+	mockHA.SetState(SyncBoxSoftwarePowerEntity, "unavailable", nil)
+
+	// Simulate permanent turn_on failure
+	mockHA.SetServiceError("switch", "turn_on", fmt.Errorf("Z-Wave node unresponsive"))
+
+	recoveryDone := make(chan struct{})
+	var sleepDurations []time.Duration
+	var sleepMu sync.Mutex
+	manager.sleepFunc = func(d time.Duration) {
+		sleepMu.Lock()
+		sleepDurations = append(sleepDurations, d)
+		sleepMu.Unlock()
+	}
+	manager.timeNow = time.Now
+
+	// Run recovery synchronously via goroutine and wait for completion
+	go func() {
+		manager.checkAndRecoverSyncBox()
+		close(recoveryDone)
+	}()
+
+	<-recoveryDone
+
+	// Verify service calls: only successful calls are recorded by the mock
+	// 1 turn_off (succeeds), 0 turn_on (all 3 attempts failed, so not recorded)
+	calls := mockHA.GetServiceCalls()
+	var turnOnCalls, turnOffCalls []ha.ServiceCall
+	for _, call := range calls {
+		if call.Domain == "switch" && call.Service == "turn_on" {
+			turnOnCalls = append(turnOnCalls, call)
+		}
+		if call.Domain == "switch" && call.Service == "turn_off" {
+			turnOffCalls = append(turnOffCalls, call)
+		}
+	}
+
+	if len(turnOffCalls) != 1 {
+		t.Errorf("Expected 1 turn_off call, got %d", len(turnOffCalls))
+	}
+	if len(turnOnCalls) != 0 {
+		t.Errorf("Expected 0 successful turn_on calls (all failed), got %d", len(turnOnCalls))
+	}
+
+	// Verify sleep was called for: debounce + power cycle delay + 2 retry delays (between attempts 1-2 and 2-3)
+	sleepMu.Lock()
+	sleepCount := len(sleepDurations)
+	sleepMu.Unlock()
+	if sleepCount != 4 {
+		t.Errorf("Expected 4 sleep calls (debounce + power cycle delay + 2 retries), got %d: %v",
+			sleepCount, sleepDurations)
 	}
 }

--- a/homeautomation-go/test/integration/scenario_tv_test.go
+++ b/homeautomation-go/test/integration/scenario_tv_test.go
@@ -316,6 +316,38 @@ func TestScenario_AppleTVPlaybackStateChanges(t *testing.T) {
 	}
 }
 
+// TestScenario_SyncBoxUnavailable_ClearsTVStates verifies that when the sync box
+// goes unavailable (crash), isTVon and isTVPlaying are cleared immediately.
+// This prevents stale isTVPlaying=true from causing the lighting plugin to skip
+// the living room (deferring to Hue Sync, which isn't running).
+func TestScenario_SyncBoxUnavailable_ClearsTVStates(t *testing.T) {
+	t.Parallel()
+	server, manager, cleanup := setupTVScenarioTest(t)
+	defer cleanup()
+
+	t.Log("GIVEN: TV is on, playing via Apple TV")
+
+	// Set initial states - everything on and playing
+	server.SetState("remote.big_beautiful_oled", "on", map[string]interface{}{})
+	server.SetState("switch.sync_box_power", "on", map[string]interface{}{})
+	server.SetState("media_player.big_beautiful_oled", "playing", map[string]interface{}{
+		"friendly_name": "Apple TV",
+	})
+	server.SetState("select.sync_box_hdmi_input", "AppleTV", map[string]interface{}{})
+
+	waitForBoolState(t, manager, "isTVon", true, "isTVon should be true when sync box is on")
+	waitForBoolState(t, manager, "isTVPlaying", true, "isTVPlaying should be true when AppleTV is playing")
+
+	t.Log("WHEN: Sync box goes unavailable (crash)")
+
+	server.SetState("switch.sync_box_power", "unavailable", map[string]interface{}{})
+
+	t.Log("THEN: isTVon and isTVPlaying should both become false")
+
+	waitForBoolState(t, manager, "isTVon", false, "isTVon should be false after sync box goes unavailable")
+	waitForBoolState(t, manager, "isTVPlaying", false, "isTVPlaying should be false after sync box goes unavailable")
+}
+
 // TestScenario_TVOffSyncBoxOn verifies that when the TV is off but the sync box
 // powers on independently, isTVPlaying remains false and light sync is not enabled.
 // This prevents the bug where sync box turning on overnight caused 9+ hours of light sync.


### PR DESCRIPTION
## Summary

- **Clear `isTVon` and `isTVPlaying` immediately when sync box goes unavailable** — prevents stale `isTVPlaying=true` from causing the lighting plugin to skip the living room (deferring to Hue Sync, which wasn't running)
- **Add exponential backoff retry loop (3 attempts: 5s, 10s, 20s) to power-on step** — both in full power cycle recovery and new `ensurePhysicalPowerOn()` method, preventing a single Z-Wave transient error from leaving the device off for hours
- **When physical power is found off during recovery, turn it back on** instead of assuming it was "intentionally unpowered" — fixes the case where a failed power-on left the device off and subsequent restarts refused to recover

## Context

On 2026-02-11 at 20:08 CST, the Hue Sync Box crashed (`unavailable`). The recovery system power-cycled the Z-Wave switch: the turn-off succeeded, but the turn-on failed with Z-Wave error 1405 (transient decoding error). With no retry logic, the device was left powered off for ~3 hours. On subsequent app restarts, the code saw physical power was off and assumed it was "intentionally unpowered", blocking any recovery.

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] All unit tests pass with `-race` (75% coverage)
- [x] All integration tests pass with `-race`
- [x] New unit test: `TestTVManager_SyncBoxUnavailable_ClearsTVStates` — verifies synchronous state clearing
- [x] New unit test: `TestTVManager_PowerCycleRecovery_RetryOnTurnOnFailure` — 2 transient failures then success
- [x] New unit test: `TestTVManager_PowerCycleRecovery_AllRetriesExhausted` — all retries fail
- [x] Updated unit test: `TestTVManager_SyncBoxPhysicalPowerOff_TurnsItOn` — expects turn_on call instead of no-op
- [x] New integration test: `TestScenario_SyncBoxUnavailable_ClearsTVStates` — end-to-end GIVEN/WHEN/THEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)