### PR TITLE
Fix #777: Remove global musicPlaybackType fallback in fade-in check

### DIFF
--- a/docs/reference/CONCURRENCY_LESSONS.md
+++ b/docs/reference/CONCURRENCY_LESSONS.md
@@ -1204,7 +1204,7 @@ T+5ms:  winddown fade-in checks musicPlaybackType → "sleep-prep" ≠ "winddown
 T+5ms:  sleep-prep fade-in checks musicPlaybackType → "sleep-prep" = "sleep-prep" → continues ✓
 ```
 
-**Fix**: Check zone-level state (a map of active zones) instead of the global scalar:
+**Fix**: Check zone-level state (a map of active zones) instead of the global scalar. Critically, do NOT keep a fallback path that checks the global scalar — it defeats the fix:
 ```go
 // WRONG: Single global variable can only represent one zone
 musicType, _ := m.stateManager.GetString("musicPlaybackType")
@@ -1213,16 +1213,25 @@ if musicType != startingMusicType {
     return
 }
 
-// RIGHT: Check if the zone that started this fade-in is still active
-if !m.zoneManager.IsZoneActive(startingMusicType) {
+// ALSO WRONG: Fallback path re-introduces the race (issue #777)
+if m.zoneManager != nil {
+    // ... zone check (correct) ...
+} else {
+    // Falls back to global musicPlaybackType check — STILL RACES
+}
+
+// RIGHT: Only use zone-level check, skip when zone manager is nil
+if m.zoneManager != nil && !m.zoneManager.IsZoneActive(startingMusicType) {
     return  // Zone was genuinely stopped
 }
+// When zoneManager is nil, context cancellation provides safety
 ```
 
 **General Pattern**:
 - **Identify**: A shared variable that multiple goroutines read/write to track "am I still active?"
 - **Problem**: The variable can only hold one value, but N goroutines need N independent values
 - **Solution**: Replace with a concurrent-safe collection (map + mutex) where each goroutine checks its own entry
+- **Corollary**: When replacing a check, remove the old path entirely. A fallback to the old check defeats the fix
 
 **Where Applied**:
 - `internal/plugins/music/fadein.go` - Multi-zone fade-in checks `IsZoneActive()` instead of global `musicPlaybackType`
@@ -1231,6 +1240,7 @@ if !m.zoneManager.IsZoneActive(startingMusicType) {
 **Tests That Validate This**:
 - `TestFadeInSpeaker_MultiZone_DoesNotAbortWhenOtherZoneActive` - Both zones' fade-ins complete
 - `TestFadeInSpeaker_ZoneRemoved_AbortsFadeIn` - Fade-in correctly aborts when zone is stopped
+- `TestFadeInSpeaker_NoZoneManager_DoesNotAbortOnPlaybackTypeMismatch` - No abort when zone manager absent (issue #777)
 - `TestMultiZoneStartup_BothZonesActive` - Both zones become active simultaneously
 
 ---

--- a/homeautomation-go/internal/plugins/music/fadein.go
+++ b/homeautomation-go/internal/plugins/music/fadein.go
@@ -667,31 +667,21 @@ func (m *Manager) fadeInSpeaker(ctx context.Context, speakerName string, targetV
 		}
 
 		// Check if this speaker's zone is still active.
-		// In a multi-zone system, musicPlaybackType is a single global variable that
-		// can only represent one zone. When multiple zones start simultaneously, the
-		// last zone to call setMusicPlaybackType wins, causing all other zones' fade-
-		// ins to see a mismatch and abort (issue #772). Instead, we check whether the
-		// zone that started this fade-in is still active in the zone manager.
-		if m.zoneManager != nil {
-			if !m.zoneManager.IsZoneActive(startingMusicType) {
-				m.logger.Info("Zone no longer active during fade-in, stopping",
-					zap.String("speaker", speakerName),
-					zap.String("zone", startingMusicType))
-				m.clearFadeInProgress(entityID)
-				return
-			}
-		} else {
-			// Fallback for non-zone mode (unit tests without zone manager):
-			// check global musicPlaybackType as before
-			musicType, err := m.stateManager.GetString("musicPlaybackType")
-			if err == nil && musicType != startingMusicType {
-				m.logger.Info("Music type changed during fade-in, stopping",
-					zap.String("speaker", speakerName),
-					zap.String("starting_type", startingMusicType),
-					zap.String("current_type", musicType))
-				m.clearFadeInProgress(entityID)
-				return
-			}
+		// musicPlaybackType is a single global variable that can only represent one
+		// zone. When multiple zones start simultaneously, the last zone to call
+		// setMusicPlaybackType wins, causing all other zones' fade-ins to see a
+		// mismatch and abort (issue #772, #777). We ONLY check via the zone manager's
+		// IsZoneActive(), which correctly tracks all concurrent zones independently.
+		//
+		// When zoneManager is nil (unit tests that don't set up zones), we skip this
+		// check entirely — context cancellation (cancelAllFadeIns) already provides
+		// adequate protection against stale fade-ins when new playback starts.
+		if m.zoneManager != nil && !m.zoneManager.IsZoneActive(startingMusicType) {
+			m.logger.Info("Zone no longer active during fade-in, stopping",
+				zap.String("speaker", speakerName),
+				zap.String("zone", startingMusicType))
+			m.clearFadeInProgress(entityID)
+			return
 		}
 
 		// Set volume

--- a/homeautomation-go/internal/plugins/music/manager_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_test.go
@@ -3655,6 +3655,53 @@ func TestFadeInSpeaker_MultiZone_DoesNotAbortWhenOtherZoneActive(t *testing.T) {
 		"Winddown speaker fade-in must complete even when musicPlaybackType differs (issue #772)")
 }
 
+// TestFadeInSpeaker_NoZoneManager_DoesNotAbortOnPlaybackTypeMismatch verifies that
+// fade-in does NOT abort based on global musicPlaybackType when no zone manager is set.
+// This catches the regression from issue #777 where the fallback path (checking global
+// musicPlaybackType) caused false aborts during multi-zone startup.
+//
+// INVARIANT: The global musicPlaybackType scalar must NEVER be used to abort fade-ins.
+// Context cancellation (cancelAllFadeIns) is the only mechanism for aborting stale fade-ins.
+func TestFadeInSpeaker_NoZoneManager_DoesNotAbortOnPlaybackTypeMismatch(t *testing.T) {
+	t.Parallel()
+	env := testutil.NewEnv(t)
+
+	config := &MusicConfig{
+		Music: map[string]MusicMode{
+			"sleep-prep": {},
+			"winddown":   {},
+		},
+	}
+
+	manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, false, nil, nil)
+	manager.SetSleepFunc(func(d time.Duration) {})
+
+	// Deliberately do NOT set up a zone manager (simulating the fallback path)
+	// Set musicPlaybackType to a DIFFERENT value than the fade-in's starting type
+	// This simulates the multi-zone race: sleep-prep starts fade-in, but winddown
+	// overwrites musicPlaybackType to "winddown"
+	require.NoError(t, env.StateMgr.SetString("musicPlaybackType", "winddown"))
+
+	// GIVEN: No zone manager, musicPlaybackType="winddown"
+	// WHEN: Fade-in starts with startingMusicType="sleep-prep" (mismatch)
+	// THEN: Fade-in should complete anyway (no abort based on global musicPlaybackType)
+	t.Log("GIVEN: No zone manager, musicPlaybackType=winddown (different from sleep-prep)")
+	t.Log("WHEN: Fade-in starts for sleep-prep speaker")
+	t.Log("THEN: Fade-in must complete (global musicPlaybackType check removed, issue #777)")
+	manager.fadeInSpeaker(context.Background(), "Front Room", 3, "sleep-prep")
+
+	calls := env.MockHA.GetServiceCalls()
+	volumeSetCount := 0
+	for _, call := range calls {
+		if call.Domain == "media_player" && call.Service == "volume_set" {
+			volumeSetCount++
+		}
+	}
+	// Expected: 1 (set to 0) + 3 (fade from 1 to 3) = 4 volume_set calls
+	assert.Equal(t, 4, volumeSetCount,
+		"Fade-in must NOT abort based on global musicPlaybackType mismatch (issue #777)")
+}
+
 // TestFadeInSpeaker_ZoneRemoved_AbortsFadeIn verifies that fade-in correctly
 // aborts when the speaker's zone is stopped (no longer active).
 func TestFadeInSpeaker_ZoneRemoved_AbortsFadeIn(t *testing.T) {


### PR DESCRIPTION
Resolves #777

## Summary
- Removed the fallback path in `fadeInSpeaker()` that checked global `musicPlaybackType` when `zoneManager` was nil
- The fallback re-introduced the multi-zone race condition that #772/#775 attempted to fix: when two zones start simultaneously, the last zone to write `musicPlaybackType` wins, causing all other zones' fade-ins to see a mismatch and abort
- Now only uses `IsZoneActive()` for the zone check (correct per-zone behavior), and skips the check entirely when `zoneManager` is nil — context cancellation (`cancelAllFadeIns`) already provides adequate protection against stale fade-ins
- Added test `TestFadeInSpeaker_NoZoneManager_DoesNotAbortOnPlaybackTypeMismatch` that reproduces the exact issue #777 scenario
- Updated CONCURRENCY_LESSONS.md Lesson 16 with the corollary: "When replacing a check, remove the old path entirely"

## Root Cause
The fix in #775 added an `if m.zoneManager != nil` branch to use `IsZoneActive()` instead of global `musicPlaybackType`, but kept an `else` fallback that still checked the global scalar. Production logs showed the fallback path was being taken ("Music type changed during fade-in, stopping" with `starting_type`/`current_type` fields), causing sleep-prep speakers to abort their fade-ins when winddown overwrote `musicPlaybackType`.

## Test Plan
- [x] New test `TestFadeInSpeaker_NoZoneManager_DoesNotAbortOnPlaybackTypeMismatch` passes — fade-in completes despite musicPlaybackType mismatch when no zone manager
- [x] Existing test `TestFadeInSpeaker_MultiZone_DoesNotAbortWhenOtherZoneActive` passes — zone manager path still works
- [x] Existing test `TestFadeInSpeaker_ZoneRemoved_AbortsFadeIn` passes — fade-in still aborts when zone is genuinely stopped
- [x] All unit tests pass (75.5% coverage)
- [x] All integration tests pass
- [x] Pre-push hook passed (yamllint, diagrams, build, tests, coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)