### PR TITLE
fix: npm permissions for devcontainer CI on self-hosted runners

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -452,6 +452,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Configure npm for user-local global installs
+        run: |
+          mkdir -p $HOME/.npm-global
+          npm config set prefix $HOME/.npm-global
+          echo "$HOME/.npm-global/bin" >> $GITHUB_PATH
+
       - name: Build and push devcontainer
         uses: devcontainers/ci@v0.3
         with:


### PR DESCRIPTION
## Summary
- The `devcontainers/ci@v0.3` action runs `npm install -g @devcontainers/cli` which fails with `EACCES` on the self-hosted homelab runner because the runner user cannot write to `/usr/lib/node_modules/`
- This causes `build-devcontainer` to fail, which silently skips all agent review jobs (design, code, test, concurrency, docs reviews)
- Fix: configure npm to use a user-writable global prefix directory (`$HOME/.npm-global`) before the action runs

## Context
This was observed on PR #868 where all agent reviews showed as "Skipped" or "Failed" in the summary comments, but the PR Tests checks all passed normally. The `build-devcontainer` failure was only visible by inspecting the Claude Code Review workflow run logs.

## Test plan
- [ ] Verify `build-devcontainer` job succeeds on the self-hosted runner
- [ ] Verify agent review jobs run and post comments on PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)