### PR TITLE
Fix #918: Suppress near_home geofence false positive on departure

### DIFF
--- a/homeautomation-go/internal/plugins/statetracking/manager.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager.go
@@ -25,6 +25,12 @@ const (
 
 	// OwnerReturnHomeResetDelay is how long before didOwnerJustReturnHome auto-resets
 	OwnerReturnHomeResetDelay = 10 * time.Minute
+
+	// DepartureCooldown is how long after leaving the home zone to suppress
+	// near_home triggers. On departure, the home zone (smaller) clears before
+	// the near_home zone (larger) fires. Without this cooldown, the near_home
+	// trigger is indistinguishable from a genuine arrival.
+	DepartureCooldown = 2 * time.Minute
 )
 
 // Manager handles automatic computation of derived state variables.
@@ -57,6 +63,10 @@ type Manager struct {
 	ownerReturnHomeTimer clock.Timer
 
 	timerMutex sync.Mutex
+
+	// Departure timestamps to suppress near_home false positives (issue #918)
+	nickDepartureTime     time.Time
+	carolineDepartureTime time.Time
 
 	// Shadow state tracking
 	shadowTracker *shadowstate.StateTrackingTracker
@@ -371,7 +381,10 @@ func (m *Manager) handleNickHomeChange(entityID string, oldState, newState *ha.S
 			m.logger.Debug("Nobody else was home, not announcing Nick's arrival")
 		}
 	} else if newState.State != "on" && oldState.State == "on" {
-		// Nick left home - clear didOwnerJustReturnHome
+		// Nick left home - record departure time and clear didOwnerJustReturnHome
+		m.timerMutex.Lock()
+		m.nickDepartureTime = m.clock.Now()
+		m.timerMutex.Unlock()
 		m.clearOwnerJustReturnedHome()
 	}
 }
@@ -417,7 +430,10 @@ func (m *Manager) handleCarolineHomeChange(entityID string, oldState, newState *
 			m.logger.Debug("Nobody else was home, not announcing Caroline's arrival")
 		}
 	} else if newState.State != "on" && oldState.State == "on" {
-		// Caroline left home - clear didOwnerJustReturnHome
+		// Caroline left home - record departure time and clear didOwnerJustReturnHome
+		m.timerMutex.Lock()
+		m.carolineDepartureTime = m.clock.Now()
+		m.timerMutex.Unlock()
 		m.clearOwnerJustReturnedHome()
 	}
 }
@@ -485,6 +501,19 @@ func (m *Manager) handleNickNearHomeChange(entityID string, oldState, newState *
 		}
 
 		if !isNickHome {
+			// Check departure cooldown to distinguish arrival from departure (issue #918)
+			m.timerMutex.Lock()
+			timeSinceDeparture := m.clock.Now().Sub(m.nickDepartureTime)
+			recentlyDeparted := !m.nickDepartureTime.IsZero() && timeSinceDeparture < DepartureCooldown
+			m.timerMutex.Unlock()
+
+			if recentlyDeparted {
+				m.logger.Info("Nick near_home triggered but recently departed - suppressing (departure cooldown)",
+					zap.Duration("timeSinceDeparture", timeSinceDeparture),
+					zap.Duration("cooldown", DepartureCooldown))
+				return
+			}
+
 			// Nick is NOT home and just triggered near_home → he is ARRIVING
 			m.logger.Info("Nick near_home triggered while NOT home - setting didOwnerJustReturnHome",
 				zap.Bool("isNickHome", isNickHome))
@@ -520,6 +549,19 @@ func (m *Manager) handleCarolineNearHomeChange(entityID string, oldState, newSta
 		}
 
 		if !isCarolineHome {
+			// Check departure cooldown to distinguish arrival from departure (issue #918)
+			m.timerMutex.Lock()
+			timeSinceDeparture := m.clock.Now().Sub(m.carolineDepartureTime)
+			recentlyDeparted := !m.carolineDepartureTime.IsZero() && timeSinceDeparture < DepartureCooldown
+			m.timerMutex.Unlock()
+
+			if recentlyDeparted {
+				m.logger.Info("Caroline near_home triggered but recently departed - suppressing (departure cooldown)",
+					zap.Duration("timeSinceDeparture", timeSinceDeparture),
+					zap.Duration("cooldown", DepartureCooldown))
+				return
+			}
+
 			// Caroline is NOT home and just triggered near_home → she is ARRIVING
 			m.logger.Info("Caroline near_home triggered while NOT home - setting didOwnerJustReturnHome",
 				zap.Bool("isCarolineHome", isCarolineHome))

--- a/homeautomation-go/internal/plugins/statetracking/manager_test.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"homeautomation/internal/clock"
 	"homeautomation/internal/ha"
 	"homeautomation/internal/state"
 
@@ -1034,6 +1035,102 @@ func TestStateTrackingManager_NearHomeDetection(t *testing.T) {
 			if didOwnerReturn != tt.expectedResult {
 				t.Errorf("Expected didOwnerJustReturnHome=%v, got %v (entityID=%s, alreadyHome=%v)",
 					tt.expectedResult, didOwnerReturn, tt.entityID, tt.isAlreadyHome)
+			}
+		})
+	}
+}
+
+// TestStateTrackingManager_NearHomeDepartureCooldown tests that near_home triggers
+// are suppressed during the departure cooldown period (issue #918).
+func TestStateTrackingManager_NearHomeDepartureCooldown(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name             string
+		homeEntityID     string
+		nearHomeEntityID string
+		homeStateVar     string
+		timeSinceDepart  time.Duration
+		expectedResult   bool
+	}{
+		{
+			name:             "Nick near_home suppressed during cooldown",
+			homeEntityID:     "input_boolean.nick_home",
+			nearHomeEntityID: "input_boolean.nick_near_home",
+			homeStateVar:     "isNickHome",
+			timeSinceDepart:  1 * time.Minute,
+			expectedResult:   false,
+		},
+		{
+			name:             "Nick near_home allowed after cooldown",
+			homeEntityID:     "input_boolean.nick_home",
+			nearHomeEntityID: "input_boolean.nick_near_home",
+			homeStateVar:     "isNickHome",
+			timeSinceDepart:  3 * time.Minute,
+			expectedResult:   true,
+		},
+		{
+			name:             "Caroline near_home suppressed during cooldown",
+			homeEntityID:     "input_boolean.caroline_home",
+			nearHomeEntityID: "input_boolean.caroline_near_home",
+			homeStateVar:     "isCarolineHome",
+			timeSinceDepart:  30 * time.Second,
+			expectedResult:   false,
+		},
+		{
+			name:             "Caroline near_home allowed after cooldown",
+			homeEntityID:     "input_boolean.caroline_home",
+			nearHomeEntityID: "input_boolean.caroline_near_home",
+			homeStateVar:     "isCarolineHome",
+			timeSinceDepart:  5 * time.Minute,
+			expectedResult:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockHA := ha.NewMockClient()
+			logger := zap.NewNop()
+			stateMgr := state.NewManager(mockHA, logger, false)
+
+			mockClock := clock.NewMockClock(time.Now())
+
+			// Setup: person is home initially
+			if err := stateMgr.SetBool(tt.homeStateVar, true); err != nil {
+				t.Fatalf("Failed to set %s: %v", tt.homeStateVar, err)
+			}
+			if err := stateMgr.SetBool("didOwnerJustReturnHome", false); err != nil {
+				t.Fatalf("Failed to set didOwnerJustReturnHome: %v", err)
+			}
+
+			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil)
+			manager.SetClock(mockClock)
+			if err := manager.Start(); err != nil {
+				t.Fatalf("Failed to start manager: %v", err)
+			}
+			defer manager.Stop()
+
+			// Simulate person leaving home (on -> off)
+			mockHA.SetState(tt.homeEntityID, "on", nil)
+			mockHA.SetState(tt.homeEntityID, "off", nil)
+
+			// Clear any didOwnerJustReturnHome set by initial arrival event
+			_ = stateMgr.SetBool("didOwnerJustReturnHome", false)
+
+			// Advance time by the configured duration
+			mockClock.AdvanceAndProcess(tt.timeSinceDepart)
+
+			// Simulate near_home going on
+			mockHA.SetState(tt.nearHomeEntityID, "off", nil)
+			mockHA.SetState(tt.nearHomeEntityID, "on", nil)
+
+			// Verify result
+			didOwnerReturn, err := stateMgr.GetBool("didOwnerJustReturnHome")
+			if err != nil {
+				t.Fatalf("Failed to get didOwnerJustReturnHome: %v", err)
+			}
+			if didOwnerReturn != tt.expectedResult {
+				t.Errorf("Expected didOwnerJustReturnHome=%v, got %v (timeSinceDepart=%v)",
+					tt.expectedResult, didOwnerReturn, tt.timeSinceDepart)
 			}
 		})
 	}

--- a/homeautomation-go/test/integration/scenario_security_test.go
+++ b/homeautomation-go/test/integration/scenario_security_test.go
@@ -342,3 +342,81 @@ func TestScenario_OnlyOwnersTriggersGarage(t *testing.T) {
 
 	t.Log("✓ Garage automation only triggers for owners, not guests")
 }
+
+// TestScenario_NearHomeDepartureDoesNotOpenGarage tests that passing through the
+// near_home geofence while LEAVING does not falsely trigger didOwnerJustReturnHome.
+// Regression test for issue #918: on departure, the home zone (smaller) clears first,
+// then the near_home zone (larger) fires. At that point isHome is already false,
+// making it look like an arrival.
+func TestScenario_NearHomeDepartureDoesNotOpenGarage(t *testing.T) {
+	t.Parallel()
+	server, _, _, manager, mockClock, cleanup := setupSecurityScenarioTestWithMockClock(t)
+	defer cleanup()
+
+	t.Log("GIVEN: Nick is home")
+	server.SetState("input_boolean.nick_home", "on", nil)
+	server.SetState("input_boolean.nick_near_home", "off", nil)
+	server.SetState("binary_sensor.garage_door_vehicle_detected", "off", nil)
+	waitForBoolState(t, manager, "isNickHome", true, "isNickHome should be true initially")
+
+	// Clear the didOwnerJustReturnHome that was set by the arrival above
+	waitForBoolState(t, manager, "didOwnerJustReturnHome", true, "didOwnerJustReturnHome set by initial arrival")
+	waitForProcessing(t, manager)
+	mockClock.AdvanceAndProcess(11 * time.Minute)
+	waitForBoolState(t, manager, "didOwnerJustReturnHome", false, "didOwnerJustReturnHome should auto-reset")
+
+	t.Log("WHEN: Nick leaves home (home zone clears first)")
+	server.SetState("input_boolean.nick_home", "off", nil)
+	waitForBoolState(t, manager, "isNickHome", false, "isNickHome should be false after departure")
+
+	snapshot := server.ServiceCallCount()
+
+	t.Log("AND: Nick passes through near_home geofence on the way out (1 minute later)")
+	mockClock.AdvanceAndProcess(1 * time.Minute)
+	server.SetState("input_boolean.nick_near_home", "on", nil)
+
+	t.Log("THEN: didOwnerJustReturnHome should NOT be set (departure, not arrival)")
+	waitForProcessing(t, manager)
+
+	didReturn, err := manager.GetBool("didOwnerJustReturnHome")
+	require.NoError(t, err)
+	assert.False(t, didReturn, "didOwnerJustReturnHome should remain false during departure through near_home")
+
+	t.Log("AND: Garage door should NOT be opened")
+	garageOpenCall := FindServiceCallWithEntityID(server.GetServiceCallsSince(snapshot), "cover", "open_cover", "cover.garage_door_door")
+	assert.Nil(t, garageOpenCall, "Garage should NOT open when passing through near_home on departure")
+
+	t.Log("✓ Near-home geofence correctly suppressed during departure")
+}
+
+// TestScenario_NearHomeArrivalStillWorks tests that genuine arrivals through the
+// near_home geofence still trigger didOwnerJustReturnHome correctly after the
+// departure cooldown fix.
+func TestScenario_NearHomeArrivalStillWorks(t *testing.T) {
+	t.Parallel()
+	server, _, _, manager, mockClock, cleanup := setupSecurityScenarioTestWithMockClock(t)
+	defer cleanup()
+
+	t.Log("GIVEN: Nick is not home (has been away for a while)")
+	server.SetState("input_boolean.nick_home", "off", nil)
+	server.SetState("input_boolean.nick_near_home", "off", nil)
+	server.SetState("binary_sensor.garage_door_vehicle_detected", "off", nil)
+	waitForBoolState(t, manager, "isNickHome", false, "isNickHome should be false")
+	waitForProcessing(t, manager)
+
+	// Advance well past any cooldown period
+	mockClock.AdvanceAndProcess(10 * time.Minute)
+
+	snapshot := server.ServiceCallCount()
+
+	t.Log("WHEN: Nick enters near_home geofence (genuine arrival)")
+	server.SetState("input_boolean.nick_near_home", "on", nil)
+
+	t.Log("THEN: didOwnerJustReturnHome should be set to true")
+	waitForBoolState(t, manager, "didOwnerJustReturnHome", true, "didOwnerJustReturnHome should be true for genuine arrival via near_home")
+
+	t.Log("AND: Garage door should be opened")
+	waitForServiceCallWithEntitySince(t, server, snapshot, "cover", "open_cover", "cover.garage_door_door", "Garage should open for genuine near_home arrival")
+
+	t.Log("✓ Genuine near-home arrival still triggers garage correctly")
+}


### PR DESCRIPTION
Resolves #918

## Summary
- Added a 2-minute departure cooldown to prevent the `near_home` geofence from falsely triggering `didOwnerJustReturnHome` when leaving home
- When `isNickHome`/`isCarolineHome` transitions to `false`, the departure timestamp is recorded
- In `handleNickNearHomeChange`/`handleCarolineNearHomeChange`, the trigger is suppressed if the person departed within the cooldown window
- Genuine arrivals (no recent departure) are unaffected

## Root Cause
On departure, the home zone (smaller radius) clears first, setting `isHome=false`. The near_home zone (larger radius) fires second. Since `isHome` was already `false`, the code incorrectly concluded "not home + near_home = ARRIVING" and opened the garage.

## Test Plan
- **Unit tests**: `TestStateTrackingManager_NearHomeDepartureCooldown` — 4 cases covering cooldown suppression and expiry for both Nick and Caroline
- **Integration tests**: 
  - `TestScenario_NearHomeDepartureDoesNotOpenGarage` — full departure sequence with mock clock, verifies garage stays closed
  - `TestScenario_NearHomeArrivalStillWorks` — genuine arrival after cooldown expires, verifies garage opens
- All existing near_home and security tests continue to pass

🤖 Generated with Claude Code