### PR TITLE
feat: Add dehumidifier to load shedding

### DIFF
--- a/docs/flows/LOAD_SHEDDING.md
+++ b/docs/flows/LOAD_SHEDDING.md
@@ -4,9 +4,9 @@ This document describes the load shedding automation flow, which manages HVAC th
 
 ## Overview
 
-The load shedding plugin controls thermostats and EV charger based on energy levels to:
-1. Restrict HVAC and disable EV charger when battery is low (red/black)
-2. Return to normal schedules and re-enable EV charger when energy is available (green/white)
+The load shedding plugin controls thermostats, EV charger, and dehumidifier based on energy levels to:
+1. Restrict HVAC, disable EV charger, and disable dehumidifier when battery is low (red/black)
+2. Return to normal schedules and re-enable EV charger and dehumidifier when energy is available (green/white)
 3. **Thermal battery**: Pre-condition the house by shifting HVAC setpoints when energy is abundant (white)
 4. Maintain hysteresis to prevent rapid toggling (yellow)
 
@@ -59,6 +59,7 @@ flowchart TD
         turnOnHold["Turn on thermostat hold<br/>(both zones)"]
         setTemp["Set temperature range<br/>65°F - 80°F"]
         turnOffEV["Turn off EV charger"]
+        turnOffDehum["Turn off dehumidifier"]
     end
 
     alreadyOn -->|Yes| skipOn
@@ -69,12 +70,14 @@ flowchart TD
     rateLimit -->|No| turnOnHold
     turnOnHold --> setTemp
     setTemp --> turnOffEV
+    turnOffEV --> turnOffDehum
 
     style skipOn fill:#95a5a6,color:#fff
     style skipHold fill:#95a5a6,color:#fff
     style skipRate fill:#f39c12,color:#fff
     style setTemp fill:#e74c3c,color:#fff
     style turnOffEV fill:#e74c3c,color:#fff
+    style turnOffDehum fill:#e74c3c,color:#fff
 ```
 
 ### Disable Load Shedding (Energy Restored)
@@ -96,6 +99,7 @@ flowchart TD
     subgraph Actions["Disable Actions"]
         turnOffHold["Turn off thermostat hold<br/>(both zones)"]
         turnOnEV["Turn on EV charger"]
+        turnOnDehum["Turn on dehumidifier"]
     end
 
     alreadyOff -->|Yes| skipOff
@@ -105,12 +109,14 @@ flowchart TD
     rateLimit -->|Yes| skipRate
     rateLimit -->|No| turnOffHold
     turnOffHold --> turnOnEV
+    turnOnEV --> turnOnDehum
 
     style skipOff fill:#95a5a6,color:#fff
     style skipHold fill:#95a5a6,color:#fff
     style skipRate fill:#f39c12,color:#fff
     style turnOffHold fill:#27ae60,color:#fff
     style turnOnEV fill:#27ae60,color:#fff
+    style turnOnDehum fill:#27ae60,color:#fff
 ```
 
 ## Thermal Battery (Energy Level White)
@@ -257,6 +263,7 @@ Without hysteresis, the system would rapidly toggle at threshold boundaries (e.g
 | `climate.most_of_house_thermostat` | Thermostat | Main zone climate control |
 | `climate.primary_suite_thermostat` | Thermostat | Primary suite climate control |
 | `switch.leaf_charger` | EV Charger | Nissan Leaf charger plug |
+| `switch.dehumidifier_power_control` | Dehumidifier | Whole-house dehumidifier |
 
 ## Temperature Range
 

--- a/homeautomation-go/internal/plugins/loadshedding/manager.go
+++ b/homeautomation-go/internal/plugins/loadshedding/manager.go
@@ -34,6 +34,9 @@ const (
 	// EV Charger entity
 	evChargerSwitch = "switch.leaf_charger"
 
+	// Dehumidifier entity
+	dehumidifierSwitch = "switch.dehumidifier_power_control"
+
 	// Temperature ranges
 	tempLowRestricted  = 65.0
 	tempHighRestricted = 80.0
@@ -341,11 +344,12 @@ func (m *Manager) executeEnableLoadShedding(energyLevel string, trigger string) 
 	}
 
 	if m.readOnly {
-		m.logger.Info("READ-ONLY: Would enable thermostat hold mode and turn off EV charger",
+		m.logger.Info("READ-ONLY: Would enable thermostat hold mode, turn off EV charger, and turn off dehumidifier",
 			zap.Strings("thermostat_entities", []string{thermostatHoldHouse, thermostatHoldSuite}),
-			zap.String("ev_charger_entity", evChargerSwitch))
+			zap.String("ev_charger_entity", evChargerSwitch),
+			zap.String("dehumidifier_entity", dehumidifierSwitch))
 		// Record shadow state even in read-only mode for consistency
-		reason := fmt.Sprintf("Energy state is %s (low battery) - would restrict HVAC and disable EV charger", energyLevel)
+		reason := fmt.Sprintf("Energy state is %s (low battery) - would restrict HVAC, disable EV charger, and disable dehumidifier", energyLevel)
 		m.recordAction(true, "enable", reason, true, tempLowRestricted, tempHighRestricted, trigger)
 		return
 	}
@@ -395,8 +399,21 @@ func (m *Manager) executeEnableLoadShedding(energyLevel string, trigger string) 
 		m.logger.Info("✓ Successfully turned off EV charger")
 	}
 
+	// Turn off dehumidifier to reduce load
+	m.logger.Info("Executing: Turn off dehumidifier",
+		zap.String("entity", dehumidifierSwitch))
+
+	if err := m.haClient.CallService(m.ctx, "switch", "turn_off", map[string]interface{}{
+		"entity_id": dehumidifierSwitch,
+	}); err != nil {
+		m.logger.Error("Failed to turn off dehumidifier", zap.Error(err))
+		// Continue - previous controls already succeeded
+	} else {
+		m.logger.Info("✓ Successfully turned off dehumidifier")
+	}
+
 	m.logger.Info("=== LOAD SHEDDING ACTIVATED ===",
-		zap.String("action", "HVAC restricted and EV charger disabled to conserve battery"))
+		zap.String("action", "HVAC restricted, EV charger disabled, and dehumidifier disabled to conserve battery"))
 
 	// Update state tracking and last action time
 	m.stateMu.Lock()
@@ -472,11 +489,12 @@ func (m *Manager) executeDisableLoadShedding(energyLevel string, trigger string)
 	}
 
 	if m.readOnly {
-		m.logger.Info("READ-ONLY: Would disable thermostat hold mode and turn on EV charger (restore schedule)",
+		m.logger.Info("READ-ONLY: Would disable thermostat hold mode, turn on EV charger, and turn on dehumidifier (restore schedule)",
 			zap.Strings("thermostat_entities", []string{thermostatHoldHouse, thermostatHoldSuite}),
-			zap.String("ev_charger_entity", evChargerSwitch))
+			zap.String("ev_charger_entity", evChargerSwitch),
+			zap.String("dehumidifier_entity", dehumidifierSwitch))
 		// Record shadow state even in read-only mode for consistency
-		reason := fmt.Sprintf("Energy state is %s (battery restored) - would return to normal HVAC and re-enable EV charger", energyLevel)
+		reason := fmt.Sprintf("Energy state is %s (battery restored) - would return to normal HVAC, re-enable EV charger, and re-enable dehumidifier", energyLevel)
 		m.recordAction(false, "disable", reason, false, 0, 0, trigger)
 		return
 	}
@@ -508,8 +526,21 @@ func (m *Manager) executeDisableLoadShedding(energyLevel string, trigger string)
 		m.logger.Info("✓ Successfully turned on EV charger")
 	}
 
+	// Turn on dehumidifier (restore normal operation)
+	m.logger.Info("Executing: Turn on dehumidifier",
+		zap.String("entity", dehumidifierSwitch))
+
+	if err := m.haClient.CallService(m.ctx, "switch", "turn_on", map[string]interface{}{
+		"entity_id": dehumidifierSwitch,
+	}); err != nil {
+		m.logger.Error("Failed to turn on dehumidifier", zap.Error(err))
+		// Continue - previous controls already succeeded
+	} else {
+		m.logger.Info("✓ Successfully turned on dehumidifier")
+	}
+
 	m.logger.Info("=== LOAD SHEDDING DEACTIVATED ===",
-		zap.String("action", "HVAC returned to normal schedule and EV charger re-enabled"))
+		zap.String("action", "HVAC returned to normal schedule, EV charger re-enabled, and dehumidifier re-enabled"))
 
 	// Update state tracking and last action time
 	m.stateMu.Lock()

--- a/homeautomation-go/internal/plugins/loadshedding/manager_test.go
+++ b/homeautomation-go/internal/plugins/loadshedding/manager_test.go
@@ -36,7 +36,7 @@ func TestLoadShedding_EnergyStateRed(t *testing.T) {
 
 	// Verify service calls
 	calls := env.MockHA.GetServiceCalls()
-	assert.GreaterOrEqual(t, len(calls), 3, "Expected at least 3 service calls (thermostat hold, temp range, EV charger)")
+	assert.GreaterOrEqual(t, len(calls), 4, "Expected at least 4 service calls (thermostat hold, temp range, EV charger, dehumidifier)")
 
 	// Check for switch.turn_on call (thermostat holds)
 	call := testutil.AssertServiceCall(t, calls, "switch", "turn_on")
@@ -57,6 +57,10 @@ func TestLoadShedding_EnergyStateRed(t *testing.T) {
 	// Check for switch.turn_off call (EV charger)
 	evCall := testutil.FindServiceCallWithEntity(calls, "switch", "turn_off", evChargerSwitch)
 	assert.NotNil(t, evCall, "Expected switch.turn_off service call for EV charger")
+
+	// Check for switch.turn_off call (dehumidifier)
+	dehumCall := testutil.FindServiceCallWithEntity(calls, "switch", "turn_off", dehumidifierSwitch)
+	assert.NotNil(t, dehumCall, "Expected switch.turn_off service call for dehumidifier")
 }
 
 func TestLoadShedding_EnergyStateBlack(t *testing.T) {
@@ -74,13 +78,17 @@ func TestLoadShedding_EnergyStateBlack(t *testing.T) {
 
 	// Verify service calls (should be same as red)
 	calls := env.MockHA.GetServiceCalls()
-	assert.GreaterOrEqual(t, len(calls), 3, "Expected at least 3 service calls (thermostat hold, temp range, EV charger)")
+	assert.GreaterOrEqual(t, len(calls), 4, "Expected at least 4 service calls (thermostat hold, temp range, EV charger, dehumidifier)")
 
 	testutil.AssertServiceCall(t, calls, "switch", "turn_on")
 
 	// Check for switch.turn_off call (EV charger)
 	evCall := testutil.FindServiceCallWithEntity(calls, "switch", "turn_off", evChargerSwitch)
 	assert.NotNil(t, evCall, "Expected switch.turn_off service call for EV charger")
+
+	// Check for switch.turn_off call (dehumidifier)
+	dehumCall := testutil.FindServiceCallWithEntity(calls, "switch", "turn_off", dehumidifierSwitch)
+	assert.NotNil(t, dehumCall, "Expected switch.turn_off service call for dehumidifier")
 }
 
 func TestLoadShedding_EnergyStateGreen(t *testing.T) {
@@ -108,7 +116,7 @@ func TestLoadShedding_EnergyStateGreen(t *testing.T) {
 
 	// Verify service calls
 	calls := env.MockHA.GetServiceCalls()
-	assert.GreaterOrEqual(t, len(calls), 2, "Expected at least 2 service calls (thermostat hold off, EV charger on)")
+	assert.GreaterOrEqual(t, len(calls), 3, "Expected at least 3 service calls (thermostat hold off, EV charger on, dehumidifier on)")
 
 	// Check for switch.turn_off call (thermostat holds)
 	foundThermostatOff := false
@@ -127,6 +135,10 @@ func TestLoadShedding_EnergyStateGreen(t *testing.T) {
 	// Check for switch.turn_on call (EV charger)
 	evCall := testutil.FindServiceCallWithEntity(calls, "switch", "turn_on", evChargerSwitch)
 	assert.NotNil(t, evCall, "Expected switch.turn_on service call for EV charger")
+
+	// Check for switch.turn_on call (dehumidifier)
+	dehumCall := testutil.FindServiceCallWithEntity(calls, "switch", "turn_on", dehumidifierSwitch)
+	assert.NotNil(t, dehumCall, "Expected switch.turn_on service call for dehumidifier")
 }
 
 func TestLoadShedding_EnergyStateWhite(t *testing.T) {
@@ -154,7 +166,7 @@ func TestLoadShedding_EnergyStateWhite(t *testing.T) {
 
 	// Verify service calls (should be same as green)
 	calls := env.MockHA.GetServiceCalls()
-	assert.GreaterOrEqual(t, len(calls), 2, "Expected at least 2 service calls (thermostat hold off, EV charger on)")
+	assert.GreaterOrEqual(t, len(calls), 3, "Expected at least 3 service calls (thermostat hold off, EV charger on, dehumidifier on)")
 
 	foundThermostatOff := false
 	for _, call := range calls {
@@ -170,6 +182,10 @@ func TestLoadShedding_EnergyStateWhite(t *testing.T) {
 	// Check for switch.turn_on call (EV charger)
 	evCall := testutil.FindServiceCallWithEntity(calls, "switch", "turn_on", evChargerSwitch)
 	assert.NotNil(t, evCall, "Expected switch.turn_on service call for EV charger")
+
+	// Check for switch.turn_on call (dehumidifier)
+	dehumCall := testutil.FindServiceCallWithEntity(calls, "switch", "turn_on", dehumidifierSwitch)
+	assert.NotNil(t, dehumCall, "Expected switch.turn_on service call for dehumidifier")
 }
 
 func TestLoadShedding_RateLimiting(t *testing.T) {
@@ -365,6 +381,11 @@ func TestLoadShedding_DeferredActionAfterRateLimit(t *testing.T) {
 	evCall := testutil.FindServiceCallWithEntity(calls, "switch", "turn_on", evChargerSwitch)
 	assert.NotNil(t, evCall,
 		"Deferred action should execute switch.turn_on for EV charger after rate limit expires")
+
+	// Verify dehumidifier was turned on in deferred action
+	dehumCall := testutil.FindServiceCallWithEntity(calls, "switch", "turn_on", dehumidifierSwitch)
+	assert.NotNil(t, dehumCall,
+		"Deferred action should execute switch.turn_on for dehumidifier after rate limit expires")
 
 	// Verify load shedding state is now disabled
 	assert.False(t, ls.IsLoadSheddingOn(), "Load shedding should be disabled after deferred action")


### PR DESCRIPTION
## Summary
- Add `switch.dehumidifier_power_control` to load shedding controlled devices, following the same pattern as the EV charger (`switch.leaf_charger`)
- Dehumidifier is turned off during load shedding (red/black energy) and turned back on when energy is restored (green/white)
- Updated tests to verify dehumidifier service calls in all enable/disable/deferred paths
- Updated flow documentation and Mermaid diagrams in `docs/flows/LOAD_SHEDDING.md`

## Test plan
- [x] `make unit-tests` — all pass (75.1% coverage)
- [x] `make integration-tests` — all pass
- [x] `make validate-mermaid` — diagrams valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)