### PR TITLE
fix: Correct evening/winddown zone triggers to match dayPhase values

### DIFF
--- a/configs/music_config.yaml
+++ b/configs/music_config.yaml
@@ -56,22 +56,38 @@ zones:
         value: false
   - name: "evening"
     priority: 40
-    trigger:
-      - variable: dayPhase
-        value: evening
-      - variable: isAnyoneHome
-        value: true
-      - variable: isAnyoneAsleep
-        value: false
+    trigger_groups:
+      - triggers:
+          - variable: dayPhase
+            value: sunset
+          - variable: isAnyoneHome
+            value: true
+          - variable: isAnyoneAsleep
+            value: false
+      - triggers:
+          - variable: dayPhase
+            value: dusk
+          - variable: isAnyoneHome
+            value: true
+          - variable: isAnyoneAsleep
+            value: false
   - name: "winddown"
     priority: 40
-    trigger:
-      - variable: dayPhase
-        value: winddown
-      - variable: isAnyoneHome
-        value: true
-      - variable: isAnyoneAsleep
-        value: false
+    trigger_groups:
+      - triggers:
+          - variable: dayPhase
+            value: winddown
+          - variable: isAnyoneHome
+            value: true
+          - variable: isAnyoneAsleep
+            value: false
+      - triggers:
+          - variable: dayPhase
+            value: night
+          - variable: isAnyoneHome
+            value: true
+          - variable: isAnyoneAsleep
+            value: false
   # sex and wakeup zones are manually triggered via musicPlaybackType
   # They don't have automatic triggers
   - name: "sex"


### PR DESCRIPTION
## Summary
- The evening music zone triggered on `dayPhase: evening`, a value that never exists. The dayphase calculator produces `sunset → dusk`, not `evening`. This caused music to stop at sunset with all volumes dropping to 0 and no new zone activating.
- The winddown zone only matched `winddown` but not `night`, causing the same gap when the night phase began.
- Updated both zones to use `trigger_groups` (OR logic) matching the same dayPhase values as the auto-generated `ensureZones()` fallback: evening matches `sunset` OR `dusk`, winddown matches `winddown` OR `night`.

## Test plan
- [x] Unit tests pass (75.3% coverage)
- [x] Integration tests pass (11/11)
- [ ] Verify in production that evening music starts when dayPhase transitions to sunset
- [ ] Verify winddown music continues when dayPhase transitions to night

🤖 Generated with [Claude Code](https://claude.com/claude-code)