### PR TITLE
fix: Force devcontainer rebuild to update Claude Code from 2.1.59

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -44,6 +44,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Claude Code CLI globally
+# Cache-bust: 2026-03-12 - force rebuild to pick up latest version
 RUN npm install -g @anthropic-ai/claude-code
 
 # Create directories for vscode user with correct ownership


### PR DESCRIPTION
## Summary
- Add cache-bust comment to force Docker to rebuild the `npm install -g @anthropic-ai/claude-code` layer
- The devcontainer has been running Claude Code **2.1.59** from a cached Docker layer, which hangs silently when using `CLAUDE_CODE_OAUTH_TOKEN` auth with `--print`

## Diagnosis
Debug tracing confirmed the exact hang point:
```
15:24:40  === Starting claude --print ===
16:23:59  ##[error]The operation was canceled.   ← 59 minutes of silence
```
- Environment setup: works
- `gh api` calls: works
- `claude --print`: **hangs with zero output** (no init JSON, no error)
- Claude Code version in devcontainer: **2.1.59** (cached layer)
- Current version: **2.1.70**

All 10+ resolve-issue runs since March 10 failed this way. The token was also refreshed (GitHub App installed) but the hang persists — confirming it's a CLI version issue, not a token issue.

## Test plan
- [ ] Merge and trigger issue #830 via assignment
- [ ] Verify the devcontainer rebuilds with a new Claude Code version
- [ ] Verify `claude --print` produces output and resolves the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)