### PR TITLE
Fix #761: Replace evening Spotify editorial playlists with Tidal equivalents

### DIFF
--- a/configs/music_config.yaml
+++ b/configs/music_config.yaml
@@ -250,29 +250,41 @@ music:
           - variable: isMasterAsleep
             value: true
     playback_options:
-      # Instrumental Study
-      - uri: spotify:playlist:37i9dQZF1DX9sIqqvKsjG8
-        media_type: playlist
+      # BRAIN & FOCUS INSTRUMENTALS (Tidal equivalent of Instrumental Study)
+      # yamllint disable-line rule:line-length
+      - uri: >-
+          https://tidal.com/browse/playlist/da8546c7-eb6e-49b3-bdcc-ed09966df03b
+        media_type: tidal
         volume_multiplier: 1.2
-      # Jazz in the background
-      - uri: spotify:playlist:37i9dQZF1DWV7EzJMK2FUI
-        media_type: playlist
+      # Late Night Jazz (Tidal equivalent of Jazz in the Background)
+      # yamllint disable-line rule:line-length
+      - uri: >-
+          https://tidal.com/browse/playlist/e7dde025-2ea1-4413-af9e-6c53bfa50733
+        media_type: tidal
         volume_multiplier: 1.0
-      # This is Hilary Hahn
-      - uri: spotify:playlist:37i9dQZF1DZ06evO3ngxkl
-        media_type: playlist
+      # Hilary Hahn Essentials (Tidal equivalent of This is Hilary Hahn)
+      # yamllint disable-line rule:line-length
+      - uri: >-
+          https://tidal.com/browse/playlist/e4c7182a-273b-4727-8980-7fe0ad8138f4
+        media_type: tidal
         volume_multiplier: 1.5
-      # Blowin' in the wind radio
-      - uri: spotify:playlist:37i9dQZF1E8Q7fAfKoKDtW
-        media_type: playlist
+      # Singer-Songwriter Classics (Tidal equivalent of Blowin' in the Wind Radio)
+      # yamllint disable-line rule:line-length
+      - uri: >-
+          https://tidal.com/browse/playlist/d3454ad3-41f5-497b-8fdf-25af07738d5a
+        media_type: tidal
         volume_multiplier: 1.0
-      # Calming Classical (Needs much higher volumes for parity)
-      - uri: spotify:playlist:37i9dQZF1DWVFeEut75IAL
-        media_type: playlist
+      # Relaxing Classical (Tidal equivalent of Calming Classical)
+      # yamllint disable-line rule:line-length
+      - uri: >-
+          https://tidal.com/browse/playlist/741b54e8-3fde-4ce4-b797-7874e33227ce
+        media_type: tidal
         volume_multiplier: 1.5
-      # Chilled Jazz
-      - uri: spotify:playlist:37i9dQZF1DX2vYju3i0lNX
-        media_type: playlist
+      # COOL: A Jazz Playlist (Tidal equivalent of Chilled Jazz)
+      # yamllint disable-line rule:line-length
+      - uri: >-
+          https://tidal.com/browse/playlist/6fb95baf-9e5d-4731-95ac-424da6e98aa2
+        media_type: tidal
         volume_multiplier: 1.0
       # Instrumental Classical
       - uri: spotify:playlist:5fSuIObNY9SB8gUMt1xrsB


### PR DESCRIPTION
Resolves #761

## Summary
- Replaced 6 Spotify editorial playlists in the evening music mode with Tidal equivalents:
  - **Instrumental Study** → BRAIN & FOCUS INSTRUMENTALS (instrumental classical/neoclassical for focus)
  - **Jazz in the Background** → Late Night Jazz (mellow instrumental jazz standards)
  - **This is Hilary Hahn** → Hilary Hahn Essentials (violin/classical artist spotlight)
  - **Blowin' in the Wind Radio** → Singer-Songwriter Classics (folk/acoustic singer-songwriters)
  - **Calming Classical** → Relaxing Classical (quiet classical background music)
  - **Chilled Jazz** → COOL: A Jazz Playlist (cool/mellow jazz)
- Updated `media_type` from `playlist` to `tidal` for all converted entries
- Preserved original volume multipliers (1.0-1.5) — classical entries retain elevated multipliers
- Left untouched: user playlist (Instrumental Classical), all local HTTP stream entries

## Test Plan
- [x] `make unit-tests` passes (75.4% coverage)
- [x] `make integration-tests` passes
- [x] `make pre-commit` passes (formatting, linting, build)
- [x] yamllint validates `music_config.yaml`
- [ ] Manual verification: deploy and confirm Tidal playlists play correctly during evening mode via SoCo-CLI

🤖 Generated with Claude Code