### PR TITLE
fix: Recalculate isTVPlaying when sync box powers on

### DIFF
--- a/homeautomation-go/internal/plugins/tv/manager.go
+++ b/homeautomation-go/internal/plugins/tv/manager.go
@@ -352,6 +352,18 @@ func (m *Manager) handleSyncBoxPowerChange(entityID string, oldState, newState *
 		}
 		// Update shadow state
 		m.shadowTracker.UpdateTVPlaying(false)
+	} else {
+		// Sync box turned on — recalculate isTVPlaying based on current HDMI input.
+		// This handles the race where HDMI input change arrives before power change
+		// (both at the same second), so the HDMI handler saw isTVon=false.
+		hdmiInputState, err := m.haClient.GetState("select.sync_box_hdmi_input")
+		if err != nil {
+			m.logger.Warn("Failed to get HDMI input state for recalculation", zap.Error(err))
+			return
+		}
+		if hdmiInputState != nil {
+			m.calculateTVPlaying(hdmiInputState.State)
+		}
 	}
 }
 

--- a/homeautomation-go/test/integration/scenario_tv_test.go
+++ b/homeautomation-go/test/integration/scenario_tv_test.go
@@ -381,3 +381,43 @@ func TestScenario_TVOffSyncBoxOn(t *testing.T) {
 	// But isTVPlaying stays false because calculateTVPlaying checks TV remote state
 	waitForBoolState(t, manager, "isTVPlaying", false, "isTVPlaying should remain false (TV panel is off)")
 }
+
+// TestScenario_SyncBoxPowerOnRecalculates verifies that when the sync box powers on
+// and the HDMI input changes at the same time, isTVPlaying is correctly recalculated.
+// This reproduces a production race condition where both events arrive at the same second:
+//
+//	19:16:50 - select.sync_box_hdmi_input: AppleTV -> Nintendo Switch
+//	19:16:50 - switch.sync_box_power: off -> on
+//
+// If the HDMI input change is processed first, calculateTVPlaying sees isTVon=false
+// (sync box power hasn't been processed yet) and sets isTVPlaying=false. Then
+// handleSyncBoxPowerChange sets isTVon=true but must recalculate isTVPlaying.
+func TestScenario_SyncBoxPowerOnRecalculates(t *testing.T) {
+	t.Parallel()
+	server, manager, cleanup := setupTVScenarioTest(t)
+	defer cleanup()
+
+	t.Log("GIVEN: TV panel is on, sync box is off, HDMI input is AppleTV")
+
+	// Set initial states - TV panel on, sync box off
+	server.SetState("remote.big_beautiful_oled", "on", map[string]interface{}{})
+	server.SetState("switch.sync_box_power", "off", map[string]interface{}{})
+	server.SetState("select.sync_box_hdmi_input", "AppleTV", map[string]interface{}{})
+	server.SetState("media_player.big_beautiful_oled", "idle", map[string]interface{}{
+		"friendly_name": "Apple TV",
+	})
+
+	// Wait for initial state
+	waitForBoolState(t, manager, "isTVon", false, "isTVon should be false when sync box is off")
+
+	t.Log("WHEN: HDMI input switches to Nintendo Switch AND sync box powers on (simultaneous events)")
+
+	// Simulate the race: HDMI input change arrives first, then power change
+	server.SetState("select.sync_box_hdmi_input", "Nintendo Switch", map[string]interface{}{})
+	server.SetState("switch.sync_box_power", "on", map[string]interface{}{})
+
+	t.Log("THEN: isTVon should be true AND isTVPlaying should be true (non-AppleTV input assumes playing)")
+
+	waitForBoolState(t, manager, "isTVon", true, "isTVon should be true when sync box is on")
+	waitForBoolState(t, manager, "isTVPlaying", true, "isTVPlaying should be true — sync box power-on must recalculate based on current HDMI input")
+}


### PR DESCRIPTION
## Summary

- Fixes a race condition where `isTVPlaying` stays `false` when sync box power and HDMI input change at the same second
- When sync box powers on, `handleSyncBoxPowerChange` now fetches the current HDMI input and calls `calculateTVPlaying()`, mirroring the pattern used by `handleAppleTVPlayingChange`
- Adds integration test reproducing the exact production scenario (HDMI input change arriving before power change)

## Root Cause

Production logs showed both events at 19:16:50:
```
select.sync_box_hdmi_input: AppleTV -> Nintendo Switch
switch.sync_box_power: off -> on
```

If the HDMI input handler runs first, `calculateTVPlaying("Nintendo Switch")` checks `isTVon` which is still `false` (power not yet processed), so it returns `isTVPlaying=false`. Then `handleSyncBoxPowerChange` sets `isTVon=true` but never recalculated `isTVPlaying`. Result: sitting room speaker isn't muted even though TV is actively in use on Nintendo Switch.

## Test plan

- [x] `make unit-tests` — all existing tests pass
- [x] `make integration-tests` — all existing + new test pass
- [x] New `TestScenario_SyncBoxPowerOnRecalculates` specifically validates the simultaneous-event race condition
- [x] Existing `TestScenario_TVOffSyncBoxOn` still passes (sync box on with TV panel off → `isTVPlaying` stays false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)