### PR TITLE
chore: migrate Claude Code from npm to native installer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# Devcontainer Dockerfile with pre-installed Claude Code and Playwright
+# Devcontainer Dockerfile with pre-installed AI CLIs and Playwright
 # This caches system packages and tools so rebuilds are faster
 # Consolidates devcontainer features into Dockerfile for better layer caching
 
@@ -37,17 +37,13 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js LTS (needed for Claude Code and Playwright)
+# Install Node.js LTS (needed for Codex, Crush, and Playwright)
 ARG NODE_VERSION=20
 RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Claude Code CLI globally
-ARG CLAUDE_CODE_VERSION=2.1.75
-RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
-
-# Install AI coding assistants (Crush + Codex)
+# Install AI coding assistants (Crush + Codex) via npm
 ARG CRUSH_CLI_VERSION=0.53.0
 ARG CODEX_CLI_VERSION=0.117.0
 RUN npm install -g @charmland/crush@${CRUSH_CLI_VERSION} @openai/codex@${CODEX_CLI_VERSION}
@@ -63,9 +59,13 @@ RUN mkdir -p /home/vscode/.claude/tmp \
     && chown -R vscode:vscode /home/vscode/.claude \
     && chown -R vscode:vscode /home/vscode/.cache
 
-# Switch to vscode user for plugin installation
+# Switch to vscode user for Claude Code native install and plugin setup
 USER vscode
 WORKDIR /home/vscode
+
+# Install Claude Code via native installer (auto-updates, no npm dependency)
+RUN curl -fsSL https://claude.ai/install.sh | bash
+ENV PATH="/home/vscode/.claude/bin:${PATH}"
 
 # Set TMPDIR to avoid EXDEV errors during plugin installation
 ENV TMPDIR=/home/vscode/.claude/tmp

--- a/.github/workflows/update-ai-clis.yml
+++ b/.github/workflows/update-ai-clis.yml
@@ -23,34 +23,28 @@ jobs:
       - name: Check for AI CLI updates
         id: check
         run: |
-          CURRENT_CLAUDE=$(grep -oP 'ARG CLAUDE_CODE_VERSION=\K[0-9.]+' .devcontainer/Dockerfile)
           CURRENT_CRUSH=$(grep -oP 'ARG CRUSH_CLI_VERSION=\K[0-9.]+' .devcontainer/Dockerfile)
           CURRENT_CODEX=$(grep -oP 'ARG CODEX_CLI_VERSION=\K[0-9.]+' .devcontainer/Dockerfile)
 
-          LATEST_CLAUDE=$(npm view @anthropic-ai/claude-code version)
           LATEST_CRUSH=$(npm view @charmland/crush version | sed 's/^v//')
           LATEST_CODEX=$(npm view @openai/codex version)
 
-          echo "current_claude=$CURRENT_CLAUDE" >> "$GITHUB_OUTPUT"
           echo "current_crush=$CURRENT_CRUSH" >> "$GITHUB_OUTPUT"
           echo "current_codex=$CURRENT_CODEX" >> "$GITHUB_OUTPUT"
-          echo "latest_claude=$LATEST_CLAUDE" >> "$GITHUB_OUTPUT"
           echo "latest_crush=$LATEST_CRUSH" >> "$GITHUB_OUTPUT"
           echo "latest_codex=$LATEST_CODEX" >> "$GITHUB_OUTPUT"
 
-          if [ "$CURRENT_CLAUDE" != "$LATEST_CLAUDE" ] || [ "$CURRENT_CRUSH" != "$LATEST_CRUSH" ] || [ "$CURRENT_CODEX" != "$LATEST_CODEX" ]; then
+          if [ "$CURRENT_CRUSH" != "$LATEST_CRUSH" ] || [ "$CURRENT_CODEX" != "$LATEST_CODEX" ]; then
             echo "needs_update=true" >> "$GITHUB_OUTPUT"
           else
             echo "needs_update=false" >> "$GITHUB_OUTPUT"
           fi
-          echo "Claude Code: $CURRENT_CLAUDE -> $LATEST_CLAUDE"
           echo "Crush: $CURRENT_CRUSH -> $LATEST_CRUSH"
           echo "Codex: $CURRENT_CODEX -> $LATEST_CODEX"
 
       - name: Update Dockerfile
         if: steps.check.outputs.needs_update == 'true'
         run: |
-          sed -i "s/ARG CLAUDE_CODE_VERSION=.*/ARG CLAUDE_CODE_VERSION=${{ steps.check.outputs.latest_claude }}/" .devcontainer/Dockerfile
           sed -i "s/ARG CRUSH_CLI_VERSION=.*/ARG CRUSH_CLI_VERSION=${{ steps.check.outputs.latest_crush }}/" .devcontainer/Dockerfile
           sed -i "s/ARG CODEX_CLI_VERSION=.*/ARG CODEX_CLI_VERSION=${{ steps.check.outputs.latest_codex }}/" .devcontainer/Dockerfile
 
@@ -65,9 +59,10 @@ jobs:
           body: |
             Automated weekly update of the AI CLIs bundled in the devcontainer.
 
-            - **Claude Code:** ${{ steps.check.outputs.current_claude }} → ${{ steps.check.outputs.latest_claude }}
             - **Crush:** ${{ steps.check.outputs.current_crush }} → ${{ steps.check.outputs.latest_crush }}
             - **Codex:** ${{ steps.check.outputs.current_codex }} → ${{ steps.check.outputs.latest_codex }}
+
+            Note: Claude Code uses the native installer and auto-updates independently.
 
             🤖 Generated automatically by the `update-ai-clis` workflow.
           branch: chore/update-ai-clis

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The devcontainer automatically:
 - Installs Go 1.25 and all required dependencies
 - Sets up Go modules (`go mod tidy && go mod download`)
 - Installs git hooks (pre-commit and pre-push validation)
-- Installs GitHub CLI, Codex CLI, and Playwright (with Chromium)
+- Installs Claude Code (native installer), GitHub CLI, Codex CLI, and Playwright (with Chromium)
 - Configures VS Code extensions for Go and Mermaid
 
 ### Manual Setup (Without Devcontainer)


### PR DESCRIPTION
## Summary
- Replaces npm-based Claude Code install (`@anthropic-ai/claude-code`) with the native installer (`curl -fsSL https://claude.ai/install.sh | bash`), which provides auto-updates and removes the Node.js dependency for Claude Code
- Removes Claude Code from the `update-ai-clis` workflow since it's no longer version-pinned (Crush + Codex remain)
- Codex, Crush, and Playwright still use Node.js/npm (still the recommended install method for those tools)

Closes #928

## Test plan
- [ ] Devcontainer builds successfully
- [ ] `claude --version` works as vscode user
- [ ] Claude plugin installation still works
- [ ] `codex --version` and `crush --version` still work
- [ ] `update-ai-clis` workflow only tracks Crush + Codex

🤖 Generated with [Claude Code](https://claude.com/claude-code)