### PR TITLE
Fix #933: Stabilize integration test timing

### DIFF
--- a/homeautomation-go/test/integration/scenario_concurrent_triggers_test.go
+++ b/homeautomation-go/test/integration/scenario_concurrent_triggers_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"context"
 	"testing"
-	"time"
 
 	"homeautomation/internal/plugins/lighting"
 	"homeautomation/internal/plugins/music"
@@ -204,12 +203,13 @@ func TestScenario_RapidPresenceChanges_StableState(t *testing.T) {
 
 	// Simulate rapid presence changes
 	for i := 0; i < 5; i++ {
+		expectedHome := i%2 == 0
 		if i%2 == 0 {
 			env.server.SetState("input_boolean.caroline_home", "on", map[string]interface{}{})
 		} else {
 			env.server.SetState("input_boolean.caroline_home", "off", map[string]interface{}{})
 		}
-		time.Sleep(20 * time.Millisecond) // Intentional: simulates rapid sensor changes
+		waitForBoolState(t, env.stateManager, "isCarolineHome", expectedHome, "presence change %d should propagate", i)
 	}
 
 	// Final state: Caroline is home (last toggle was i=4, even → on)

--- a/homeautomation-go/test/integration/scenario_security_test.go
+++ b/homeautomation-go/test/integration/scenario_security_test.go
@@ -368,6 +368,7 @@ func TestScenario_NearHomeDepartureDoesNotOpenGarage(t *testing.T) {
 	t.Log("WHEN: Nick leaves home (home zone clears first)")
 	server.SetState("input_boolean.nick_home", "off", nil)
 	waitForBoolState(t, manager, "isNickHome", false, "isNickHome should be false after departure")
+	waitForProcessing(t, manager)
 
 	snapshot := server.ServiceCallCount()
 

--- a/homeautomation-go/test/integration/scenario_wakeup_zone_resolution_test.go
+++ b/homeautomation-go/test/integration/scenario_wakeup_zone_resolution_test.go
@@ -158,9 +158,9 @@ func TestScenario_WakeUp_DebouncesRapidTriggers(t *testing.T) {
 	// These three changes would each independently trigger zone resolution
 	// without debouncing. With debouncing, they should coalesce into one.
 	env.server.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
-	time.Sleep(30 * time.Millisecond) // Intentional: simulates real timing between state changes
+	waitForBoolState(t, env.stateManager, "isAnyoneAsleep", false, "isAnyoneAsleep should update before next wake event")
 	env.server.SetState("input_boolean.master_asleep", "off", map[string]interface{}{})
-	time.Sleep(30 * time.Millisecond) // Intentional: simulates real timing between state changes
+	waitForBoolState(t, env.stateManager, "isMasterAsleep", false, "isMasterAsleep should update before next wake event")
 	env.server.SetState("input_boolean.wake_sequence_active", "on", map[string]interface{}{})
 
 	// Wait for debounce timer to fire using channel synchronization


### PR DESCRIPTION
Resolves #933

## Summary
- ensure departure cooldown test waits for statetracking to record Nick's departure before near_home triggers
- replace rapid presence timing sleeps with deterministic waitForBoolState propagation
- swap wake sequence sleeps for state-based waits so debounce scenario stays reliable under CI load

## Test Plan
- make unit-tests
- make integration-tests
- make pre-commit

🤖 Generated with Codex