### PR TITLE
Fix #755: Wakeup zone cleanup should not kill unrelated active zones

### DIFF
--- a/homeautomation-go/internal/plugins/music/manager.go
+++ b/homeautomation-go/internal/plugins/music/manager.go
@@ -273,7 +273,12 @@ func (m *Manager) Stop() {
 // handleMusicPlaybackTypeChange is called when musicPlaybackType changes.
 // The zone manager orchestrates playback directly via orchestrateZonePlayback
 // when zones start. musicPlaybackType is set by startZone for fade-in safety
-// check consistency; this handler only handles the stop case (empty string).
+// check consistency.
+//
+// When musicPlaybackType is cleared to "", this triggers zone resolution to
+// re-evaluate which zones should be active. Auto-triggered zones (morning,
+// evening) continue playing; manually-triggered zones (wakeup, sex) stop
+// because their musicPlaybackType fallback no longer matches.
 //
 // For manually-triggered zones (sex, wakeup) that are activated by setting
 // musicPlaybackType directly, this handler triggers zone resolution so the
@@ -289,13 +294,25 @@ func (m *Manager) handleMusicPlaybackTypeChange(key string, oldValue, newValue i
 		return
 	}
 
-	// If empty string, stop playback and all zones
+	// If empty string, re-evaluate zones rather than stopping everything.
+	// This ensures auto-triggered zones (morning, evening, etc.) continue playing
+	// while manually-triggered zones (wakeup, sex) stop because their
+	// musicPlaybackType fallback no longer matches (zone_manager.go getActiveZoneConfigs).
+	//
+	// Fix for issue #755: Previously this called StopAllZones which killed all zones
+	// including the morning zone that was already playing. The morning zone then had
+	// to restart from scratch (regroup speakers, fade in over ~6 minutes).
 	if newType == "" {
-		m.logger.Info("Stopping music playback")
-		if m.zoneManager != nil {
-			m.zoneManager.StopAllZones("musicPlaybackType cleared")
+		m.logger.Info("musicPlaybackType cleared, resolving zones to stop manually-triggered zones")
+		if m.zoneManager != nil && !m.zoneManager.IsResolving() {
+			if err := m.zoneManager.ResolveZones("musicPlaybackType cleared"); err != nil {
+				m.logger.Error("Failed to resolve zones after musicPlaybackType cleared",
+					zap.Error(err))
+			}
+		} else if m.zoneManager == nil {
+			// Fallback when zone manager is not initialized (startup, tests)
+			m.stopPlayback()
 		}
-		m.stopPlayback()
 		return
 	}
 

--- a/homeautomation-go/internal/plugins/music/zone_manager.go
+++ b/homeautomation-go/internal/plugins/music/zone_manager.go
@@ -771,6 +771,39 @@ func (zm *ZoneManager) ResolveZonesWithContext(eventCtx *state.EventContext, tri
 		}
 	}
 
+	// If zones were stopped but other zones remain active and musicPlaybackType
+	// is stale (empty or refers to a stopped zone), update it to the highest-priority
+	// remaining zone. This handles the case where musicPlaybackType was cleared
+	// (e.g., wakeup → "") but auto-triggered zones (morning) continue playing.
+	// Without this, musicPlaybackType would stay "" even though music is still active.
+	if len(zonesToStop) > 0 {
+		currentType, _ := zm.manager.stateManager.GetString("musicPlaybackType")
+		zm.mu.RLock()
+		_, stoppedZoneStillTracked := zm.activeZones[currentType]
+		remainingCount := len(zm.activeZones)
+		// Find highest-priority remaining zone
+		var highestPriorityZone string
+		var highestPriority int
+		for name, zone := range zm.activeZones {
+			if zone.Priority > highestPriority {
+				highestPriority = zone.Priority
+				highestPriorityZone = name
+			}
+		}
+		zm.mu.RUnlock()
+
+		if remainingCount > 0 && (currentType == "" || (!stoppedZoneStillTracked && currentType != highestPriorityZone)) {
+			zm.logger.Info("Updating musicPlaybackType to reflect remaining active zone",
+				zap.String("old_type", currentType),
+				zap.String("new_type", highestPriorityZone),
+				zap.String("trigger", trigger))
+			if err := zm.manager.setMusicPlaybackType(highestPriorityZone); err != nil {
+				zm.logger.Warn("Failed to update musicPlaybackType for remaining zone",
+					zap.Error(err))
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/homeautomation-go/test/integration/scenario_wakeup_zone_resolution_test.go
+++ b/homeautomation-go/test/integration/scenario_wakeup_zone_resolution_test.go
@@ -362,6 +362,130 @@ func TestScenario_WakeUp_StopsWhenWakeSequenceEnds(t *testing.T) {
 	t.Log("SUCCESS: Wakeup zone stopped and musicPlaybackType cleared when wake sequence ended")
 }
 
+// ============================================================================
+// Test: Clearing musicPlaybackType does not stop auto-triggered zones
+// ============================================================================
+
+// TestScenario_WakeUp_ClearingPlaybackTypeDoesNotStopMorningZone validates that
+// when sleephygiene clears musicPlaybackType to "" (wake sequence ending), the
+// morning zone continues playing without being stopped and restarted.
+//
+// User story: "When I say 'good morning' to Siri after my alarm goes off,
+// the whole-house morning music should keep playing seamlessly. It should NOT
+// cut out for 6 minutes while speakers regroup."
+//
+// PRODUCTION BUG (2026-03-02, Issue #755):
+// When the wake sequence ended (isMasterAsleep → false), sleephygiene cleared
+// musicPlaybackType to "". The music plugin's handleMusicPlaybackTypeChange
+// interpreted "" as "stop everything" (StopAllZones), killing the morning zone
+// that was already playing on whole-house speakers. The morning zone then had
+// to restart from scratch: break all speaker groups, re-group, and fade in
+// over ~6 minutes.
+//
+// INVARIANTS:
+// - Clearing musicPlaybackType must NOT stop auto-triggered zones (morning, evening, etc.)
+// - Only manually-triggered zones (wakeup, sex) should stop when their musicPlaybackType is cleared
+// - Morning zone must continue uninterrupted through the wakeup → morning transition
+func TestScenario_WakeUp_ClearingPlaybackTypeDoesNotStopMorningZone(t *testing.T) {
+	t.Parallel()
+	env, cleanup := setupWakeupZoneResolutionTest(t)
+	defer cleanup()
+
+	// ===== GIVEN: Morning phase, wake sequence active, both wakeup and morning zones playing
+	t.Log("GIVEN: Morning phase, wake sequence active, wakeup music on bedroom, morning music on whole-house speakers")
+
+	// Set up the wake sequence state (morning zone + wakeup zone should both be active)
+	env.server.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
+	env.server.SetState("input_text.day_phase", "morning", map[string]interface{}{})
+	env.server.SetState("input_boolean.master_asleep", "on", map[string]interface{}{})
+	env.server.SetState("input_boolean.anyone_asleep", "on", map[string]interface{}{})
+	env.server.SetState("input_boolean.wake_sequence_active", "on", map[string]interface{}{})
+
+	// Wait for initial zone resolution
+	waitForProcessing(t, env.stateManager)
+	time.Sleep(100 * time.Millisecond)
+
+	// Set musicPlaybackType="wakeup" to activate wakeup zone (simulates T+30)
+	env.server.SetState("input_text.music_playback_type", "wakeup", map[string]interface{}{})
+
+	waitForProcessing(t, env.stateManager)
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify both zones are active
+	activeZones := env.music.GetActiveZones()
+	zoneNames := getZoneNames(activeZones)
+	require.Contains(t, zoneNames, "wakeup", "Expected wakeup zone to be active, got: %v", zoneNames)
+	require.Contains(t, zoneNames, "morning", "Expected morning zone to be active, got: %v", zoneNames)
+
+	// Clear service calls from setup — we only care about calls after the transition
+	env.server.ClearServiceCalls()
+
+	// ===== WHEN: User wakes up (isMasterAsleep → false), triggering sleephygiene
+	// to clear isWakeSequenceActive and musicPlaybackType
+	t.Log("WHEN: isMasterAsleep → false (sleephygiene clears isWakeSequenceActive and musicPlaybackType)")
+
+	// Simulate the production flow: only isMasterAsleep changes externally.
+	// Sleephygiene's handleMasterAsleepChange will:
+	//   1. Set isWakeSequenceActive=false
+	//   2. Clear musicPlaybackType="" (because it was "wakeup")
+	// We also set isAnyoneAsleep=false since state tracking would update this.
+	env.server.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
+	env.server.SetState("input_boolean.master_asleep", "off", map[string]interface{}{})
+
+	// Wait for all handlers to process
+	waitForProcessing(t, env.stateManager)
+	time.Sleep(300 * time.Millisecond)
+
+	// ===== THEN: Morning zone should still be active (never stopped), wakeup zone stopped
+	t.Log("THEN: Morning zone continues uninterrupted, wakeup zone stops")
+
+	activeZones = env.music.GetActiveZones()
+	zoneNames = getZoneNames(activeZones)
+
+	assert.NotContains(t, zoneNames, "wakeup",
+		"Wakeup zone should have stopped after musicPlaybackType was cleared")
+	assert.Contains(t, zoneNames, "morning",
+		"Morning zone should still be active — clearing musicPlaybackType must not stop auto-triggered zones")
+
+	// CRITICAL: Verify no StopAllZones behavior occurred.
+	// If StopAllZones fired, morning zone speakers (Kitchen, Sitting Room) would have
+	// been faded out (volume_set to 0) before being restarted. Check that morning
+	// zone speakers were NOT set to volume 0.
+	calls := env.server.GetServiceCalls()
+	morningZoneSpeakers := map[string]bool{
+		"media_player.kitchen":      true,
+		"media_player.sitting_room": true,
+	}
+	for _, call := range calls {
+		if call.Domain == "media_player" && call.Service == "volume_set" {
+			entityID, _ := call.ServiceData["entity_id"].(string)
+			volumeLevel, _ := call.ServiceData["volume_level"].(float64)
+			if morningZoneSpeakers[entityID] && volumeLevel == 0 {
+				t.Errorf("Morning zone speaker %s was set to volume 0 — StopAllZones killed it (issue #755)", entityID)
+			}
+		}
+	}
+
+	// Verify musicPlaybackType transitioned to "morning" (set by morning zone)
+	musicType, err := env.stateManager.GetString("musicPlaybackType")
+	require.NoError(t, err)
+	assert.Equal(t, "morning", musicType,
+		"musicPlaybackType should be 'morning' after transition")
+
+	t.Logf("Active zones after transition: %v", zoneNames)
+	t.Logf("Total service calls: %d", len(calls))
+	for i, call := range calls {
+		if i >= 15 {
+			t.Logf("  ... and %d more calls", len(calls)-15)
+			break
+		}
+		t.Logf("  Call %d: %s.%s entity=%v vol=%v", i, call.Domain, call.Service,
+			call.ServiceData["entity_id"], call.ServiceData["volume_level"])
+	}
+
+	t.Log("SUCCESS: Morning zone continued uninterrupted through wakeup zone cleanup (issue #755 fixed)")
+}
+
 // getZoneNames is a helper to extract zone names from a slice of zones
 func getZoneNames(zones []*music.Zone) []string {
 	names := make([]string, len(zones))


### PR DESCRIPTION
Resolves #755

## Summary
- Changed the music plugin's `handleMusicPlaybackTypeChange` to call `ResolveZones()` instead of `StopAllZones()` when `musicPlaybackType` is cleared to `""`
- This re-evaluates zone triggers rather than blindly stopping everything, so auto-triggered zones (morning, evening, etc.) continue playing while manually-triggered zones (wakeup, sex) stop naturally because their musicPlaybackType fallback no longer matches
- Added logic in `ResolveZonesWithContext` to sync `musicPlaybackType` to the highest-priority remaining zone when zones are stopped but others continue

## What was happening
1. Wake sequence ended → sleephygiene cleared `musicPlaybackType` to `""`
2. Music plugin's handler called `StopAllZones`, killing the morning zone too
3. Morning zone restarted from scratch: 6 minutes of speaker regrouping and fade-in

## What happens now
1. Wake sequence ended → sleephygiene clears `musicPlaybackType` to `""`
2. Music plugin's handler calls `ResolveZones` instead
3. Zone resolution: wakeup zone stops (no triggers, no fallback match), morning zone continues (triggers still match)
4. `musicPlaybackType` updated to `"morning"` to reflect the active zone

## Test Plan
- [x] Added `TestScenario_WakeUp_ClearingPlaybackTypeDoesNotStopMorningZone` integration test (TDD: written before fix, verified it fails, then passes)
- [x] Existing `TestScenario_WakeUp_StopsWhenWakeSequenceEnds` still passes
- [x] Existing `TestScenario_WakeUp_DebouncesRapidTriggers` still passes
- [x] All unit tests pass (75% coverage)
- [x] All integration tests pass
- [x] Pre-push hook validation passes (yamllint, diagrams, unit tests, integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)