### PR TITLE
fix: Eliminate duplicate PR Tests runs on claude/** branches

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -8,7 +8,7 @@ name: PR Tests
 # - GitHub-hosted runners: safe for untrusted code (ephemeral VMs)
 # - READ-ONLY permissions (contents: read, pull-requests: read)
 # - No secrets are exposed to PR builds
-# - Push trigger limited to claude/** branches (requires write access)
+# - pull_request trigger covers all branches targeting main (including claude/**)
 # - workflow_dispatch requires write access
 # - Fork PR check retained for consistency and to avoid wasting CI minutes
 #
@@ -25,9 +25,6 @@ on:
       - main
       - master
       - '**'
-  push:
-    branches:
-      - 'claude/**'  # Only test development branches; main/master tested in docker-build-push.yml
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
## Summary
- Removed the `push` trigger for `claude/**` branches from `pr-tests.yml`
- The `pull_request` trigger (matching all branches via `'**'`) already covers these PRs, making the `push` trigger redundant
- The duplicate runs caused `cancel-in-progress` to kill the first run, leaving a stale failed check on PRs

## Test plan
- [ ] Push a commit to an open PR on a `claude/**` branch
- [ ] Confirm only one PR Tests workflow run fires (not two)
- [ ] Confirm no stale failed checks appear on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)