### PR TITLE
Fix #787: Make startup speaker unjoin resilient to unresponsive Sonos speakers

### DIFF
--- a/homeautomation-go/internal/plugins/music/fadein.go
+++ b/homeautomation-go/internal/plugins/music/fadein.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"strings"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -76,29 +77,45 @@ func (m *Manager) fadeOutSpeakers() {
 // This must be called before building a new speaker group to ensure speakers
 // aren't already grouped together in unpredictable ways.
 // Matches Node-RED behavior: "Break group for player" -> player.become.standalone
+//
+// Unjoin calls run concurrently with a short timeout (speakerUnjoinTimeout) to
+// prevent unresponsive speakers from blocking startup or playback transitions.
+// When speakers are systematically unreachable (e.g., HA Sonos integration issues),
+// sequential unjoin with full retries could block for 18+ minutes (6 speakers ×
+// 3 min retry budget each), causing HA to close the websocket and crash the app.
+// See: https://github.com/NickBorgers/home-automation/issues/787
 func (m *Manager) breakSpeakerGroups(participants []ParticipantWithVolume) {
 	m.logger.Info("Breaking existing speaker groups before building new group",
 		zap.Int("participant_count", len(participants)))
 
-	// Unjoin each speaker from any existing group
+	// Unjoin all speakers concurrently with a short timeout per speaker.
+	// Each unjoin is independent and best-effort — if a speaker is unreachable,
+	// we log a warning and continue rather than blocking for minutes of retries.
+	var wg sync.WaitGroup
 	for _, p := range participants {
-		entityID := m.getSpeakerEntityID(p.PlayerName)
+		wg.Add(1)
+		go func(p ParticipantWithVolume) {
+			defer wg.Done()
+			entityID := m.getSpeakerEntityID(p.PlayerName)
 
-		m.logger.Debug("Unjoining speaker from existing group",
-			zap.String("speaker", p.PlayerName),
-			zap.String("entity_id", entityID))
-
-		// Use media_player.unjoin to break the speaker out of any existing group
-		// This is equivalent to Sonos "player.become.standalone"
-		if err := m.callServiceWithRetry("media_player", "unjoin", map[string]interface{}{
-			"entity_id": entityID,
-		}); err != nil {
-			// Log warning but continue - speaker might not be in a group
-			m.logger.Warn("Failed to unjoin speaker (may not be in a group)",
+			m.logger.Debug("Unjoining speaker from existing group",
 				zap.String("speaker", p.PlayerName),
-				zap.Error(err))
-		}
+				zap.String("entity_id", entityID))
+
+			// Use best-effort call with short timeout instead of callServiceWithRetry.
+			// This limits each unjoin to ~15s instead of ~3 minutes of retries.
+			if err := m.callServiceBestEffort("media_player", "unjoin", map[string]interface{}{
+				"entity_id": entityID,
+			}, speakerUnjoinTimeout); err != nil {
+				// Log warning but continue - speaker might not be in a group
+				// or might be temporarily unreachable
+				m.logger.Warn("Failed to unjoin speaker (best-effort, continuing)",
+					zap.String("speaker", p.PlayerName),
+					zap.Error(err))
+			}
+		}(p)
 	}
+	wg.Wait()
 
 	// Allow time for Sonos to process the unjoin commands before building new group
 	m.sleepFunc(speakerUnjoinSettleDelay)

--- a/homeautomation-go/internal/plugins/music/helpers.go
+++ b/homeautomation-go/internal/plugins/music/helpers.go
@@ -1,8 +1,10 @@
 package music
 
 import (
+	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 )
@@ -99,6 +101,36 @@ func (m *Manager) validateConfiguredSpeakers() {
 			}
 		}
 	}
+}
+
+// callServiceBestEffort calls a Home Assistant service with a short timeout and
+// no retries. Used for cleanup operations (like unjoin) where blocking on
+// unresponsive speakers would be worse than skipping them.
+// The timeout bounds the total time including the HA client's internal retries —
+// context cancellation prevents retry attempts after the deadline.
+func (m *Manager) callServiceBestEffort(domain, service string, serviceData map[string]interface{}, timeout time.Duration) error {
+	if m.readOnly {
+		m.logger.Debug("Read-only mode: would call service (best-effort)",
+			zap.String("domain", domain),
+			zap.String("service", service),
+			zap.Any("service_data", serviceData))
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(m.ctx, timeout)
+	defer cancel()
+
+	m.logger.Debug("Calling HA service (best-effort)",
+		zap.String("domain", domain),
+		zap.String("service", service),
+		zap.Duration("timeout", timeout),
+		zap.Any("service_data", serviceData))
+
+	if err := m.haClient.CallService(ctx, domain, service, serviceData); err != nil {
+		return fmt.Errorf("best-effort service call failed: %w", err)
+	}
+
+	return nil
 }
 
 // callServiceWithRetry wraps callService with refresh-on-error logic

--- a/homeautomation-go/internal/plugins/music/manager_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_test.go
@@ -2260,78 +2260,216 @@ func TestCallServiceWithRetry(t *testing.T) {
 	}
 }
 
+func TestCallServiceBestEffort(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Succeeds when service responds quickly", func(t *testing.T) {
+		t.Parallel()
+		env := testutil.NewEnv(t)
+		config := &MusicConfig{Music: map[string]MusicMode{}}
+		manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, false, nil, nil)
+
+		err := manager.callServiceBestEffort("media_player", "unjoin", map[string]interface{}{
+			"entity_id": "media_player.kitchen",
+		}, 5*time.Second)
+
+		if err != nil {
+			t.Errorf("Expected success, got error: %v", err)
+		}
+	})
+
+	t.Run("Returns error when service fails", func(t *testing.T) {
+		t.Parallel()
+		env := testutil.NewEnv(t)
+		config := &MusicConfig{Music: map[string]MusicMode{}}
+		manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, false, nil, nil)
+
+		env.MockHA.SetServiceError("media_player", "unjoin", fmt.Errorf("speaker unreachable"))
+
+		err := manager.callServiceBestEffort("media_player", "unjoin", map[string]interface{}{
+			"entity_id": "media_player.kitchen",
+		}, 5*time.Second)
+
+		if err == nil {
+			t.Error("Expected error for unreachable speaker")
+		}
+	})
+
+	t.Run("Respects context timeout", func(t *testing.T) {
+		t.Parallel()
+		// Use an already-cancelled parent context
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		env := testutil.NewEnv(t)
+		config := &MusicConfig{Music: map[string]MusicMode{}}
+		manager := NewManager(ctx, env.MockHA, env.StateMgr, config, env.Logger, false, nil, nil)
+
+		err := manager.callServiceBestEffort("media_player", "unjoin", map[string]interface{}{
+			"entity_id": "media_player.kitchen",
+		}, 5*time.Second)
+
+		if err == nil {
+			t.Error("Expected error when parent context is cancelled")
+		}
+	})
+
+	t.Run("Skips in read-only mode", func(t *testing.T) {
+		t.Parallel()
+		env := testutil.NewEnv(t)
+		config := &MusicConfig{Music: map[string]MusicMode{}}
+		manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, true, nil, nil)
+
+		err := manager.callServiceBestEffort("media_player", "unjoin", map[string]interface{}{
+			"entity_id": "media_player.kitchen",
+		}, 5*time.Second)
+
+		if err != nil {
+			t.Errorf("Expected success in read-only mode, got error: %v", err)
+		}
+
+		// No service calls should have been recorded
+		calls := env.MockHA.GetServiceCalls()
+		for _, call := range calls {
+			if call.Domain == "media_player" && call.Service == "unjoin" {
+				t.Error("Should not have made service call in read-only mode")
+			}
+		}
+	})
+}
+
 func TestBreakSpeakerGroups(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
-		name             string
-		participants     []ParticipantWithVolume
-		failCount        int
-		setupEntities    []string
-		minUnjoinCalls   int
-		expectedSpeakers []string
-	}{
-		{
-			name: "All speakers unjoined successfully",
-			participants: []ParticipantWithVolume{
-				{PlayerName: "Kitchen", Volume: 9},
-				{PlayerName: "Living Room", Volume: 10},
-				{PlayerName: "Bedroom", Volume: 8},
-			},
-			minUnjoinCalls:   3,
-			expectedSpeakers: []string{"media_player.kitchen", "media_player.living_room", "media_player.bedroom"},
-		},
-		{
-			name: "Continues processing after unjoin failure",
-			participants: []ParticipantWithVolume{
-				{PlayerName: "Kitchen", Volume: 9},
-				{PlayerName: "Living Room", Volume: 10},
-			},
-			failCount:        1,
-			setupEntities:    []string{"media_player.kitchen", "media_player.living_room"},
-			minUnjoinCalls:   2,
-			expectedSpeakers: []string{"media_player.kitchen", "media_player.living_room"},
-		},
-	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			env := testutil.NewEnv(t)
-			config := &MusicConfig{Music: map[string]MusicMode{}}
-			manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, false, nil, nil)
-			manager.SetSleepFunc(func(d time.Duration) {})
+	t.Run("All speakers unjoined successfully", func(t *testing.T) {
+		t.Parallel()
+		env := testutil.NewEnv(t)
+		config := &MusicConfig{Music: map[string]MusicMode{}}
+		manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, false, nil, nil)
+		manager.SetSleepFunc(func(d time.Duration) {})
 
-			for _, entity := range tt.setupEntities {
-				env.MockHA.SetState(entity, "idle", nil)
-			}
-			if tt.failCount > 0 {
-				env.MockHA.SetServiceFailCount("media_player", "unjoin", tt.failCount, fmt.Errorf("speaker not reachable"))
-			}
-			snapshot := env.MockHA.ServiceCallCount()
+		participants := []ParticipantWithVolume{
+			{PlayerName: "Kitchen", Volume: 9},
+			{PlayerName: "Living Room", Volume: 10},
+			{PlayerName: "Bedroom", Volume: 8},
+		}
+		snapshot := env.MockHA.ServiceCallCount()
 
-			manager.breakSpeakerGroups(tt.participants)
+		manager.breakSpeakerGroups(participants)
 
-			calls := env.MockHA.GetServiceCallsSince(snapshot)
-			unjoinCalls := 0
-			unjoinedSpeakers := make(map[string]bool)
-			for _, call := range calls {
-				if call.Domain == "media_player" && call.Service == "unjoin" {
-					unjoinCalls++
-					if entityID, ok := call.Data["entity_id"].(string); ok {
-						unjoinedSpeakers[entityID] = true
-					}
+		calls := env.MockHA.GetServiceCallsSince(snapshot)
+		unjoinedSpeakers := make(map[string]bool)
+		for _, call := range calls {
+			if call.Domain == "media_player" && call.Service == "unjoin" {
+				if entityID, ok := call.Data["entity_id"].(string); ok {
+					unjoinedSpeakers[entityID] = true
 				}
 			}
+		}
 
-			if unjoinCalls < tt.minUnjoinCalls {
-				t.Errorf("Expected at least %d unjoin calls, got %d", tt.minUnjoinCalls, unjoinCalls)
+		expected := []string{"media_player.kitchen", "media_player.living_room", "media_player.bedroom"}
+		for _, e := range expected {
+			if !unjoinedSpeakers[e] {
+				t.Errorf("Expected unjoin call for %s", e)
 			}
-			for _, expected := range tt.expectedSpeakers {
-				if !unjoinedSpeakers[expected] {
-					t.Errorf("Expected unjoin call for %s", expected)
+		}
+	})
+
+	t.Run("Continues processing all speakers after unjoin failure", func(t *testing.T) {
+		t.Parallel()
+		env := testutil.NewEnv(t)
+		config := &MusicConfig{Music: map[string]MusicMode{}}
+		manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, false, nil, nil)
+		manager.SetSleepFunc(func(d time.Duration) {})
+
+		// Set up 3 speakers, with 1 failure — the other 2 should still succeed
+		participants := []ParticipantWithVolume{
+			{PlayerName: "Kitchen", Volume: 9},
+			{PlayerName: "Living Room", Volume: 10},
+			{PlayerName: "Bedroom", Volume: 8},
+		}
+		env.MockHA.SetServiceFailCount("media_player", "unjoin", 1, fmt.Errorf("speaker not reachable"))
+		snapshot := env.MockHA.ServiceCallCount()
+
+		manager.breakSpeakerGroups(participants)
+
+		// With best-effort concurrent unjoin, 1 of 3 calls fails (not recorded by mock),
+		// but the other 2 should succeed. The key invariant is that all speakers are
+		// attempted regardless of individual failures.
+		calls := env.MockHA.GetServiceCallsSince(snapshot)
+		unjoinCalls := 0
+		for _, call := range calls {
+			if call.Domain == "media_player" && call.Service == "unjoin" {
+				unjoinCalls++
+			}
+		}
+
+		// At least 2 of 3 speakers should have successful unjoin calls
+		// (1 failure out of 3 concurrent calls)
+		if unjoinCalls < 2 {
+			t.Errorf("Expected at least 2 successful unjoin calls, got %d", unjoinCalls)
+		}
+	})
+
+	t.Run("Respects context cancellation for unresponsive speakers", func(t *testing.T) {
+		t.Parallel()
+		// Use a cancelled context to verify that unjoin calls respect timeouts
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		env := testutil.NewEnv(t)
+		config := &MusicConfig{Music: map[string]MusicMode{}}
+		manager := NewManager(ctx, env.MockHA, env.StateMgr, config, env.Logger, false, nil, nil)
+		manager.SetSleepFunc(func(d time.Duration) {})
+
+		participants := []ParticipantWithVolume{
+			{PlayerName: "Kitchen", Volume: 9},
+			{PlayerName: "Living Room", Volume: 10},
+		}
+
+		// Should complete quickly without hanging — cancelled context
+		// causes callServiceBestEffort to return immediately
+		manager.breakSpeakerGroups(participants)
+
+		// With cancelled context, the mock returns errors for all calls
+		// The key verification is that the function returned (didn't hang)
+	})
+
+	t.Run("Runs unjoin calls concurrently", func(t *testing.T) {
+		t.Parallel()
+		env := testutil.NewEnv(t)
+		config := &MusicConfig{Music: map[string]MusicMode{}}
+		manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, false, nil, nil)
+		manager.SetSleepFunc(func(d time.Duration) {})
+
+		// With 6 speakers, concurrent execution should be fast
+		participants := []ParticipantWithVolume{
+			{PlayerName: "Kitchen", Volume: 9},
+			{PlayerName: "Living Room", Volume: 10},
+			{PlayerName: "Bedroom", Volume: 8},
+			{PlayerName: "Sitting Room", Volume: 7},
+			{PlayerName: "Primary Bathroom", Volume: 6},
+			{PlayerName: "Kids Bathroom", Volume: 5},
+		}
+		snapshot := env.MockHA.ServiceCallCount()
+
+		manager.breakSpeakerGroups(participants)
+
+		calls := env.MockHA.GetServiceCallsSince(snapshot)
+		unjoinedSpeakers := make(map[string]bool)
+		for _, call := range calls {
+			if call.Domain == "media_player" && call.Service == "unjoin" {
+				if entityID, ok := call.Data["entity_id"].(string); ok {
+					unjoinedSpeakers[entityID] = true
 				}
 			}
-		})
-	}
+		}
+
+		// All 6 speakers should be unjoined
+		if len(unjoinedSpeakers) != 6 {
+			t.Errorf("Expected 6 unjoin calls, got %d", len(unjoinedSpeakers))
+		}
+	})
 }
 
 func TestExecutePlayback_BreakThenBuildSequence(t *testing.T) {

--- a/homeautomation-go/internal/plugins/music/orchestration.go
+++ b/homeautomation-go/internal/plugins/music/orchestration.go
@@ -31,6 +31,13 @@ const (
 	// to allow the Sonos system to stabilize before forming new groups.
 	speakerUnjoinSettleDelay = 500 * time.Millisecond
 
+	// speakerUnjoinTimeout is the maximum time to wait for a single unjoin call.
+	// Unjoin is best-effort cleanup — if a speaker is unresponsive, we skip it
+	// rather than blocking startup or playback transitions for minutes.
+	// This bounds each unjoin to ~15s (one HA attempt at 10s + margin) instead of
+	// the default CallService retry loop (~3 minutes with 12 retries).
+	speakerUnjoinTimeout = 15 * time.Second
+
 	// speakerGroupSettleDelay is the delay after building a speaker group
 	// to allow the Sonos system to stabilize before starting playback.
 	speakerGroupSettleDelay = 500 * time.Millisecond


### PR DESCRIPTION
Resolves #787

## Summary
- Added `callServiceBestEffort()` helper that uses a short context timeout (15s) and skips the music-level refresh+retry logic, for cleanup operations where blocking on unresponsive speakers is worse than skipping them
- Changed `breakSpeakerGroups()` to run unjoin calls **concurrently** (via goroutines + WaitGroup) instead of sequentially, each bounded by `speakerUnjoinTimeout` (15s)
- Total worst-case unjoin time drops from ~18 minutes (6 speakers × ~3 min retry budget each, sequentially) to ~15 seconds (all speakers in parallel, single attempt with short timeout)

## How It Works
When Sonos speakers are unresponsive (e.g., HA Sonos integration degradation), the previous sequential unjoin with full retry budgets (~3 min per speaker via `CallService`'s 12 retries) would block for 18+ minutes with 6 speakers. This caused HA to close the websocket connection, crashing the app and creating a restart loop.

The fix uses two techniques:
1. **Concurrency**: All unjoin calls run in parallel via goroutines, so the total time is bounded by the slowest single speaker rather than the sum of all speakers
2. **Short timeout**: Each unjoin uses `context.WithTimeout` (15s) which cancels the HA client's retry loop after the first attempt, instead of allowing 12 retries over ~3 minutes

## Test Plan
- [x] Added `TestCallServiceBestEffort` — verifies success, error handling, context timeout, and read-only mode
- [x] Updated `TestBreakSpeakerGroups` — verifies concurrent unjoin, failure handling, context cancellation, and 6-speaker scenarios
- [x] All existing music plugin unit tests pass (84.7% coverage)
- [x] All integration tests pass
- [x] Pre-push validation passes (formatting, linting, build, unit tests, integration tests, 75.5% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)