### PR TITLE
fix: Enable thermostat hold mode during thermal battery

### DIFF
--- a/homeautomation-go/internal/plugins/loadshedding/thermal_battery.go
+++ b/homeautomation-go/internal/plugins/loadshedding/thermal_battery.go
@@ -154,6 +154,22 @@ func (m *Manager) activateThermalBattery() {
 		}
 	}
 
+	// Enable thermostat hold mode BEFORE shifting setpoints.
+	// Without hold, the thermostat's built-in schedule can immediately override the shifted setpoints.
+	if m.readOnly {
+		m.logger.Info("READ-ONLY: Would enable thermostat hold mode for thermal battery",
+			zap.Strings("entities", []string{thermostatHoldHouse, thermostatHoldSuite}))
+	} else {
+		m.logger.Info("Thermal battery: enabling thermostat hold mode",
+			zap.Strings("entities", []string{thermostatHoldHouse, thermostatHoldSuite}))
+		if err := m.haClient.CallService(m.ctx, "switch", "turn_on", map[string]interface{}{
+			"entity_id": []string{thermostatHoldHouse, thermostatHoldSuite},
+		}); err != nil {
+			m.logger.Error("Failed to enable thermostat hold mode for thermal battery", zap.Error(err))
+			return
+		}
+	}
+
 	// Apply offset to each thermostat
 	direction := "" // for ntfy notification
 	for entityID, sp := range savedSetpoints {
@@ -293,6 +309,17 @@ func (m *Manager) deactivateThermalBattery(reason string) {
 				zap.String("entity", entityID), zap.Error(err))
 			// Continue trying other thermostats
 		}
+	}
+
+	// Disable thermostat hold mode AFTER reverting setpoints,
+	// so the schedule resumes with the original temperatures in place.
+	m.logger.Info("Thermal battery: disabling thermostat hold mode",
+		zap.Strings("entities", []string{thermostatHoldHouse, thermostatHoldSuite}))
+	if err := m.haClient.CallService(m.ctx, "switch", "turn_off", map[string]interface{}{
+		"entity_id": []string{thermostatHoldHouse, thermostatHoldSuite},
+	}); err != nil {
+		m.logger.Error("Failed to disable thermostat hold mode for thermal battery", zap.Error(err))
+		// Continue with deactivation anyway - holds can be manually cleared
 	}
 
 	m.thermalBatteryActive = false

--- a/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
+++ b/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
@@ -61,10 +61,23 @@ func TestThermalBattery_ActivatesOnWhiteEnergyLevel(t *testing.T) {
 	// Verify thermal battery is active
 	assert.True(t, ls.IsThermalBatteryActive(), "Thermal battery should be active at white energy level")
 
-	// Verify climate.set_temperature calls were made (one per thermostat)
+	// Verify thermostat hold was enabled before temperature changes
 	calls := env.MockHA.GetServiceCalls()
+	holdCalls := 0
 	climateCalls := 0
-	for _, call := range calls {
+	holdCallIndex := -1
+	for i, call := range calls {
+		if call.Domain == "switch" && call.Service == "turn_on" {
+			if entities, ok := call.Data["entity_id"].([]string); ok {
+				for _, e := range entities {
+					if e == thermostatHoldHouse || e == thermostatHoldSuite {
+						holdCalls++
+						holdCallIndex = i
+						break
+					}
+				}
+			}
+		}
 		if call.Domain == "climate" && call.Service == "set_temperature" {
 			climateCalls++
 			entityID, _ := call.Data["entity_id"].(string)
@@ -77,8 +90,12 @@ func TestThermalBattery_ActivatesOnWhiteEnergyLevel(t *testing.T) {
 			case climateSuite:
 				assert.Equal(t, 68.0, temp, "Suite thermostat should be shifted from 71 to 68")
 			}
+
+			// Hold must be enabled before any temperature shift
+			assert.Greater(t, i, holdCallIndex, "Thermostat hold should be enabled before setting temperature")
 		}
 	}
+	assert.Equal(t, 1, holdCalls, "Should have made 1 switch.turn_on call for thermostat holds")
 	assert.Equal(t, 2, climateCalls, "Should have made 2 climate.set_temperature calls")
 
 	// Verify shadow state
@@ -112,12 +129,16 @@ func TestThermalBattery_DeactivatesOnGreenEnergyLevel(t *testing.T) {
 	// Verify thermal battery is deactivated
 	assert.False(t, ls.IsThermalBatteryActive(), "Thermal battery should be inactive after green")
 
-	// Verify setpoints were reverted
+	// Verify setpoints were reverted and hold was disabled
 	calls := env.MockHA.GetServiceCalls()
 	revertCalls := 0
-	for _, call := range calls {
+	holdOffCalls := 0
+	lastRevertIndex := -1
+	holdOffIndex := -1
+	for i, call := range calls {
 		if call.Domain == "climate" && call.Service == "set_temperature" {
 			revertCalls++
+			lastRevertIndex = i
 			entityID, _ := call.Data["entity_id"].(string)
 			temp, _ := call.Data["temperature"].(float64)
 
@@ -128,8 +149,21 @@ func TestThermalBattery_DeactivatesOnGreenEnergyLevel(t *testing.T) {
 				assert.Equal(t, 71.0, temp, "Suite thermostat should be reverted to 71")
 			}
 		}
+		if call.Domain == "switch" && call.Service == "turn_off" {
+			if entities, ok := call.Data["entity_id"].([]string); ok {
+				for _, e := range entities {
+					if e == thermostatHoldHouse || e == thermostatHoldSuite {
+						holdOffCalls++
+						holdOffIndex = i
+						break
+					}
+				}
+			}
+		}
 	}
 	assert.Equal(t, 2, revertCalls, "Should have made 2 climate.set_temperature calls to revert")
+	assert.Equal(t, 1, holdOffCalls, "Should have made 1 switch.turn_off call to disable thermostat holds")
+	assert.Greater(t, holdOffIndex, lastRevertIndex, "Hold should be disabled after setpoints are reverted")
 
 	// Verify shadow state
 	shadow := ls.GetShadowState()


### PR DESCRIPTION
## Summary
- Thermal battery was setting shifted temperature setpoints on both thermostats but **not enabling hold mode**, allowing the thermostat's built-in schedule to immediately override the shifted setpoint on one or both thermostats
- Now enables thermostat holds **before** shifting setpoints on activation, and disables holds **after** reverting setpoints on deactivation — matching how load shedding already handles holds
- Adds test assertions verifying hold enable/disable calls and their ordering relative to temperature changes

## Test plan
- [x] All 18 thermal battery unit tests pass (including updated ordering assertions)
- [x] All unit tests pass (75.4% coverage)
- [x] All integration tests pass
- [ ] Verify in production that both thermostats reflect the shifted setpoint when thermal battery activates at white energy level

🤖 Generated with [Claude Code](https://claude.com/claude-code)