### PR TITLE
Fix #748: Bump evening base volumes for Bedroom and Primary Bathroom

### DIFF
--- a/configs/music_config.yaml
+++ b/configs/music_config.yaml
@@ -232,7 +232,7 @@ music:
           - variable: isTVPlaying
             value: true
       - player_name: "Bedroom"
-        base_volume: 6
+        base_volume: 8
         exclude_if:
           - variable: isMasterAsleep
             value: true
@@ -245,7 +245,7 @@ music:
         base_volume: 8
         leave_muted_if: []
       - player_name: "Primary Bathroom"
-        base_volume: 6
+        base_volume: 8
         exclude_if:
           - variable: isMasterAsleep
             value: true


### PR DESCRIPTION
Resolves #748

## Summary
- Bumped Bedroom evening `base_volume` from 6 to 8
- Bumped Primary Bathroom evening `base_volume` from 6 to 8
- Aligns these speakers with the rest of the evening participants (Kitchen 9, Kids Bathroom 8, Sitting Room 8, Front Room 8)

## Test Plan
- [x] Unit tests pass (`make unit-tests`)
- [x] Integration tests pass (`make integration-tests`)
- [x] Config validation passes (yamllint)
- [ ] Verify evening music volume is perceptibly louder in Bedroom and Primary Bathroom

🤖 Generated with [Claude Code](https://claude.com/claude-code)