### PR TITLE
Fix #756: Add outdoor humidity comparison for unconditioned space alerts

### DIFF
--- a/docs/human/VISUAL_ARCHITECTURE.md
+++ b/docs/human/VISUAL_ARCHITECTURE.md
@@ -959,6 +959,7 @@ graph LR
 
     subgraph "HA Entities (Sensors)"
         HumiditySensors[sensor.*_humidity]
+        WeatherStationHumidity[sensor.weather_station_humidity]
         WaterLeakSensors[binary_sensor.*water_leak*]
         BatteryStateSensors[sensor.*_battery]
         NodeStatusSensors[sensor.*_node_status]
@@ -1050,6 +1051,7 @@ graph LR
     AnyoneHome --> ChristmasPlugin
 
     HumiditySensors --> EnvironmentalPlugin
+    WeatherStationHumidity -->|Outdoor Reference| EnvironmentalPlugin
     WaterLeakSensors --> EnvironmentalPlugin
     EnvironmentalPlugin -.->|Notifications| Ntfy[ntfy.sh]
 

--- a/homeautomation-go/internal/ha/labels.go
+++ b/homeautomation-go/internal/ha/labels.go
@@ -15,6 +15,13 @@ const (
 
 	// IndoorLabel is used to identify indoor devices for humidity alerting
 	IndoorLabel = "indoor"
+
+	// UnconditionedLabel identifies unconditioned spaces (barns, attics, sheds) for humidity alerting.
+	// These spaces naturally track outdoor humidity and use relaxed thresholds.
+	// Devices with this label are automatically treated as indoor (alertable) with:
+	// - Higher absolute thresholds (75% warning, 80% critical vs 55%/65% for conditioned)
+	// - Alert suppression when humidity tracks close to outdoor levels
+	UnconditionedLabel = "unconditioned"
 )
 
 // DeviceLabelChecker provides centralized device label checking functionality.

--- a/homeautomation-go/internal/plugins/environmental/manager.go
+++ b/homeautomation-go/internal/plugins/environmental/manager.go
@@ -19,14 +19,25 @@ import (
 
 // Humidity thresholds (RH percentage)
 const (
-	// Warning threshold - approaching mold risk
-	HumidityWarningThreshold = 55.0
-	// Critical threshold - definite mold risk
-	HumidityCriticalThreshold = 65.0
-	// Hysteresis: warning clears when humidity drops to this level
-	HumidityWarningClear = 50.0
-	// Hysteresis: critical clears when humidity drops to this level
-	HumidityCriticalClear = 60.0
+	// Conditioned space thresholds (living areas with HVAC)
+	HumidityWarningThreshold  = 55.0 // Warning - approaching mold risk
+	HumidityCriticalThreshold = 65.0 // Critical - definite mold risk
+	HumidityWarningClear      = 50.0 // Hysteresis: warning clears at this level
+	HumidityCriticalClear     = 60.0 // Hysteresis: critical clears at this level
+
+	// Unconditioned space thresholds (barns, attics, sheds)
+	// These spaces naturally track outdoor humidity, so thresholds are higher.
+	// Alert suppression also applies when tracking close to outdoor levels.
+	UnconditionedWarningThreshold  = 75.0 // Warning for unconditioned spaces
+	UnconditionedCriticalThreshold = 80.0 // Critical / absolute ceiling for unconditioned spaces
+	UnconditionedWarningClear      = 70.0 // Hysteresis: warning clears at this level
+	UnconditionedCriticalClear     = 75.0 // Hysteresis: critical clears at this level
+
+	// Outdoor humidity comparison
+	OutdoorHumidityEntityID = "sensor.weather_station_humidity"
+	// OutdoorHumidityMargin is the margin above outdoor humidity within which
+	// unconditioned spaces are considered to be simply tracking outdoor conditions.
+	OutdoorHumidityMargin = 5.0
 
 	// Debounce: condition must be sustained this long before alerting
 	SustainedConditionDuration = 30 * time.Minute
@@ -38,14 +49,15 @@ const (
 
 // HumiditySensor represents a discovered humidity sensor
 type HumiditySensor struct {
-	EntityID      string
-	DeviceID      string
-	FriendlyName  string
-	IsIndoor      bool // true = alerts enabled, false = informational only
-	Value         float64
-	Valid         bool
-	WarningStart  time.Time
-	CriticalStart time.Time
+	EntityID        string
+	DeviceID        string
+	FriendlyName    string
+	IsIndoor        bool // true = alerts enabled, false = informational only
+	IsUnconditioned bool // true = unconditioned space (barn, attic) with relaxed thresholds
+	Value           float64
+	Valid           bool
+	WarningStart    time.Time
+	CriticalStart   time.Time
 }
 
 // WaterLeakSensor represents a discovered water leak sensor
@@ -83,6 +95,10 @@ type Manager struct {
 
 	// Current alert level for humidity ("none", "warning", "critical")
 	currentAlertLevel string
+
+	// Outdoor reference humidity (from weather station) for comparison
+	outdoorHumidity      float64
+	outdoorHumidityValid bool
 
 	// Rate limiting for humidity
 	lastWarningNotification    time.Time
@@ -147,9 +163,13 @@ func (m *Manager) Start() error {
 	m.mu.Lock()
 	sensorCount := len(m.sensors)
 	indoorCount := 0
+	unconditionedCount := 0
 	for _, s := range m.sensors {
 		if s.IsIndoor {
 			indoorCount++
+		}
+		if s.IsUnconditioned {
+			unconditionedCount++
 		}
 	}
 	m.mu.Unlock()
@@ -160,6 +180,7 @@ func (m *Manager) Start() error {
 		m.logger.Info("Humidity sensors discovered",
 			zap.Int("total", sensorCount),
 			zap.Int("indoor_alertable", indoorCount),
+			zap.Int("unconditioned", unconditionedCount),
 			zap.Int("outdoor_informational", sensorCount-indoorCount))
 	}
 
@@ -245,13 +266,21 @@ func (m *Manager) discoverHumiditySensors() error {
 	labelChecker := ha.NewDeviceLabelChecker(devices)
 
 	indoorDevices := make(map[string]bool)
+	unconditionedDevices := make(map[string]bool)
 	for _, device := range devices {
 		if labelChecker.HasLabelIgnoreCase(device.ID, ha.IndoorLabel) {
 			indoorDevices[device.ID] = true
 		}
+		if labelChecker.HasLabelIgnoreCase(device.ID, ha.UnconditionedLabel) {
+			unconditionedDevices[device.ID] = true
+			// Unconditioned label implies indoor monitoring (with relaxed thresholds)
+			indoorDevices[device.ID] = true
+		}
 	}
 
-	m.logger.Info("Indoor devices discovered", zap.Int("count", len(indoorDevices)))
+	m.logger.Info("Indoor devices discovered",
+		zap.Int("count", len(indoorDevices)),
+		zap.Int("unconditioned", len(unconditionedDevices)))
 
 	// Create HumiditySensor structs and subscribe to each
 	m.mu.Lock()
@@ -265,11 +294,12 @@ func (m *Manager) discoverHumiditySensors() error {
 		}
 
 		sensor := &HumiditySensor{
-			EntityID:     state.EntityID,
-			DeviceID:     deviceID,
-			FriendlyName: friendlyName,
-			IsIndoor:     isIndoor,
-			Valid:        false,
+			EntityID:        state.EntityID,
+			DeviceID:        deviceID,
+			FriendlyName:    friendlyName,
+			IsIndoor:        isIndoor,
+			IsUnconditioned: unconditionedDevices[deviceID],
+			Valid:           false,
 		}
 
 		// Parse initial value
@@ -285,6 +315,7 @@ func (m *Manager) discoverHumiditySensors() error {
 			zap.String("friendly_name", friendlyName),
 			zap.String("device_id", deviceID),
 			zap.Bool("is_indoor", isIndoor),
+			zap.Bool("is_unconditioned", sensor.IsUnconditioned),
 			zap.Float64("current_value", sensor.Value))
 	}
 	m.mu.Unlock()
@@ -298,6 +329,20 @@ func (m *Manager) discoverHumiditySensors() error {
 			errs = append(errs, err)
 		}
 	}
+
+	// Initialize outdoor reference humidity from weather station sensor
+	m.mu.Lock()
+	if sensor, ok := m.sensors[OutdoorHumidityEntityID]; ok && sensor.Valid {
+		m.outdoorHumidity = sensor.Value
+		m.outdoorHumidityValid = true
+		m.logger.Info("Outdoor reference sensor found for humidity comparison",
+			zap.Float64("humidity", sensor.Value))
+	} else if _, ok := m.sensors[OutdoorHumidityEntityID]; ok {
+		m.logger.Info("Outdoor reference sensor found but value not yet available")
+	} else {
+		m.logger.Info("Outdoor reference sensor not found - unconditioned spaces will use absolute thresholds only")
+	}
+	m.mu.Unlock()
 
 	// Update shadow state with all discovered sensors
 	m.updateShadowSensors()
@@ -442,6 +487,10 @@ func (m *Manager) handleHumidityChange(entityID string, oldState, newState *ha.S
 		if sensor, ok := m.sensors[entityID]; ok {
 			sensor.Valid = false
 		}
+		if entityID == OutdoorHumidityEntityID {
+			m.outdoorHumidityValid = false
+			m.shadowTracker.UpdateOutdoorHumidity(0, false)
+		}
 		m.mu.Unlock()
 		return
 	}
@@ -456,6 +505,13 @@ func (m *Manager) handleHumidityChange(entityID string, oldState, newState *ha.S
 
 	sensor.Value = humidity
 	sensor.Valid = true
+
+	// Track outdoor reference humidity from weather station
+	isOutdoorRef := entityID == OutdoorHumidityEntityID
+	if isOutdoorRef {
+		m.outdoorHumidity = humidity
+		m.outdoorHumidityValid = true
+	}
 	m.mu.Unlock()
 
 	m.logger.Debug("Humidity sensor changed",
@@ -466,9 +522,13 @@ func (m *Manager) handleHumidityChange(entityID string, oldState, newState *ha.S
 
 	// Update shadow state
 	m.updateShadowSensors()
+	if isOutdoorRef {
+		m.shadowTracker.UpdateOutdoorHumidity(humidity, true)
+	}
 
-	// Only evaluate alerts for indoor sensors
-	if sensor.IsIndoor {
+	// Evaluate alerts for indoor sensors, or when outdoor reference changes
+	// (outdoor changes can affect suppression for unconditioned sensors)
+	if sensor.IsIndoor || isOutdoorRef {
 		m.evaluateHumidity()
 	}
 }
@@ -518,12 +578,13 @@ func (m *Manager) updateShadowSensors() {
 	sensorData := make([]shadowstate.HumiditySensorData, 0, len(m.sensors))
 	for _, sensor := range m.sensors {
 		sensorData = append(sensorData, shadowstate.HumiditySensorData{
-			EntityID:     sensor.EntityID,
-			FriendlyName: sensor.FriendlyName,
-			DeviceID:     sensor.DeviceID,
-			IsIndoor:     sensor.IsIndoor,
-			Value:        sensor.Value,
-			Valid:        sensor.Valid,
+			EntityID:        sensor.EntityID,
+			FriendlyName:    sensor.FriendlyName,
+			DeviceID:        sensor.DeviceID,
+			IsIndoor:        sensor.IsIndoor,
+			IsUnconditioned: sensor.IsUnconditioned,
+			Value:           sensor.Value,
+			Valid:           sensor.Valid,
 		})
 	}
 
@@ -637,8 +698,26 @@ func (m *Manager) evaluateHumidity() {
 			continue
 		}
 
-		isWarning := sensor.Value >= HumidityWarningThreshold
-		isCritical := sensor.Value >= HumidityCriticalThreshold
+		// Determine effective thresholds based on sensor type
+		warningThreshold := HumidityWarningThreshold
+		criticalThreshold := HumidityCriticalThreshold
+		if sensor.IsUnconditioned {
+			warningThreshold = UnconditionedWarningThreshold
+			criticalThreshold = UnconditionedCriticalThreshold
+		}
+
+		// Suppress unconditioned sensors that are simply tracking outdoor humidity.
+		// Suppression applies when:
+		// 1. Sensor is in an unconditioned space
+		// 2. Outdoor humidity reference is available
+		// 3. Indoor reading is within margin of outdoor reading
+		// 4. Indoor reading is below the absolute ceiling (80%)
+		suppressed := sensor.IsUnconditioned && m.outdoorHumidityValid &&
+			sensor.Value <= m.outdoorHumidity+OutdoorHumidityMargin &&
+			sensor.Value < UnconditionedCriticalThreshold
+
+		isWarning := !suppressed && sensor.Value >= warningThreshold
+		isCritical := !suppressed && sensor.Value >= criticalThreshold
 
 		// Warning tracking
 		if isWarning {
@@ -728,18 +807,32 @@ func (m *Manager) getConditionStartTime() time.Time {
 
 // checkConditionResolved checks if the alert condition has resolved with hysteresis
 func (m *Manager) checkConditionResolved(now time.Time) {
-	// Determine clear threshold based on current alert level
-	clearThreshold := HumidityWarningClear
-	if m.currentAlertLevel == "critical" {
-		clearThreshold = HumidityCriticalClear
-	}
-
 	// Check if ALL indoor sensors are below their clear thresholds
 	allCleared := true
 	for _, sensor := range m.sensors {
 		if !sensor.IsIndoor {
 			continue
 		}
+
+		// Suppressed unconditioned sensors (tracking outdoor humidity) are considered cleared
+		if sensor.IsUnconditioned && sensor.Valid && m.outdoorHumidityValid &&
+			sensor.Value <= m.outdoorHumidity+OutdoorHumidityMargin &&
+			sensor.Value < UnconditionedCriticalThreshold {
+			continue
+		}
+
+		// Determine per-sensor clear threshold
+		clearThreshold := HumidityWarningClear
+		if m.currentAlertLevel == "critical" {
+			clearThreshold = HumidityCriticalClear
+		}
+		if sensor.IsUnconditioned {
+			clearThreshold = UnconditionedWarningClear
+			if m.currentAlertLevel == "critical" {
+				clearThreshold = UnconditionedCriticalClear
+			}
+		}
+
 		// An alerted sensor going unavailable means we lost visibility, not that it cleared
 		if !sensor.Valid && m.alertedSensorNames[sensor.FriendlyName] {
 			allCleared = false
@@ -785,7 +878,12 @@ func (m *Manager) sendAlertNotification(now time.Time, level string) {
 		if !sensor.IsIndoor || !sensor.Valid {
 			continue
 		}
-		if sensor.Value >= HumidityWarningThreshold {
+		// Use per-sensor warning threshold to determine which sensors to include
+		threshold := HumidityWarningThreshold
+		if sensor.IsUnconditioned {
+			threshold = UnconditionedWarningThreshold
+		}
+		if sensor.Value >= threshold {
 			sensorLocations = append(sensorLocations, sensor.FriendlyName)
 			if sensor.Value > maxHumidity {
 				maxHumidity = sensor.Value
@@ -821,21 +919,26 @@ func (m *Manager) sendAlertNotification(now time.Time, level string) {
 		return
 	}
 
-	// Build notification message
+	// Build notification message with optional outdoor humidity context
 	var title, message string
 	var priority int
 	var tags []string
 
+	outdoorContext := ""
+	if m.outdoorHumidityValid {
+		outdoorContext = fmt.Sprintf(" Outdoor: %.0f%%.", m.outdoorHumidity)
+	}
+
 	if level == "critical" {
 		title = "High Humidity Critical"
-		message = fmt.Sprintf("Humidity at %.0f%% (%s) for 30+ minutes. Mold risk - take action!",
-			maxHumidity, formatSensorLocations(sensorLocations))
+		message = fmt.Sprintf("Humidity at %.0f%% (%s) for 30+ minutes.%s Mold risk - take action!",
+			maxHumidity, formatSensorLocations(sensorLocations), outdoorContext)
 		priority = ntfy.PriorityHigh
 		tags = []string{"rotating_light", "droplet"}
 	} else {
 		title = "High Humidity Warning"
-		message = fmt.Sprintf("Humidity at %.0f%% (%s) for 30+ minutes. Check ventilation.",
-			maxHumidity, formatSensorLocations(sensorLocations))
+		message = fmt.Sprintf("Humidity at %.0f%% (%s) for 30+ minutes.%s Check ventilation.",
+			maxHumidity, formatSensorLocations(sensorLocations), outdoorContext)
 		priority = ntfy.PriorityDefault
 		tags = []string{"warning", "droplet"}
 	}
@@ -990,6 +1093,8 @@ func (m *Manager) Reset() {
 		sensor.NotificationSent = false
 	}
 	m.currentAlertLevel = "none"
+	m.outdoorHumidity = 0
+	m.outdoorHumidityValid = false
 	m.lastWarningNotification = time.Time{}
 	m.lastCriticalNotification = time.Time{}
 	m.lastResolutionNotification = time.Time{}
@@ -1031,6 +1136,22 @@ func (m *Manager) SimulateSensorChange(entityID string, humidity float64) {
 		EntityID: entityID,
 		State:    fmt.Sprintf("%.1f", humidity),
 	})
+}
+
+// SetOutdoorHumidity sets the outdoor reference humidity for testing
+func (m *Manager) SetOutdoorHumidity(humidity float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.outdoorHumidity = humidity
+	m.outdoorHumidityValid = true
+}
+
+// ClearOutdoorHumidity clears the outdoor reference humidity for testing
+func (m *Manager) ClearOutdoorHumidity() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.outdoorHumidity = 0
+	m.outdoorHumidityValid = false
 }
 
 // SimulateSensorUnavailable simulates a sensor going unavailable (for testing)

--- a/homeautomation-go/internal/plugins/environmental/manager_test.go
+++ b/homeautomation-go/internal/plugins/environmental/manager_test.go
@@ -15,9 +15,11 @@ import (
 
 // Test sensor entity IDs
 const (
-	testIndoorSensor1  = "sensor.indoor_humidity_1"
-	testIndoorSensor2  = "sensor.indoor_humidity_2"
-	testOutdoorSensor1 = "sensor.outdoor_humidity_1"
+	testIndoorSensor1        = "sensor.indoor_humidity_1"
+	testIndoorSensor2        = "sensor.indoor_humidity_2"
+	testOutdoorSensor1       = "sensor.outdoor_humidity_1"
+	testUnconditionedSensor1 = "sensor.unconditioned_humidity_1"
+	testWeatherStation       = OutdoorHumidityEntityID // "sensor.weather_station_humidity"
 )
 
 // setupMockEnvironment creates a mock HA client with test devices and entity registry
@@ -1886,5 +1888,592 @@ func TestEnvironmentalManager_WaterLeak_RenotificationAfterClear(t *testing.T) {
 	notificationCount := countNtfyNotifications(mockNtfy)
 	if notificationCount != 2 {
 		t.Errorf("Expected 2 notifications (new leak after clearing), got %d", notificationCount)
+	}
+}
+
+// ============================================================================
+// Unconditioned Space / Outdoor Humidity Comparison Tests
+// ============================================================================
+
+func TestEnvironmentalManager_UnconditionedSensor_SuppressedByOutdoor(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := NewManagerWithClock(mockHA, stateMgr, logger, false, nil, mockNtfy, mockClock)
+
+	// Add unconditioned sensor (barn) and set outdoor humidity
+	manager.AddSensor(&HumiditySensor{
+		EntityID:        testUnconditionedSensor1,
+		FriendlyName:    "Barn Humidity",
+		IsIndoor:        true,
+		IsUnconditioned: true,
+		Valid:           true,
+	})
+	manager.SetOutdoorHumidity(70.0) // Outdoor at 70%
+
+	// Simulate barn at 61% (below outdoor 70% + 5% margin = 75%)
+	// This matches the issue scenario: barn at 61%, outdoor at ~70%
+	manager.SimulateSensorChange(testUnconditionedSensor1, 61.0)
+	mockClock.Advance(31 * time.Minute)
+	manager.SimulateSensorChange(testUnconditionedSensor1, 61.0)
+
+	// Should NOT trigger alert (suppressed - tracking outdoor humidity)
+	alertLevel := manager.GetCurrentState()
+	if alertLevel != "none" {
+		t.Errorf("Expected no alert for unconditioned sensor tracking outdoor humidity, got '%s'", alertLevel)
+	}
+
+	notificationCount := countNtfyNotifications(mockNtfy)
+	if notificationCount > 0 {
+		t.Errorf("Expected no notifications for suppressed unconditioned sensor, got %d", notificationCount)
+	}
+}
+
+func TestEnvironmentalManager_UnconditionedSensor_AtticSuppressedByOutdoor(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := NewManagerWithClock(mockHA, stateMgr, logger, false, nil, mockNtfy, mockClock)
+
+	// Add unconditioned sensor (attic) and set outdoor humidity
+	manager.AddSensor(&HumiditySensor{
+		EntityID:        testUnconditionedSensor1,
+		FriendlyName:    "Attic High Humidity",
+		IsIndoor:        true,
+		IsUnconditioned: true,
+		Valid:           true,
+	})
+	manager.SetOutdoorHumidity(69.6) // From the issue
+
+	// Simulate attic at 56% (well below outdoor)
+	manager.SimulateSensorChange(testUnconditionedSensor1, 56.0)
+	mockClock.Advance(31 * time.Minute)
+	manager.SimulateSensorChange(testUnconditionedSensor1, 56.0)
+
+	// Should NOT trigger alert (suppressed)
+	alertLevel := manager.GetCurrentState()
+	if alertLevel != "none" {
+		t.Errorf("Expected no alert for attic at 56%% with outdoor at 69.6%%, got '%s'", alertLevel)
+	}
+}
+
+func TestEnvironmentalManager_UnconditionedSensor_HigherThresholds(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := NewManagerWithClock(mockHA, stateMgr, logger, false, nil, mockNtfy, mockClock)
+
+	// Add unconditioned sensor with outdoor humidity available
+	manager.AddSensor(&HumiditySensor{
+		EntityID:        testUnconditionedSensor1,
+		FriendlyName:    "Barn Humidity",
+		IsIndoor:        true,
+		IsUnconditioned: true,
+		Valid:           true,
+	})
+	manager.SetOutdoorHumidity(50.0) // Outdoor is moderate
+
+	// Barn at 60% - above conditioned threshold (55%) but below unconditioned (75%)
+	// Also exceeds outdoor + margin (50+5=55), so not suppressed
+	manager.SimulateSensorChange(testUnconditionedSensor1, 60.0)
+	mockClock.Advance(31 * time.Minute)
+	manager.SimulateSensorChange(testUnconditionedSensor1, 60.0)
+
+	// Should NOT alert - below unconditioned warning threshold of 75%
+	alertLevel := manager.GetCurrentState()
+	if alertLevel != "none" {
+		t.Errorf("Expected no alert for unconditioned sensor at 60%% (below 75%% threshold), got '%s'", alertLevel)
+	}
+}
+
+func TestEnvironmentalManager_UnconditionedSensor_WarningAboveThreshold(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := NewManagerWithClock(mockHA, stateMgr, logger, false, nil, mockNtfy, mockClock)
+
+	// Add unconditioned sensor
+	manager.AddSensor(&HumiditySensor{
+		EntityID:        testUnconditionedSensor1,
+		FriendlyName:    "Barn Humidity",
+		IsIndoor:        true,
+		IsUnconditioned: true,
+		Valid:           true,
+	})
+	manager.SetOutdoorHumidity(50.0) // Outdoor moderate
+
+	// Barn at 78% - exceeds outdoor + margin AND above unconditioned warning (75%)
+	manager.SimulateSensorChange(testUnconditionedSensor1, 78.0)
+	mockClock.Advance(31 * time.Minute)
+	manager.SimulateSensorChange(testUnconditionedSensor1, 78.0)
+
+	// Should trigger warning
+	alertLevel := manager.GetCurrentState()
+	if alertLevel != "warning" {
+		t.Errorf("Expected 'warning' for unconditioned sensor at 78%%, got '%s'", alertLevel)
+	}
+
+	notificationCount := countNtfyNotifications(mockNtfy)
+	if notificationCount != 1 {
+		t.Errorf("Expected 1 notification, got %d", notificationCount)
+	}
+}
+
+func TestEnvironmentalManager_UnconditionedSensor_AbsoluteCeiling(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := NewManagerWithClock(mockHA, stateMgr, logger, false, nil, mockNtfy, mockClock)
+
+	// Add unconditioned sensor with HIGH outdoor humidity
+	manager.AddSensor(&HumiditySensor{
+		EntityID:        testUnconditionedSensor1,
+		FriendlyName:    "Barn Humidity",
+		IsIndoor:        true,
+		IsUnconditioned: true,
+		Valid:           true,
+	})
+	manager.SetOutdoorHumidity(85.0) // Very high outdoor
+
+	// Barn at 82% - below outdoor + margin (85+5=90), BUT >= absolute ceiling (80%)
+	// Should NOT be suppressed because 82% >= UnconditionedCriticalThreshold
+	manager.SimulateSensorChange(testUnconditionedSensor1, 82.0)
+	mockClock.Advance(31 * time.Minute)
+	manager.SimulateSensorChange(testUnconditionedSensor1, 82.0)
+
+	// Should trigger critical (absolute ceiling)
+	alertLevel := manager.GetCurrentState()
+	if alertLevel != "critical" {
+		t.Errorf("Expected 'critical' for unconditioned sensor at 82%% (absolute ceiling), got '%s'", alertLevel)
+	}
+
+	notification := getLastNtfyNotification(mockNtfy)
+	if notification == nil {
+		t.Fatal("Expected notification for absolute ceiling breach")
+	}
+	if notification.Title != "High Humidity Critical" {
+		t.Errorf("Expected critical notification, got '%s'", notification.Title)
+	}
+}
+
+func TestEnvironmentalManager_UnconditionedSensor_OutdoorUnavailable(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := NewManagerWithClock(mockHA, stateMgr, logger, false, nil, mockNtfy, mockClock)
+
+	// Add unconditioned sensor WITHOUT outdoor reference
+	manager.AddSensor(&HumiditySensor{
+		EntityID:        testUnconditionedSensor1,
+		FriendlyName:    "Barn Humidity",
+		IsIndoor:        true,
+		IsUnconditioned: true,
+		Valid:           true,
+	})
+	// Do NOT set outdoor humidity - simulates weather station unavailable
+
+	// Barn at 60% - above conditioned threshold (55%) but below unconditioned (75%)
+	manager.SimulateSensorChange(testUnconditionedSensor1, 60.0)
+	mockClock.Advance(31 * time.Minute)
+	manager.SimulateSensorChange(testUnconditionedSensor1, 60.0)
+
+	// Should NOT alert - uses unconditioned thresholds (75%) as fallback
+	alertLevel := manager.GetCurrentState()
+	if alertLevel != "none" {
+		t.Errorf("Expected no alert at 60%% with unconditioned thresholds (75%%), got '%s'", alertLevel)
+	}
+
+	// Now raise to 78% - above unconditioned warning threshold
+	manager.SimulateSensorChange(testUnconditionedSensor1, 78.0)
+	mockClock.Advance(31 * time.Minute)
+	manager.SimulateSensorChange(testUnconditionedSensor1, 78.0)
+
+	alertLevel = manager.GetCurrentState()
+	if alertLevel != "warning" {
+		t.Errorf("Expected 'warning' at 78%% with unconditioned thresholds, got '%s'", alertLevel)
+	}
+}
+
+func TestEnvironmentalManager_UnconditionedSensor_SuppressionAtExactMargin(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := NewManagerWithClock(mockHA, stateMgr, logger, false, nil, mockNtfy, mockClock)
+
+	manager.AddSensor(&HumiditySensor{
+		EntityID:        testUnconditionedSensor1,
+		FriendlyName:    "Barn Humidity",
+		IsIndoor:        true,
+		IsUnconditioned: true,
+		Valid:           true,
+	})
+	manager.SetOutdoorHumidity(70.0) // Outdoor at 70%
+
+	// At exactly outdoor + margin (70 + 5 = 75), should still be suppressed
+	manager.SimulateSensorChange(testUnconditionedSensor1, 75.0)
+	mockClock.Advance(31 * time.Minute)
+	manager.SimulateSensorChange(testUnconditionedSensor1, 75.0)
+
+	alertLevel := manager.GetCurrentState()
+	if alertLevel != "none" {
+		t.Errorf("Expected no alert at exact margin boundary (75%% with outdoor 70%%), got '%s'", alertLevel)
+	}
+
+	// Just above margin: 75.1% > 70 + 5 = 75, NOT suppressed, and >= 75 = warning
+	manager.Reset()
+	manager.SetOutdoorHumidity(70.0)
+	manager.SimulateSensorChange(testUnconditionedSensor1, 75.1)
+	mockClock.Advance(31 * time.Minute)
+	manager.SimulateSensorChange(testUnconditionedSensor1, 75.1)
+
+	alertLevel = manager.GetCurrentState()
+	if alertLevel != "warning" {
+		t.Errorf("Expected 'warning' just above margin (75.1%% with outdoor 70%%), got '%s'", alertLevel)
+	}
+}
+
+func TestEnvironmentalManager_MixedConditionedAndUnconditioned(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := NewManagerWithClock(mockHA, stateMgr, logger, false, nil, mockNtfy, mockClock)
+
+	// Add one conditioned (living room) and one unconditioned (barn)
+	manager.AddSensor(&HumiditySensor{
+		EntityID:     testIndoorSensor1,
+		FriendlyName: "Living Room Humidity",
+		IsIndoor:     true,
+		Valid:        true,
+	})
+	manager.AddSensor(&HumiditySensor{
+		EntityID:        testUnconditionedSensor1,
+		FriendlyName:    "Barn Humidity",
+		IsIndoor:        true,
+		IsUnconditioned: true,
+		Valid:           true,
+	})
+	manager.SetOutdoorHumidity(70.0)
+
+	// Barn at 61% (suppressed - tracking outdoor) + Living room at 58% (conditioned warning)
+	manager.SimulateSensorChange(testUnconditionedSensor1, 61.0)
+	manager.SimulateSensorChange(testIndoorSensor1, 58.0)
+	mockClock.Advance(31 * time.Minute)
+	manager.SimulateSensorChange(testIndoorSensor1, 58.0)
+
+	// Should trigger warning from the conditioned sensor only
+	alertLevel := manager.GetCurrentState()
+	if alertLevel != "warning" {
+		t.Errorf("Expected 'warning' from conditioned sensor, got '%s'", alertLevel)
+	}
+
+	// Notification should mention the living room, not the barn
+	notification := getLastNtfyNotification(mockNtfy)
+	if notification == nil {
+		t.Fatal("Expected notification")
+	}
+	if !strings.Contains(notification.Body, "Living Room") {
+		t.Errorf("Expected notification to mention Living Room, got: %s", notification.Body)
+	}
+	if strings.Contains(notification.Body, "Barn") {
+		t.Errorf("Expected notification NOT to mention suppressed Barn sensor, got: %s", notification.Body)
+	}
+}
+
+func TestEnvironmentalManager_OutdoorHumidityDropTriggersReEvaluation(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := NewManagerWithClock(mockHA, stateMgr, logger, false, nil, mockNtfy, mockClock)
+
+	// Add unconditioned sensor and weather station sensor
+	manager.AddSensor(&HumiditySensor{
+		EntityID:        testUnconditionedSensor1,
+		FriendlyName:    "Barn Humidity",
+		IsIndoor:        true,
+		IsUnconditioned: true,
+		Valid:           true,
+	})
+	manager.AddSensor(&HumiditySensor{
+		EntityID:     testWeatherStation,
+		FriendlyName: "Weather Station Humidity",
+		IsIndoor:     false,
+		Valid:        true,
+	})
+	manager.SetOutdoorHumidity(80.0)
+
+	// Barn at 78% - suppressed (78 <= 80+5)
+	manager.SimulateSensorChange(testUnconditionedSensor1, 78.0)
+	mockClock.Advance(31 * time.Minute)
+	manager.SimulateSensorChange(testUnconditionedSensor1, 78.0)
+
+	alertLevel := manager.GetCurrentState()
+	if alertLevel != "none" {
+		t.Errorf("Expected no alert while barn tracks outdoor humidity, got '%s'", alertLevel)
+	}
+
+	// Outdoor humidity drops significantly via weather station update
+	// 78 > 50 + 5 = 55, and 78 >= 75 → warning should start tracking
+	manager.SimulateSensorChange(testWeatherStation, 50.0)
+
+	// Need sustained duration - advance time and re-trigger
+	mockClock.Advance(31 * time.Minute)
+	manager.SimulateSensorChange(testUnconditionedSensor1, 78.0)
+
+	alertLevel = manager.GetCurrentState()
+	if alertLevel != "warning" {
+		t.Errorf("Expected 'warning' after outdoor humidity dropped and barn exceeds threshold, got '%s'", alertLevel)
+	}
+}
+
+func TestEnvironmentalManager_NotificationIncludesOutdoorHumidity(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := NewManagerWithClock(mockHA, stateMgr, logger, false, nil, mockNtfy, mockClock)
+
+	manager.AddSensor(&HumiditySensor{
+		EntityID:     testIndoorSensor1,
+		FriendlyName: "Indoor Humidity 1",
+		IsIndoor:     true,
+		Valid:        true,
+	})
+	manager.SetOutdoorHumidity(45.0)
+
+	// Trigger a sustained warning
+	manager.SimulateSensorChange(testIndoorSensor1, 58.0)
+	mockClock.Advance(31 * time.Minute)
+	manager.SimulateSensorChange(testIndoorSensor1, 58.0)
+
+	notification := getLastNtfyNotification(mockNtfy)
+	if notification == nil {
+		t.Fatal("Expected notification")
+	}
+	// Notification should include outdoor humidity context
+	if !strings.Contains(notification.Body, "Outdoor: 45%") {
+		t.Errorf("Expected notification to include outdoor humidity context, got: %s", notification.Body)
+	}
+}
+
+func TestEnvironmentalManager_ConditionedSensorUnchangedByOutdoor(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := NewManagerWithClock(mockHA, stateMgr, logger, false, nil, mockNtfy, mockClock)
+
+	// Conditioned indoor sensor - should use original thresholds regardless of outdoor
+	manager.AddSensor(&HumiditySensor{
+		EntityID:     testIndoorSensor1,
+		FriendlyName: "Indoor Humidity 1",
+		IsIndoor:     true,
+		Valid:        true,
+	})
+	manager.SetOutdoorHumidity(90.0) // Very high outdoor
+
+	// Indoor at 58% - above conditioned threshold (55%), should still alert
+	// even though outdoor is 90% (conditioned spaces have HVAC)
+	manager.SimulateSensorChange(testIndoorSensor1, 58.0)
+	mockClock.Advance(31 * time.Minute)
+	manager.SimulateSensorChange(testIndoorSensor1, 58.0)
+
+	alertLevel := manager.GetCurrentState()
+	if alertLevel != "warning" {
+		t.Errorf("Expected 'warning' for conditioned sensor at 58%% even with high outdoor, got '%s'", alertLevel)
+	}
+}
+
+func TestEnvironmentalManager_UnconditionedDiscovery(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+
+	// Add device with "unconditioned" label (no "indoor" label needed)
+	mockHA.AddDevice(&ha.Device{
+		ID:     "device_barn",
+		Name:   "Barn Sensor",
+		Labels: []string{"Unconditioned"}, // Case-insensitive
+	})
+	// Add device with "indoor" label (conditioned)
+	mockHA.AddDevice(&ha.Device{
+		ID:     "device_living",
+		Name:   "Living Room Sensor",
+		Labels: []string{"Indoor"},
+	})
+	// Add outdoor device (no labels)
+	mockHA.AddDevice(&ha.Device{
+		ID:     "device_outdoor",
+		Name:   "Weather Station",
+		Labels: []string{},
+	})
+
+	mockHA.AddEntityRegistryEntry(&ha.EntityRegistryEntry{
+		EntityID: "sensor.barn_humidity",
+		DeviceID: "device_barn",
+	})
+	mockHA.AddEntityRegistryEntry(&ha.EntityRegistryEntry{
+		EntityID: "sensor.living_humidity",
+		DeviceID: "device_living",
+	})
+	mockHA.AddEntityRegistryEntry(&ha.EntityRegistryEntry{
+		EntityID: "sensor.weather_station_humidity",
+		DeviceID: "device_outdoor",
+	})
+
+	mockHA.SetState("sensor.barn_humidity", "55.0", map[string]interface{}{
+		"device_class":  "humidity",
+		"friendly_name": "Barn Humidity",
+	})
+	mockHA.SetState("sensor.living_humidity", "45.0", map[string]interface{}{
+		"device_class":  "humidity",
+		"friendly_name": "Living Room Humidity",
+	})
+	mockHA.SetState("sensor.weather_station_humidity", "70.0", map[string]interface{}{
+		"device_class":  "humidity",
+		"friendly_name": "Weather Station Humidity",
+	})
+
+	mockNtfy := ntfy.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	manager := NewManager(mockHA, stateMgr, logger, false, nil, mockNtfy)
+	err := manager.Start()
+	if err != nil {
+		t.Fatalf("Failed to start manager: %v", err)
+	}
+	defer manager.Stop()
+
+	sensors := manager.GetSensors()
+
+	// Barn should be indoor AND unconditioned (label implies indoor)
+	barn, ok := sensors["sensor.barn_humidity"]
+	if !ok {
+		t.Fatal("Barn sensor not discovered")
+	}
+	if !barn.IsIndoor {
+		t.Error("Expected barn to be classified as indoor (unconditioned implies indoor)")
+	}
+	if !barn.IsUnconditioned {
+		t.Error("Expected barn to be classified as unconditioned")
+	}
+
+	// Living room should be indoor but NOT unconditioned
+	living, ok := sensors["sensor.living_humidity"]
+	if !ok {
+		t.Fatal("Living room sensor not discovered")
+	}
+	if !living.IsIndoor {
+		t.Error("Expected living room to be classified as indoor")
+	}
+	if living.IsUnconditioned {
+		t.Error("Expected living room NOT to be classified as unconditioned")
+	}
+
+	// Weather station should be neither indoor nor unconditioned
+	weather, ok := sensors["sensor.weather_station_humidity"]
+	if !ok {
+		t.Fatal("Weather station not discovered")
+	}
+	if weather.IsIndoor {
+		t.Error("Expected weather station NOT to be classified as indoor")
+	}
+	if weather.IsUnconditioned {
+		t.Error("Expected weather station NOT to be classified as unconditioned")
+	}
+}
+
+func TestEnvironmentalManager_UnconditionedHysteresis(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := NewManagerWithClock(mockHA, stateMgr, logger, false, nil, mockNtfy, mockClock)
+
+	manager.AddSensor(&HumiditySensor{
+		EntityID:        testUnconditionedSensor1,
+		FriendlyName:    "Barn Humidity",
+		IsIndoor:        true,
+		IsUnconditioned: true,
+		Valid:           true,
+	})
+	manager.SetOutdoorHumidity(40.0) // Low outdoor
+
+	// Trigger warning at 78%
+	manager.SimulateSensorChange(testUnconditionedSensor1, 78.0)
+	mockClock.Advance(31 * time.Minute)
+	manager.SimulateSensorChange(testUnconditionedSensor1, 78.0)
+
+	if manager.GetCurrentState() != "warning" {
+		t.Fatal("Expected warning at 78%")
+	}
+
+	// Drop to 72% - above unconditioned clear threshold (70%), should remain warning
+	manager.SimulateSensorChange(testUnconditionedSensor1, 72.0)
+	if manager.GetCurrentState() != "warning" {
+		t.Error("Expected warning to persist at 72% (above unconditioned clear threshold of 70%)")
+	}
+
+	// Drop to 69% - below unconditioned clear threshold (70%), should resolve
+	manager.SimulateSensorChange(testUnconditionedSensor1, 69.0)
+	if manager.GetCurrentState() != "none" {
+		t.Error("Expected alert to resolve at 69% (below unconditioned clear threshold of 70%)")
 	}
 }

--- a/homeautomation-go/internal/shadowstate/tracker.go
+++ b/homeautomation-go/internal/shadowstate/tracker.go
@@ -1247,6 +1247,16 @@ func (et *EnvironmentalTracker) UpdateHumiditySensors(sensors []HumiditySensorDa
 	et.State().Metadata.LastUpdated = time.Now()
 }
 
+// UpdateOutdoorHumidity updates the outdoor reference humidity value
+func (et *EnvironmentalTracker) UpdateOutdoorHumidity(humidity float64, valid bool) {
+	et.Lock()
+	defer et.Unlock()
+
+	et.State().Outputs.OutdoorHumidity = humidity
+	et.State().Outputs.OutdoorHumidityValid = valid
+	et.State().Metadata.LastUpdated = time.Now()
+}
+
 // UpdateAlertLevel updates the current alert level and sustained status
 func (et *EnvironmentalTracker) UpdateAlertLevel(level string, conditionStartTime time.Time, isSustained bool) {
 	et.Lock()
@@ -1332,13 +1342,15 @@ func (et *EnvironmentalTracker) GetState() *EnvironmentalShadowState {
 			Current: copyInputMap(s.Inputs.Current),
 		},
 		Outputs: EnvironmentalOutputs{
-			HumiditySensors:    make([]HumiditySensorData, len(s.Outputs.HumiditySensors)),
-			WaterLeakSensors:   make([]WaterLeakSensorData, len(s.Outputs.WaterLeakSensors)),
-			ActiveWaterLeaks:   make([]WaterLeakAlert, len(s.Outputs.ActiveWaterLeaks)),
-			AlertLevel:         s.Outputs.AlertLevel,
-			ConditionStartTime: s.Outputs.ConditionStartTime,
-			IsSustained:        s.Outputs.IsSustained,
-			LastUpdate:         s.Outputs.LastUpdate,
+			HumiditySensors:      make([]HumiditySensorData, len(s.Outputs.HumiditySensors)),
+			WaterLeakSensors:     make([]WaterLeakSensorData, len(s.Outputs.WaterLeakSensors)),
+			ActiveWaterLeaks:     make([]WaterLeakAlert, len(s.Outputs.ActiveWaterLeaks)),
+			AlertLevel:           s.Outputs.AlertLevel,
+			ConditionStartTime:   s.Outputs.ConditionStartTime,
+			IsSustained:          s.Outputs.IsSustained,
+			OutdoorHumidity:      s.Outputs.OutdoorHumidity,
+			OutdoorHumidityValid: s.Outputs.OutdoorHumidityValid,
+			LastUpdate:           s.Outputs.LastUpdate,
 		},
 		Metadata: s.Metadata,
 	}

--- a/homeautomation-go/internal/shadowstate/types.go
+++ b/homeautomation-go/internal/shadowstate/types.go
@@ -759,6 +759,8 @@ type EnvironmentalOutputs struct {
 	AlertLevel           string                 `json:"alertLevel"`                     // Overall humidity level: "none", "warning", "critical"
 	ConditionStartTime   time.Time              `json:"conditionStartTime,omitempty"`   // When current condition started
 	IsSustained          bool                   `json:"isSustained"`                    // Whether condition is sustained (30+ min)
+	OutdoorHumidity      float64                `json:"outdoorHumidity"`                // Current outdoor reference humidity
+	OutdoorHumidityValid bool                   `json:"outdoorHumidityValid"`           // Whether outdoor reading is available
 	LastNotification     *NotificationRecord    `json:"lastNotification,omitempty"`     // Last alert notification sent
 	LastResolutionNotice *NotificationRecord    `json:"lastResolutionNotice,omitempty"` // Last resolution notification sent
 	LastWaterLeakNotice  *WaterLeakNotification `json:"lastWaterLeakNotice,omitempty"`  // Last water leak notification sent
@@ -767,12 +769,13 @@ type EnvironmentalOutputs struct {
 
 // HumiditySensorData represents a single humidity sensor's state for shadow tracking
 type HumiditySensorData struct {
-	EntityID     string  `json:"entityId"`
-	FriendlyName string  `json:"friendlyName"`
-	DeviceID     string  `json:"deviceId,omitempty"`
-	IsIndoor     bool    `json:"isIndoor"` // true = alerts enabled, false = informational only
-	Value        float64 `json:"value"`
-	Valid        bool    `json:"valid"`
+	EntityID        string  `json:"entityId"`
+	FriendlyName    string  `json:"friendlyName"`
+	DeviceID        string  `json:"deviceId,omitempty"`
+	IsIndoor        bool    `json:"isIndoor"`        // true = alerts enabled, false = informational only
+	IsUnconditioned bool    `json:"isUnconditioned"` // true = unconditioned space (barn, attic) with relaxed thresholds
+	Value           float64 `json:"value"`
+	Valid           bool    `json:"valid"`
 }
 
 // WaterLeakSensorData represents a discovered water leak sensor


### PR DESCRIPTION
Resolves #756

## Summary

- **New `unconditioned` device label** for barns, attics, and sheds that naturally track outdoor humidity. Adding this label to a device in Home Assistant automatically enables monitoring with appropriate thresholds (no need to also add `indoor` — the label implies it).
- **Relaxed thresholds for unconditioned spaces**: 75% warning / 80% critical (vs 55%/65% for conditioned living spaces with HVAC)
- **Outdoor humidity comparison**: Uses `sensor.weather_station_humidity` as reference. When an unconditioned sensor reads within 5% of outdoor humidity, alerts are suppressed — this is normal tracking behavior, not a problem.
- **Absolute ceiling at 80%**: Always triggers critical regardless of outdoor humidity (mold protection)
- **Notifications include outdoor context**: Alert messages now show outdoor humidity percentage when available
- **Re-evaluation on outdoor changes**: When outdoor humidity drops significantly, previously suppressed sensors are re-evaluated

### Research-Based Design

Based on building science research:
- **Barns and attics naturally track outdoor humidity** — this is expected physics, not a defect
- **Dew point comparison is ideal** but RH comparison with margin is practical for the available sensor data
- **Mold risk becomes serious above 70-80% RH** depending on temperature, so 80% absolute ceiling protects against structural damage regardless of outdoor conditions

### Example (from the issue)
| Sensor | Reading | Outdoor | Result |
|--------|---------|---------|--------|
| Barn (unconditioned) | 61% | 70% | **Suppressed** — tracking outdoor |
| Attic High (unconditioned) | 56% | 70% | **Suppressed** — tracking outdoor |
| Barn (unconditioned) | 82% | 50% | **Critical** — exceeds absolute ceiling |
| Living Room (conditioned) | 58% | 70% | **Warning** — HVAC should control this |

## Test Plan

- [x] 13 new unit tests covering all scenarios: suppression, higher thresholds, absolute ceiling, outdoor unavailable, margin boundaries, mixed conditioned/unconditioned, outdoor drop re-evaluation, discovery with labels, hysteresis
- [x] All existing tests pass (no regressions)
- [x] Integration tests pass
- [x] Coverage 82.8% for environmental plugin
- [x] Mermaid diagrams validated
- [ ] In production: Add `unconditioned` label to barn, attic, and well shed devices in Home Assistant

🤖 Generated with [Claude Code](https://claude.com/claude-code)