### PR TITLE
fix: Pass CLAUDE_CODE_OAUTH_TOKEN into devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,8 @@
     "source=${localEnv:HOME}/.config/gh,target=/tmp/gh-config,type=bind"
   ],
   "remoteEnv": {
-    "SSH_AUTH_SOCK": ""
+    "SSH_AUTH_SOCK": "",
+    "CLAUDE_CODE_OAUTH_TOKEN": "${localEnv:CLAUDE_CODE_OAUTH_TOKEN}"
   },
   "updateRemoteUserUID": true,
   "remoteUser": "vscode"


### PR DESCRIPTION
## Summary
- The CI runner has `CLAUDE_CODE_OAUTH_TOKEN` set as an env var, but `devcontainers/ci` spawns a new Docker container where runner env vars don't automatically propagate
- Claude Code inside the devcontainer sees `apiKeySource: none` and fails authentication
- Fix: add `${localEnv:CLAUDE_CODE_OAUTH_TOKEN}` to `remoteEnv` in `devcontainer.json`, which bridges the host env var into the container

## Test plan
- [ ] Merge this PR, then retrigger Claude Code Review on PR #868
- [ ] Verify agents authenticate successfully and post review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)