### PR TITLE
Condense inline PR review comment instructions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -976,6 +976,7 @@ jobs:
 
             For line-specific design concerns, you may also post inline review comments via
             \`gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews\` with event=COMMENT.
+            Only comment on lines visible in the diff.
             Use sparingly — most design feedback is cross-cutting and belongs in the summary only.
 
             **SUMMARY COMMENT (always required):**


### PR DESCRIPTION
## Summary
- Replace ~22-line verbose inline comment instruction blocks in each of the 4 reviewer prompts (code, design, test, concurrency) with ~3-line condensed versions
- Claude agents already know how to use `gh api` — the full examples with `-f 'comments[0][path]=...'` syntax were unnecessary hand-holding
- Add missing `REPO` env var to test-review and concurrency-review steps (needed for the inline review API call)

## Test plan
- [x] YAML syntax validated with `python3 -c "import yaml; yaml.safe_load(open(...))"`
- [ ] Verify CI workflow parses correctly (GitHub Actions will validate on PR)
- [ ] Verify next PR review still produces inline comments correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)