### PR TITLE
Fix #746: Use active PlaybackOption's VolumeMultiplier for dynamically-added speakers

### DIFF
--- a/homeautomation-go/internal/plugins/music/zone_manager.go
+++ b/homeautomation-go/internal/plugins/music/zone_manager.go
@@ -15,14 +15,15 @@ import (
 
 // Zone represents an active music zone with its own Sonos group
 type Zone struct {
-	Name         string
-	MusicType    string
-	Priority     int
-	LeadSpeaker  string
-	Participants []ParticipantWithVolume
-	PlaylistURI  string
-	MediaType    string
-	StartedAt    time.Time
+	Name             string
+	MusicType        string
+	Priority         int
+	LeadSpeaker      string
+	Participants     []ParticipantWithVolume
+	PlaylistURI      string
+	MediaType        string
+	VolumeMultiplier float64 // from active PlaybackOption; used when speakers are added dynamically
+	StartedAt        time.Time
 
 	// Playback monitoring (managed by Manager)
 	monitorCancel context.CancelFunc
@@ -868,14 +869,15 @@ func (zm *ZoneManager) startZone(zoneName string, speakers []string, trigger str
 
 	// Create zone struct
 	zone := &Zone{
-		Name:         zoneName,
-		MusicType:    zoneName,
-		Priority:     zoneConfig.Priority,
-		LeadSpeaker:  leadSpeaker,
-		Participants: participants,
-		PlaylistURI:  playbackOption.URI,
-		MediaType:    playbackOption.MediaType,
-		StartedAt:    time.Now(),
+		Name:             zoneName,
+		MusicType:        zoneName,
+		Priority:         zoneConfig.Priority,
+		LeadSpeaker:      leadSpeaker,
+		Participants:     participants,
+		PlaylistURI:      playbackOption.URI,
+		MediaType:        playbackOption.MediaType,
+		VolumeMultiplier: playbackOption.VolumeMultiplier,
+		StartedAt:        time.Now(),
 	}
 
 	// Store zone state
@@ -1023,7 +1025,7 @@ func (zm *ZoneManager) updateZoneSpeakers(zoneName string, newSpeakers []string,
 		for _, s := range speakersToAdd {
 			for _, p := range mode.Participants {
 				if p.PlayerName == s {
-					volume := zm.manager.calculateVolume(p.BaseVolume, 1.0)
+					volume := zm.manager.calculateVolume(p.BaseVolume, zone.VolumeMultiplier)
 					updatedParticipants = append(updatedParticipants, ParticipantWithVolume{
 						PlayerName:    p.PlayerName,
 						BaseVolume:    p.BaseVolume,

--- a/homeautomation-go/internal/plugins/music/zone_manager_test.go
+++ b/homeautomation-go/internal/plugins/music/zone_manager_test.go
@@ -1123,3 +1123,87 @@ func TestUpdateZoneSpeakers_UpdatesParticipants(t *testing.T) {
 	assert.False(t, hasBedroom, "Bedroom should be removed from speakerZone")
 	zm.mu.RUnlock()
 }
+
+// TestUpdateZoneSpeakers_UsesZoneVolumeMultiplier verifies that dynamically-added
+// speakers inherit the zone's VolumeMultiplier from the active PlaybackOption,
+// rather than using a hardcoded 1.0 multiplier. (Issue #746)
+func TestUpdateZoneSpeakers_UsesZoneVolumeMultiplier(t *testing.T) {
+	t.Parallel()
+
+	logger := zap.NewNop()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+
+	// Use a config with a non-1.0 VolumeMultiplier to expose the bug
+	config := &MusicConfig{
+		Zones: []ZoneConfig{
+			{
+				Name:     "sleep",
+				Priority: 100,
+				Triggers: []TriggerCondition{
+					{Variable: "isAnyoneAsleep", Value: true},
+					{Variable: "isAnyoneHome", Value: true},
+				},
+			},
+		},
+		Music: map[string]MusicMode{
+			"sleep": {
+				Participants: []Participant{
+					{PlayerName: "Bedroom", BaseVolume: 10},
+					{PlayerName: "Kitchen", BaseVolume: 20},
+				},
+				PlaybackOptions: []PlaybackOption{
+					{URI: "http://rain.example/1.m4a", MediaType: "music", VolumeMultiplier: 0.5},
+				},
+			},
+		},
+	}
+
+	mgr := NewManager(context.Background(), mockClient, stateManager, config, logger, true, nil, nil)
+	zm := NewZoneManager(mgr, config, logger)
+
+	// Set up state
+	require.NoError(t, stateManager.SetBool("isAnyoneHome", true))
+	require.NoError(t, stateManager.SetBool("isAnyoneAsleep", true))
+
+	// Simulate an active sleep zone with only Bedroom, using VolumeMultiplier=0.5
+	// BaseVolume=10 * 0.5 = volume 5
+	zm.mu.Lock()
+	zm.activeZones["sleep"] = &Zone{
+		Name:             "sleep",
+		MusicType:        "sleep",
+		Priority:         100,
+		LeadSpeaker:      "Bedroom",
+		VolumeMultiplier: 0.5,
+		Participants: []ParticipantWithVolume{
+			{PlayerName: "Bedroom", BaseVolume: 10, Volume: 5, DefaultVolume: 5},
+		},
+		StartedAt: time.Now(),
+	}
+	zm.speakerZone["Bedroom"] = "sleep"
+	zm.mu.Unlock()
+
+	// Dynamically add Kitchen speaker to the zone
+	err := zm.updateZoneSpeakers("sleep", []string{"Bedroom", "Kitchen"}, "test-dynamic-add")
+	assert.NoError(t, err)
+
+	// Verify the dynamically-added Kitchen speaker uses VolumeMultiplier=0.5
+	// Kitchen BaseVolume=20, expected volume = 20 * 0.5 = 10 (not 20 from 1.0 multiplier)
+	zm.mu.RLock()
+	zone := zm.activeZones["sleep"]
+	require.Len(t, zone.Participants, 2)
+
+	var kitchenParticipant *ParticipantWithVolume
+	for i, p := range zone.Participants {
+		if p.PlayerName == "Kitchen" {
+			kitchenParticipant = &zone.Participants[i]
+			break
+		}
+	}
+	require.NotNil(t, kitchenParticipant, "Kitchen should be in zone participants")
+	assert.Equal(t, 10, kitchenParticipant.Volume,
+		"Dynamically-added speaker should use zone's VolumeMultiplier (0.5), not hardcoded 1.0")
+	assert.Equal(t, 10, kitchenParticipant.DefaultVolume,
+		"DefaultVolume should also use zone's VolumeMultiplier")
+	zm.mu.RUnlock()
+}

--- a/homeautomation-go/internal/plugins/music/zones.go
+++ b/homeautomation-go/internal/plugins/music/zones.go
@@ -141,8 +141,8 @@ func (m *Manager) addSpeakersToZone(zone *Zone, speakers []string, trigger strin
 			continue
 		}
 
-		// Calculate and set volume
-		volume := m.calculateVolume(p.BaseVolume, 1.0) // Use default multiplier
+		// Calculate and set volume using the zone's active playback option multiplier
+		volume := m.calculateVolume(p.BaseVolume, zone.VolumeMultiplier)
 
 		// Create ParticipantWithVolume to check mute conditions
 		participant := ParticipantWithVolume{


### PR DESCRIPTION
Resolves #746

## Summary
- Added `VolumeMultiplier` field to the `Zone` struct to store the active `PlaybackOption`'s multiplier at zone creation time
- Updated `addSpeakersToZone()` (zones.go) to use `zone.VolumeMultiplier` instead of hardcoded `1.0`
- Updated `updateZoneSpeakers()` (zone_manager.go) to use `zone.VolumeMultiplier` instead of hardcoded `1.0`
- Added test `TestUpdateZoneSpeakers_UsesZoneVolumeMultiplier` that verifies dynamically-added speakers inherit the correct volume multiplier (uses `VolumeMultiplier: 0.5` to catch the previous bug)

## Test Plan
- [x] New unit test verifies Kitchen speaker (BaseVolume=20) added dynamically to a zone with VolumeMultiplier=0.5 gets volume=10 (not 20)
- [x] All existing unit tests pass (75.4% coverage)
- [x] All integration tests pass
- [x] Pre-commit and pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)