### PR TITLE
Fix #867: Resolve flaky TestReconnectStateSync race condition

### DIFF
--- a/homeautomation-go/test/integration/integration_test.go
+++ b/homeautomation-go/test/integration/integration_test.go
@@ -785,9 +785,12 @@ func TestReconnectStateSync(t *testing.T) {
 
 	// CRITICAL: Verify state was synced after reconnect
 	// The state manager should now see Nick as home (changed while disconnected)
-	nickHome, err := manager.GetBool("isNickHome")
-	require.NoError(t, err)
-	assert.True(t, nickHome, "Nick should be home after reconnect sync - state changed while disconnected")
+	// Note: callbackInvoked is set before SyncFromHA() completes, so we must poll
+	// until the state is actually synced rather than asserting immediately.
+	waitForCondition(t, func() bool {
+		nickHome, err := manager.GetBool("isNickHome")
+		return err == nil && nickHome
+	}, "Nick should be home after reconnect sync - state changed while disconnected")
 
 	t.Log("✅ State successfully synchronized after reconnection!")
 


### PR DESCRIPTION
Resolves #867

## Summary
- The `TestReconnectStateSync` test had a race condition: the reconnect callback sets `callbackInvoked = true` **before** `SyncFromHA()` completes
- The test waited for `callbackInvoked`, then immediately asserted state — but `SyncFromHA()` hadn't finished yet
- Replaced the immediate `assert.True` with `waitForCondition` polling to wait until the state is actually synced

## Root Cause
In the reconnect callback (line 726-735), `callbackInvoked` is set first, then `manager.SyncFromHA()` runs. The test's `waitForCondition` on `callbackInvoked` returns true before sync completes, causing the subsequent `manager.GetBool("isNickHome")` to read stale state intermittently.

## Test Plan
- Ran `TestReconnectStateSync` 5x with `-race -count=5` — all pass
- Full integration test suite passes
- Full unit test suite passes

🤖 Generated with Claude Code