### PR TITLE
docs: Add SoCo-CLI testing guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -451,7 +451,7 @@ When modifying the SoCo-CLI integration (`homeautomation-go/internal/plugins/mus
 
 The SoCo-CLI HTTP API (v0.4.82) provides direct UPnP control of Sonos speakers. All endpoints are `GET` requests with path-based parameters. Swagger docs are available at `/docs`.
 
-**Response format** (matches `SoCoResponse` struct in `sococli.go`):
+**Response format** (Go struct `SoCoResponse` in `sococli.go` captures all fields except `args`):
 ```json
 {"speaker": "Kitchen", "action": "volume", "args": [], "exit_code": 0, "result": "9", "error_msg": ""}
 ```


### PR DESCRIPTION
## Summary
- Adds a "Testing SoCo-CLI Changes" section to AGENTS.md documenting how to test the SoCo-CLI HTTP API integration
- Includes read-only query commands, write commands, available speaker inventory, and key implementation details (timeouts, retries, URL encoding, fallback behavior)
- Verified all endpoints and speaker names against the live API at `https://soco-cli.featherback-mermaid.ts.net/`

## Test plan
- [ ] Review that curl examples work against the live SoCo-CLI API
- [ ] Verify speaker names match `configs/music_config.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)