### PR TITLE
Reduce AI over-engineering in resolve-issue and review pipelines

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -962,7 +962,8 @@ jobs:
                  data transfers. A shared 30s default is usually wrong.)
                - Is there graceful degradation if the external service is unavailable?
                - Does error handling distinguish transient vs permanent errors?
-            6. Evaluate design decisions: simpler alternatives, edge cases, architectural fit, production risk.
+            6. Evaluate design decisions: could a simpler approach work? Flag new abstractions,
+               helpers, or wrapper types that serve only one call site as BLOCKING over-engineering.
 
             Reference docs/architecture/ARCHITECTURE.md and docs/reference/SHADOW_STATE.md for context.
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -454,6 +454,10 @@ jobs:
             - Use \`make pre-commit\` for linting/formatting
             - Follow shadow state pattern (docs/reference/SHADOW_STATE.md)
             - Never use \`git push --no-verify\`
+            - Write the minimum code that solves the issue. No more.
+            - Don't add helpers, utilities, or abstractions unless the issue requires them.
+            - Don't refactor adjacent code or make "while I'm here" improvements.
+            - If three similar lines work, don't extract a function.
 
             TDD FOR CROSS-PLUGIN FEATURES:
             - If implementing a feature that spans multiple plugins, write the user story test FIRST
@@ -464,9 +468,9 @@ jobs:
             - Reference: scenario_sleephygiene_test.go for TDD-style cross-plugin tests
 
             BEFORE CREATING THE PR — SELF-REVIEW:
-            6. Run \`git diff --stat\` and verify your changes match the issue scope.
-               If you introduced abstractions beyond what the issue asked for, the PR
-               title and description MUST reflect the full scope.
+            6. Run \`git diff --stat\` and verify ONLY issue-scoped changes remain.
+               If the diff includes code beyond the issue scope, REMOVE IT.
+               The fix should be the smallest correct change.
             7. For any new external service calls: verify retry logic and appropriate timeouts.
             8. For any new test helpers with shared state: verify mutex protection.
             9. Verify new tests exercise the CURRENT production code path, not a legacy path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,8 @@ For periodic/timer-based plugins that don't use subscriptions (e.g., `dayphase`,
 
 **Style:** Follow `gofmt`, use `staticcheck`, 120 char max line length, godoc comments on exports.
 
+**Scope Discipline:** Solve what was asked, nothing more. Don't add helpers or abstractions for one-time operations. Don't refactor adjacent code. Three similar lines is better than a premature abstraction.
+
 **Testing:** 65% minimum coverage, table-driven tests, always use `-race` flag.
 
 **Error Handling:** Always check errors, wrap with context (`fmt.Errorf("context: %w", err)`), never panic.


### PR DESCRIPTION
## Summary
- Add minimalism rules to resolve-issue prompt (don't add unnecessary helpers, abstractions, or adjacent refactors)
- Tighten self-review step to remove out-of-scope changes instead of just documenting them
- Add **Scope Discipline** guideline to AGENTS.md Go Code Standards
- Make design-review flag single-use abstractions as BLOCKING over-engineering

## Test plan
- [ ] Open a test issue to trigger resolve-issue and verify the resulting PR has minimal, focused changes
- [ ] Verify design-review flags single-use abstractions as blocking if present

🤖 Generated with [Claude Code](https://claude.com/claude-code)