### PR TITLE
Fix #909: Align hue_config_test.yaml isWakeSequenceActive with production

### DIFF
--- a/homeautomation-go/test/integration/testdata/hue_config_test.yaml
+++ b/homeautomation-go/test/integration/testdata/hue_config_test.yaml
@@ -32,7 +32,7 @@ rooms:
       #
       # Priority 1: Wake sequence in progress -> yield to sleephygiene
       # This takes absolute priority to prevent race condition with wake sequence
-      - action: on
+      - action: skip
         variable: isWakeSequenceActive
         value: true
       # Priority 2: No one home and awake -> OFF


### PR DESCRIPTION
Resolves #909

## Summary
- Changed `action: on` to `action: skip` for `isWakeSequenceActive` condition on Master Bedroom in `hue_config_test.yaml` to match production `hue_config.yaml`

## Test Plan
- Unit tests pass (`make unit-tests`)
- Integration tests pass (`make integration-tests`)
- Pre-push validation passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)