### PR TITLE
Fix #710: Increase integration test state wait timeout to prevent flaky failures

### DIFF
--- a/homeautomation-go/test/integration/helpers_test.go
+++ b/homeautomation-go/test/integration/helpers_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -16,15 +17,28 @@ import (
 // ============================================================================
 
 const (
-	// stateWaitTimeout is the maximum time to wait for state changes.
-	// This should be long enough to handle slow CI environments but short
-	// enough that tests don't hang for too long on actual failures.
-	stateWaitTimeout = 2 * time.Second
+	// defaultStateWaitTimeout is the default maximum time to wait for state changes.
+	// This should be long enough to handle slow CI environments (where many parallel
+	// tests compete for CPU) but short enough that tests don't hang too long on
+	// actual failures. Override with TEST_WAIT_TIMEOUT env var (e.g. "10s").
+	defaultStateWaitTimeout = 5 * time.Second
 
 	// statePollInterval is how often to check if the expected state is reached.
 	// Smaller values make tests faster in normal conditions but increase CPU usage.
 	statePollInterval = 10 * time.Millisecond
 )
+
+// stateWaitTimeout is the maximum time to wait for state changes.
+// Initialized from TEST_WAIT_TIMEOUT env var or defaultStateWaitTimeout.
+var stateWaitTimeout = defaultStateWaitTimeout
+
+func init() {
+	if v := os.Getenv("TEST_WAIT_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			stateWaitTimeout = d
+		}
+	}
+}
 
 // ============================================================================
 // State Polling Helpers

--- a/homeautomation-go/test/integration/scenario_sleephygiene_test.go
+++ b/homeautomation-go/test/integration/scenario_sleephygiene_test.go
@@ -517,7 +517,7 @@ func TestScenario_WakeSequence_VolumeFadesOutMonotonically(t *testing.T) {
 	select {
 	case <-done:
 		t.Log("Fade-out completed")
-	case <-time.After(2 * time.Second):
+	case <-time.After(stateWaitTimeout):
 		t.Fatal("Fade-out did not complete within timeout")
 	}
 


### PR DESCRIPTION
Resolves #710

## Summary
- Increased `stateWaitTimeout` from 2s to 5s — the previous value was too tight for cross-plugin state propagation when integration tests run in parallel under CPU load, causing intermittent failures in `TestScenario_SexModeActivationDeactivationCycle`
- Implemented the `TEST_WAIT_TIMEOUT` environment variable (already documented in AGENTS.md but never wired up) so the timeout can be tuned without code changes (e.g. `TEST_WAIT_TIMEOUT=10s make integration-tests`)
- Replaced a hardcoded `time.After(2 * time.Second)` in the sleephygiene test with the shared `stateWaitTimeout` variable for consistency

## Root Cause
The deactivation flow in the sex mode plugin involves sequential operations (restore music state → re-evaluate lighting → update shadow state). When all integration tests run in parallel and compete for CPU, these operations can take longer than 2 seconds to propagate through the state management layer. The polling-based `waitForStringState` and `waitForServiceCallWithEntity` helpers would time out before the state changes completed.

## Test Plan
- [x] `make unit-tests` — all pass (75.3% coverage)
- [x] `make integration-tests` — all pass
- [x] `make pre-commit` — formatting, linting, vet, staticcheck all pass
- [x] `make pre-push` — full validation suite passes
- Verify by running the full integration suite multiple times: `make cache-clear-integration && make integration-tests`
- To further stress test: `TEST_WAIT_TIMEOUT=2s make integration-tests` should reproduce the original flakiness

🤖 Generated with Claude Code