### PR TITLE
refactor: Remove 17 unused backward-compatible input type aliases

### DIFF
--- a/homeautomation-go/internal/shadowstate/types.go
+++ b/homeautomation-go/internal/shadowstate/types.go
@@ -124,25 +124,8 @@ type SensorConfigShadowState = ShadowState[ReadOnlyInputs, SensorConfigOutputs]
 type WaterFlowShadowState = ShadowState[ReadOnlyInputs, WaterFlowOutputs]
 type EVChargerShadowState = ShadowState[ReadOnlyInputs, EVChargerOutputs]
 
-// Backward-compatible input type aliases
-type LightingInputs = ActionInputs
-type MusicInputs = ActionInputs
-type SecurityInputs = ActionInputs
-type LoadSheddingInputs = ActionInputs
-type SleepHygieneInputs = ActionInputs
-type SexModeInputs = ActionInputs
-type ChristmasInputs = ActionInputs
-type EnergyInputs = ReadOnlyInputs
-type StateTrackingInputs = ReadOnlyInputs
-type DayPhaseInputs = ReadOnlyInputs
-type TVInputs = ReadOnlyInputs
+// SystemInputs is used by cmd/app/run.go for system plugin shadow state.
 type SystemInputs = ReadOnlyInputs
-type EnvironmentalInputs = ReadOnlyInputs
-type SensorHealthInputs = ReadOnlyInputs
-type InfrastructureInputs = ReadOnlyInputs
-type SensorConfigInputs = ReadOnlyInputs
-type WaterFlowInputs = ReadOnlyInputs
-type EVChargerInputs = ReadOnlyInputs
 
 // ============================================================================
 // Constructors


### PR DESCRIPTION
## Summary

- Removes 17 unused type aliases from `homeautomation-go/internal/shadowstate/types.go` (lines 128-145)
- These were backward-compatible input type aliases (e.g., `LightingInputs`, `MusicInputs`, `EnergyInputs`) that mapped to either `ActionInputs` or `ReadOnlyInputs`
- None of these 17 aliases were referenced anywhere in the codebase -- they were dead code left over from a refactor that consolidated input types
- Retains `SystemInputs = ReadOnlyInputs` which is actively used in `cmd/app/run.go`

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `make unit-tests` passes (75.1% coverage)
- [x] `make integration-tests` passes
- [x] Pre-push hook passes all validations

🤖 Generated with [Claude Code](https://claude.com/claude-code)