### PR TITLE
fix: Deduplicate test caching so pre-push reuses unit/integration caches

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -8,9 +8,9 @@
 # LICENSE, .github/), tests are skipped and only diagram validation runs.
 # CI always runs the full suite regardless of paths (safety net).
 #
-# CACHING: This hook uses test-cache.sh to skip tests if no code has
-# changed since the last successful run. To force re-run:
-#   .githooks/test-cache.sh --clear-one pre-push
+# CACHING: The unit-tests and integration-tests Makefile targets use
+# test-cache.sh to skip tests if no code has changed since the last
+# successful run. To force re-run: make cache-clear
 #
 # Installation: This hook is automatically installed by the devcontainer
 # postCreateCommand. To manually install, run:
@@ -113,7 +113,7 @@ echo ""
 echo "🔧 Code changes detected. Running full validation suite."
 echo ""
 
-if .githooks/test-cache.sh pre-push pre-push; then
+if make pre-push; then
     echo ""
     echo "✅ Pre-push hook passed! Proceeding with push..."
     exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ A pre-push git hook validates all changes before pushing. It runs:
 ```bash
 make unit-tests        # Run unit tests WITH CACHING (preferred)
 make integration-tests # Run integration tests WITH CACHING (preferred)
-make pre-push          # Run full validation (same as CI, no cache)
+make pre-push          # Run full validation (reuses unit/integration caches)
 make pre-commit        # Fast checks only (formatting, linting, build)
 make format-go         # Auto-format code
 make lint-go           # Run linters
@@ -241,7 +241,6 @@ make integration-tests    # Integration tests with caching
 
 # No caching (runs every time)
 make test-no-cache        # All tests with race detection (no cache)
-make pre-push             # Full validation (no cache, same as CI)
 
 # Cache management (see "Troubleshooting Test Cache" below for details)
 make cache-status                # Check cache state

--- a/Makefile
+++ b/Makefile
@@ -238,50 +238,24 @@ pre-commit: ## Run fast pre-commit checks (style, format, lint, build)
 
 pre-push: ## Run comprehensive pre-push validation (build, tests, race detector, coverage >=65%)
 	@echo ""
-	@echo "🔍 Running pre-push validation (5 steps)..."
+	@echo "🔍 Running pre-push validation (3 steps)..."
 	@echo "════════════════════════════════════════════════════════════════════════════"
 	@echo ""
-	@echo "⏳ Step 1/5: Validating generated diagrams are up-to-date..."
+	@echo "⏳ Step 1/3: Validating generated diagrams are up-to-date..."
 	@$(MAKE) validate-diagrams
 	@echo ""
-	@echo "✅ Step 1/5 complete: Diagrams valid"
+	@echo "✅ Step 1/3 complete: Diagrams valid"
 	@echo ""
-	@echo "⏳ Step 2/5: Compiling all code (including tests)..."
-	@cd homeautomation-go && go build ./...
-	@echo "✅ Step 2/5 complete: All code compiles"
+	@echo "⏳ Step 2/3: Running unit tests (build + race detector + coverage ≥65%)..."
+	@$(MAKE) unit-tests
+	@echo "✅ Step 2/3 complete: Unit tests passed"
 	@echo ""
-	@echo "⏳ Step 3/5: Running unit tests with race detector and coverage..."
-	@echo "   (excluding integration tests, testutil, and diagramgen - same as CI)"
-	@echo "   This may take 2-5 minutes on first run."
-	@cd homeautomation-go && go test $$(go list ./... | grep -v /test/integration | grep -v /pkg/testutil | grep -v /cmd/diagramgen) \
-	  -race -coverprofile=coverage.out -covermode=atomic -timeout=5m
-	@echo "✅ Step 3/5 complete: Unit tests passed with race detector"
-	@echo ""
-	@echo "⏳ Step 4/5: Checking test coverage (≥65%)..."
-	@cd homeautomation-go && \
-	  coverage=$$(go tool cover -func=coverage.out | grep total | awk '{print $$3}' | sed 's/%//') && \
-	  echo "Total coverage: $${coverage}%" && \
-	  if [ "$$(echo "$$coverage < 65" | bc -l)" = "1" ]; then \
-	    echo "❌ ERROR: Test coverage $${coverage}% is below required 65%"; \
-	    rm -f coverage.out; \
-	    exit 1; \
-	  fi && \
-	  echo "✅ Step 4/5 complete: Test coverage $${coverage}% meets requirement" && \
-	  rm -f coverage.out
-	@echo ""
-	@echo "⏳ Step 5/5: Running integration tests with race detector..."
-	@echo "   This may take 3-10 minutes on first run."
-	@cd homeautomation-go && go test ./test/integration/... -race -timeout=10m
-	@echo "✅ Step 5/5 complete: Integration tests passed"
+	@echo "⏳ Step 3/3: Running integration tests (race detector)..."
+	@$(MAKE) integration-tests
+	@echo "✅ Step 3/3 complete: Integration tests passed"
 	@echo ""
 	@echo "════════════════════════════════════════════════════════════════════════════"
 	@echo "🎉 Pre-push validation passed!"
-	@echo ""
-	@echo "✅ Generated diagrams are up-to-date"
-	@echo "✅ All code compiles"
-	@echo "✅ Unit tests passed with race detector"
-	@echo "✅ Test coverage meets minimum requirement (≥65%)"
-	@echo "✅ Integration tests passed"
 	@echo "════════════════════════════════════════════════════════════════════════════"
 
 pre-push-docs-only: ## Run lightweight pre-push validation for documentation-only changes


### PR DESCRIPTION
## Summary

- **`make pre-push` duplicated all test/coverage commands** from `unit-tests-impl` inline (~30 lines of `go test`, coverage parsing, etc.), and the pre-push hook wrapped it in a separate `pre-push.hash` cache
- This meant running `make unit-tests && make integration-tests` before `git push` didn't help — the hook re-ran everything via its independent cache
- Now `make pre-push` calls the cached `unit-tests` and `integration-tests` targets directly, so a single set of caches serves all entry points (`make unit-tests`, `make integration-tests`, `make pre-push`, and `git push`)

## What changed

| File | Change |
|------|--------|
| `Makefile` | `pre-push` target now calls `$(MAKE) unit-tests` / `$(MAKE) integration-tests` instead of duplicating their logic |
| `.githooks/pre-push` | Calls `make pre-push` directly instead of going through `test-cache.sh` (sub-targets handle their own caching) |
| `AGENTS.md` | Updated docs to reflect that `pre-push` reuses caches |

## Verification

Tested the full flow:
1. `make cache-clear && make pre-push` — cold cache, runs all tests, passes
2. `make pre-push` — warm cache, both test steps show `CACHED`, completes in seconds
3. `git push` — pre-push hook calls `make pre-push`, both test caches hit

## Test plan

- [x] `make cache-clear && make pre-push` passes from cold cache
- [x] Second `make pre-push` hits both caches
- [x] `git push` pre-push hook reuses warm caches
- [x] Pre-commit hook still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)