### PR TITLE
fix: Raise music volume safety cap from 15 to 30

### DIFF
--- a/homeautomation-go/internal/plugins/music/manager_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_test.go
@@ -500,7 +500,8 @@ func TestCalculateVolume(t *testing.T) {
 		{"No multiplier", 9, 1.0, 9},
 		{"1.5x multiplier", 10, 1.5, 15},
 		{"Rounds correctly", 9, 1.1, 10},
-		{"Caps at 15", 16, 1.1, 15},
+		{"Above old cap", 16, 1.1, 18},
+		{"Caps at 30", 20, 2.0, 30},
 		{"Zero base", 0, 1.5, 0},
 	}
 

--- a/homeautomation-go/internal/plugins/music/playlists.go
+++ b/homeautomation-go/internal/plugins/music/playlists.go
@@ -136,9 +136,9 @@ func (m *Manager) WaitForSync() {
 // calculateVolume calculates final volume from base and multiplier
 func (m *Manager) calculateVolume(baseVolume int, multiplier float64) int {
 	volume := math.Round(float64(baseVolume) * multiplier)
-	// Cap at 15 (Sonos max for Spotify playback scale)
-	if volume > 15 {
-		volume = 15
+	// Safety cap to prevent accidentally blasting speakers
+	if volume > 30 {
+		volume = 30
 	}
 	if volume < 0 {
 		volume = 0


### PR DESCRIPTION
## Summary
- The `calculateVolume()` function had a hard cap of 15, set as a conservative default in the initial music plugin implementation (Nov 2025) and never revisited
- This caused all sleep zone speakers (configured at `base_volume: 16`) to be silently capped to 15, and prevented `volume_multiplier` from working correctly for quieter content (e.g., evening Beethoven at `6 × 2.5` was capped instead of reaching the intended volume)
- Raised the safety cap to 30 to allow configured volumes to take effect while still preventing accidental speaker blasting

## Test plan
- [x] `TestCalculateVolume` updated: old "Caps at 15" case now validates `16 × 1.1 = 18`, new "Caps at 30" case validates the new safety boundary
- [x] Unit tests pass
- [x] Integration tests pass
- [ ] Verify Sonos speakers in sleep zone reach volume 16 after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)