### PR TITLE
Fix #807: Reduce integration test flakiness under CI load

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Run integration tests
         run: make integration-tests-impl
+        env:
+          TEST_WAIT_TIMEOUT: 10s
 
   build-and-push:
     name: Build and Push Docker Image

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -127,6 +127,8 @@ jobs:
 
       - name: Run integration tests
         run: make integration-tests-impl
+        env:
+          TEST_WAIT_TIMEOUT: 10s
 
   config-tests:
     name: Config Validation Tests

--- a/homeautomation-go/test/integration/scenario_nighttime_safety_test.go
+++ b/homeautomation-go/test/integration/scenario_nighttime_safety_test.go
@@ -608,8 +608,11 @@ func TestScenario_SleepToMorningTransition_BedroomMutedUntilActualWake(t *testin
 	env.server.SetState("input_text.music_playback_type", "morning", map[string]interface{}{})
 	waitForStringState(t, env.stateManager, "musicPlaybackType", "morning", "Music type should be morning")
 
-	// Wait for all music plugin service calls (mute/volume) to complete
+	// Wait for all music plugin service calls (mute/volume) to complete.
+	// waitForProcessing handles HA WebSocket handlers; the brief sleep allows
+	// any fire-and-forget zone orchestration goroutines to finish their work.
 	waitForProcessing(t, env.stateManager)
+	time.Sleep(200 * time.Millisecond)
 
 	// ========== THEN ==========
 	t.Log("THEN: Bedroom should be MUTED during morning music while master sleeps")

--- a/homeautomation-go/test/integration/scenario_security_test.go
+++ b/homeautomation-go/test/integration/scenario_security_test.go
@@ -193,10 +193,10 @@ func TestScenario_DidOwnerJustReturnHomeAutoReset(t *testing.T) {
 
 	t.Log("WHEN: 10 minutes pass (simulated via mock clock)")
 
-	// Brief real sleep to ensure the mock clock timer from setOwnerJustReturnedHome()
-	// is fully registered. The waitForBoolState above confirms the state was set, but
-	// the timer registration happens after SetBool in the handler goroutine.
-	time.Sleep(50 * time.Millisecond)
+	// Wait for all handler goroutines to complete, including timer registration
+	// in setOwnerJustReturnedHome(). waitForBoolState above confirms the state was
+	// set, but the timer registration happens after SetBool in the handler goroutine.
+	waitForProcessing(t, manager)
 
 	// Use mock clock to advance time instantly; AdvanceAndProcess fires callbacks
 	// and yields to the scheduler so any woken goroutines can complete
@@ -231,9 +231,9 @@ func TestScenario_MultipleArrivalsWithin10Minutes(t *testing.T) {
 
 	t.Log("WHEN: Caroline arrives 2 minutes later (simulated)")
 
-	// Brief real sleep to ensure Nick's mock clock timer is fully registered
-	// before advancing the clock.
-	time.Sleep(50 * time.Millisecond)
+	// Wait for all handler goroutines to complete, including Nick's timer
+	// registration in setOwnerJustReturnedHome(), before advancing the clock.
+	waitForProcessing(t, manager)
 
 	// Use mock clock to advance time instantly
 	mockClock.AdvanceAndProcess(2 * time.Minute)
@@ -249,9 +249,9 @@ func TestScenario_MultipleArrivalsWithin10Minutes(t *testing.T) {
 
 	t.Log("AND: Timer should have been extended (10 minutes from Caroline's arrival)")
 
-	// Brief real sleep to ensure Caroline's mock clock timer is fully registered
-	// before advancing the clock.
-	time.Sleep(50 * time.Millisecond)
+	// Wait for all handler goroutines to complete, including Caroline's timer
+	// registration in setOwnerJustReturnedHome(), before advancing the clock.
+	waitForProcessing(t, manager)
 
 	// Advance 9 minutes - should still be true (timer was reset by Caroline's arrival)
 	mockClock.AdvanceAndProcess(9 * time.Minute)

--- a/homeautomation-go/test/integration/scenario_sensor_monitoring_test.go
+++ b/homeautomation-go/test/integration/scenario_sensor_monitoring_test.go
@@ -595,6 +595,8 @@ func TestScenario_SensorHealth_NodeStatusMonitoring(t *testing.T) {
 
 	// Advance mock clock past the debounce delay and process timer callbacks
 	env.mockClock.AdvanceAndProcess(sensorhealth.NodeDeadDebounceDelay + 1*time.Second)
+	// Wait for handler goroutines (including AfterFunc callback) to complete
+	waitForProcessing(t, env.manager)
 
 	// Wait for dead device notification (notification is sent by AfterFunc callback)
 	waitForCondition(t, func() bool {
@@ -641,6 +643,8 @@ func TestScenario_SensorHealth_NodeStatusMonitoring(t *testing.T) {
 	env.server.SetState("sensor.front_door_lock_node_status", "alive", map[string]interface{}{
 		"friendly_name": "Front Door Lock Node Status",
 	})
+	// Wait for handler goroutines to process the state change
+	waitForProcessing(t, env.manager)
 
 	// Wait for recovery notification
 	waitForCondition(t, func() bool {

--- a/homeautomation-go/test/integration/scenario_sexmode_test.go
+++ b/homeautomation-go/test/integration/scenario_sexmode_test.go
@@ -386,6 +386,8 @@ func TestScenario_SexModeDeactivation_DifferentDayPhases(t *testing.T) {
 				eightSleepCalls := FilterServiceCalls(allCalls, "climate", "set_temperature")
 				return len(eightSleepCalls) >= 2
 			}, stateWaitTimeout, statePollInterval, "Both Eight Sleep beds should be adjusted during activation")
+			// Wait for all activation handler goroutines to fully complete before snapshot
+			waitForProcessing(t, stateManager)
 
 			snapshot := server.ServiceCallCount()
 


### PR DESCRIPTION
Resolves #807

## Summary

- **Set `TEST_WAIT_TIMEOUT=10s` in CI workflows** (`pr-tests.yml` and `docker-build-push.yml`) — doubles the default 5s polling timeout for all `waitFor*` helpers, giving CI runners under load more time to complete state propagation
- **Replace `time.Sleep(50ms)` with `waitForProcessing()`** in security tests (`DidOwnerJustReturnHomeAutoReset`, `MultipleArrivalsWithin10Minutes`) — ensures mock clock timer registration completes deterministically instead of relying on a fixed delay that can be insufficient under load
- **Add `waitForProcessing()` before service call snapshots** in sex mode deactivation test (`DifferentDayPhases`) — ensures all activation side effects finish before asserting deactivation behavior
- **Add `waitForProcessing()` after mock clock advance and state changes** in sensor health test (`NodeStatusMonitoring`) — ensures AfterFunc callbacks and recovery handlers complete before assertions
- **Add stabilization sleep for fire-and-forget goroutines** in nighttime safety test (`BedroomMutedUntilActualWake`) — zone orchestration goroutines aren't tracked by `waitForProcessing()`, so a brief sleep allows them to complete

## Test Plan

- [x] All integration tests pass locally (`make integration-tests-impl`)
- [x] All unit tests pass with 75.4% coverage (`make unit-tests-impl`)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Full pre-push validation passes
- [ ] Verify CI passes on this PR (tests the `TEST_WAIT_TIMEOUT=10s` env var)
- [ ] Monitor CI failures on subsequent main merges to confirm flakiness reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)