### PR TITLE
debug: Add smoke test to diagnose claude --print hang

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -438,6 +438,15 @@ jobs:
             ISSUE_COMMENTS=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" --jq '.[] | "---\n**\(.user.login)** commented at \(.created_at):\n\(.body)\n"' 2>/dev/null | head -c 50000 || echo "")
             echo "=== Issue comments fetched (${#ISSUE_COMMENTS} chars) ==="
 
+            # Smoke test: verify Claude Code can start and authenticate
+            echo "=== Smoke test: claude --print 'say hello' ==="
+            timeout 120 claude --print --dangerously-skip-permissions "say hello" < /dev/null 2>&1 || {
+              echo "=== SMOKE TEST FAILED (exit code $?) ==="
+              echo "Claude Code cannot start or authenticate. Aborting."
+              exit 1
+            }
+            echo "=== Smoke test passed ==="
+
             echo "=== Starting claude --print at $(date -u) ==="
             claude --print \
               --verbose \


### PR DESCRIPTION
## Summary
- Claude Code 2.1.74 is confirmed installed (version pin worked) but `claude --print` still produces zero output and hangs indefinitely
- This adds a simple smoke test (`claude --print 'say hello'` with 120s timeout) before the real invocation to isolate whether the issue is authentication, startup, or prompt-related

## Context
Run 23033270819 confirmed:
- Claude Code 2.1.74 is installed ✅
- `gh api` calls work fine ✅  
- `claude --print` starts at 02:23:01 → zero output → cancelled at 03:43:59

## Test plan
- [ ] Merge and re-trigger issue #830
- [ ] If smoke test fails: auth/startup issue
- [ ] If smoke test passes but main prompt hangs: prompt or model issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)