### PR TITLE
fix: Move tee output to /tmp in remaining workflows

### DIFF
--- a/.github/workflows/claude-diagnose-workflow-failure.yml
+++ b/.github/workflows/claude-diagnose-workflow-failure.yml
@@ -271,12 +271,12 @@ jobs:
             For TEST_FAILURE/CONFIG_FAILURE: 'This failure type is handled by the Claude Code Review workflow.'
             For INFRASTRUCTURE_FAILURE: 'This is a transient external service issue that will self-resolve. No action needed.'
 
-            Be thorough in your analysis. Examine the actual error messages in the logs." < /dev/null 2>&1 | tee /workspaces/home-automation/diagnose-output.jsonl
+            Be thorough in your analysis. Examine the actual error messages in the logs." < /dev/null 2>&1 | tee /tmp/diagnose-output.jsonl
 
       - name: Upload diagnosis output
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: workflow-diagnosis-output
-          path: diagnose-output.jsonl
+          path: /tmp/diagnose-output.jsonl
           retention-days: 7

--- a/.github/workflows/ha-deprecation-check.yml
+++ b/.github/workflows/ha-deprecation-check.yml
@@ -245,14 +245,14 @@ jobs:
             - Be thorough in scanning - check ALL plugin files
             - Only report deprecations that actually affect code in THIS repository
             - Do not report theoretical deprecations that aren't used here
-            - Include specific file paths and line numbers in the issue" < /dev/null 2>&1 | tee /workspaces/home-automation/deprecation-check-output.jsonl
+            - Include specific file paths and line numbers in the issue" < /dev/null 2>&1 | tee /tmp/deprecation-check-output.jsonl
 
       - name: Upload deprecation check output
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: deprecation-check-output
-          path: ${{ github.workspace }}/deprecation-check-output.jsonl
+          path: /tmp/deprecation-check-output.jsonl
           retention-days: 30  # Intentionally longer than 7-day default since this runs monthly
 
       - name: Validate deprecation check result


### PR DESCRIPTION
## Summary
- Same `/workspaces/` → `/tmp/` tee fix from PRs #891 and #899, applied to the two remaining workflows:
  - `claude-diagnose-workflow-failure.yml`
  - `ha-deprecation-check.yml`

## Test plan
- [ ] These workflows don't run on every PR — verify on next scheduled/triggered run

🤖 Generated with [Claude Code](https://claude.com/claude-code)