### PR TITLE
debug: Add connectivity and identity checks before claude --print

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -438,6 +438,16 @@ jobs:
             ISSUE_COMMENTS=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" --jq '.[] | "---\n**\(.user.login)** commented at \(.created_at):\n\(.body)\n"' 2>/dev/null | head -c 50000 || echo "")
             echo "=== Issue comments fetched (${#ISSUE_COMMENTS} chars) ==="
 
+            echo "=== whoami: $(whoami) ==="
+            echo "=== id: $(id) ==="
+            echo "=== CLAUDE_CODE_OAUTH_TOKEN length: ${#CLAUDE_CODE_OAUTH_TOKEN} ==="
+
+            # Quick connectivity test to Anthropic API
+            echo "=== Testing API connectivity ==="
+            curl -s -o /dev/null -w "HTTP %{http_code} in %{time_total}s" https://api.anthropic.com/ || echo "FAILED"
+            echo ""
+
+            # Run claude with stderr separated to see any errors
             echo "=== Starting claude --print at $(date -u) ==="
             claude --print \
               --verbose \


### PR DESCRIPTION
## Summary
claude --print hangs silently in CI with zero output. Adding diagnostics:
- `whoami` / `id` — verify running as vscode, not root
- Token length — verify CLAUDE_CODE_OAUTH_TOKEN is present
- `curl https://api.anthropic.com/` — verify network connectivity

## What we know
- Claude Code 2.1.74 confirmed installed ✅
- gh API calls work from inside the container ✅
- `claude --print` starts, produces ZERO output, hangs for 2 hours
- Locally (same token, `docker run -u vscode`): works instantly ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)