### PR TITLE
fix: Prevent lighting plugin interference during wake sequence

### DIFF
--- a/configs/hue_config.yaml
+++ b/configs/hue_config.yaml
@@ -26,30 +26,32 @@ rooms:
   - hue_group: Primary Suite
     hass_area_id: master_bedroom
     conditions:
-      # CRITICAL: isWakeSequenceActive MUST be checked
+      # CRITICAL: isWakeSequenceActive and isMasterAsleep MUST be checked
       # BEFORE isAnyoneHomeAndAwake!
       #
-      # BUG FIX (2026-01-13 production incident):
-      # During wake sequence, isMasterAsleep=true so isAnyoneHomeAndAwake=false.
-      # If isAnyoneHomeAndAwake is checked first, the lighting plugin turns off
-      # the bedroom lights immediately after sleephygiene turns them on,
-      # causing wake cancellation
-      # ("Bedroom lights turned off during wake sequence").
+      # BUG FIX (2026-02-24 production incident):
+      # During wake sequence, sleephygiene controls the bedroom lights with
+      # a slow fade-in. The lighting plugin must completely hands-off during
+      # wake sequence to avoid interfering with the fade-in.
+      #
+      # Similarly, when master is asleep (but not wake sequence), the lighting
+      # plugin should not control the bedroom lights. Sleephygiene manages
+      # sleep state lighting.
       #
       # Priority 1: Wake sequence in progress -> yield to sleephygiene
-      # This takes absolute priority to prevent race condition
-      # with wake sequence
-      - action: on
+      # This takes absolute priority to prevent interference with wake sequence
+      - action: skip
         variable: isWakeSequenceActive
         value: true
-      # Priority 2: No one home and awake -> OFF
+      # Priority 2: Master asleep -> yield to sleephygiene
+      # Bedroom is in sleep mode, don't interfere
+      - action: skip
+        variable: isMasterAsleep
+        value: true
+      # Priority 3: No one home and awake -> OFF
       - action: off
         variable: isAnyoneHomeAndAwake
         value: false
-      # Priority 3: Master asleep -> OFF
-      - action: off
-        variable: isMasterAsleep
-        value: true
       # Priority 4: Master not asleep -> ON
       - action: on
         variable: isMasterAsleep


### PR DESCRIPTION
## Summary

Fixes lighting plugin interference with sleephygiene's wake sequence that occurred this morning (2026-02-24 8:06-8:20 AM). During the wake sequence, the lighting plugin was activating the Primary Suite morning scene while sleephygiene was performing a slow fade-in, causing lights to jump to high brightness then drop back to low.

## Root Cause

The lighting plugin config used `action: on` for `isWakeSequenceActive=true`, which activated a scene instead of yielding control. This interfered with sleephygiene's 25-minute fade-in from 1% to 100% brightness.

## Changes

**Primary Suite lighting conditions (`configs/hue_config.yaml`):**

1. **isWakeSequenceActive=true**: Changed from `action: on` → `action: skip`
   - Lighting plugin now completely hands-off during wake sequence
   - Sleephygiene has exclusive control of fade-in

2. **isMasterAsleep=true**: Changed from `action: off` → `action: skip`
   - Lighting plugin no longer interferes with sleep state lighting
   - Sleephygiene manages bedroom lights during sleep

3. **Reordered conditions**: Sleep state checks now come before home/awake checks
   - Prevents race conditions between plugins

4. **Updated comments**: Documents 2026-02-24 incident and clarifies separation of concerns

## Timeline of Original Issue

- **8:01:55 AM** - Alarm triggered, wake sequence started
- **8:01:57 AM** - Lighting plugin activated Primary Suite morning scene (❌ wrong)
- **8:06:57 AM** - Sleephygiene started fade-in, reset lights to 1% (conflict!)
- **User observed**: Lights went high → dropped to low unexpectedly

## Expected Behavior After Fix

- **8:01:55 AM** - Wake sequence starts
- **8:06:57 AM** - Sleephygiene fades lights 1% → 100% over 25 minutes (no interference)
- **8:20:56 AM** - Wake sequence ends, lighting plugin resumes normal control

## Testing

- ✅ All unit tests pass (74.9% coverage)
- ✅ All integration tests pass
- ✅ Config loads without errors
- ✅ Pre-push validation passed

## Impact

Sleephygiene now has exclusive control over bedroom lighting during sleep and wake sequences. Lighting plugin only manages bedroom when master is fully awake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)