### PR TITLE
Fix Tidal playback playing stale Spotify content

### DIFF
--- a/homeautomation-go/internal/plugins/music/manager_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_test.go
@@ -2913,9 +2913,12 @@ func TestStartPlaybackWithVerification_TidalDispatch(t *testing.T) {
 	t.Run("tidal dispatches to SoCo-CLI client", func(t *testing.T) {
 		var actions []string
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/Kitchen/play_from_queue" {
+			switch {
+			case r.URL.Path == "/Kitchen/clear_queue":
+				actions = append(actions, "clear_queue")
+			case r.URL.Path == "/Kitchen/play_from_queue":
 				actions = append(actions, "play_from_queue")
-			} else {
+			default:
 				actions = append(actions, "sharelink")
 			}
 			resp := SoCoResponse{Result: "ok", ExitCode: 0}
@@ -2940,7 +2943,7 @@ func TestStartPlaybackWithVerification_TidalDispatch(t *testing.T) {
 		attempts, err := manager.startPlaybackWithVerification("media_player.kitchen", "Kitchen", option)
 		require.NoError(t, err)
 		assert.Equal(t, 1, attempts)
-		assert.Equal(t, []string{"sharelink", "play_from_queue"}, actions)
+		assert.Equal(t, []string{"clear_queue", "sharelink", "play_from_queue"}, actions)
 
 		// Verify no HA play_media calls were made (Tidal goes through SoCo-CLI)
 		for _, call := range env.MockHA.GetServiceCalls() {

--- a/homeautomation-go/internal/plugins/music/sococli.go
+++ b/homeautomation-go/internal/plugins/music/sococli.go
@@ -79,9 +79,29 @@ func (c *SoCoClient) PlayFromQueue(speakerName string) error {
 	return c.doGet(endpoint, "play_from_queue", speakerName)
 }
 
-// PlayShareLink is a convenience method that adds a Tidal share link to the queue
-// and starts playback. This is the main entry point for Tidal playlist playback.
+// ClearQueue removes all items from the specified speaker's queue.
+// This should be called before ShareLink to prevent stale content from playing.
+func (c *SoCoClient) ClearQueue(speakerName string) error {
+	if c.readOnly {
+		c.logger.Info("READ_ONLY: Would send clear_queue to SoCo-CLI",
+			zap.String("speaker", speakerName))
+		return nil
+	}
+
+	// GET /{speaker}/clear_queue
+	endpoint := fmt.Sprintf("%s/%s/clear_queue",
+		c.baseURL,
+		url.PathEscape(speakerName))
+
+	return c.doGet(endpoint, "clear_queue", speakerName)
+}
+
+// PlayShareLink clears the queue, adds a Tidal share link, and starts playback.
+// This is the main entry point for Tidal playlist playback.
 func (c *SoCoClient) PlayShareLink(speakerName, tidalURL string) error {
+	if err := c.ClearQueue(speakerName); err != nil {
+		return fmt.Errorf("clear_queue failed: %w", err)
+	}
 	if err := c.ShareLink(speakerName, tidalURL); err != nil {
 		return fmt.Errorf("sharelink failed: %w", err)
 	}

--- a/homeautomation-go/internal/plugins/music/sococli_test.go
+++ b/homeautomation-go/internal/plugins/music/sococli_test.go
@@ -155,17 +155,60 @@ func TestSoCoClient_PlayFromQueue(t *testing.T) {
 	})
 }
 
+func TestSoCoClient_ClearQueue(t *testing.T) {
+	t.Parallel()
+	logger := zaptest.NewLogger(t)
+
+	t.Run("successful clear_queue", func(t *testing.T) {
+		var requestPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestPath = r.URL.Path
+			resp := SoCoResponse{
+				Result:   "",
+				ExitCode: 0,
+				Speaker:  "Front Room",
+				Action:   "clear_queue",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		client := NewSoCoClient(server.URL, logger, false)
+		err := client.ClearQueue("Front Room")
+		require.NoError(t, err)
+		assert.Equal(t, "/Front Room/clear_queue", requestPath)
+	})
+
+	t.Run("read-only mode does not call server", func(t *testing.T) {
+		callCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		client := NewSoCoClient(server.URL, logger, true)
+		err := client.ClearQueue("Front Room")
+		assert.NoError(t, err)
+		assert.Equal(t, 0, callCount, "server should not have been called")
+	})
+}
+
 func TestSoCoClient_PlayShareLink(t *testing.T) {
 	t.Parallel()
 	logger := zaptest.NewLogger(t)
 
-	t.Run("calls sharelink then play_from_queue", func(t *testing.T) {
+	t.Run("calls clear_queue then sharelink then play_from_queue", func(t *testing.T) {
 		var actions []string
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			action := "unknown"
-			if r.URL.Path == "/Kitchen/play_from_queue" {
+			switch {
+			case r.URL.Path == "/Kitchen/clear_queue":
+				action = "clear_queue"
+			case r.URL.Path == "/Kitchen/play_from_queue":
 				action = "play_from_queue"
-			} else {
+			default:
 				action = "sharelink"
 			}
 			actions = append(actions, action)
@@ -183,14 +226,33 @@ func TestSoCoClient_PlayShareLink(t *testing.T) {
 		client := NewSoCoClient(server.URL, logger, false)
 		err := client.PlayShareLink("Kitchen", "https://tidal.com/browse/playlist/abc123")
 		require.NoError(t, err)
-		assert.Equal(t, []string{"sharelink", "play_from_queue"}, actions)
+		assert.Equal(t, []string{"clear_queue", "sharelink", "play_from_queue"}, actions)
 	})
 
-	t.Run("returns error if sharelink fails", func(t *testing.T) {
+	t.Run("returns error if clear_queue fails", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			resp := SoCoResponse{
 				ExitCode: 1,
-				ErrorMsg: "bad url",
+				ErrorMsg: "speaker not found",
+			}
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		client := NewSoCoClient(server.URL, logger, false)
+		err := client.PlayShareLink("Kitchen", "https://tidal.com/browse/playlist/abc123")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "clear_queue failed")
+	})
+
+	t.Run("returns error if sharelink fails", func(t *testing.T) {
+		callNum := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callNum++
+			resp := SoCoResponse{ExitCode: 0, Result: "ok"}
+			if callNum == 2 {
+				// Second call (sharelink) fails
+				resp = SoCoResponse{ExitCode: 1, ErrorMsg: "bad url"}
 			}
 			json.NewEncoder(w).Encode(resp)
 		}))
@@ -207,8 +269,8 @@ func TestSoCoClient_PlayShareLink(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			callNum++
 			resp := SoCoResponse{ExitCode: 0, Result: "ok"}
-			if callNum > 1 {
-				// Second call (play_from_queue) fails
+			if callNum == 3 {
+				// Third call (play_from_queue) fails
 				resp = SoCoResponse{ExitCode: 1, ErrorMsg: "queue empty"}
 			}
 			json.NewEncoder(w).Encode(resp)


### PR DESCRIPTION
## Summary
- **Bug**: When playing Tidal playlists via SoCo-CLI, the Sonos queue was not cleared first. If the queue contained stale content (e.g., a Spotify playlist from a previous session), `play_from_queue` would play the old content instead of the newly added Tidal playlist.
- **Fix**: Added `clear_queue` call before `sharelink` in `PlayShareLink`, so the sequence is now: `clear_queue` → `sharelink` → `play_from_queue`.
- **Verified**: Manually tested on production Sonos speakers — clearing the queue before adding the Tidal sharelink resolved the issue.

## Test plan
- [x] Manually tested clear_queue → sharelink → play_from_queue on production Sonos (confirmed Tidal plays instead of Spotify)
- [x] Unit tests updated and passing (SoCo-CLI client tests, Tidal dispatch test)
- [x] Integration tests passing
- [x] Pre-push validation passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)