### PR TITLE
fix: Re-apply repeat/shuffle to new leader during seamless zone transitions

### DIFF
--- a/homeautomation-go/internal/plugins/music/zone_manager.go
+++ b/homeautomation-go/internal/plugins/music/zone_manager.go
@@ -1155,6 +1155,29 @@ func (zm *ZoneManager) executeSeamlessTransition(st seamlessTransition, newSpeak
 	}
 	zm.manager.mu.Unlock()
 
+	// Re-apply repeat/shuffle to new leader if the leader changed.
+	// Shuffle and repeat are per-speaker Sonos properties. When the old leader
+	// (e.g., Front Room) is removed and a shared speaker (e.g., Bedroom) becomes
+	// the new leader, the new leader won't have repeat enabled — causing playback
+	// to stop at end of track instead of looping. (Issue #837)
+	if leadSpeaker != oldZone.LeadSpeaker {
+		zm.logger.Info("Leader changed during seamless transition, re-applying playback modes",
+			zap.String("old_leader", oldZone.LeadSpeaker),
+			zap.String("new_leader", leadSpeaker))
+		if err := zm.manager.speakerSetRepeat(leadSpeaker, "all"); err != nil {
+			zm.logger.Warn("Failed to set repeat on new leader",
+				zap.String("speaker", leadSpeaker),
+				zap.Error(err))
+		}
+		if oldMediaType == "playlist" || oldMediaType == "tidal" {
+			if err := zm.manager.speakerSetShuffle(leadSpeaker, true); err != nil {
+				zm.logger.Warn("Failed to set shuffle on new leader",
+					zap.String("speaker", leadSpeaker),
+					zap.Error(err))
+			}
+		}
+	}
+
 	// Handle non-shared speakers: fade out and remove from old group
 	if len(st.removeSpeakers) > 0 {
 		go zm.manager.removeSpeakersFromZone(oldZone, st.removeSpeakers, trigger)

--- a/homeautomation-go/test/integration/scenario_sleepprep_transition_test.go
+++ b/homeautomation-go/test/integration/scenario_sleepprep_transition_test.go
@@ -384,3 +384,122 @@ func TestScenario_SleepPrepToSleep_NonBedroomSpeakersBehavior(t *testing.T) {
 
 	t.Log("SUCCESS: Sleep-prep → sleep transition handled shared speakers seamlessly")
 }
+
+// ============================================================================
+// Test: Repeat mode is re-applied to new leader during seamless transition
+// ============================================================================
+
+// TestScenario_SleepPrepToSleep_RepeatModeOnNewLeader validates that when a
+// seamless zone transition changes the group leader, repeat mode is re-applied
+// to the new leader so playback loops continuously.
+//
+// User story: "When I fall asleep, rain sounds should loop all night. They
+// shouldn't stop after the current track ends just because the leader changed."
+//
+// PRODUCTION BUG (2026-03-12, Issue #837):
+// Sleep-prep zone had Front Room as leader with repeat enabled. When
+// transitioning to sleep zone, Bedroom became the new leader but repeat was
+// never re-applied. Rain sounds stopped after the ~2h FLAC file ended.
+//
+// INVARIANTS:
+// - When leader changes during seamless transition, repeat must be set on new leader
+// - Repeat mode "all" must be applied to the new leader speaker
+func TestScenario_SleepPrepToSleep_RepeatModeOnNewLeader(t *testing.T) {
+	t.Parallel()
+	env, cleanup := setupSleepPrepTransitionTest(t)
+	defer cleanup()
+
+	// ===== GIVEN: Sleep-prep zone is active with Front Room as leader =====
+	t.Log("GIVEN: Sleep-prep zone is active with Front Room as leader")
+
+	env.server.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
+	env.server.SetState("input_text.day_phase", "night", map[string]interface{}{})
+	env.server.SetState("input_boolean.master_asleep", "off", map[string]interface{}{})
+	env.server.SetState("input_boolean.wake_sequence_active", "off", map[string]interface{}{})
+	env.server.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
+
+	waitForProcessing(t, env.stateManager)
+
+	waitForCondition(t, func() bool {
+		zones := env.music.GetActiveZones()
+		for _, z := range zones {
+			if z.Name == "sleep-prep" && z.PlaylistURI != "" {
+				return true
+			}
+		}
+		return false
+	}, "sleep-prep zone should be active with a playlist URI")
+
+	activeZones := env.music.GetActiveZones()
+	var sleepPrepZone *music.Zone
+	for _, z := range activeZones {
+		if z.Name == "sleep-prep" {
+			sleepPrepZone = z
+			break
+		}
+	}
+	require.NotNil(t, sleepPrepZone, "Sleep-prep zone should exist")
+	assert.Equal(t, "Front Room", sleepPrepZone.LeadSpeaker,
+		"Sleep-prep leader should be Front Room (first participant in config)")
+
+	// Wait for initial orchestration to complete
+	waitForServiceCallsToStabilize(t, env.server, 200*time.Millisecond)
+
+	// Snapshot service calls to isolate the transition
+	snapshot := env.server.ServiceCallCount()
+
+	// ===== WHEN: isMasterAsleep becomes true (triggering sleep zone) =====
+	t.Log("WHEN: isMasterAsleep becomes true — leader changes from Front Room to Bedroom")
+
+	env.server.SetState("input_boolean.master_asleep", "on", map[string]interface{}{})
+
+	waitForProcessing(t, env.stateManager)
+
+	// Wait for sleep zone to become active
+	waitForCondition(t, func() bool {
+		zones := env.music.GetActiveZones()
+		for _, z := range zones {
+			if z.Name == "sleep" {
+				return true
+			}
+		}
+		return false
+	}, "sleep zone should be active")
+
+	waitForServiceCallsToStabilizeSince(t, env.server, snapshot, 300*time.Millisecond)
+
+	// ===== THEN: Repeat mode should be set on the new leader (Bedroom) =====
+	t.Log("THEN: Repeat mode should be re-applied to new leader (Bedroom)")
+
+	// Verify leader changed
+	activeZones = env.music.GetActiveZones()
+	var sleepZone *music.Zone
+	for _, z := range activeZones {
+		if z.Name == "sleep" {
+			sleepZone = z
+			break
+		}
+	}
+	require.NotNil(t, sleepZone, "Sleep zone should exist")
+	assert.Equal(t, "Bedroom", sleepZone.LeadSpeaker,
+		"Sleep zone leader should be Bedroom (first participant in sleep config)")
+
+	// Check that repeat_set was called on the new leader during the transition
+	calls := env.server.GetServiceCallsSince(snapshot)
+	bedroomRepeatSet := false
+	for _, call := range calls {
+		entityID, _ := call.ServiceData["entity_id"].(string)
+		if entityID == "media_player.bedroom" &&
+			call.Domain == "media_player" && call.Service == "repeat_set" {
+			repeat, _ := call.ServiceData["repeat"].(string)
+			if repeat == "all" {
+				bedroomRepeatSet = true
+			}
+		}
+	}
+	assert.True(t, bedroomRepeatSet,
+		"Repeat mode 'all' must be set on new leader (Bedroom) during seamless transition — "+
+			"without this, playback stops when current track ends (Issue #837)")
+
+	t.Log("SUCCESS: Repeat mode re-applied to new leader during seamless transition")
+}

--- a/homeautomation-go/test/integration/testdata/music_config_test.yaml
+++ b/homeautomation-go/test/integration/testdata/music_config_test.yaml
@@ -169,6 +169,9 @@ music:
 
   sleep-prep:
     participants:
+      - player_name: "Front Room"
+        base_volume: 9
+        leave_muted_if: []
       - player_name: "Bedroom"
         base_volume: 16
         leave_muted_if: []
@@ -177,9 +180,6 @@ music:
         leave_muted_if:
           - variable: isTVPlaying
             value: true
-      - player_name: "Front Room"
-        base_volume: 9
-        leave_muted_if: []
       - player_name: "Kitchen"
         base_volume: 16
         leave_muted_if: []


### PR DESCRIPTION
## Summary

- When a seamless zone transition changes the group leader (e.g., sleep-prep → sleep), repeat and shuffle modes are now re-applied to the new leader speaker
- Updated test config to match production participant ordering (Front Room first in sleep-prep) so the leader-change scenario is tested
- Added integration test `TestScenario_SleepPrepToSleep_RepeatModeOnNewLeader` validating repeat mode is set on the new leader

## Root Cause

Shuffle and repeat are per-speaker Sonos properties set on the group leader during initial orchestration (`orchestration.go`). Seamless transitions (`zone_manager.go`) intentionally skip re-orchestration to avoid interrupting playback, but when the old leader is removed (Front Room) and a new leader takes over (Bedroom), the new leader never had repeat enabled — causing playback to stop at end of track.

## Fix

After the zone swap in `executeSeamlessTransition`, detect if the leader changed and re-apply `speakerSetRepeat("all")` (and `speakerSetShuffle(true)` for playlist/tidal media) to the new leader. These calls are idempotent on Sonos.

## Test plan

- [x] New test `TestScenario_SleepPrepToSleep_RepeatModeOnNewLeader` passes — verifies `repeat_set` is called on Bedroom during transition
- [x] Existing test `TestScenario_SleepPrepToSleep_NonBedroomSpeakersBehavior` still passes with updated config ordering
- [x] All unit tests pass (75.2% coverage)
- [x] All integration tests pass

Fixes #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)