### PR TITLE
Fix #796: Use color_temp_kelvin instead of deprecated color_temp

### DIFF
--- a/homeautomation-go/internal/devserver/devserver.go
+++ b/homeautomation-go/internal/devserver/devserver.go
@@ -226,14 +226,14 @@ func (d *DevServer) populateSampleData() {
 
 	// Light entities for rooms
 	d.server.SetState("light.living_room", "on", map[string]interface{}{
-		"friendly_name": "Living Room Lights",
-		"brightness":    200,
-		"color_temp":    350,
+		"friendly_name":     "Living Room Lights",
+		"brightness":        200,
+		"color_temp_kelvin": 2857,
 	})
 	d.server.SetState("light.kitchen", "on", map[string]interface{}{
-		"friendly_name": "Kitchen Lights",
-		"brightness":    255,
-		"color_temp":    300,
+		"friendly_name":     "Kitchen Lights",
+		"brightness":        255,
+		"color_temp_kelvin": 3333,
 	})
 	d.server.SetState("light.bedroom", "off", map[string]interface{}{
 		"friendly_name": "Bedroom Lights",

--- a/homeautomation-go/internal/plugins/sleephygiene/manager.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager.go
@@ -950,10 +950,10 @@ func (m *Manager) turnOnMasterBedroomLights() {
 
 	// First, ensure lights start dim and white
 	if err := m.haClient.CallService(m.ctx, "light", "turn_on", map[string]interface{}{
-		"entity_id":      "light.primary_suite",
-		"transition":     0,
-		"color_temp":     290,
-		"brightness_pct": 1,
+		"entity_id":         "light.primary_suite",
+		"transition":        0,
+		"color_temp_kelvin": 3448,
+		"brightness_pct":    1,
 	}); err != nil {
 		m.logger.Error("Failed to set initial bedroom light state", zap.Error(err))
 		return
@@ -963,10 +963,10 @@ func (m *Manager) turnOnMasterBedroomLights() {
 
 	// Then start slow transition to full brightness
 	if err := m.haClient.CallService(m.ctx, "light", "turn_on", map[string]interface{}{
-		"entity_id":      "light.primary_suite",
-		"transition":     transitionSeconds,
-		"color_temp":     290,
-		"brightness_pct": 100,
+		"entity_id":         "light.primary_suite",
+		"transition":        transitionSeconds,
+		"color_temp_kelvin": 3448,
+		"brightness_pct":    100,
 	}); err != nil {
 		m.logger.Error("Failed to start bedroom light transition", zap.Error(err))
 		return


### PR DESCRIPTION
Resolves #796

## Summary
- Replace deprecated `color_temp` (mireds) parameter with `color_temp_kelvin` in the sleephygiene wake sequence `light.turn_on` service calls
- 290 mireds → 3448 Kelvin (same warm white color temperature)
- Update devserver mock light data to use `color_temp_kelvin` for consistency

## Changes
- `sleephygiene/manager.go`: Both light service calls in `turnOnMasterBedroomLights()` now use `color_temp_kelvin: 3448` instead of `color_temp: 290`
- `devserver/devserver.go`: Mock light entity attributes updated from `color_temp` (mireds) to `color_temp_kelvin` (Kelvin)

## Test Plan
- All unit tests pass (75.1% coverage)
- All integration tests pass
- The wake sequence light fade-in should now work correctly with current HA API

🤖 Generated with Claude Code