### PR TITLE
refactor: Inline legacy fadeOutBedroomSpeaker wrapper

### DIFF
--- a/homeautomation-go/internal/plugins/sleephygiene/manager.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager.go
@@ -757,12 +757,6 @@ func (m *Manager) updateSpeakerVolumeInState(speakerEntityID string, volume int)
 	}
 }
 
-// fadeOutBedroomSpeaker is a legacy wrapper that calls fadeOutSpeaker
-// Kept for backward compatibility with existing tests
-func (m *Manager) fadeOutBedroomSpeaker() {
-	m.fadeOutSpeaker("media_player.bedroom")
-}
-
 // scheduleWakeSequence waits for the configured delay and then triggers handleWake
 // This implements the Node-RED behavior where lights fade in 5 minutes after
 // the sleep music starts fading out

--- a/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
@@ -736,7 +736,7 @@ func TestFadeOutBedroomSpeaker_Complete(t *testing.T) {
 	// Start fade out in goroutine
 	done := make(chan bool)
 	go func() {
-		manager.fadeOutBedroomSpeaker()
+		manager.fadeOutSpeaker("media_player.bedroom")
 		done <- true
 	}()
 
@@ -811,7 +811,7 @@ func TestFadeOutBedroomSpeaker_AbortedByFlag(t *testing.T) {
 	// Start fade out in goroutine
 	done := make(chan bool)
 	go func() {
-		manager.fadeOutBedroomSpeaker()
+		manager.fadeOutSpeaker("media_player.bedroom")
 		done <- true
 	}()
 
@@ -876,7 +876,7 @@ func TestFadeOutBedroomSpeaker_CancelledByWakeSequenceEnd(t *testing.T) {
 	// Start fade out in goroutine
 	done := make(chan bool)
 	go func() {
-		manager.fadeOutBedroomSpeaker()
+		manager.fadeOutSpeaker("media_player.bedroom")
 		done <- true
 	}()
 
@@ -952,7 +952,7 @@ func TestFadeOutBedroomSpeaker_VolumeSequence(t *testing.T) {
 	// Start fade out in goroutine
 	done := make(chan bool)
 	go func() {
-		manager.fadeOutBedroomSpeaker()
+		manager.fadeOutSpeaker("media_player.bedroom")
 		done <- true
 	}()
 


### PR DESCRIPTION
## Summary

- Removed `fadeOutBedroomSpeaker()` from `manager.go` -- a legacy wrapper that simply delegated to `fadeOutSpeaker("media_player.bedroom")`
- Updated all 4 test call sites in `manager_test.go` to call `fadeOutSpeaker("media_player.bedroom")` directly
- No production code called this wrapper; it was only used by tests

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `make unit-tests` passes (75.2% coverage, above 65% threshold)
- [x] `make integration-tests` passes
- [x] Pre-push hook passes all validation steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)