### PR TITLE
Make Front Room the lead speaker in Sonos groups

### DIFF
--- a/configs/music_config.yaml
+++ b/configs/music_config.yaml
@@ -100,6 +100,9 @@ zones:
 music:
   morning:
     participants:
+      - player_name: "Front Room"
+        base_volume: 8
+        leave_muted_if: []
       - player_name: "Kitchen"
         base_volume: 9
         leave_muted_if:
@@ -121,9 +124,6 @@ music:
         leave_muted_if:
           - variable: isTVPlaying
             value: true
-      - player_name: "Front Room"
-        base_volume: 8
-        leave_muted_if: []
       - player_name: "Primary Bathroom"
         base_volume: 9
         exclude_if:
@@ -153,6 +153,9 @@ music:
         volume_multiplier: 1.3
   day:
     participants:
+      - player_name: "Front Room"
+        base_volume: 9
+        leave_muted_if: []
       - player_name: "Kitchen"
         base_volume: 9
         leave_muted_if:
@@ -173,9 +176,6 @@ music:
         leave_muted_if:
           - variable: isTVPlaying
             value: true
-      - player_name: "Front Room"
-        base_volume: 9
-        leave_muted_if: []
       - player_name: "Primary Bathroom"
         base_volume: 9
         leave_muted_if:
@@ -221,6 +221,9 @@ music:
         volume_multiplier: 1.0
   evening:
     participants:
+      - player_name: "Front Room"
+        base_volume: 8
+        leave_muted_if: []
       - player_name: "Kitchen"
         base_volume: 9
         leave_muted_if:
@@ -241,9 +244,6 @@ music:
         leave_muted_if:
           - variable: isTVPlaying
             value: true
-      - player_name: "Front Room"
-        base_volume: 8
-        leave_muted_if: []
       - player_name: "Primary Bathroom"
         base_volume: 6
         exclude_if:
@@ -345,6 +345,9 @@ music:
         volume_multiplier: 1.8
   winddown:
     participants:
+      - player_name: "Front Room"
+        base_volume: 7
+        leave_muted_if: []
       - player_name: "Kitchen"
         base_volume: 10
         leave_muted_if:
@@ -365,9 +368,6 @@ music:
         leave_muted_if:
           - variable: isTVPlaying
             value: true
-      - player_name: "Front Room"
-        base_volume: 7
-        leave_muted_if: []
       - player_name: "Primary Bathroom"
         base_volume: 8
         exclude_if:
@@ -395,6 +395,9 @@ music:
   # Plays during night phase to help direct people to bed
   sleep-prep:
     participants:
+      - player_name: "Front Room"
+        base_volume: 9
+        leave_muted_if: []
       - player_name: "Bedroom"
         base_volume: 16
         leave_muted_if: []
@@ -403,9 +406,6 @@ music:
         leave_muted_if:
           - variable: isTVPlaying
             value: true
-      - player_name: "Front Room"
-        base_volume: 9
-        leave_muted_if: []
       - player_name: "Kitchen"
         base_volume: 16
         leave_muted_if: []


### PR DESCRIPTION
## Summary
- Moves "Front Room" to the first participant position (Sonos group coordinator) in all 5 zones where it appears: morning, day, evening, winddown, and sleep-prep
- The first participant in each zone's list becomes the Sonos group leader that coordinates streaming to all other speakers
- Zones without Front Room (sleep, sex, wakeup) are unchanged

## Motivation
The Kitchen Sonos speaker has worse WiFi coverage and its WAP is more heavily loaded than Front Room's, causing traffic drops. Making Front Room the group coordinator shifts the streaming coordination burden to the speaker with better network connectivity.

## Test plan
- [x] Unit tests pass (75.1% coverage)
- [x] Integration tests pass
- [ ] Verify in production that Front Room becomes the group coordinator when music starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)