### PR TITLE
Fix #739: Correct reversed Sonos join parameters in addSpeakersToZone

### DIFF
--- a/homeautomation-go/internal/plugins/music/manager_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_test.go
@@ -3452,3 +3452,134 @@ func TestBuildSpeakerGroupAsync_WaitGroupCompletion(t *testing.T) {
 		t.Errorf("Expected 3 completed join calls after WaitGroup.Wait(), got %d", originalCalls)
 	}
 }
+
+// TestAddSpeakersToZone_JoinParameterOrder verifies that addSpeakersToZone sends the
+// media_player.join service call with correct parameter order:
+//   - entity_id = lead speaker (group coordinator)
+//   - group_members = [follower] (speaker joining the group)
+//
+// Regression test for issue #739: the parameters were previously reversed, causing
+// the follower to be set as entity_id and the lead as group_member. This made the
+// Sonos join fail or disrupt the existing group when speakers were dynamically added.
+func TestAddSpeakersToZone_JoinParameterOrder(t *testing.T) {
+	t.Parallel()
+	env := testutil.NewEnv(t)
+
+	config := &MusicConfig{
+		Music: map[string]MusicMode{
+			"winddown": {
+				Participants: []Participant{
+					{PlayerName: "Kitchen", BaseVolume: 10},
+					{PlayerName: "Primary Bathroom", BaseVolume: 6},
+				},
+				PlaybackOptions: []PlaybackOption{
+					{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0},
+				},
+			},
+		},
+	}
+
+	manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, false, nil, nil)
+	manager.SetSleepFunc(func(d time.Duration) {})
+
+	// Set state so shouldIncludeInZone passes (isMasterAsleep=false)
+	_ = env.StateMgr.SetBool("isMasterAsleep", false)
+
+	// Create an active zone with Kitchen as lead
+	zone := &Zone{
+		Name:        "winddown",
+		MusicType:   "winddown",
+		LeadSpeaker: "Kitchen",
+		Participants: []ParticipantWithVolume{
+			{PlayerName: "Kitchen", BaseVolume: 10, Volume: 10},
+		},
+	}
+
+	env.MockHA.ClearServiceCalls()
+
+	// Dynamically add Primary Bathroom to the active zone
+	manager.addSpeakersToZone(zone, []string{"Primary Bathroom"}, "test")
+
+	// Verify the join call has correct parameter order
+	calls := env.MockHA.GetServiceCalls()
+	var joinCalls []ha.ServiceCall
+	for _, call := range calls {
+		if call.Domain == "media_player" && call.Service == "join" {
+			joinCalls = append(joinCalls, call)
+		}
+	}
+	require.NotEmpty(t, joinCalls, "Expected at least one media_player.join call")
+
+	joinCall := joinCalls[0]
+	// entity_id must be the LEAD speaker (group coordinator)
+	entityID, ok := joinCall.Data["entity_id"].(string)
+	require.True(t, ok, "entity_id should be a string")
+	assert.Equal(t, "media_player.kitchen", entityID,
+		"entity_id must be the lead speaker (group coordinator), not the follower")
+
+	// group_members must contain the FOLLOWER (speaker joining the group)
+	groupMembers, ok := joinCall.Data["group_members"].([]string)
+	require.True(t, ok, "group_members should be a []string")
+	assert.Contains(t, groupMembers, "media_player.primary_bathroom",
+		"group_members must contain the follower speaker, not the lead")
+}
+
+// TestAddSpeakersToZone_ExcludeIfRespected verifies that addSpeakersToZone
+// checks exclude_if conditions before joining a speaker to the Sonos group.
+// This is defense-in-depth: assignSpeakersToZones already filters, but
+// addSpeakersToZone should also validate to prevent bugs in callers.
+func TestAddSpeakersToZone_ExcludeIfRespected(t *testing.T) {
+	t.Parallel()
+	env := testutil.NewEnv(t)
+
+	config := &MusicConfig{
+		Music: map[string]MusicMode{
+			"winddown": {
+				Participants: []Participant{
+					{PlayerName: "Kitchen", BaseVolume: 10},
+					{
+						PlayerName: "Primary Bathroom",
+						BaseVolume: 6,
+						ExcludeIf: []MuteCondition{
+							{Variable: "isMasterAsleep", Value: true},
+						},
+					},
+				},
+				PlaybackOptions: []PlaybackOption{
+					{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0},
+				},
+			},
+		},
+	}
+
+	manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, false, nil, nil)
+	manager.SetSleepFunc(func(d time.Duration) {})
+
+	// Set isMasterAsleep=true so Primary Bathroom should be excluded
+	_ = env.StateMgr.SetBool("isMasterAsleep", true)
+
+	zone := &Zone{
+		Name:        "winddown",
+		MusicType:   "winddown",
+		LeadSpeaker: "Kitchen",
+		Participants: []ParticipantWithVolume{
+			{PlayerName: "Kitchen", BaseVolume: 10, Volume: 10},
+		},
+	}
+
+	env.MockHA.ClearServiceCalls()
+
+	// Try to add Primary Bathroom — should be excluded by exclude_if
+	manager.addSpeakersToZone(zone, []string{"Primary Bathroom"}, "test")
+
+	// No join call should be made for the excluded speaker
+	calls := env.MockHA.GetServiceCalls()
+	joinCallCount := 0
+	for _, call := range calls {
+		if call.Domain == "media_player" && call.Service == "join" {
+			joinCallCount++
+		}
+	}
+	assert.Equal(t, 0, joinCallCount,
+		"No join call should be made when speaker is excluded by exclude_if condition")
+}

--- a/homeautomation-go/internal/plugins/music/zones.go
+++ b/homeautomation-go/internal/plugins/music/zones.go
@@ -105,9 +105,19 @@ func (m *Manager) addSpeakersToZone(zone *Zone, speakers []string, trigger strin
 		speakerSet[s] = true
 	}
 
+	leadEntityID := m.getSpeakerEntityID(zone.LeadSpeaker)
+
 	// Find participants to add
 	for _, p := range mode.Participants {
 		if !speakerSet[p.PlayerName] {
+			continue
+		}
+
+		// Check exclude_if conditions (consistent with assignSpeakersToZones)
+		if !m.shouldIncludeInZone(p) {
+			m.logger.Debug("Speaker excluded from zone during dynamic add",
+				zap.String("speaker", p.PlayerName),
+				zap.String("zone", zone.Name))
 			continue
 		}
 
@@ -119,10 +129,10 @@ func (m *Manager) addSpeakersToZone(zone *Zone, speakers []string, trigger strin
 		}
 
 		// Join the zone's Sonos group
-		leadEntityID := m.getSpeakerEntityID(zone.LeadSpeaker)
+		// entity_id = lead (group coordinator), group_members = speakers joining
 		if err := m.callServiceWithRetry("media_player", "join", map[string]interface{}{
-			"entity_id":     entityID,
-			"group_members": []string{leadEntityID},
+			"entity_id":     leadEntityID,
+			"group_members": []string{entityID},
 		}); err != nil {
 			m.logger.Error("Failed to join speaker to zone",
 				zap.String("speaker", p.PlayerName),


### PR DESCRIPTION
Resolves #739

## Summary

- **Root cause**: `addSpeakersToZone()` in `zones.go` had `entity_id` and `group_members` parameters **reversed** in the `media_player.join` service call. Every other join call in the codebase (`buildSpeakerGroup`, `joinSpeakerWithRetry`) correctly uses `entity_id=lead, group_members=[follower]`, but `addSpeakersToZone` had them swapped. This caused the Sonos join to fail or disrupt the existing speaker group when speakers were dynamically added to an active zone (e.g., when a state change makes a previously-excluded speaker eligible).

- **Fix**: Corrected the parameter order to match all other join calls: `entity_id` = lead speaker (group coordinator), `group_members` = [follower speakers joining the group]

- **Defense-in-depth**: Added `exclude_if` condition check in `addSpeakersToZone`, consistent with the checks in `assignSpeakersToZones` and `orchestratePlayback`. This prevents speakers from being dynamically added when their exclusion conditions are met.

## Changes

| File | Change |
|------|--------|
| `zones.go` | Fix reversed `entity_id`/`group_members` in join call; add `exclude_if` check; move `leadEntityID` outside loop |
| `manager_test.go` | Add `TestAddSpeakersToZone_JoinParameterOrder` — verifies correct join parameter order |
| `manager_test.go` | Add `TestAddSpeakersToZone_ExcludeIfRespected` — verifies exclude_if prevents dynamic speaker addition |
| `manager_test.go` | (From PR #740) `TestProductionConfig_PrimaryBathroomFollowsBedroom` — validates config invariant |
| `manager_test.go` | (From PR #740) `TestProductionConfig_WinddownZoneAssignment` — validates zone assignment logic |

## Test plan
- [x] `TestAddSpeakersToZone_JoinParameterOrder` passes — verifies entity_id=lead, group_members=[follower]
- [x] `TestAddSpeakersToZone_ExcludeIfRespected` passes — verifies excluded speakers are not joined
- [x] `TestProductionConfig_PrimaryBathroomFollowsBedroom` passes — config invariant holds
- [x] `TestProductionConfig_WinddownZoneAssignment` passes — zone assignment correct
- [x] Full unit test suite passes (75.1% coverage)
- [x] Full integration test suite passes (all 11 tests)
- [x] Pre-commit checks pass (formatting, linting, build)
- [x] Pre-push validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)