### PR TITLE
Fix #769: Increase septic aerator failure debounce to 10 minutes

### DIFF
--- a/docs/flows/SEPTIC_MONITORING.md
+++ b/docs/flows/SEPTIC_MONITORING.md
@@ -25,7 +25,7 @@ flowchart TD
     C -->|50-300W| E[Normal - Clear Timers]
     C -->|> 300W| F[Track Pump Running Start]
 
-    D --> G{Duration > 5 min?}
+    D --> G{Duration > 10 min?}
     G -->|No| H[Continue Monitoring]
     G -->|Yes| I[AERATOR FAILURE<br/>Send Alert + TTS]
 
@@ -42,7 +42,7 @@ flowchart TD
 
 | Condition | Threshold | Debounce | Severity |
 |-----------|-----------|----------|----------|
-| Aerator Failure | Power < 50W | 5 minutes | Urgent |
+| Aerator Failure | Power < 50W | 10 minutes | Urgent |
 | Pump Stuck Running | Power > 300W | 60 minutes | Urgent |
 
 ## Notification Flow
@@ -88,7 +88,7 @@ stateDiagram-v2
     Normal --> HighPowerTracking: Power > 300W
 
     LowPowerTracking --> Normal: Power returns to 50-300W
-    LowPowerTracking --> AeratorFailure: Duration > 5 min
+    LowPowerTracking --> AeratorFailure: Duration > 10 min
 
     HighPowerTracking --> Normal: Power returns to 50-300W
     HighPowerTracking --> PumpStuck: Duration > 60 min
@@ -131,7 +131,7 @@ The plugin uses hardcoded thresholds based on the system specifications:
 const (
     AeratorMinPowerW = 50.0              // Below = aerator failure
     PumpMaxNormalPowerW = 300.0          // Above = pump running
-    AeratorFailureDebounceMinutes = 5    // Debounce for transient dips
+    AeratorFailureDebounceMinutes = 10   // Debounce for transient dips (increased from 5, see #769)
     PumpStuckThresholdMinutes = 60       // Pump should cycle off within this time
 )
 ```

--- a/homeautomation-go/internal/plugins/infrastructure/manager.go
+++ b/homeautomation-go/internal/plugins/infrastructure/manager.go
@@ -28,8 +28,9 @@ const (
 	// PumpMaxNormalPowerW is the max power before considering pump is running
 	PumpMaxNormalPowerW = 300.0
 
-	// AeratorFailureDebounceMinutes is how long low power must persist before alerting
-	AeratorFailureDebounceMinutes = 5
+	// AeratorFailureDebounceMinutes is how long low power must persist before alerting.
+	// Set to 10 minutes to filter out transient SPAN sensor blips (see issue #769).
+	AeratorFailureDebounceMinutes = 10
 
 	// PumpStuckThresholdMinutes is how long pump can run before alerting
 	PumpStuckThresholdMinutes = 60
@@ -289,7 +290,7 @@ func (m *Manager) evaluateConditions() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Check for aerator failure (low power for > 5 minutes)
+	// Check for aerator failure (low power for > 10 minutes)
 	if !m.lowPowerStartTime.IsZero() {
 		duration := now.Sub(m.lowPowerStartTime)
 		if duration >= AeratorFailureDebounceMinutes*time.Minute && !m.isAeratorFailure {

--- a/homeautomation-go/internal/plugins/infrastructure/manager_test.go
+++ b/homeautomation-go/internal/plugins/infrastructure/manager_test.go
@@ -139,21 +139,21 @@ func TestInfrastructureManager_AeratorFailureWithDebounce(t *testing.T) {
 		t.Errorf("Expected 0 notifications during debounce period, got %d", count)
 	}
 
-	// Advance time by 3 minutes (still within debounce)
-	mockClock.Advance(3 * time.Minute)
+	// Advance time by 5 minutes (still within 10 minute debounce)
+	mockClock.Advance(5 * time.Minute)
 	manager.TriggerEvaluation()
 
 	if manager.IsAeratorFailure() {
-		t.Error("Should not trigger aerator failure before 5 minute debounce")
+		t.Error("Should not trigger aerator failure before 10 minute debounce")
 	}
 
-	// Advance past 5 minute threshold
-	mockClock.Advance(3 * time.Minute)
+	// Advance past 10 minute threshold
+	mockClock.Advance(6 * time.Minute)
 	manager.TriggerEvaluation()
 
 	// Now should be in failure state
 	if !manager.IsAeratorFailure() {
-		t.Error("Should be in aerator failure state after 5+ minutes of low power")
+		t.Error("Should be in aerator failure state after 10+ minutes of low power")
 	}
 
 	// Should have sent notification
@@ -223,6 +223,49 @@ func TestInfrastructureManager_TransientPowerDipNoAlert(t *testing.T) {
 	}
 }
 
+func TestInfrastructureManager_TransientBlipUnder10MinutesNoAlert(t *testing.T) {
+	// Regression test for issue #769: a ~5-minute sensor blip should NOT trigger an alert
+	// with the 10-minute debounce threshold.
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	startTime := time.Now()
+	mockClock := clock.NewMockClock(startTime)
+
+	manager := createTestManager(mockHA, mockNtfy, mockClock)
+
+	// Start with normal power
+	manager.SimulatePowerReading(100.0)
+
+	// Power drops to 0W (sensor blip)
+	manager.SimulatePowerReading(0.0)
+
+	// Advance 5 minutes - still within 10 minute debounce
+	mockClock.Advance(5 * time.Minute)
+	manager.TriggerEvaluation()
+
+	if manager.IsAeratorFailure() {
+		t.Error("Should not trigger aerator failure after only 5 minutes (debounce is 10 minutes)")
+	}
+
+	// Power recovers after ~5 minutes (like the issue scenario)
+	manager.SimulatePowerReading(96.0)
+
+	// Advance more time and evaluate again
+	mockClock.Advance(10 * time.Minute)
+	manager.TriggerEvaluation()
+
+	// Should never have triggered any alerts
+	if manager.IsAeratorFailure() {
+		t.Error("Should not be in aerator failure state after recovery")
+	}
+
+	if count := countNtfyNotifications(mockNtfy); count != 0 {
+		t.Errorf("Expected 0 notifications for transient blip under 10 minutes, got %d", count)
+	}
+}
+
 func TestInfrastructureManager_PumpStuckAlert(t *testing.T) {
 	t.Parallel()
 
@@ -280,7 +323,7 @@ func TestInfrastructureManager_RecoveryNotification(t *testing.T) {
 
 	// Simulate aerator failure
 	manager.SimulatePowerReading(30.0)
-	mockClock.Advance(6 * time.Minute)
+	mockClock.Advance(11 * time.Minute)
 	manager.TriggerEvaluation()
 
 	// Verify failure alert was sent
@@ -331,7 +374,7 @@ func TestInfrastructureManager_RateLimiting(t *testing.T) {
 
 	// Trigger first failure
 	manager.SimulatePowerReading(30.0)
-	mockClock.Advance(6 * time.Minute)
+	mockClock.Advance(11 * time.Minute)
 	manager.TriggerEvaluation()
 
 	initialCount := countNtfyNotifications(mockNtfy)
@@ -342,7 +385,7 @@ func TestInfrastructureManager_RateLimiting(t *testing.T) {
 
 	// Immediately trigger another failure
 	manager.SimulatePowerReading(30.0)
-	mockClock.Advance(6 * time.Minute)
+	mockClock.Advance(11 * time.Minute)
 	manager.TriggerEvaluation()
 
 	// Should NOT send another alert due to rate limiting (4 hour cooldown)
@@ -358,7 +401,7 @@ func TestInfrastructureManager_RateLimiting(t *testing.T) {
 	// But we need to reset the failure state first
 	manager.Reset()
 	manager.SimulatePowerReading(30.0)
-	mockClock.Advance(6 * time.Minute)
+	mockClock.Advance(11 * time.Minute)
 	manager.TriggerEvaluation()
 
 	// Now should have sent another notification
@@ -379,7 +422,7 @@ func TestInfrastructureManager_RecoveryRateLimiting(t *testing.T) {
 
 	// Trigger failure
 	manager.SimulatePowerReading(30.0)
-	mockClock.Advance(6 * time.Minute)
+	mockClock.Advance(11 * time.Minute)
 	manager.TriggerEvaluation()
 
 	// First recovery
@@ -388,7 +431,7 @@ func TestInfrastructureManager_RecoveryRateLimiting(t *testing.T) {
 
 	// Immediately fail and recover again
 	manager.SimulatePowerReading(30.0)
-	mockClock.Advance(6 * time.Minute)
+	mockClock.Advance(11 * time.Minute)
 	manager.TriggerEvaluation()
 	manager.SimulatePowerReading(100.0)
 
@@ -416,7 +459,7 @@ func TestInfrastructureManager_ReadOnlyMode(t *testing.T) {
 
 	// Trigger failure
 	manager.SimulatePowerReading(30.0)
-	mockClock.Advance(6 * time.Minute)
+	mockClock.Advance(11 * time.Minute)
 	manager.TriggerEvaluation()
 
 	// ntfy notifications should still be sent (read-only only affects HA calls)
@@ -461,7 +504,7 @@ func TestInfrastructureManager_ShadowStateTracking(t *testing.T) {
 
 	// Trigger failure
 	manager.SimulatePowerReading(30.0)
-	mockClock.Advance(6 * time.Minute)
+	mockClock.Advance(11 * time.Minute)
 	manager.TriggerEvaluation()
 
 	shadowState = manager.GetShadowState()
@@ -492,7 +535,7 @@ func TestInfrastructureManager_Reset(t *testing.T) {
 
 	// Trigger failure and get notification
 	manager.SimulatePowerReading(30.0)
-	mockClock.Advance(6 * time.Minute)
+	mockClock.Advance(11 * time.Minute)
 	manager.TriggerEvaluation()
 
 	initialCount := countNtfyNotifications(mockNtfy)
@@ -584,7 +627,7 @@ func TestInfrastructureManager_NtfyClientNil(t *testing.T) {
 
 	// Trigger failure - should not panic
 	manager.SimulatePowerReading(30.0)
-	mockClock.Advance(6 * time.Minute)
+	mockClock.Advance(11 * time.Minute)
 	manager.TriggerEvaluation()
 
 	// Should still track state correctly


### PR DESCRIPTION
Resolves #769

## Summary
- Increased `AeratorFailureDebounceMinutes` from 5 to 10 minutes to filter out transient SPAN sensor blips that were causing false aerator failure alerts
- Added regression test (`TestInfrastructureManager_TransientBlipUnder10MinutesNoAlert`) that validates the exact scenario from the issue: a ~5-minute power drop to 0W followed by recovery should NOT trigger an alert
- Updated all existing tests to use the new 10-minute threshold
- Updated `docs/flows/SEPTIC_MONITORING.md` flowcharts, state diagrams, and configuration reference

## Test Plan
- [x] New regression test verifies 5-minute blip does not trigger alert with 10-minute debounce
- [x] Existing debounce test verifies alert fires after 10+ minutes of sustained low power
- [x] Existing transient dip test still passes (2-minute blip, no alert)
- [x] All unit tests pass (75.1% coverage)
- [x] All integration tests pass
- [x] Pre-commit checks pass (formatting, linting, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)