### PR TITLE
debug: Smoke test v2 with SIGKILL and stderr capture

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -439,13 +439,21 @@ jobs:
             echo "=== Issue comments fetched (${#ISSUE_COMMENTS} chars) ==="
 
             # Smoke test: verify Claude Code can start and authenticate
-            echo "=== Smoke test: claude --print 'say hello' ==="
-            timeout 120 claude --print --dangerously-skip-permissions "say hello" < /dev/null 2>&1 || {
-              echo "=== SMOKE TEST FAILED (exit code $?) ==="
-              echo "Claude Code cannot start or authenticate. Aborting."
+            echo "=== Smoke test: claude --print 'say hello' at $(date -u) ==="
+            echo "=== CLAUDE_CODE_OAUTH_TOKEN length: ${#CLAUDE_CODE_OAUTH_TOKEN} ==="
+            echo "=== Node version: $(node --version) ==="
+            echo "=== Which claude: $(which claude) ==="
+            # Use --kill-after to SIGKILL if SIGTERM is ignored
+            timeout --kill-after=10 60 claude --print --dangerously-skip-permissions "say hello" < /dev/null > /tmp/smoke-stdout.txt 2> /tmp/smoke-stderr.txt
+            SMOKE_EXIT=$?
+            echo "=== Smoke test exit code: ${SMOKE_EXIT} ==="
+            echo "=== Smoke stdout: $(cat /tmp/smoke-stdout.txt | head -20) ==="
+            echo "=== Smoke stderr: $(cat /tmp/smoke-stderr.txt | head -20) ==="
+            if [ ${SMOKE_EXIT} -ne 0 ]; then
+              echo "=== SMOKE TEST FAILED — Claude Code cannot start or authenticate ==="
               exit 1
-            }
-            echo "=== Smoke test passed ==="
+            fi
+            echo "=== Smoke test passed at $(date -u) ==="
 
             echo "=== Starting claude --print at $(date -u) ==="
             claude --print \


### PR DESCRIPTION
## Summary
- Previous smoke test hung because `timeout` sends SIGTERM which Claude Code ignores
- Now uses `timeout --kill-after=10 60` to SIGKILL after 10s grace period
- Captures stdout/stderr separately for diagnostics
- Logs token length, node version, claude path

## Expected outcome
Within ~90s of the resolve-issue step starting, we'll get either:
- Smoke test output showing Claude works → proceeds to real prompt
- Timeout exit code 124/137 → confirms Claude Code hangs at startup (auth issue)
- Stderr output showing the actual error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)