### PR TITLE
fix: Add debug tracing to resolve-issue to diagnose hanging

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -414,6 +414,14 @@ jobs:
             REPO=${{ github.repository }}
             CLAUDE_CONFIG_DIR=/workspaces/home-automation/.claude-session
           runCmd: |
+            # Debug: trace each step to diagnose hanging (see issue #830 et al.)
+            set -x
+            echo "=== resolve-issue runCmd starting at $(date -u) ==="
+            echo "ISSUE_NUMBER=${ISSUE_NUMBER}"
+            echo "REPO=${REPO}"
+            echo "Claude version: $(claude --version 2>&1 || echo 'claude not found')"
+            echo "gh version: $(gh --version 2>&1 | head -1)"
+
             # Use < /dev/null to prevent hanging on TTY input
             # Use tee to capture output for artifact upload
             # Use --verbose and --output-format stream-json for complete conversation logs
@@ -421,11 +429,16 @@ jobs:
 
             # Fetch issue body via API to avoid multi-line env var escaping issues
             # (see https://github.com/NickBorgers/home-automation/issues/441)
+            echo "=== Fetching issue body ==="
             ISSUE_BODY=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '.body')
+            echo "=== Issue body fetched (${#ISSUE_BODY} chars) ==="
 
             # Fetch all comments on the issue (may contain additional context/requirements)
+            echo "=== Fetching issue comments ==="
             ISSUE_COMMENTS=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" --jq '.[] | "---\n**\(.user.login)** commented at \(.created_at):\n\(.body)\n"' 2>/dev/null | head -c 50000 || echo "")
+            echo "=== Issue comments fetched (${#ISSUE_COMMENTS} chars) ==="
 
+            echo "=== Starting claude --print at $(date -u) ==="
             claude --print \
               --verbose \
               --output-format stream-json \


### PR DESCRIPTION
## Summary
- Add `set -x` and echo statements to the resolve-issue devcontainer script
- Traces each step: env vars, claude version, gh api calls, claude start
- Will reveal exactly where the script hangs (all 10+ runs since March 10 produce zero output)

## Context
The resolve-issue job has been silently hanging in every run since March 10.
- Last working run: March 10 04:05 UTC (Claude Code 2.1.59, completed in 12 min)
- All subsequent runs: zero output from devcontainer for hours until timeout
- The `tee` file is never created, meaning the bash script produces no stdout at all
- The `claude` job (issue_comment handler) has been skipped in every "successful" run

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger one of the stalled issues (e.g., assign #830)
- [ ] Check logs to see where the script hangs
- [ ] Fix the root cause based on diagnostic output

🤖 Generated with [Claude Code](https://claude.com/claude-code)