### PR TITLE
fix: Remove embedded double quotes breaking shell parsing in CI prompt

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -486,7 +486,7 @@ jobs:
             - Never use \`git push --no-verify\`
             - Write the minimum code that solves the issue. No more.
             - Don't add helpers, utilities, or abstractions unless the issue requires them.
-            - Don't refactor adjacent code or make "while I'm here" improvements.
+            - Don't refactor adjacent code or make unrelated improvements.
             - If three similar lines work, don't extract a function.
 
             TDD FOR CROSS-PLUGIN FEATURES:


### PR DESCRIPTION
The resolve-issue prompt contains `"while I'm here"` (with double quotes) inside a double-quoted shell string. This terminates the string early — the shell interprets the rest of the prompt as commands, causing `claude --print` to appear to hang silently.

This was introduced when the prompt was added and has been the root cause all along.