### PR TITLE
Fix #924: Update sex playlist to new Tidal playlist

### DIFF
--- a/configs/music_config.yaml
+++ b/configs/music_config.yaml
@@ -500,7 +500,7 @@ music:
     playback_options:
       # Sensual songs for naughty times (Tidal) — 256 tracks, sensual mood
       # yamllint disable-line rule:line-length
-      - uri: "https://tidal.com/browse/playlist/c9e5c9db-ebd8-4a89-872d-db09672677d8"
+      - uri: "https://tidal.com/browse/playlist/326e15e7-cab6-4600-9687-affd6d6ba5a9"
         media_type: tidal
         volume_multiplier: 1.0
   wakeup:


### PR DESCRIPTION
Resolves #924

## Summary
- Updated the sex zone playlist URI in `configs/music_config.yaml` from `c9e5c9db-ebd8-4a89-872d-db09672677d8` to `326e15e7-cab6-4600-9687-affd6d6ba5a9`

## Test Plan
- Unit tests pass (75.2% coverage)
- Integration tests pass
- Verify in production that the new playlist loads correctly on Sonos speakers

🤖 Generated with [Claude Code](https://claude.com/claude-code)