### PR TITLE
Fix #903: Fail all-reviews-passed on PR reopen to prevent review bypass

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1832,6 +1832,12 @@ jobs:
             exit 0
           fi
 
+          # PR reopen trigger only resets the label — real reviews come from workflow_run
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "PR reopened — waiting for PR Tests to trigger the real review run"
+            exit 1
+          fi
+
           # If tests failed and we're still under max attempts, fix-test-failures ran
           # and pushed changes - this workflow run is complete, next run will continue
           TESTS_PASSED="${{ needs.get-context.outputs.tests_passed }}"


### PR DESCRIPTION
Resolves #903

## Summary
- Added an early exit in the `all-reviews-passed` job's `check-results` step that fails (`exit 1`) when `github.event_name == 'pull_request'`
- The PR reopen trigger only needs to reset the `agent-reviews-passed` label (handled by `get-context`); the real reviews come from the `workflow_run` trigger after PR Tests complete
- This prevents `check_result("skipped")` from treating skipped reviews as passing on reopen

## Test Plan
- Close and reopen a PR — the `All Required Agent Reviews` check should now fail instead of passing
- The `workflow_run` trigger (after PR Tests) continues to work normally since `github.event_name` will be `workflow_run`, not `pull_request`

🤖 Generated with Claude Code