### PR TITLE
Add Claude Code credential sharing to devcontainer

### DIFF
--- a/.devcontainer/init-host-credentials.sh
+++ b/.devcontainer/init-host-credentials.sh
@@ -9,3 +9,13 @@ cd "$(dirname "$0")"
 
 # GitHub CLI token
 gh auth token > .gh-token 2>/dev/null || true
+
+# Claude Code credentials
+CLAUDE_CREDS="$HOME/.claude/.credentials.json"
+if [ -f "$CLAUDE_CREDS" ]; then
+    cp "$CLAUDE_CREDS" .claude-credentials
+    chmod 600 .claude-credentials
+    echo "[init-host-credentials] Claude Code credentials captured."
+else
+    echo "[init-host-credentials] No Claude Code credentials found — skipping."
+fi

--- a/.devcontainer/init-host-credentials.sh
+++ b/.devcontainer/init-host-credentials.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")"
 # GitHub CLI token
 gh auth token > .gh-token 2>/dev/null || true
 
-# Claude Code credentials
+# Claude Code credentials and config
 CLAUDE_CREDS="$HOME/.claude/.credentials.json"
 if [ -f "$CLAUDE_CREDS" ]; then
     cp "$CLAUDE_CREDS" .claude-credentials
@@ -18,4 +18,13 @@ if [ -f "$CLAUDE_CREDS" ]; then
     echo "[init-host-credentials] Claude Code credentials captured."
 else
     echo "[init-host-credentials] No Claude Code credentials found — skipping."
+fi
+
+CLAUDE_CONFIG="$HOME/.claude.json"
+if [ -f "$CLAUDE_CONFIG" ]; then
+    cp "$CLAUDE_CONFIG" .claude-config
+    chmod 600 .claude-config
+    echo "[init-host-credentials] Claude Code config captured."
+else
+    echo "[init-host-credentials] No Claude Code config found — skipping."
 fi

--- a/.devcontainer/init-host-credentials.sh
+++ b/.devcontainer/init-host-credentials.sh
@@ -11,19 +11,23 @@ cd "$(dirname "$0")"
 gh auth token > .gh-token 2>/dev/null || true
 
 # Claude Code credentials and config
+CLAUDE_CREDS_FILE=".claude-credentials"
+rm -f "$CLAUDE_CREDS_FILE"
 CLAUDE_CREDS="$HOME/.claude/.credentials.json"
 if [ -f "$CLAUDE_CREDS" ]; then
-    cp "$CLAUDE_CREDS" .claude-credentials
-    chmod 600 .claude-credentials
+    cp "$CLAUDE_CREDS" "$CLAUDE_CREDS_FILE"
+    chmod 600 "$CLAUDE_CREDS_FILE"
     echo "[init-host-credentials] Claude Code credentials captured."
 else
     echo "[init-host-credentials] No Claude Code credentials found — skipping."
 fi
 
+CLAUDE_CONFIG_FILE=".claude-config"
+rm -f "$CLAUDE_CONFIG_FILE"
 CLAUDE_CONFIG="$HOME/.claude.json"
 if [ -f "$CLAUDE_CONFIG" ]; then
-    cp "$CLAUDE_CONFIG" .claude-config
-    chmod 600 .claude-config
+    cp "$CLAUDE_CONFIG" "$CLAUDE_CONFIG_FILE"
+    chmod 600 "$CLAUDE_CONFIG_FILE"
     echo "[init-host-credentials] Claude Code config captured."
 else
     echo "[init-host-credentials] No Claude Code config found — skipping."

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -72,10 +72,25 @@ if [ -s "$CLAUDE_CONFIG_FILE" ]; then
         # Merge: host config as base, container config on top (preserves plugin settings)
         python3 -c "
 import json, sys
+from copy import deepcopy
+
+
+def deep_merge(base, overlay):
+    if isinstance(base, dict) and isinstance(overlay, dict):
+        merged = deepcopy(base)
+        for key, value in overlay.items():
+            if key in merged:
+                merged[key] = deep_merge(merged[key], value)
+            else:
+                merged[key] = deepcopy(value)
+        return merged
+    return deepcopy(overlay)
+
+
 host = json.load(open(sys.argv[1]))
 container = json.load(open(sys.argv[2]))
-host.update(container)
-json.dump(host, open(sys.argv[2], 'w'), indent=2)
+merged = deep_merge(host, container)
+json.dump(merged, open(sys.argv[2], 'w'), indent=2)
 " "$CLAUDE_CONFIG_FILE" "$EXISTING_CONFIG"
     else
         cp "$CLAUDE_CONFIG_FILE" "$EXISTING_CONFIG"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -48,6 +48,19 @@ else
     echo "Warning: No gh token found; gh CLI credentials not available."
 fi
 
+# Set up Claude Code credentials from host (written by initializeCommand)
+CLAUDE_CREDS_FILE="$SCRIPT_DIR/.claude-credentials"
+if [ -s "$CLAUDE_CREDS_FILE" ]; then
+    echo "Setting up Claude Code credentials..."
+    mkdir -p "$HOME/.claude"
+    cp "$CLAUDE_CREDS_FILE" "$HOME/.claude/.credentials.json"
+    chmod 600 "$HOME/.claude/.credentials.json"
+    echo "Claude Code credentials configured."
+    rm -f "$CLAUDE_CREDS_FILE"
+else
+    echo "Warning: No Claude credentials found; Claude Code credentials not available."
+fi
+
 # Helper to read pinned versions from the Dockerfile (single source of truth)
 DEVCONTAINER_DOCKERFILE="$SCRIPT_DIR/Dockerfile"
 get_arg_version() {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -61,6 +61,32 @@ else
     echo "Warning: No Claude credentials found; Claude Code credentials not available."
 fi
 
+# Merge host Claude Code config into container config (written by initializeCommand)
+# The container .claude.json has plugin settings from the Dockerfile build;
+# the host .claude.json has hasCompletedOnboarding and account info.
+CLAUDE_CONFIG_FILE="$SCRIPT_DIR/.claude-config"
+if [ -s "$CLAUDE_CONFIG_FILE" ]; then
+    echo "Merging Claude Code config from host..."
+    EXISTING_CONFIG="$HOME/.claude.json"
+    if [ -s "$EXISTING_CONFIG" ]; then
+        # Merge: host config as base, container config on top (preserves plugin settings)
+        python3 -c "
+import json, sys
+host = json.load(open(sys.argv[1]))
+container = json.load(open(sys.argv[2]))
+host.update(container)
+json.dump(host, open(sys.argv[2], 'w'), indent=2)
+" "$CLAUDE_CONFIG_FILE" "$EXISTING_CONFIG"
+    else
+        cp "$CLAUDE_CONFIG_FILE" "$EXISTING_CONFIG"
+    fi
+    chmod 600 "$EXISTING_CONFIG"
+    echo "Claude Code config merged."
+    rm -f "$CLAUDE_CONFIG_FILE"
+else
+    echo "Warning: No Claude config found; skipping config merge."
+fi
+
 # Helper to read pinned versions from the Dockerfile (single source of truth)
 DEVCONTAINER_DOCKERFILE="$SCRIPT_DIR/Dockerfile"
 get_arg_version() {

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ config-test/.yamllint
 
 # Devcontainer secrets (written by initializeCommand, consumed by postCreateCommand)
 .devcontainer/.gh-token
+.devcontainer/.claude-credentials
 
 # Claude Code artifacts
 claude-review-output.jsonl

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ config-test/.yamllint
 # Devcontainer secrets (written by initializeCommand, consumed by postCreateCommand)
 .devcontainer/.gh-token
 .devcontainer/.claude-credentials
+.devcontainer/.claude-config
 
 # Claude Code artifacts
 claude-review-output.jsonl

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The devcontainer automatically:
 - Installs git hooks (pre-commit and pre-push validation)
 - Installs GitHub CLI, Codex CLI, and Playwright (with Chromium)
 - Configures VS Code extensions for Go and Mermaid
+- Imports your host GitHub CLI token and Claude Code credentials into the container so long as you are logged in locally before opening the devcontainer (you will see warnings during startup if host credentials are missing)
 
 ### Manual Setup (Without Devcontainer)
 


### PR DESCRIPTION
## Summary

- Adds host-to-container Claude Code authentication forwarding using the same file-based handoff pattern as the existing GitHub token sharing
- Credentials are extracted from `~/.claude/.credentials.json` during `initializeCommand` (init-host-credentials.sh), installed into the container's `~/.claude/` during `postCreateCommand` (post-create.sh), and the intermediate file is cleaned up afterward
- Gracefully skipped if Claude Code credentials are not available on the host
- The intermediate `.claude-credentials` file is gitignored alongside the existing `.gh-token`

## Test plan

- [ ] Verify devcontainer builds successfully with Claude credentials present on host
- [ ] Verify devcontainer builds successfully without Claude credentials on host (graceful skip)
- [ ] Verify `claude` CLI works inside the devcontainer after build
- [ ] Verify `.claude-credentials` file is cleaned up after postCreateCommand

🤖 Generated with [Claude Code](https://claude.com/claude-code)