### PR TITLE
fix: Set TERM and LANG for proper CLI rendering in tmux

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,9 @@
   "initializeCommand": "bash .devcontainer/init-host-credentials.sh",
   "remoteEnv": {
     "SSH_AUTH_SOCK": "",
-    "OPENAI_API_KEY": "fake-key"
+    "OPENAI_API_KEY": "fake-key",
+    "TERM": "xterm-256color",
+    "LANG": "en_US.UTF-8"
   },
   "updateRemoteUserUID": true,
   "remoteUser": "vscode"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -10,10 +10,53 @@ echo "=== Setting up devcontainer ==="
 
 # Configure tmux to use xterm-256color so CLI tools (e.g. Claude Code) render correctly
 echo "Configuring tmux..."
-cat > "$HOME/.tmux.conf" << 'TMUXEOF'
+TMUX_CONF="$HOME/.tmux.conf"
+TMUX_BLOCK_START="# >>> home-automation devcontainer tmux >>>"
+TMUX_BLOCK_END="# <<< home-automation devcontainer tmux <<<"
+TMUX_MANAGED_BLOCK=$(cat <<'TMUXEOF'
+# >>> home-automation devcontainer tmux >>>
 set -g default-terminal "xterm-256color"
 set-environment -g LANG en_US.UTF-8
+# <<< home-automation devcontainer tmux <<<
 TMUXEOF
+)
+
+if [ -f "$TMUX_CONF" ] && grep -Fq "$TMUX_BLOCK_START" "$TMUX_CONF"; then
+    python3 - "$TMUX_CONF" "$TMUX_BLOCK_START" "$TMUX_BLOCK_END" "$TMUX_MANAGED_BLOCK" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+start = sys.argv[2]
+end = sys.argv[3]
+block = sys.argv[4]
+
+lines = path.read_text().splitlines()
+output = []
+inside_block = False
+replaced = False
+
+for line in lines:
+    if line == start:
+        if not replaced:
+            output.extend(block.splitlines())
+            replaced = True
+        inside_block = True
+        continue
+    if line == end and inside_block:
+        inside_block = False
+        continue
+    if not inside_block:
+        output.append(line)
+
+path.write_text("\n".join(output) + "\n")
+PY
+else
+    if [ -f "$TMUX_CONF" ] && [ -s "$TMUX_CONF" ]; then
+        printf '\n' >> "$TMUX_CONF"
+    fi
+    printf '%s\n' "$TMUX_MANAGED_BLOCK" >> "$TMUX_CONF"
+fi
 
 # Fix DNS order to prioritize Tailscale MagicDNS
 # (Also runs via postStartCommand on every container start)

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -8,6 +8,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "=== Setting up devcontainer ==="
 
+# Configure tmux to use xterm-256color so CLI tools (e.g. Claude Code) render correctly
+echo "Configuring tmux..."
+cat > "$HOME/.tmux.conf" << 'TMUXEOF'
+set -g default-terminal "xterm-256color"
+set-environment -g LANG en_US.UTF-8
+TMUXEOF
+
 # Fix DNS order to prioritize Tailscale MagicDNS
 # (Also runs via postStartCommand on every container start)
 echo "Checking DNS configuration..."


### PR DESCRIPTION
## Summary
- Add `TERM=xterm-256color` and `LANG=en_US.UTF-8` to `remoteEnv` in devcontainer.json
- Add `~/.tmux.conf` provisioning in post-create.sh so tmux sessions inherit correct TERM and LANG
- Fixes Unicode rendering issues in CLI tools (e.g. Claude Code) when launched via `dcs` (tmux)

## Test plan
- [x] Verified `TERM=xterm-256color` and `LANG=en_US.UTF-8` inside tmux sessions
- [x] Verified Claude Code renders correctly when launched via tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)