### PR TITLE
refactor: Remove unused ActionRecord type from shadowstate

### DIFF
--- a/homeautomation-go/internal/shadowstate/types.go
+++ b/homeautomation-go/internal/shadowstate/types.go
@@ -23,14 +23,6 @@ type (
 	InputSnapshot = pkgshadow.InputSnapshot
 )
 
-// ActionRecord represents a single action taken by a plugin
-type ActionRecord struct {
-	Timestamp  time.Time              `json:"timestamp"`
-	ActionType string                 `json:"actionType"`
-	Reason     string                 `json:"reason"`
-	Details    map[string]interface{} `json:"details,omitempty"`
-}
-
 // ============================================================================
 // Generic Shadow State Types
 // ============================================================================


### PR DESCRIPTION
## Summary

- Removes the `ActionRecord` struct from `homeautomation-go/internal/shadowstate/types.go` (lines 26-32), which was defined but never referenced anywhere in the codebase
- The `time` import remains as it is used extensively by other types in the file
- No functional changes; build and all tests pass

## Test plan

- [x] Verified `ActionRecord` has zero references outside its own definition via codebase-wide grep
- [x] Verified `time` import is still needed by other types in the file
- [x] `go build ./...` compiles successfully
- [x] `make unit-tests` passes (75.5% coverage)
- [x] Integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)