### PR TITLE
Fix stale retry loops overriding newer lighting actions for same room

### DIFF
--- a/homeautomation-go/internal/plugins/lighting/manager.go
+++ b/homeautomation-go/internal/plugins/lighting/manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 
 	"homeautomation/internal/ha"
 	"homeautomation/internal/shadowstate"
@@ -27,6 +28,11 @@ type Manager struct {
 
 	// Context for graceful shutdown
 	ctx context.Context
+
+	// Per-room context cancellation to prevent stale commands from
+	// retry loops overriding newer actions for the same room.
+	roomContexts   map[string]context.CancelFunc
+	roomContextsMu sync.Mutex
 }
 
 // NewManager creates a new Lighting Control manager
@@ -42,6 +48,7 @@ func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.M
 		shadowTracker: shadowTracker,
 		subHelper:     shadowstate.NewSubscriptionHelper(haClient, stateManager, registry, shadowTracker, "lighting", logger.Named("lighting")),
 		ctx:           ctx,
+		roomContexts:  make(map[string]context.CancelFunc),
 	}
 }
 
@@ -108,10 +115,36 @@ func (m *Manager) Start() error {
 func (m *Manager) Stop() {
 	m.logger.Info("Stopping Lighting Control Manager")
 
+	// Cancel all in-flight room operations
+	m.cancelAllRoomContexts()
+
 	// Unsubscribe from all subscriptions
 	m.subHelper.UnsubscribeAll()
 
 	m.logger.Info("Lighting Control Manager stopped")
+}
+
+// getRoomContext cancels any in-flight operation for the room and returns a fresh context.
+// Follows the pattern from music plugin's startFadeInWithContext (fadein.go:570-586).
+func (m *Manager) getRoomContext(roomName string) context.Context {
+	m.roomContextsMu.Lock()
+	defer m.roomContextsMu.Unlock()
+	if cancel, exists := m.roomContexts[roomName]; exists {
+		cancel()
+	}
+	ctx, cancel := context.WithCancel(m.ctx)
+	m.roomContexts[roomName] = cancel
+	return ctx
+}
+
+// cancelAllRoomContexts cancels all in-flight room operations.
+func (m *Manager) cancelAllRoomContexts() {
+	m.roomContextsMu.Lock()
+	defer m.roomContextsMu.Unlock()
+	for _, cancel := range m.roomContexts {
+		cancel()
+	}
+	m.roomContexts = make(map[string]context.CancelFunc)
 }
 
 // handleDayPhaseChange processes day phase changes and activates scenes
@@ -294,6 +327,9 @@ func (m *Manager) evaluateAllRooms(dayPhase string, trigger string) {
 
 // evaluateAndActivateRoom evaluates a room's conditions and activates the appropriate scene
 func (m *Manager) evaluateAndActivateRoom(room *RoomConfig, dayPhase string, trigger string) {
+	// Cancel any in-flight operation for this room - new evaluation supersedes
+	roomCtx := m.getRoomContext(room.HueGroup)
+
 	m.logger.Debug("Evaluating room",
 		zap.String("room", room.HueGroup),
 		zap.String("area_id", room.HASSAreaID),
@@ -314,14 +350,15 @@ func (m *Manager) evaluateAndActivateRoom(room *RoomConfig, dayPhase string, tri
 			zap.String("room", room.HueGroup),
 			zap.String("day_phase", dayPhase),
 			zap.String("matched_condition", matchedVar))
-		m.activateScene(room, dayPhase, trigger)
+		m.activateScene(roomCtx, room, dayPhase, trigger)
 	case "off":
 		m.logger.Info("Room should be turned off",
 			zap.String("room", room.HueGroup),
 			zap.String("matched_condition", matchedVar))
-		m.turnOffRoom(room, trigger)
+		m.turnOffRoom(roomCtx, room, trigger)
 	case "skip":
 		// Skip action: do nothing for this room (e.g., when Hue Sync is controlling the lights)
+		// Previous operation cancelled by getRoomContext, no new action needed
 		m.logger.Info("Skipping room - external control active",
 			zap.String("room", room.HueGroup),
 			zap.String("matched_condition", matchedVar))
@@ -419,7 +456,7 @@ func toSnakeCase(str string) string {
 }
 
 // activateScene activates a Hue scene for a room
-func (m *Manager) activateScene(room *RoomConfig, dayPhase string, trigger string) {
+func (m *Manager) activateScene(ctx context.Context, room *RoomConfig, dayPhase string, trigger string) {
 	// Construct scene entity ID: scene.{snake_case(hue_group + " " + day_phase)}
 	sceneName := room.HueGroup + " " + dayPhase
 	sceneEntityID := "scene." + toSnakeCase(sceneName)
@@ -463,9 +500,16 @@ func (m *Manager) activateScene(room *RoomConfig, dayPhase string, trigger strin
 		serviceData["dynamic"] = false
 	}
 
-	// Call the service with the constructed entity ID
-	err := m.haClient.CallService(m.ctx, "scene", "turn_on", serviceData)
+	// Call the service with the room-scoped context (cancelled if room is re-evaluated)
+	err := m.haClient.CallService(ctx, "scene", "turn_on", serviceData)
 	if err != nil {
+		if ctx.Err() != nil {
+			m.logger.Info("Scene activation superseded by newer evaluation",
+				zap.String("room", room.HueGroup),
+				zap.String("scene", dayPhase),
+				zap.String("entity_id", sceneEntityID))
+			return
+		}
 		m.logger.Error("Failed to activate scene",
 			zap.String("room", room.HueGroup),
 			zap.String("scene", dayPhase),
@@ -486,7 +530,7 @@ func (m *Manager) activateScene(room *RoomConfig, dayPhase string, trigger strin
 }
 
 // turnOffRoom turns off lights in a room
-func (m *Manager) turnOffRoom(room *RoomConfig, trigger string) {
+func (m *Manager) turnOffRoom(ctx context.Context, room *RoomConfig, trigger string) {
 	if m.readOnly {
 		m.logger.Info("READ-ONLY: Would turn off room",
 			zap.String("room", room.HueGroup),
@@ -510,8 +554,15 @@ func (m *Manager) turnOffRoom(room *RoomConfig, trigger string) {
 		"area_id": room.HASSAreaID,
 	}
 
-	err := m.haClient.CallService(m.ctx, "light", "turn_off", serviceData)
+	// Call the service with the room-scoped context (cancelled if room is re-evaluated)
+	err := m.haClient.CallService(ctx, "light", "turn_off", serviceData)
 	if err != nil {
+		if ctx.Err() != nil {
+			m.logger.Info("Room turn-off superseded by newer evaluation",
+				zap.String("room", room.HueGroup),
+				zap.String("area_id", room.HASSAreaID))
+			return
+		}
 		m.logger.Error("Failed to turn off room",
 			zap.String("room", room.HueGroup),
 			zap.String("area_id", room.HASSAreaID),

--- a/homeautomation-go/internal/plugins/lighting/manager_test.go
+++ b/homeautomation-go/internal/plugins/lighting/manager_test.go
@@ -167,7 +167,7 @@ func TestActivateScene(t *testing.T) {
 			manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, tt.readOnly, nil)
 
 			room := &config.Rooms[0]
-			manager.activateScene(room, tt.dayPhase, "test_trigger")
+			manager.activateScene(context.Background(), room, tt.dayPhase, "test_trigger")
 
 			calls := env.MockHA.GetServiceCalls()
 			assert.Equal(t, tt.expectedCalls, len(calls))
@@ -202,7 +202,7 @@ func TestTurnOffRoom(t *testing.T) {
 			manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, tt.readOnly, nil)
 
 			room := &config.Rooms[0]
-			manager.turnOffRoom(room, "test_trigger")
+			manager.turnOffRoom(context.Background(), room, "test_trigger")
 
 			calls := env.MockHA.GetServiceCalls()
 			assert.Equal(t, tt.expectedCalls, len(calls))
@@ -661,4 +661,61 @@ func TestToSnakeCase(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestGetRoomContextCancelsPrevious(t *testing.T) {
+	t.Parallel()
+	env := testutil.NewEnv(t)
+	config := createTestConfig()
+	manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, false, nil)
+
+	// Get first context for Living Room
+	ctx1 := manager.getRoomContext("Living Room")
+	assert.NoError(t, ctx1.Err(), "First context should be active")
+
+	// Get second context for Living Room - should cancel the first
+	ctx2 := manager.getRoomContext("Living Room")
+	assert.Error(t, ctx1.Err(), "First context should be cancelled after second getRoomContext")
+	assert.NoError(t, ctx2.Err(), "Second context should be active")
+
+	// Get context for a different room - should not affect Living Room
+	ctx3 := manager.getRoomContext("Primary Suite")
+	assert.NoError(t, ctx2.Err(), "Living Room context should still be active")
+	assert.NoError(t, ctx3.Err(), "Primary Suite context should be active")
+}
+
+func TestTurnOffRoomContextCancellation(t *testing.T) {
+	t.Parallel()
+	env := testutil.NewEnv(t)
+	config := createTestConfig()
+	manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, false, nil)
+
+	// Call turnOffRoom with a pre-cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	room := &config.Rooms[0]
+	manager.turnOffRoom(ctx, room, "test_trigger")
+
+	// No service calls should be made since context was already cancelled
+	calls := env.MockHA.GetServiceCalls()
+	assert.Equal(t, 0, len(calls), "No service calls expected with cancelled context")
+}
+
+func TestActivateSceneContextCancellation(t *testing.T) {
+	t.Parallel()
+	env := testutil.NewEnv(t)
+	config := createTestConfig()
+	manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, false, nil)
+
+	// Call activateScene with a pre-cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	room := &config.Rooms[0]
+	manager.activateScene(ctx, room, "Morning", "test_trigger")
+
+	// No service calls should be made since context was already cancelled
+	calls := env.MockHA.GetServiceCalls()
+	assert.Equal(t, 0, len(calls), "No service calls expected with cancelled context")
 }

--- a/homeautomation-go/pkg/testutil/mock_ha_server.go
+++ b/homeautomation-go/pkg/testutil/mock_ha_server.go
@@ -213,7 +213,8 @@ func (s *MockHAServer) InitializeStates() {
 		"apple_tv_playing", "tv_playing", "tv_on",
 		"fade_out_in_progress", "free_energy_available", "grid_available",
 		"expecting_someone", "reset",
-		"wake_sequence_active", // Added for wake sequence user story tests
+		"wake_sequence_active",          // Added for wake sequence user story tests
+		"front_of_house_person_present", // Person detection at front of house
 	}
 
 	for _, name := range boolEntities {

--- a/homeautomation-go/test/integration/scenario_lighting_test.go
+++ b/homeautomation-go/test/integration/scenario_lighting_test.go
@@ -439,6 +439,73 @@ func TestScenario_MultipleStateChanges_HandlesCorrectly(t *testing.T) {
 	t.Log("SUCCESS: Handled multiple rapid state changes without errors")
 }
 
+// TestScenario_PersonDetectionOverridesSuneventTurnOff validates that when a room
+// is re-evaluated (e.g., person detected), any in-flight operation from a prior
+// evaluation (e.g., sunevent turn-off retry loop) is cancelled so the newer action wins.
+//
+// Regression test for: stale retry loop from sunevent change sent light.turn_off
+// commands that overrode a person detection scene activation, causing lights to flicker.
+func TestScenario_PersonDetectionOverridesSuneventTurnOff(t *testing.T) {
+	t.Parallel()
+	server, _, stateManager, cleanup := setupLightingScenarioTest(t)
+	defer cleanup()
+
+	// GIVEN: Someone is home, no person at front, day phase is evening
+	t.Log("GIVEN: Someone is home, no person at front, day phase is evening")
+	server.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
+	server.SetState("input_boolean.anyone_home_and_awake", "on", map[string]interface{}{})
+	server.SetState("input_boolean.front_of_house_person_present", "off", map[string]interface{}{})
+	server.SetState("input_text.day_phase", "evening", map[string]interface{}{})
+	server.SetState("input_text.sun_event", "sunset", map[string]interface{}{})
+	waitForProcessing(t, stateManager)
+	server.ClearServiceCalls()
+
+	// WHEN: Sunevent changes (triggers evaluation for all rooms, including Front of House)
+	t.Log("WHEN: Sunevent changes to dusk (would turn off front lights since no person)")
+	server.SetState("input_text.sun_event", "dusk", map[string]interface{}{})
+	waitForProcessing(t, stateManager)
+
+	// AND THEN: Person is detected at the front (triggers re-evaluation of Front of House)
+	t.Log("AND THEN: Person detected at front of house")
+	server.SetState("input_boolean.front_of_house_person_present", "on", map[string]interface{}{})
+
+	// Wait for the person detection to trigger scene activation
+	waitForServiceCall(t, server, "scene", "turn_on", "person detection should trigger scene activation for Front of House")
+
+	// THEN: The last service action for Front of House should be a scene activation (turn-on),
+	// not a turn-off. The sunevent turn-off should have been superseded.
+	t.Log("THEN: Last action for Front of House should be scene activation, not turn-off")
+	calls := server.GetServiceCalls()
+
+	// Find the last service call that targeted front_of_house
+	var lastFrontAction *ServiceCall
+	for i := len(calls) - 1; i >= 0; i-- {
+		call := calls[i]
+		// Check for scene activation (entity_id contains "front_of_house")
+		if entityID, ok := call.ServiceData["entity_id"].(string); ok {
+			if contains(entityID, "front_of_house") {
+				lastFrontAction = &calls[i]
+				break
+			}
+		}
+		// Check for light turn-off (area_id is "front_of_house")
+		if areaID, ok := call.ServiceData["area_id"].(string); ok {
+			if areaID == "front_of_house" {
+				lastFrontAction = &calls[i]
+				break
+			}
+		}
+	}
+
+	require.NotNil(t, lastFrontAction, "Should have at least one service call for Front of House")
+	assert.Equal(t, "scene", lastFrontAction.Domain,
+		"Last action for Front of House should be scene activation (person detected), not light.turn_off")
+	assert.Equal(t, "turn_on", lastFrontAction.Service,
+		"Last action for Front of House should be turn_on")
+	t.Logf("Last Front of House action: %s.%s (entity_id=%v)",
+		lastFrontAction.Domain, lastFrontAction.Service, lastFrontAction.ServiceData["entity_id"])
+}
+
 // Helper function to check if a string contains a substring (case-insensitive)
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) &&

--- a/homeautomation-go/test/integration/testdata/hue_config_test.yaml
+++ b/homeautomation-go/test/integration/testdata/hue_config_test.yaml
@@ -49,3 +49,20 @@ rooms:
         value: false
     increase_brightness_if_true: ~
     transition_seconds: 5
+  - hue_group: Front of House
+    hass_area_id: front_of_house
+    conditions:
+      # Priority 1: Person detected -> ON (security override)
+      - action: on
+        variable: isFrontOfHousePersonPresent
+        value: true
+      # Priority 2: No one home -> OFF
+      - action: off
+        variable: isAnyoneHome
+        value: false
+      # Priority 3: Someone home -> ON
+      - action: on
+        variable: isAnyoneHome
+        value: true
+    increase_brightness_if_true: ~
+    transition_seconds: 5


### PR DESCRIPTION
## Summary

- Add per-room context cancellation to the lighting plugin so that when a room is re-evaluated, any in-flight `CallService` retry loop from a prior evaluation is cancelled immediately
- Prevents stale `light.turn_off` commands from overriding newer `scene.turn_on` activations for the same room (e.g., person detection after a sunevent change)
- Follows the existing pattern from the music plugin's fade-in cancellation (`fadein.go:570-586`)

## Problem

When walking in front of the house, a person detection event correctly turned the front lights ON. However, a stale retry loop from a prior sunevent change was still sending `light.turn_off` commands, causing the lights to turn OFF ~7 seconds later. Then ~90 seconds later, the retry loop finished and the handler continued to the next room, turning lights back ON again.

## How it works

Each room gets a cancellable context via `getRoomContext(roomName)`. When a room is re-evaluated, the previous context is cancelled, which causes `CallService` to exit its retry loop (it checks `ctx.Done()` before each attempt and during retry delays). The new evaluation then proceeds with a fresh context.

## Test plan

- [x] `make unit-tests` — all existing + 3 new unit tests pass (75.0% coverage)
- [x] `make integration-tests` — all existing + 1 new regression test pass
- [x] `make pre-commit` — formatting, linting, build pass
- [x] New `TestGetRoomContextCancelsPrevious` — verifies prior context cancelled, different rooms independent
- [x] New `TestTurnOffRoomContextCancellation` — verifies no service calls with pre-cancelled context
- [x] New `TestActivateSceneContextCancellation` — same for scene activation
- [x] New `TestScenario_PersonDetectionOverridesSuneventTurnOff` — regression integration test for the flicker scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)