### PR TITLE
fix: Queue-based playback for HTTP playlists (repeat support)

### DIFF
--- a/homeautomation-go/internal/plugins/music/sococli.go
+++ b/homeautomation-go/internal/plugins/music/sococli.go
@@ -259,22 +259,38 @@ func (c *SoCoClient) Play(speakerName string) error {
 	return c.doGet(endpoint, "play", speakerName)
 }
 
-// PlayURI plays a media URI on a speaker.
-func (c *SoCoClient) PlayURI(speakerName, uri string) error {
+// AddURIToQueue adds a media URI to the speaker's queue.
+// Uses a longer per-attempt timeout since Sonos may need to fetch and parse M3U playlists.
+func (c *SoCoClient) AddURIToQueue(speakerName, uri string) error {
 	if c.readOnly {
-		c.logger.Debug("READ_ONLY: Would play_uri via SoCo-CLI",
+		c.logger.Info("READ_ONLY: Would add_uri_to_queue via SoCo-CLI",
 			zap.String("speaker", speakerName),
 			zap.String("uri", uri))
 		return nil
 	}
 
-	// GET /{speaker}/play_uri/{uri}
-	endpoint := fmt.Sprintf("%s/%s/play_uri/%s",
+	// GET /{speaker}/add_uri_to_queue/{uri}
+	endpoint := fmt.Sprintf("%s/%s/add_uri_to_queue/%s",
 		c.baseURL,
 		url.PathEscape(speakerName),
 		url.PathEscape(uri))
 
-	return c.doGet(endpoint, "play_uri", speakerName)
+	return c.doGetWithRetry(endpoint, "add_uri_to_queue", speakerName, socoLongTimeout)
+}
+
+// PlayURIFromQueue clears the queue, adds a URI to the queue, and starts playback.
+// This ensures the content is in the Sonos queue so that repeat mode works correctly.
+func (c *SoCoClient) PlayURIFromQueue(speakerName, uri string) error {
+	if err := c.ClearQueue(speakerName); err != nil {
+		return fmt.Errorf("clear_queue failed: %w", err)
+	}
+	if err := c.AddURIToQueue(speakerName, uri); err != nil {
+		return fmt.Errorf("add_uri_to_queue failed: %w", err)
+	}
+	if err := c.PlayFromQueue(speakerName); err != nil {
+		return fmt.Errorf("play_from_queue failed: %w", err)
+	}
+	return nil
 }
 
 // SetShuffle enables or disables shuffle mode on a speaker.

--- a/homeautomation-go/internal/plugins/music/sococli_test.go
+++ b/homeautomation-go/internal/plugins/music/sococli_test.go
@@ -434,7 +434,7 @@ func TestSoCoClient_Play(t *testing.T) {
 	})
 }
 
-func TestSoCoClient_PlayURI(t *testing.T) {
+func TestSoCoClient_AddURIToQueue(t *testing.T) {
 	t.Parallel()
 	logger := zaptest.NewLogger(t)
 
@@ -448,9 +448,114 @@ func TestSoCoClient_PlayURI(t *testing.T) {
 		defer server.Close()
 
 		client := NewSoCoClient(server.URL, logger, false)
-		err := client.PlayURI("Kitchen", "http://example.com/rain.mp3")
+		err := client.AddURIToQueue("Kitchen", "http://example.com/rain.m3u")
 		require.NoError(t, err)
-		assert.Contains(t, requestPath, "/Kitchen/play_uri/")
+		assert.Contains(t, requestPath, "/Kitchen/add_uri_to_queue/")
+	})
+
+	t.Run("non-zero exit code returns error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			resp := SoCoResponse{ExitCode: 1, ErrorMsg: "invalid URI"}
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		client := NewSoCoClient(server.URL, logger, false)
+		err := client.AddURIToQueue("Kitchen", "http://example.com/rain.m3u")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid URI")
+	})
+
+	t.Run("read-only mode does not call server", func(t *testing.T) {
+		callCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+		}))
+		defer server.Close()
+
+		client := NewSoCoClient(server.URL, logger, true)
+		err := client.AddURIToQueue("Kitchen", "http://example.com/rain.m3u")
+		assert.NoError(t, err)
+		assert.Equal(t, 0, callCount, "server should not have been called")
+	})
+}
+
+func TestSoCoClient_PlayURIFromQueue(t *testing.T) {
+	t.Parallel()
+	logger := zaptest.NewLogger(t)
+
+	t.Run("calls clear_queue then add_uri_to_queue then play_from_queue", func(t *testing.T) {
+		var actions []string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			action := "unknown"
+			switch {
+			case r.URL.Path == "/Kitchen/clear_queue":
+				action = "clear_queue"
+			case r.URL.Path == "/Kitchen/play_from_queue":
+				action = "play_from_queue"
+			default:
+				action = "add_uri_to_queue"
+			}
+			actions = append(actions, action)
+			resp := SoCoResponse{Result: "success", ExitCode: 0}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		client := NewSoCoClient(server.URL, logger, false)
+		err := client.PlayURIFromQueue("Kitchen", "http://example.com/rain.m3u")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"clear_queue", "add_uri_to_queue", "play_from_queue"}, actions)
+	})
+
+	t.Run("returns error if clear_queue fails", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			resp := SoCoResponse{ExitCode: 1, ErrorMsg: "speaker not found"}
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		client := NewSoCoClient(server.URL, logger, false)
+		err := client.PlayURIFromQueue("Kitchen", "http://example.com/rain.m3u")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "clear_queue failed")
+	})
+
+	t.Run("returns error if add_uri_to_queue fails", func(t *testing.T) {
+		callNum := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callNum++
+			resp := SoCoResponse{ExitCode: 0, Result: "ok"}
+			if callNum == 2 {
+				resp = SoCoResponse{ExitCode: 1, ErrorMsg: "invalid URI"}
+			}
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		client := NewSoCoClient(server.URL, logger, false)
+		err := client.PlayURIFromQueue("Kitchen", "http://example.com/rain.m3u")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "add_uri_to_queue failed")
+	})
+
+	t.Run("returns error if play_from_queue fails", func(t *testing.T) {
+		callNum := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callNum++
+			resp := SoCoResponse{ExitCode: 0, Result: "ok"}
+			if callNum == 3 {
+				resp = SoCoResponse{ExitCode: 1, ErrorMsg: "queue empty"}
+			}
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		client := NewSoCoClient(server.URL, logger, false)
+		err := client.PlayURIFromQueue("Kitchen", "http://example.com/rain.m3u")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "play_from_queue failed")
 	})
 }
 

--- a/homeautomation-go/internal/plugins/music/speaker_commands.go
+++ b/homeautomation-go/internal/plugins/music/speaker_commands.go
@@ -140,17 +140,17 @@ func (m *Manager) speakerPlay(speakerName string) error {
 }
 
 // speakerPlayMedia starts playback of specific media content on a speaker.
-// Routes to SoCo-CLI (play_uri) when available. Note: SoCo play_uri does not
-// support all media types that HA's play_media does (e.g., Spotify URIs).
+// Routes to SoCo-CLI (queue-based: clear_queue → add_uri_to_queue → play_from_queue)
+// when available. Queue-based playback ensures Sonos repeat mode works correctly.
 // For Tidal playback, use socoClient.PlayShareLink directly instead.
 func (m *Manager) speakerPlayMedia(speakerName, mediaContentID, mediaContentType string) error {
 	if m.socoClient != nil {
 		if mediaContentType != "" {
-			m.logger.Debug("SoCo-CLI play_uri does not use mediaContentType; parameter ignored",
+			m.logger.Debug("SoCo-CLI queue-based playback does not use mediaContentType; parameter ignored",
 				zap.String("speaker", speakerName),
 				zap.String("mediaContentType", mediaContentType))
 		}
-		return m.socoClient.PlayURI(speakerName, mediaContentID)
+		return m.socoClient.PlayURIFromQueue(speakerName, mediaContentID)
 	}
 	entityID := m.getSpeakerEntityID(speakerName)
 	return m.callServiceWithRetry("media_player", "play_media", map[string]interface{}{

--- a/homeautomation-go/internal/plugins/music/speaker_commands_test.go
+++ b/homeautomation-go/internal/plugins/music/speaker_commands_test.go
@@ -352,8 +352,12 @@ func TestSpeakerPlayMedia_RoutesThroughSoCo(t *testing.T) {
 	err := manager.speakerPlayMedia("Kitchen", "http://example.com/stream.mp3", "music")
 	require.NoError(t, err)
 
-	require.Equal(t, 1, paths.Len())
-	assert.Contains(t, paths.Get(0), "/Kitchen/play_uri/")
+	// Queue-based playback: clear_queue → add_uri_to_queue → play_from_queue
+	allPaths := paths.All()
+	require.Len(t, allPaths, 3)
+	assert.Equal(t, "/Kitchen/clear_queue", allPaths[0])
+	assert.Contains(t, allPaths[1], "/Kitchen/add_uri_to_queue/")
+	assert.Equal(t, "/Kitchen/play_from_queue", allPaths[2])
 }
 
 func TestSpeakerPlayMedia_FallsBackToHA(t *testing.T) {


### PR DESCRIPTION
## Summary
- Sleep music (rain sounds) stops after ~2 hours because `repeat all` only works on the Sonos queue, but HTTP M3U playlists were played via `play_uri` (outside the queue)
- Switch `speakerPlayMedia` SoCo path from `play_uri` to queue-based playback (`clear_queue` → `add_uri_to_queue` → `play_from_queue`), matching the pattern used for Tidal
- Remove unused `PlayURI` method; add `AddURIToQueue` and `PlayURIFromQueue` to `SoCoClient`

## Test plan
- [x] `make unit-tests` — all pass (75.3% coverage)
- [x] `make integration-tests` — all pass
- [ ] Deploy and verify sleep rain sounds loop past the 2-hour mark
- [ ] Verify Tidal playback still works (unchanged code path via `PlayShareLink`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)