### PR TITLE
fix: Resolve workspace permission issues in CI devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
   },
   "onCreateCommand": "bash .devcontainer/setup-user.sh \"${localEnv:USER}\"",
   "postCreateCommand": "bash .devcontainer/post-create.sh",
-  "postStartCommand": "bash .devcontainer/fix-dns-order.sh",
+  "postStartCommand": "bash .devcontainer/fix-dns-order.sh && sudo chown -R \"$(id -u):$(id -g)\" /workspaces 2>/dev/null || true",
   "forwardPorts": [],
   "portsAttributes": {},
   "mounts": [

--- a/.devcontainer/setup-user.sh
+++ b/.devcontainer/setup-user.sh
@@ -23,7 +23,8 @@ if id "$TARGET_USER" &>/dev/null; then
 fi
 
 # Detect host UID/GID from workspace file ownership
-WORKSPACE="/workspaces/home-automation-two"
+# Detect workspace directory dynamically
+WORKSPACE=$(find /workspaces -maxdepth 1 -mindepth 1 -type d 2>/dev/null | head -1)
 if [ -d "$WORKSPACE" ]; then
     TARGET_UID=$(stat -c '%u' "$WORKSPACE")
     TARGET_GID=$(stat -c '%g' "$WORKSPACE")

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -339,14 +339,14 @@ jobs:
               --model opus \
               --dangerously-skip-permissions \
               --max-turns 400 \
-              "$PROMPT" < /dev/null 2>&1 | tee /workspaces/home-automation/claude-conversation.jsonl
+              "$PROMPT" < /dev/null 2>&1 | tee /tmp/claude-conversation.jsonl
 
       - name: Upload Claude conversation log
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: claude-conversation-log
-          path: claude-conversation.jsonl
+          path: /tmp/claude-conversation.jsonl
           retention-days: 7
 
       - name: Upload Claude session data
@@ -493,14 +493,14 @@ jobs:
 
             If you cannot resolve the issue (unclear requirements, needs human decision, etc.),
             comment on the issue explaining what clarification is needed:
-            gh issue comment ${ISSUE_NUMBER} --body 'YOUR_EXPLANATION'" < /dev/null 2>&1 | tee /workspaces/home-automation/resolve-issue-conversation.jsonl
+            gh issue comment ${ISSUE_NUMBER} --body 'YOUR_EXPLANATION'" < /dev/null 2>&1 | tee /tmp/resolve-issue-conversation.jsonl
 
       - name: Upload issue resolution conversation log
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: resolve-issue-conversation-log
-          path: resolve-issue-conversation.jsonl
+          path: /tmp/resolve-issue-conversation.jsonl
           retention-days: 7
 
       - name: Upload Claude session data


### PR DESCRIPTION
## Summary
- **postStartCommand**: `chown /workspaces` to container user so tee, git, and Claude can write to the workspace
- **setup-user.sh**: Detect workspace directory dynamically instead of hardcoding `/workspaces/home-automation-two`
- **claude.yml**: Write tee output to `/tmp` instead of `/workspaces` (same fix as PR #891 for `claude-code-review.yml`)

These fix the `EACCES: permission denied` errors that were causing agent jobs to report failure even when reviews completed successfully.

## Test plan
- [ ] Merge and retrigger `resolve-issue` on #867
- [ ] Verify no permission denied errors in agent jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)