### PR TITLE
Fix #797: Skip Tidal playlists when SoCo-CLI is not configured

### DIFF
--- a/homeautomation-go/internal/plugins/music/manager.go
+++ b/homeautomation-go/internal/plugins/music/manager.go
@@ -137,6 +137,56 @@ func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.M
 	}
 }
 
+// validateTidalAvailability checks whether Tidal playlists are configured but
+// SoCo-CLI is not available, and logs warnings about affected music modes.
+// Tidal playlists will be skipped at playback time; modes with only Tidal
+// playlists will have no playable options.
+func (m *Manager) validateTidalAvailability() {
+	if m.socoClient != nil {
+		return // SoCo-CLI configured, all playlists available
+	}
+
+	var degradedModes []string
+	var brokenModes []string
+	totalTidal := 0
+
+	for modeName, mode := range m.config.Music {
+		tidalCount := 0
+		for _, opt := range mode.PlaybackOptions {
+			if opt.MediaType == "tidal" {
+				tidalCount++
+			}
+		}
+		if tidalCount == 0 {
+			continue
+		}
+		totalTidal += tidalCount
+
+		nonTidalCount := len(mode.PlaybackOptions) - tidalCount
+		if nonTidalCount == 0 {
+			brokenModes = append(brokenModes, modeName)
+		} else {
+			degradedModes = append(degradedModes, modeName)
+		}
+	}
+
+	if totalTidal == 0 {
+		return
+	}
+
+	m.logger.Warn("SoCo-CLI not configured: Tidal playlists will be skipped (set SOCO_CLI_URL to enable)",
+		zap.Int("tidal_playlists_skipped", totalTidal))
+
+	if len(degradedModes) > 0 {
+		m.logger.Warn("Music modes with reduced playlist options (some Tidal playlists skipped)",
+			zap.Strings("modes", degradedModes))
+	}
+	if len(brokenModes) > 0 {
+		m.logger.Error("Music modes with NO playable options (all playlists are Tidal)",
+			zap.Strings("modes", brokenModes))
+	}
+}
+
 // SetSleepFunc allows overriding the sleep function for testing
 func (m *Manager) SetSleepFunc(fn SleepFunc) {
 	m.sleepFunc = fn
@@ -177,6 +227,9 @@ func (m *Manager) GetActiveZones() []*Zone {
 // Start begins monitoring state changes and managing music playback
 func (m *Manager) Start() error {
 	m.logger.Info("Starting Music Manager")
+
+	// Warn about unavailable Tidal playlists when SoCo-CLI is not configured
+	m.validateTidalAvailability()
 
 	// Ensure zones are always populated. LoadConfig calls ensureZones at load time,
 	// but programmatically-constructed configs (e.g., in tests) may not have zones.

--- a/homeautomation-go/internal/plugins/music/orchestration.go
+++ b/homeautomation-go/internal/plugins/music/orchestration.go
@@ -94,6 +94,23 @@ const (
 	playbackRecoveryDelay = 2 * time.Second
 )
 
+// filterPlaybackOptions returns only the playback options that can be used
+// with the current system configuration. Tidal options are excluded when
+// SoCo-CLI is not configured (socoClient is nil).
+func (m *Manager) filterPlaybackOptions(options []PlaybackOption) []PlaybackOption {
+	if m.socoClient != nil {
+		return options
+	}
+
+	filtered := make([]PlaybackOption, 0, len(options))
+	for _, opt := range options {
+		if opt.MediaType != "tidal" {
+			filtered = append(filtered, opt)
+		}
+	}
+	return filtered
+}
+
 // orchestratePlayback coordinates the complete playback flow
 func (m *Manager) orchestratePlayback(musicType string, trigger string) error {
 	m.logger.Info("Orchestrating playback", zap.String("type", musicType), zap.String("trigger", trigger))
@@ -104,9 +121,24 @@ func (m *Manager) orchestratePlayback(musicType string, trigger string) error {
 		return fmt.Errorf("unknown music type: %s", musicType)
 	}
 
+	// Filter playback options based on available capabilities.
+	// Tidal playlists are excluded when SoCo-CLI is not configured.
+	availableOptions := m.filterPlaybackOptions(mode.PlaybackOptions)
+	if len(availableOptions) == 0 {
+		return fmt.Errorf("no playable options for music type %s: all %d playlists require Tidal (set SOCO_CLI_URL to enable)",
+			musicType, len(mode.PlaybackOptions))
+	}
+
+	if len(availableOptions) < len(mode.PlaybackOptions) {
+		m.logger.Info("Filtered unavailable Tidal playlists",
+			zap.String("type", musicType),
+			zap.Int("total", len(mode.PlaybackOptions)),
+			zap.Int("available", len(availableOptions)))
+	}
+
 	// Select playlist with rotation
-	playlistIndex := m.getNextPlaylistIndex(musicType, len(mode.PlaybackOptions))
-	playbackOption := mode.PlaybackOptions[playlistIndex]
+	playlistIndex := m.getNextPlaylistIndex(musicType, len(availableOptions))
+	playbackOption := availableOptions[playlistIndex]
 
 	m.logger.Info("Selected playlist",
 		zap.String("type", musicType),

--- a/homeautomation-go/internal/plugins/music/playlists.go
+++ b/homeautomation-go/internal/plugins/music/playlists.go
@@ -21,6 +21,12 @@ func (m *Manager) getNextPlaylistIndex(musicType string, optionsCount int) int {
 		currentIndex = 0
 	}
 
+	// Bounds check: index may be out of range if available options count changed
+	// (e.g., Tidal playlists filtered out when SoCo-CLI unavailable)
+	if currentIndex >= optionsCount {
+		currentIndex = currentIndex % optionsCount
+	}
+
 	// Save the index to use
 	indexToUse := currentIndex
 

--- a/homeautomation-go/internal/plugins/music/tidal_filter_test.go
+++ b/homeautomation-go/internal/plugins/music/tidal_filter_test.go
@@ -1,0 +1,378 @@
+package music
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"homeautomation/internal/ha"
+	"homeautomation/internal/state"
+	"homeautomation/pkg/plugin"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestFilterPlaybackOptions(t *testing.T) {
+	t.Parallel()
+	logger := zaptest.NewLogger(t)
+
+	mixedOptions := []PlaybackOption{
+		{URI: "spotify:playlist:abc", MediaType: "playlist", VolumeMultiplier: 1.0},
+		{URI: "https://tidal.com/browse/playlist/123", MediaType: "tidal", VolumeMultiplier: 1.0},
+		{URI: "http://rain-sounds.example.com/rain.m3u", MediaType: "music", VolumeMultiplier: 1.3},
+		{URI: "https://tidal.com/browse/playlist/456", MediaType: "tidal", VolumeMultiplier: 1.0},
+	}
+
+	allTidalOptions := []PlaybackOption{
+		{URI: "https://tidal.com/browse/playlist/123", MediaType: "tidal", VolumeMultiplier: 1.0},
+		{URI: "https://tidal.com/browse/playlist/456", MediaType: "tidal", VolumeMultiplier: 1.0},
+	}
+
+	noTidalOptions := []PlaybackOption{
+		{URI: "spotify:playlist:abc", MediaType: "playlist", VolumeMultiplier: 1.0},
+		{URI: "http://rain-sounds.example.com/rain.m3u", MediaType: "music", VolumeMultiplier: 1.3},
+	}
+
+	t.Run("SoCo-CLI configured: returns all options unfiltered", func(t *testing.T) {
+		t.Parallel()
+		mockClient := ha.NewMockClient()
+		stateManager := state.NewManager(mockClient, logger, false)
+		config := &MusicConfig{Music: map[string]MusicMode{}}
+
+		manager := NewManager(context.Background(), mockClient, stateManager, config, logger, true, nil, nil)
+		manager.SetSoCoClient(NewSoCoClient("http://127.0.0.1:8000", logger, false))
+
+		result := manager.filterPlaybackOptions(mixedOptions)
+		assert.Equal(t, mixedOptions, result)
+	})
+
+	t.Run("SoCo-CLI not configured: filters out Tidal options", func(t *testing.T) {
+		t.Parallel()
+		mockClient := ha.NewMockClient()
+		stateManager := state.NewManager(mockClient, logger, false)
+		config := &MusicConfig{Music: map[string]MusicMode{}}
+
+		manager := NewManager(context.Background(), mockClient, stateManager, config, logger, true, nil, nil)
+		// socoClient is nil by default
+
+		result := manager.filterPlaybackOptions(mixedOptions)
+		assert.Len(t, result, 2)
+		assert.Equal(t, "playlist", result[0].MediaType)
+		assert.Equal(t, "music", result[1].MediaType)
+	})
+
+	t.Run("SoCo-CLI not configured: all Tidal returns empty", func(t *testing.T) {
+		t.Parallel()
+		mockClient := ha.NewMockClient()
+		stateManager := state.NewManager(mockClient, logger, false)
+		config := &MusicConfig{Music: map[string]MusicMode{}}
+
+		manager := NewManager(context.Background(), mockClient, stateManager, config, logger, true, nil, nil)
+
+		result := manager.filterPlaybackOptions(allTidalOptions)
+		assert.Empty(t, result)
+	})
+
+	t.Run("SoCo-CLI not configured: no Tidal options unchanged", func(t *testing.T) {
+		t.Parallel()
+		mockClient := ha.NewMockClient()
+		stateManager := state.NewManager(mockClient, logger, false)
+		config := &MusicConfig{Music: map[string]MusicMode{}}
+
+		manager := NewManager(context.Background(), mockClient, stateManager, config, logger, true, nil, nil)
+
+		result := manager.filterPlaybackOptions(noTidalOptions)
+		assert.Equal(t, noTidalOptions, result)
+	})
+}
+
+func TestOrchestratePlayback_TidalFiltering(t *testing.T) {
+	t.Parallel()
+
+	t.Run("skips Tidal playlists when SoCo-CLI not configured", func(t *testing.T) {
+		t.Parallel()
+		core, _ := observer.New(zap.InfoLevel)
+		logger := zap.New(core)
+
+		mockClient := ha.NewMockClient()
+		stateManager := state.NewManager(mockClient, logger, false)
+
+		config := &MusicConfig{
+			Music: map[string]MusicMode{
+				"morning": {
+					Participants: []Participant{{PlayerName: "Kitchen", BaseVolume: 9}},
+					PlaybackOptions: []PlaybackOption{
+						{URI: "spotify:playlist:abc", MediaType: "playlist", VolumeMultiplier: 1.0},
+						{URI: "https://tidal.com/browse/playlist/123", MediaType: "tidal", VolumeMultiplier: 1.0},
+					},
+				},
+				"day":      {Participants: []Participant{{PlayerName: "Kitchen", BaseVolume: 9}}, PlaybackOptions: []PlaybackOption{{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0}}},
+				"evening":  {Participants: []Participant{{PlayerName: "Kitchen", BaseVolume: 9}}, PlaybackOptions: []PlaybackOption{{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0}}},
+				"winddown": {Participants: []Participant{{PlayerName: "Kitchen", BaseVolume: 9}}, PlaybackOptions: []PlaybackOption{{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0}}},
+				"sleep":    {Participants: []Participant{{PlayerName: "Kitchen", BaseVolume: 9}}, PlaybackOptions: []PlaybackOption{{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0}}},
+				"sex":      {Participants: []Participant{{PlayerName: "Kitchen", BaseVolume: 9}}, PlaybackOptions: []PlaybackOption{{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0}}},
+				"wakeup":   {Participants: []Participant{{PlayerName: "Kitchen", BaseVolume: 9}}, PlaybackOptions: []PlaybackOption{{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0}}},
+			},
+		}
+
+		fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+		timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
+
+		manager := NewManager(context.Background(), mockClient, stateManager, config, logger, true, timeProvider, nil)
+		// socoClient is nil - SoCo-CLI not configured
+		manager.SetSleepFunc(func(d time.Duration) {})
+
+		_ = stateManager.SetString("dayPhase", "morning")
+		_ = stateManager.SetBool("isAnyoneHome", true)
+		_ = stateManager.SetBool("isAnyoneAsleep", false)
+
+		// Call orchestratePlayback - should pick the Spotify playlist, not the Tidal one
+		err := manager.orchestratePlayback("morning", "test")
+		require.NoError(t, err)
+
+		// Verify the selected URI is the Spotify one
+		manager.mu.RLock()
+		currentlyPlaying := manager.currentlyPlaying
+		manager.mu.RUnlock()
+
+		require.NotNil(t, currentlyPlaying)
+		assert.Equal(t, "spotify:playlist:abc", currentlyPlaying.URI)
+		assert.Equal(t, "playlist", currentlyPlaying.MediaType)
+	})
+
+	t.Run("returns error when all options are Tidal and SoCo-CLI not configured", func(t *testing.T) {
+		t.Parallel()
+		core, _ := observer.New(zap.InfoLevel)
+		logger := zap.New(core)
+
+		mockClient := ha.NewMockClient()
+		stateManager := state.NewManager(mockClient, logger, false)
+
+		config := &MusicConfig{
+			Music: map[string]MusicMode{
+				"wakeup": {
+					Participants: []Participant{{PlayerName: "Bedroom", BaseVolume: 6}},
+					PlaybackOptions: []PlaybackOption{
+						{URI: "https://tidal.com/browse/playlist/abc", MediaType: "tidal", VolumeMultiplier: 1.0},
+					},
+				},
+				"morning":  {Participants: []Participant{{PlayerName: "Kitchen", BaseVolume: 9}}, PlaybackOptions: []PlaybackOption{{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0}}},
+				"day":      {Participants: []Participant{{PlayerName: "Kitchen", BaseVolume: 9}}, PlaybackOptions: []PlaybackOption{{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0}}},
+				"evening":  {Participants: []Participant{{PlayerName: "Kitchen", BaseVolume: 9}}, PlaybackOptions: []PlaybackOption{{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0}}},
+				"winddown": {Participants: []Participant{{PlayerName: "Kitchen", BaseVolume: 9}}, PlaybackOptions: []PlaybackOption{{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0}}},
+				"sleep":    {Participants: []Participant{{PlayerName: "Kitchen", BaseVolume: 9}}, PlaybackOptions: []PlaybackOption{{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0}}},
+				"sex":      {Participants: []Participant{{PlayerName: "Kitchen", BaseVolume: 9}}, PlaybackOptions: []PlaybackOption{{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0}}},
+			},
+		}
+
+		fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+		timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
+
+		manager := NewManager(context.Background(), mockClient, stateManager, config, logger, true, timeProvider, nil)
+		manager.SetSleepFunc(func(d time.Duration) {})
+
+		err := manager.orchestratePlayback("wakeup", "test")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no playable options")
+		assert.Contains(t, err.Error(), "SOCO_CLI_URL")
+	})
+
+	t.Run("Tidal playlists work when SoCo-CLI is configured", func(t *testing.T) {
+		t.Parallel()
+		core, _ := observer.New(zap.InfoLevel)
+		logger := zap.New(core)
+
+		mockClient := ha.NewMockClient()
+		stateManager := state.NewManager(mockClient, logger, false)
+
+		config := &MusicConfig{
+			Music: map[string]MusicMode{
+				"wakeup": {
+					Participants: []Participant{{PlayerName: "Bedroom", BaseVolume: 6}},
+					PlaybackOptions: []PlaybackOption{
+						{URI: "https://tidal.com/browse/playlist/abc", MediaType: "tidal", VolumeMultiplier: 1.0},
+					},
+				},
+				"morning":  {Participants: []Participant{{PlayerName: "Kitchen", BaseVolume: 9}}, PlaybackOptions: []PlaybackOption{{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0}}},
+				"day":      {Participants: []Participant{{PlayerName: "Kitchen", BaseVolume: 9}}, PlaybackOptions: []PlaybackOption{{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0}}},
+				"evening":  {Participants: []Participant{{PlayerName: "Kitchen", BaseVolume: 9}}, PlaybackOptions: []PlaybackOption{{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0}}},
+				"winddown": {Participants: []Participant{{PlayerName: "Kitchen", BaseVolume: 9}}, PlaybackOptions: []PlaybackOption{{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0}}},
+				"sleep":    {Participants: []Participant{{PlayerName: "Kitchen", BaseVolume: 9}}, PlaybackOptions: []PlaybackOption{{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0}}},
+				"sex":      {Participants: []Participant{{PlayerName: "Kitchen", BaseVolume: 9}}, PlaybackOptions: []PlaybackOption{{URI: "test:uri", MediaType: "playlist", VolumeMultiplier: 1.0}}},
+			},
+		}
+
+		fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+		timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
+
+		manager := NewManager(context.Background(), mockClient, stateManager, config, logger, true, timeProvider, nil)
+		// Configure SoCo-CLI client (read-only mode since we don't have a real server)
+		manager.SetSoCoClient(NewSoCoClient("http://127.0.0.1:8000", logger, true))
+		manager.SetSleepFunc(func(d time.Duration) {})
+
+		// Call orchestratePlayback - should use the Tidal playlist since SoCo-CLI is configured
+		err := manager.orchestratePlayback("wakeup", "test")
+		require.NoError(t, err)
+
+		manager.mu.RLock()
+		currentlyPlaying := manager.currentlyPlaying
+		manager.mu.RUnlock()
+
+		require.NotNil(t, currentlyPlaying)
+		assert.Equal(t, "https://tidal.com/browse/playlist/abc", currentlyPlaying.URI)
+		assert.Equal(t, "tidal", currentlyPlaying.MediaType)
+	})
+}
+
+func TestValidateTidalAvailability(t *testing.T) {
+	t.Parallel()
+
+	t.Run("logs warning for degraded modes", func(t *testing.T) {
+		t.Parallel()
+		core, logs := observer.New(zap.WarnLevel)
+		logger := zap.New(core)
+
+		mockClient := ha.NewMockClient()
+		stateManager := state.NewManager(mockClient, logger, false)
+
+		config := &MusicConfig{
+			Music: map[string]MusicMode{
+				"morning": {
+					PlaybackOptions: []PlaybackOption{
+						{URI: "spotify:playlist:abc", MediaType: "playlist"},
+						{URI: "https://tidal.com/browse/playlist/123", MediaType: "tidal"},
+					},
+				},
+				"wakeup": {
+					PlaybackOptions: []PlaybackOption{
+						{URI: "https://tidal.com/browse/playlist/456", MediaType: "tidal"},
+					},
+				},
+				"sleep": {
+					PlaybackOptions: []PlaybackOption{
+						{URI: "http://rain.example.com/rain.m3u", MediaType: "music"},
+					},
+				},
+			},
+		}
+
+		manager := NewManager(context.Background(), mockClient, stateManager, config, logger, true, nil, nil)
+		// socoClient is nil
+
+		manager.validateTidalAvailability()
+
+		// Should have logged a general warning and specific mode warnings
+		allLogs := logs.All()
+		assert.GreaterOrEqual(t, len(allLogs), 2, "expected at least 2 log entries (general + modes)")
+
+		// Check for the general warning
+		foundGeneral := false
+		for _, entry := range allLogs {
+			if entry.Message == "SoCo-CLI not configured: Tidal playlists will be skipped (set SOCO_CLI_URL to enable)" {
+				foundGeneral = true
+			}
+		}
+		assert.True(t, foundGeneral, "expected general SoCo-CLI warning")
+
+		// Check for broken modes warning (wakeup has only Tidal)
+		foundBroken := false
+		for _, entry := range allLogs {
+			if entry.Message == "Music modes with NO playable options (all playlists are Tidal)" {
+				foundBroken = true
+			}
+		}
+		assert.True(t, foundBroken, "expected broken modes warning for wakeup")
+	})
+
+	t.Run("no warnings when SoCo-CLI configured", func(t *testing.T) {
+		t.Parallel()
+		core, logs := observer.New(zap.WarnLevel)
+		logger := zap.New(core)
+
+		mockClient := ha.NewMockClient()
+		stateManager := state.NewManager(mockClient, logger, false)
+
+		config := &MusicConfig{
+			Music: map[string]MusicMode{
+				"morning": {
+					PlaybackOptions: []PlaybackOption{
+						{URI: "https://tidal.com/browse/playlist/123", MediaType: "tidal"},
+					},
+				},
+			},
+		}
+
+		manager := NewManager(context.Background(), mockClient, stateManager, config, logger, true, nil, nil)
+		manager.SetSoCoClient(NewSoCoClient("http://127.0.0.1:8000", logger, false))
+
+		manager.validateTidalAvailability()
+
+		assert.Empty(t, logs.All(), "no warnings expected when SoCo-CLI is configured")
+	})
+
+	t.Run("no warnings when no Tidal playlists configured", func(t *testing.T) {
+		t.Parallel()
+		core, logs := observer.New(zap.WarnLevel)
+		logger := zap.New(core)
+
+		mockClient := ha.NewMockClient()
+		stateManager := state.NewManager(mockClient, logger, false)
+
+		config := &MusicConfig{
+			Music: map[string]MusicMode{
+				"morning": {
+					PlaybackOptions: []PlaybackOption{
+						{URI: "spotify:playlist:abc", MediaType: "playlist"},
+					},
+				},
+			},
+		}
+
+		manager := NewManager(context.Background(), mockClient, stateManager, config, logger, true, nil, nil)
+
+		manager.validateTidalAvailability()
+
+		assert.Empty(t, logs.All(), "no warnings expected when no Tidal playlists configured")
+	})
+}
+
+func TestGetNextPlaylistIndex_BoundsCheck(t *testing.T) {
+	t.Parallel()
+	logger := zaptest.NewLogger(t)
+
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	config := &MusicConfig{Music: map[string]MusicMode{}}
+
+	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, true, nil, nil)
+
+	t.Run("index wraps when options count decreases", func(t *testing.T) {
+		// Simulate having advanced to index 5 with 6 options
+		manager.mu.Lock()
+		manager.playlistNumbers["test_mode"] = 5
+		manager.mu.Unlock()
+
+		// Now call with only 2 options (e.g., after Tidal filtering)
+		index := manager.getNextPlaylistIndex("test_mode", 2)
+		manager.WaitForSync()
+
+		// Index 5 % 2 = 1, which should be within bounds
+		assert.Less(t, index, 2, "index should be within bounds of reduced options count")
+		assert.Equal(t, 1, index)
+	})
+
+	t.Run("index 0 stays 0 with any count", func(t *testing.T) {
+		manager.mu.Lock()
+		manager.playlistNumbers["test_mode2"] = 0
+		manager.mu.Unlock()
+
+		index := manager.getNextPlaylistIndex("test_mode2", 3)
+		manager.WaitForSync()
+
+		assert.Equal(t, 0, index)
+	})
+}


### PR DESCRIPTION
Resolves #797

## Summary
- When `SOCO_CLI_URL` is not set, the music plugin now **filters out Tidal playlists** before selection, falling back to Spotify/HTTP alternatives instead of silently failing (speakers grouped at volume 0, no audio)
- Adds **startup validation** that logs which music modes are degraded (some Tidal playlists skipped) vs broken (all playlists are Tidal)
- Adds **bounds check** in playlist rotation to handle filtered option count changes safely
- Modes with only Tidal playlists (e.g., `wakeup`) return a clear error instead of proceeding with broken playback

## How it works
1. `filterPlaybackOptions()` removes `media_type: tidal` entries when `socoClient` is nil
2. `orchestratePlayback()` uses filtered options for selection — Tidal playlists never reach the speaker grouping/volume stage
3. `validateTidalAvailability()` runs at startup and logs warnings at WARN level (degraded) and ERROR level (no options)
4. `getNextPlaylistIndex()` wraps out-of-bounds indices when the available options count decreases

## Test Plan
- [x] Unit tests: `TestFilterPlaybackOptions` — verifies filtering with/without SoCo-CLI
- [x] Unit tests: `TestOrchestratePlayback_TidalFiltering` — verifies Spotify fallback, Tidal-only error, and Tidal-with-SoCo-CLI
- [x] Unit tests: `TestValidateTidalAvailability` — verifies startup warnings
- [x] Unit tests: `TestGetNextPlaylistIndex_BoundsCheck` — verifies index wrapping
- [x] All existing unit tests pass (75.2% coverage)
- [x] All integration tests pass
- [x] Pre-commit and pre-push validation pass
- [ ] Deploy with `SOCO_CLI_URL` unset — verify morning/day/evening/winddown play non-Tidal fallbacks
- [ ] Deploy with `SOCO_CLI_URL` set — verify all playlists work including Tidal

🤖 Generated with [Claude Code](https://claude.com/claude-code)