### PR TITLE
Add tmux to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,7 +20,7 @@ RUN rm -f /etc/apt/sources.list.d/yarn.list \
     # Playwright host dependencies (recommended)
     libcairo2 libpango-1.0-0 \
     # Utilities used by Claude Code and OpenCode
-    bc ripgrep fzf \
+    bc ripgrep fzf tmux \
     # YAML validation
     yamllint \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary
- Adds `tmux` to the devcontainer's apt-get install block to support worktree workflows

## Test plan
- [ ] Rebuild devcontainer and verify `tmux` is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)