### PR TITLE
Fix #721: Replace time.Sleep with deterministic waits in flaky integration tests

### DIFF
--- a/homeautomation-go/test/integration/scenario_concurrent_triggers_test.go
+++ b/homeautomation-go/test/integration/scenario_concurrent_triggers_test.go
@@ -81,7 +81,8 @@ func setupConcurrentTest(t *testing.T) (*concurrentEnv, func()) {
 	require.NoError(t, env.lighting.Start(), "Failed to start lighting")
 	require.NoError(t, env.music.Start(), "Failed to start music")
 
-	time.Sleep(50 * time.Millisecond)
+	// Wait for plugin initialization handlers to complete
+	waitForProcessing(t, manager)
 
 	cleanup := func() {
 		env.music.Stop()
@@ -123,7 +124,7 @@ func TestScenario_SimultaneousDayPhaseAndPresence_ConsistentState(t *testing.T) 
 	env.server.SetState("input_boolean.everyone_asleep", "off", map[string]interface{}{})
 	env.server.SetState("input_text.day_phase", "morning", map[string]interface{}{})
 
-	time.Sleep(100 * time.Millisecond)
+	waitForProcessing(t, env.stateManager)
 	env.server.ClearServiceCalls()
 
 	// ========== WHEN ==========
@@ -137,8 +138,12 @@ func TestScenario_SimultaneousDayPhaseAndPresence_ConsistentState(t *testing.T) 
 	waitForStringState(t, env.stateManager, "dayPhase", "evening", "dayPhase should become evening")
 	waitForBoolState(t, env.stateManager, "isCarolineHome", true, "isCarolineHome should become true")
 
-	// Additional time for derived state computation and plugin reactions
-	time.Sleep(200 * time.Millisecond)
+	// Wait for lighting plugin to react (state cascades through state tracking first)
+	waitForCondition(t, func() bool {
+		calls := env.server.GetServiceCalls()
+		sceneActivations := filterServiceCalls(calls, "scene", "turn_on")
+		return len(sceneActivations) > 0
+	}, "Lighting should activate scenes when day phase changes")
 
 	// ========== THEN ==========
 	t.Log("THEN: Final state reflects both changes, no duplicate actions")
@@ -192,7 +197,7 @@ func TestScenario_RapidPresenceChanges_StableState(t *testing.T) {
 	env.server.SetState("input_boolean.everyone_asleep", "off", map[string]interface{}{})
 	env.server.SetState("input_text.day_phase", "evening", map[string]interface{}{})
 
-	time.Sleep(100 * time.Millisecond)
+	waitForProcessing(t, env.stateManager)
 	env.server.ClearServiceCalls()
 
 	// ========== WHEN ==========
@@ -205,11 +210,11 @@ func TestScenario_RapidPresenceChanges_StableState(t *testing.T) {
 		} else {
 			env.server.SetState("input_boolean.caroline_home", "off", map[string]interface{}{})
 		}
-		time.Sleep(20 * time.Millisecond) // Fast but not instant
+		time.Sleep(20 * time.Millisecond) // Intentional: simulates rapid sensor changes
 	}
 
 	// Final state: Caroline is home (last toggle was i=4, even → on)
-	time.Sleep(200 * time.Millisecond)
+	waitForProcessing(t, env.stateManager)
 
 	// ========== THEN ==========
 	t.Log("THEN: System reaches consistent final state without crashes")
@@ -258,7 +263,7 @@ func TestScenario_SimultaneousSleepAndDayPhase_CorrectPriority(t *testing.T) {
 	env.server.SetState("input_boolean.everyone_asleep", "off", map[string]interface{}{})
 	env.server.SetState("input_text.day_phase", "evening", map[string]interface{}{})
 
-	time.Sleep(100 * time.Millisecond)
+	waitForProcessing(t, env.stateManager)
 	env.server.ClearServiceCalls()
 
 	// ========== WHEN ==========
@@ -271,7 +276,13 @@ func TestScenario_SimultaneousSleepAndDayPhase_CorrectPriority(t *testing.T) {
 	waitForStringState(t, env.stateManager, "dayPhase", "night", "dayPhase should become night")
 	waitForBoolState(t, env.stateManager, "isMasterAsleep", true, "isMasterAsleep should become true")
 
-	time.Sleep(200 * time.Millisecond)
+	// Wait for lighting plugin to react (state cascades through state tracking first)
+	waitForCondition(t, func() bool {
+		calls := env.server.GetServiceCalls()
+		sceneActivations := filterServiceCalls(calls, "scene", "turn_on")
+		lightTurnOffs := filterServiceCalls(calls, "light", "turn_off")
+		return len(sceneActivations)+len(lightTurnOffs) > 0
+	}, "Lighting should respond to combined night + sleep state")
 
 	// ========== THEN ==========
 	t.Log("THEN: Both states are set correctly and plugins handled both changes")
@@ -329,7 +340,7 @@ func TestScenario_MultiVariableBurst_NoPanics(t *testing.T) {
 	env.server.SetState("input_boolean.anyone_home_and_awake", "on", map[string]interface{}{})
 	env.server.SetState("input_text.day_phase", "morning", map[string]interface{}{})
 
-	time.Sleep(50 * time.Millisecond)
+	waitForProcessing(t, env.stateManager)
 	env.server.ClearServiceCalls()
 
 	// ========== WHEN ==========
@@ -347,7 +358,8 @@ func TestScenario_MultiVariableBurst_NoPanics(t *testing.T) {
 	waitForStringState(t, env.stateManager, "dayPhase", "night", "dayPhase should reach night")
 	waitForBoolState(t, env.stateManager, "isMasterAsleep", true, "isMasterAsleep should become true")
 
-	time.Sleep(200 * time.Millisecond)
+	// Wait for all plugin reactions to complete
+	waitForProcessing(t, env.stateManager)
 
 	// ========== THEN ==========
 	t.Log("THEN: System is stable with consistent state (no panics/deadlocks)")

--- a/homeautomation-go/test/integration/scenario_energy_sleep_test.go
+++ b/homeautomation-go/test/integration/scenario_energy_sleep_test.go
@@ -92,7 +92,8 @@ func setupEnergySleepTest(t *testing.T, fixedTime time.Time) (*energySleepEnv, f
 	env.energy.WaitForStartup()
 	require.NoError(t, env.sleepHygiene.Start(), "Failed to start sleep hygiene")
 
-	time.Sleep(50 * time.Millisecond)
+	// Wait for plugin initialization handlers to complete
+	waitForProcessing(t, manager)
 
 	cleanup := func() {
 		env.sleepHygiene.Stop()
@@ -145,7 +146,7 @@ func TestScenario_BatteryDropsDuringWakeSequence(t *testing.T) {
 	// Set wake sequence active in state manager too
 	require.NoError(t, env.manager.SetBool("isWakeSequenceActive", true))
 
-	time.Sleep(50 * time.Millisecond)
+	waitForProcessing(t, env.manager)
 	env.server.ClearServiceCalls()
 
 	// ========== WHEN ==========
@@ -212,9 +213,11 @@ func TestScenario_WakeSequenceStartsWithLowBattery(t *testing.T) {
 		"unit_of_measurement": "%",
 	})
 
-	time.Sleep(100 * time.Millisecond)
+	// Wait for energy plugin to finish computing battery level from the 15% sensor reading
+	waitForStringStateOneOf(t, env.manager, "batteryEnergyLevel", []string{"red", "black"},
+		"Battery level should settle to red or black at 15%")
 
-	// Record battery level
+	// Record battery level after it has settled
 	batteryLevel, err := env.manager.GetString("batteryEnergyLevel")
 	assert.NoError(t, err)
 	t.Logf("Battery level before wake attempt: %s", batteryLevel)
@@ -228,7 +231,8 @@ func TestScenario_WakeSequenceStartsWithLowBattery(t *testing.T) {
 	alarmTimeMs := float64(alarmTime.Unix() * 1000)
 	env.server.SetState("input_number.alarm_time", fmt.Sprintf("%.0f", alarmTimeMs), map[string]interface{}{})
 
-	time.Sleep(200 * time.Millisecond)
+	// Wait for sleep hygiene plugin to process the alarm trigger
+	waitForProcessing(t, env.manager)
 
 	// ========== THEN ==========
 	t.Log("THEN: Wake sequence starts despite low battery")
@@ -306,11 +310,11 @@ func TestScenario_EnergyTransitions_SleepStateUnaffected(t *testing.T) {
 		env.server.SetState("sensor.span_panel_span_storage_battery_percentage_2", level, map[string]interface{}{
 			"unit_of_measurement": "%",
 		})
-		time.Sleep(100 * time.Millisecond)
+		waitForProcessing(t, env.manager)
 	}
 
 	// Wait for final battery level to settle
-	time.Sleep(100 * time.Millisecond)
+	waitForProcessing(t, env.manager)
 
 	// ========== THEN ==========
 	t.Log("THEN: Sleep state is completely unaffected by energy transitions")

--- a/homeautomation-go/test/integration/scenario_lighting_test.go
+++ b/homeautomation-go/test/integration/scenario_lighting_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"homeautomation/internal/plugins/lighting"
 	"homeautomation/internal/state"
@@ -295,10 +294,10 @@ func TestScenario_GuestArrival_ActivatesGuestScenes(t *testing.T) {
 	t.Log("WHEN: Guests arrive")
 	server.SetState("input_boolean.have_guests", "on", map[string]interface{}{})
 
-	// Brief delay to allow lighting plugin to process guest state change
+	// Wait for lighting plugin to process guest state change
 	// Note: increase_brightness_if_true: isHaveGuests may not trigger immediate scene
 	// re-evaluation - it's applied when the next scene change occurs
-	time.Sleep(100 * time.Millisecond)
+	waitForProcessing(t, stateManager)
 
 	// THEN: Verify scenes were re-evaluated for guest presence (if any)
 	t.Log("THEN: Verify scenes were re-evaluated for guest presence")

--- a/homeautomation-go/test/integration/scenario_multi_plugin_test.go
+++ b/homeautomation-go/test/integration/scenario_multi_plugin_test.go
@@ -413,6 +413,8 @@ func TestScenario_DayPhaseChange_MultiPluginCoordination(t *testing.T) {
 	// ========== WHEN (Phase 2) ==========
 	t.Log("WHEN: Day phase changes from evening → night")
 
+	// Wait for all Phase 1 service calls to settle before clearing
+	waitForProcessing(t, env.manager)
 	env.server.ClearServiceCalls()
 	env.server.SetState("input_text.day_phase", "night", map[string]interface{}{})
 

--- a/homeautomation-go/test/integration/scenario_music_lighting_test.go
+++ b/homeautomation-go/test/integration/scenario_music_lighting_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"os"
 	"testing"
-	"time"
 
 	"homeautomation/internal/plugins/lighting"
 	"homeautomation/internal/plugins/music"
 	"homeautomation/internal/plugins/statetracking"
+	"homeautomation/internal/state"
 	"homeautomation/internal/testlogger"
 
 	"github.com/stretchr/testify/assert"
@@ -36,6 +36,7 @@ import (
 // musicLightingEnv holds plugins for music + lighting tests
 type musicLightingEnv struct {
 	server        *MockHAServer
+	stateManager  *state.Manager
 	logger        *zap.Logger
 	stateTracking *statetracking.Manager
 	lighting      *lighting.Manager
@@ -54,6 +55,7 @@ func setupMusicLightingTest(t *testing.T) (*musicLightingEnv, func()) {
 	// Create plugins
 	env := &musicLightingEnv{
 		server:        server,
+		stateManager:  manager,
 		logger:        logger,
 		stateTracking: statetracking.NewManager(context.Background(), client, manager, logger, false, nil),
 		lighting:      lighting.NewManager(context.Background(), client, manager, lightingConfig, logger, false, nil),
@@ -79,7 +81,8 @@ func setupMusicLightingTest(t *testing.T) (*musicLightingEnv, func()) {
 	require.NoError(t, env.lighting.Start(), "Failed to start lighting")
 	require.NoError(t, env.music.Start(), "Failed to start music")
 
-	time.Sleep(50 * time.Millisecond)
+	// Wait for plugin initialization handlers to complete
+	waitForProcessing(t, manager)
 
 	cleanup := func() {
 		env.music.Stop()
@@ -128,7 +131,7 @@ func TestScenario_DayPhaseChange_TriggersLightingAndMusicZone(t *testing.T) {
 	env.server.SetState("input_boolean.everyone_asleep", "off", map[string]interface{}{})
 	env.server.SetState("input_text.day_phase", "afternoon", map[string]interface{}{})
 
-	time.Sleep(50 * time.Millisecond)
+	waitForProcessing(t, env.stateManager)
 	env.server.ClearServiceCalls()
 
 	// ========== WHEN ==========
@@ -136,8 +139,13 @@ func TestScenario_DayPhaseChange_TriggersLightingAndMusicZone(t *testing.T) {
 
 	env.server.SetState("input_text.day_phase", "evening", map[string]interface{}{})
 
-	// Wait for both plugins to react
-	time.Sleep(200 * time.Millisecond)
+	// Wait for both plugins to react - use polling since state changes cascade
+	// through state tracking (derived state) before reaching lighting/music plugins
+	waitForCondition(t, func() bool {
+		calls := env.server.GetServiceCalls()
+		sceneActivations := filterServiceCalls(calls, "scene", "turn_on")
+		return len(sceneActivations) >= 1
+	}, "Lighting plugin should activate scenes when day phase changes to evening")
 
 	// ========== THEN ==========
 	t.Log("THEN: Lighting activates evening scenes AND music resolves evening zone")
@@ -212,7 +220,7 @@ func TestScenario_SleepTransition_MusicAndLightingCoordinate(t *testing.T) {
 	env.server.SetState("input_boolean.everyone_asleep", "off", map[string]interface{}{})
 	env.server.SetState("input_text.day_phase", "evening", map[string]interface{}{})
 
-	time.Sleep(50 * time.Millisecond)
+	waitForProcessing(t, env.stateManager)
 	env.server.ClearServiceCalls()
 
 	// ========== WHEN ==========
@@ -220,8 +228,14 @@ func TestScenario_SleepTransition_MusicAndLightingCoordinate(t *testing.T) {
 
 	env.server.SetState("input_boolean.master_asleep", "on", map[string]interface{}{})
 
-	// Wait for both plugins to react
-	time.Sleep(200 * time.Millisecond)
+	// Wait for both plugins to react - use polling since state changes cascade
+	// through state tracking (derived state) before reaching lighting/music plugins
+	waitForCondition(t, func() bool {
+		calls := env.server.GetServiceCalls()
+		sceneActivations := filterServiceCalls(calls, "scene", "turn_on")
+		lightTurnOffs := filterServiceCalls(calls, "light", "turn_off")
+		return len(sceneActivations)+len(lightTurnOffs) > 0
+	}, "Lighting plugin should respond when master goes to sleep")
 
 	// ========== THEN ==========
 	t.Log("THEN: Music transitions to sleep zone AND lighting adjusts for sleep")
@@ -282,7 +296,7 @@ func TestScenario_MusicZoneChange_LightingUnaffected(t *testing.T) {
 	env.server.SetState("input_boolean.everyone_asleep", "off", map[string]interface{}{})
 	env.server.SetState("input_text.day_phase", "evening", map[string]interface{}{})
 
-	time.Sleep(100 * time.Millisecond)
+	waitForProcessing(t, env.stateManager)
 
 	// Record scene activations from initial setup
 	initialCalls := env.server.GetServiceCalls()
@@ -298,7 +312,7 @@ func TestScenario_MusicZoneChange_LightingUnaffected(t *testing.T) {
 	env.server.SetState("input_text.music_playback_type", "winddown", map[string]interface{}{})
 
 	// Wait for music plugin to process
-	time.Sleep(200 * time.Millisecond)
+	waitForProcessing(t, env.stateManager)
 
 	// ========== THEN ==========
 	t.Log("THEN: Lighting does NOT re-activate scenes (only music changes)")

--- a/homeautomation-go/test/integration/scenario_nighttime_safety_test.go
+++ b/homeautomation-go/test/integration/scenario_nighttime_safety_test.go
@@ -235,7 +235,8 @@ func TestScenario_SleepMusic_ContinuesWhenMasterAsleep(t *testing.T) {
 	env.server.SetState("input_text.music_playback_type", "sleep", map[string]interface{}{})
 	waitForStringState(t, env.stateManager, "musicPlaybackType", "sleep", "Music type should be sleep")
 
-	// Clear and then simulate master going to sleep
+	// Wait for all music plugin service calls to complete before clearing
+	waitForProcessing(t, env.stateManager)
 	env.server.ClearServiceCalls()
 	t.Log("WHEN: Master goes to sleep")
 
@@ -598,6 +599,9 @@ func TestScenario_SleepToMorningTransition_BedroomMutedUntilActualWake(t *testin
 	env.server.SetState("input_text.music_playback_type", "morning", map[string]interface{}{})
 	waitForStringState(t, env.stateManager, "musicPlaybackType", "morning", "Music type should be morning")
 
+	// Wait for all music plugin service calls (mute/volume) to complete
+	waitForProcessing(t, env.stateManager)
+
 	// ========== THEN ==========
 	t.Log("THEN: Bedroom should be MUTED during morning music while master sleeps")
 
@@ -759,8 +763,8 @@ func TestScenario_RapidStateChanges_NoBriefUnmute(t *testing.T) {
 		time.Sleep(10 * time.Millisecond) // Intentional: simulates rapid sensor changes
 	}
 
-	// Brief delay to allow all callbacks to process after rapid state changes
-	time.Sleep(100 * time.Millisecond)
+	// Wait for all callbacks to complete after rapid state changes
+	waitForProcessing(t, env.stateManager)
 
 	// ========== THEN ==========
 	t.Log("THEN: isMasterAsleep should remain true, no unexpected unmutes")

--- a/homeautomation-go/test/integration/scenario_security_test.go
+++ b/homeautomation-go/test/integration/scenario_security_test.go
@@ -161,8 +161,8 @@ func TestScenario_OwnerReturnsHomeGarageOccupied(t *testing.T) {
 
 	t.Log("BUT: Garage door should NOT be opened (occupied)")
 
-	// Wait a bit for any potential service calls, then verify none were made
-	time.Sleep(100 * time.Millisecond)
+	// Wait for all handlers to complete, then verify no garage open call was made
+	waitForProcessing(t, manager)
 
 	garageOpenCall := server.FindServiceCall("cover", "open_cover", "cover.garage_door_door")
 	assert.Nil(t, garageOpenCall, "Garage door should NOT open when garage is occupied")
@@ -318,7 +318,7 @@ func TestScenario_OnlyOwnersTriggersGarage(t *testing.T) {
 
 	server.SetState("input_boolean.tori_here", "off", nil)
 	server.SetState("binary_sensor.garage_door_vehicle_detected", "off", nil)
-	time.Sleep(100 * time.Millisecond)
+	waitForProcessing(t, manager)
 
 	server.ClearServiceCalls()
 

--- a/homeautomation-go/test/integration/scenario_sensor_monitoring_test.go
+++ b/homeautomation-go/test/integration/scenario_sensor_monitoring_test.go
@@ -135,8 +135,8 @@ func TestScenario_SensorMonitoring_CompleteSurfaceArea(t *testing.T) {
 		"friendly_name": "Bathroom Water Leak",
 	})
 
-	// Brief setup delay: Allow mock server state to propagate before starting plugins
-	time.Sleep(100 * time.Millisecond)
+	// Wait for mock server state to propagate before starting plugins
+	waitForProcessing(t, env.manager)
 
 	// ========== START PLUGINS ==========
 

--- a/homeautomation-go/test/integration/scenario_sexmode_test.go
+++ b/homeautomation-go/test/integration/scenario_sexmode_test.go
@@ -243,6 +243,9 @@ func TestScenario_SexModeDeactivation_RestoresMusicType(t *testing.T) {
 
 	// Verify music changed to sex
 	waitForStringState(t, stateManager, "musicPlaybackType", "sex", "Music should be 'sex' during activation")
+	// Wait for activation handler to fully complete (night scene + Eight Sleep calls)
+	waitForServiceCallWithEntity(t, server, "scene", "turn_on", "scene.primary_suite_night", "activation should complete with night scene")
+	waitForProcessing(t, stateManager)
 
 	server.ClearServiceCalls()
 
@@ -254,7 +257,7 @@ func TestScenario_SexModeDeactivation_RestoresMusicType(t *testing.T) {
 
 	waitForStringState(t, stateManager, "musicPlaybackType", "working", "musicPlaybackType should be restored")
 
-	t.Log("✓ Music type correctly restored to 'working'")
+	t.Log("Music type correctly restored to 'working'")
 }
 
 // TestScenario_SexModeDeactivation_ActivatesDayPhaseScene tests that deactivating sex mode
@@ -557,12 +560,20 @@ func TestScenario_SexModeActivationDeactivationCycle(t *testing.T) {
 	server.ClearServiceCalls()
 	server.SetState("input_boolean.sex", "on", nil)
 
-	// Verify activation
+	// Verify activation - wait for ALL side-effects, not just music state change
 	waitForStringState(t, stateManager, "musicPlaybackType", "sex", "music should switch to sex")
-	t.Log("  ✓ Activation: music set to 'sex'")
+	t.Log("  Activation: music set to 'sex'")
+
+	// Wait for night scene and Eight Sleep climate calls to complete before clearing
+	waitForServiceCallWithEntity(t, server, "scene", "turn_on", "scene.primary_suite_night", "activation should complete with night scene")
+	assert.Eventually(t, func() bool {
+		calls := server.GetServiceCalls()
+		eightSleepCalls := FilterServiceCalls(calls, "climate", "set_temperature")
+		return len(eightSleepCalls) >= 2
+	}, stateWaitTimeout, statePollInterval, "Both Eight Sleep beds should be adjusted during activation")
 
 	activationCalls := len(server.GetServiceCalls())
-	t.Logf("  ✓ Activation made %d service calls", activationCalls)
+	t.Logf("  Activation made %d service calls", activationCalls)
 
 	t.Log("AND WHEN: Sex mode is deactivated")
 
@@ -579,9 +590,9 @@ func TestScenario_SexModeActivationDeactivationCycle(t *testing.T) {
 	waitForServiceCallWithEntity(t, server, "scene", "turn_on", "scene.primary_suite_evening", "Evening scene should be activated")
 	sceneCall := server.FindServiceCall("scene", "turn_on", "scene.primary_suite_evening")
 	assert.NotNil(t, sceneCall, "Evening scene should be activated")
-	t.Log("  ✓ Deactivation: evening scene activated")
+	t.Log("  Deactivation: evening scene activated")
 
-	t.Log("✓ Full activation/deactivation cycle completed successfully")
+	t.Log("Full activation/deactivation cycle completed successfully")
 }
 
 // TestScenario_SexModeShadowState_TracksCorrectly tests that shadow state

--- a/homeautomation-go/test/integration/scenario_sleephygiene_test.go
+++ b/homeautomation-go/test/integration/scenario_sleephygiene_test.go
@@ -127,7 +127,7 @@ func TestScenario_AlarmTimeReached_TriggersBeginWakeSequence(t *testing.T) {
 
 	// Allow async handlers to process (fade out may or may not start
 	// since FixedTimeProvider doesn't advance the timer tick)
-	time.Sleep(100 * time.Millisecond)
+	waitForProcessing(t, stateManager)
 
 	// THEN: Verify begin_wake sequence started
 	t.Log("THEN: Verify begin_wake sequence started")
@@ -335,7 +335,7 @@ func TestScenario_EveningReminder_SendsStopScreensNotification(t *testing.T) {
 	server.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 
 	// Wait for automation to react (checking for optional flash call)
-	time.Sleep(100 * time.Millisecond)
+	waitForProcessing(t, stateManager)
 
 	// THEN: Verify lights flash as a reminder
 	t.Log("THEN: Verify lights flash as a reminder")
@@ -608,7 +608,7 @@ func TestScenario_SleepStateIntegration_ChecksConditions(t *testing.T) {
 	server.SetState("input_number.alarm_time", fmt.Sprintf("%.0f", alarmTimeMs), map[string]interface{}{})
 
 	// Allow async handlers to process (expecting no fade out)
-	time.Sleep(100 * time.Millisecond)
+	waitForProcessing(t, stateManager)
 
 	// THEN: Wake sequence should NOT trigger (no fade out, no service calls)
 	t.Log("THEN: Verify wake sequence does NOT trigger when master is awake")
@@ -635,7 +635,7 @@ func TestScenario_SleepStateIntegration_ChecksConditions(t *testing.T) {
 	// Trigger check again
 	server.SetState("input_number.alarm_time", fmt.Sprintf("%.0f", alarmTimeMs), map[string]interface{}{})
 	// Allow async handlers to process (expecting fade out to start)
-	time.Sleep(100 * time.Millisecond)
+	waitForProcessing(t, stateManager)
 
 	// Now fade out should start
 	fadeOutState = server.GetState("input_boolean.fade_out_in_progress")
@@ -832,7 +832,7 @@ func TestScenario_WakeSequence_LightingPluginYieldsToSleepHygiene(t *testing.T) 
 	server.SetState("input_boolean.master_asleep", "on", map[string]interface{}{})
 
 	// Allow lighting plugin to react
-	time.Sleep(100 * time.Millisecond)
+	waitForProcessing(t, manager)
 
 	// THEN: Lighting plugin should NOT turn off lights (yielded to sleephygiene)
 	t.Log("THEN: Lighting plugin should NOT turn off bedroom lights")
@@ -962,7 +962,7 @@ func TestScenario_WakeSequence_LightingConditionPriority(t *testing.T) {
 	require.NoError(t, manager.SetBool("isWakeSequenceActive", true))
 
 	// Allow lighting plugin to react to state change
-	time.Sleep(100 * time.Millisecond)
+	waitForProcessing(t, manager)
 
 	// THEN: Bedroom should NOT be turned off
 	t.Log("THEN: Verify bedroom lights are NOT turned off")

--- a/homeautomation-go/test/integration/scenario_tv_music_test.go
+++ b/homeautomation-go/test/integration/scenario_tv_music_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"context"
 	"testing"
-	"time"
 
 	"homeautomation/internal/plugins/music"
 	"homeautomation/internal/plugins/statetracking"
@@ -87,7 +86,8 @@ func setupTVMusicTest(t *testing.T) (*tvMusicEnv, func()) {
 	require.NoError(t, env.tv.Start(), "Failed to start TV")
 	require.NoError(t, env.music.Start(), "Failed to start music")
 
-	time.Sleep(50 * time.Millisecond)
+	// Wait for plugin initialization handlers to complete
+	waitForProcessing(t, manager)
 
 	cleanup := func() {
 		env.music.Stop()
@@ -128,7 +128,7 @@ func TestScenario_TVStartsPlaying_MusicSpeakersMute(t *testing.T) {
 	env.server.SetState("input_boolean.everyone_asleep", "off", map[string]interface{}{})
 	env.server.SetState("input_text.day_phase", "evening", map[string]interface{}{})
 
-	time.Sleep(100 * time.Millisecond)
+	waitForProcessing(t, env.stateManager)
 	env.server.ClearServiceCalls()
 
 	// Verify TV is not playing initially
@@ -147,7 +147,7 @@ func TestScenario_TVStartsPlaying_MusicSpeakersMute(t *testing.T) {
 	waitForBoolState(t, env.stateManager, "isTVPlaying", true, "isTVPlaying should become true")
 
 	// Wait for music plugin to react to isTVPlaying change
-	time.Sleep(200 * time.Millisecond)
+	waitForProcessing(t, env.stateManager)
 
 	// ========== THEN ==========
 	t.Log("THEN: TV state is updated and music plugin reacts to mute condition")
@@ -210,7 +210,7 @@ func TestScenario_TVStops_MusicSpeakersUnmute(t *testing.T) {
 	// Wait for TV plugin to set isTVPlaying=true
 	waitForBoolState(t, env.stateManager, "isTVPlaying", true, "isTVPlaying should be true initially")
 
-	time.Sleep(100 * time.Millisecond)
+	waitForProcessing(t, env.stateManager)
 	env.server.ClearServiceCalls()
 
 	// ========== WHEN ==========
@@ -224,7 +224,7 @@ func TestScenario_TVStops_MusicSpeakersUnmute(t *testing.T) {
 	waitForBoolState(t, env.stateManager, "isTVPlaying", false, "isTVPlaying should become false")
 
 	// Wait for music plugin to react
-	time.Sleep(200 * time.Millisecond)
+	waitForProcessing(t, env.stateManager)
 
 	// ========== THEN ==========
 	t.Log("THEN: Previously muted speakers should be unmuted")

--- a/homeautomation-go/test/integration/scenario_wake_music_fade_test.go
+++ b/homeautomation-go/test/integration/scenario_wake_music_fade_test.go
@@ -106,7 +106,8 @@ func setupWakeMusicFadeTest(t *testing.T) (*wakeMusicFadeEnv, func()) {
 	require.NoError(t, env.music.Start(), "Failed to start music")
 	require.NoError(t, env.sleepHygiene.Start(), "Failed to start sleep hygiene")
 
-	time.Sleep(50 * time.Millisecond)
+	// Wait for plugin initialization handlers to complete
+	waitForProcessing(t, stateManager)
 
 	cleanup := func() {
 		env.sleepHygiene.Stop()


### PR DESCRIPTION
Resolves #721

## Summary
- **Primary fix**: `TestScenario_SexModeActivationDeactivationCycle` was flaky because it only waited for `musicPlaybackType` to change to "sex" after activation, but did not wait for the night scene activation and Eight Sleep climate calls to complete before calling `ClearServiceCalls()` and starting the deactivation phase. Late-arriving activation calls could interfere with deactivation assertions.
- **Broader audit**: Found the same timing-dependent pattern across 12 integration test files. Replaced `time.Sleep` calls with deterministic `waitForProcessing` (for single-plugin reactions) and `waitForCondition` (for cross-plugin cascading state changes).
- **Pre-existing bug fix**: `TestScenario_WakeSequenceStartsWithLowBattery` had a race where `time.Sleep(100ms)` was too short for the energy plugin to compute battery level, causing the test to record a stale "green" level. Fixed by using `waitForStringStateOneOf` to wait for the energy level to settle.

### Files changed (12 integration test files)
| File | Change |
|------|--------|
| `scenario_sexmode_test.go` | Wait for all activation side-effects (scene + climate) before deactivation |
| `scenario_multi_plugin_test.go` | Add `waitForProcessing` before Phase 2 `ClearServiceCalls` |
| `scenario_nighttime_safety_test.go` | Add `waitForProcessing` after music type and rapid state changes |
| `scenario_music_lighting_test.go` | Replace all `time.Sleep` with `waitForProcessing`/`waitForCondition` |
| `scenario_tv_music_test.go` | Replace all `time.Sleep` with `waitForProcessing` |
| `scenario_concurrent_triggers_test.go` | Replace `time.Sleep` with `waitForProcessing`/`waitForCondition` |
| `scenario_energy_sleep_test.go` | Replace `time.Sleep`, fix battery level race |
| `scenario_sleephygiene_test.go` | Replace `time.Sleep` with `waitForProcessing` |
| `scenario_lighting_test.go` | Replace `time.Sleep` with `waitForProcessing` |
| `scenario_security_test.go` | Replace `time.Sleep` with `waitForProcessing` |
| `scenario_sensor_monitoring_test.go` | Replace `time.Sleep` with `waitForProcessing` |
| `scenario_wake_music_fade_test.go` | Replace `time.Sleep` with `waitForProcessing` |

## Test plan
- [x] `make pre-commit` passes (formatting, linting, build)
- [x] `make unit-tests` passes (75% coverage)
- [x] `make integration-tests` passes (all tests)
- [x] Pre-push hook validation passes
- [ ] Run `TestScenario_SexModeActivationDeactivationCycle` in a loop to verify flakiness is resolved:
  ```bash
  for i in $(seq 1 10); do
    go test -race -run TestScenario_SexModeActivationDeactivationCycle -count=1 ./test/integration/... 2>&1 | tail -1
  done
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)