### PR TITLE
ci: Pre-pull devcontainer image to speed up review jobs

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -521,6 +521,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Pull pre-built devcontainer image
+        run: docker pull ${{ env.DEVCONTAINER_IMAGE }}:latest
+
       - name: Run Codex to fix test failures
         id: codex-fix
         uses: devcontainers/ci@v0.3
@@ -796,6 +799,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Pull pre-built devcontainer image
+        if: steps.verify-tests.outputs.verified == 'true'
+        run: docker pull ${{ env.DEVCONTAINER_IMAGE }}:latest
+
       - name: Run Codex review in devcontainer
         if: steps.verify-tests.outputs.verified == 'true'
         uses: devcontainers/ci@v0.3
@@ -947,6 +954,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull pre-built devcontainer image
+        if: steps.verify-tests.outputs.verified == 'true'
+        run: docker pull ${{ env.DEVCONTAINER_IMAGE }}:latest
 
       - name: Design review in devcontainer
         if: steps.verify-tests.outputs.verified == 'true'
@@ -1138,6 +1149,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Pull pre-built devcontainer image
+        if: steps.verify-tests.outputs.verified == 'true'
+        run: docker pull ${{ env.DEVCONTAINER_IMAGE }}:latest
+
       - name: Test review in devcontainer
         if: steps.verify-tests.outputs.verified == 'true'
         uses: devcontainers/ci@v0.3
@@ -1293,6 +1308,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Pull pre-built devcontainer image
+        if: steps.verify-tests.outputs.verified == 'true'
+        run: docker pull ${{ env.DEVCONTAINER_IMAGE }}:latest
+
       - name: Concurrency review in devcontainer
         if: steps.verify-tests.outputs.verified == 'true'
         uses: devcontainers/ci@v0.3
@@ -1439,6 +1458,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull pre-built devcontainer image
+        if: steps.verify-tests.outputs.verified == 'true'
+        run: docker pull ${{ env.DEVCONTAINER_IMAGE }}:latest
 
       - name: Documentation review in devcontainer
         if: steps.verify-tests.outputs.verified == 'true'
@@ -1592,6 +1615,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull pre-built devcontainer image
+        if: steps.verify-tests.outputs.verified == 'true'
+        run: docker pull ${{ env.DEVCONTAINER_IMAGE }}:latest
 
       - name: Make merge decision in devcontainer
         if: steps.verify-tests.outputs.verified == 'true'


### PR DESCRIPTION
## Summary
- Adds a `docker pull` step before each `devcontainers/ci` call in all 7 downstream jobs of the Claude Code Review workflow
- The `build-devcontainer` job already builds and pushes the image to GHCR, but each downstream job was re-running the Docker build pipeline (~35s each) to resolve cache layers remotely
- Pre-pulling makes the image available locally so cache resolution is instant

## Test plan
- [ ] Verify YAML syntax passes CI validation
- [ ] Observe that the "build container" phase inside each `devcontainers/ci` step completes in <5s instead of ~35s on next PR review run

🤖 Generated with [Claude Code](https://claude.com/claude-code)