### PR TITLE
docs: add devcontainer cache helper and report

### DIFF
--- a/docs/operations/AI_GHA_PIPELINES.md
+++ b/docs/operations/AI_GHA_PIPELINES.md
@@ -665,6 +665,23 @@ Required approvals: 0  # Codex provides automated review
 2. Download the `codex-conversation-log` artifact
 3. Parse the JSONL file for the full conversation
 
+### Inspect Devcontainer Cache Reuse
+
+When a devcontainer build looks noisy, fetch the workflow log and summarize it with the helper script:
+
+```bash
+gh run view <run-id> --log > /tmp/run.log
+python3 tools/devcontainer_cache_report.py --log /tmp/run.log --job build-devcontainer
+python3 tools/devcontainer_cache_report.py --log /tmp/run.log --job resolve-issue
+```
+
+This reports:
+- BuildKit cache hits (`#11 CACHED`, etc.)
+- Registry layer reuse (`Layer already exists`)
+- Newly pushed layers (`Pushed`)
+
+Reference example: `docs/operations/DEVCONTAINER_CACHE_REPORT_2026-03-30.md`.
+
 ### Common Issues
 
 | Issue | Cause | Solution |

--- a/docs/operations/DEVCONTAINER_CACHE_REPORT_2026-03-30.md
+++ b/docs/operations/DEVCONTAINER_CACHE_REPORT_2026-03-30.md
@@ -1,0 +1,58 @@
+# Devcontainer Cache Report – GitHub Actions run 23728700999
+
+**Run:** https://github.com/NickBorgers/home-automation/actions/runs/23728700999  
+**Jobs analysed:** `build-devcontainer`, `resolve-issue`  
+**Report generated on:** 2026-04-01 using `tools/devcontainer_cache_report.py`
+
+## Summary
+- The initial `build-devcontainer` job reused **20 existing registry layers** and pushed **9 new layers**. All base apt/Node.js provisioning layers (`#11`–`#15`) were served directly from BuildKit cache.
+- The only steps that rebuilt were the expected **Claude Code installation**, **Playwright plugin installation**, and **Playwright browser download** (`#16`–`#24`), which contain time-sensitive network fetches.
+- The follow-up `resolve-issue` job hit the cache for every build step (`#11`–`#24`) and therefore **pushed zero layers**, confirming that subsequent runs skip the expensive steps entirely when the cache is warm.
+
+## Method
+```
+gh run view 23728700999 --log > /tmp/run-23728700999.log
+python3 tools/devcontainer_cache_report.py \
+  --log /tmp/run-23728700999.log \
+  --job build-devcontainer --json > /tmp/build-devcontainer.json
+python3 tools/devcontainer_cache_report.py \
+  --log /tmp/run-23728700999.log \
+  --job resolve-issue --json > /tmp/resolve-issue.json
+```
+
+The helper script parses BuildKit step numbers, cache hits, and the registry push output (`Layer already exists` vs `Pushed`) so we do not have to hand-audit the log each time.
+
+## BuildKit Step Breakdown (`build-devcontainer`)
+
+| Step | Cached? | Purpose | Duration |
+|------|---------|---------|----------|
+| #11 | ✅ | Base apt packages, fonts, utilities | served from cache |
+| #12 | ✅ | GitHub CLI apt repository + install | served from cache |
+| #13 | ✅ | NodeSource Node.js 20 installation | served from cache |
+| #14 | ✅ | Create vscode cache directories | served from cache |
+| #15 | ✅ | Switch to `/home/vscode` | served from cache |
+| #16 | ❌ | `curl https://claude.ai/install.sh` (installs Claude Code 2.1.75) | 12.4s |
+| #17 | ❌ | Install `playwright-skill` plugin via Claude marketplace | 3.5s |
+| #18 | ❌ | `npm install` + `npx playwright install chromium` (downloads browsers) | 17.3s |
+| #19–#24 | ❌ | Devcontainer feature normalization and docker-in-docker feature install | 1.0–48.7s |
+
+All earlier loader stages (`#1`–`#8`) represent metadata fetches and are expected to complete quickly; they do not materially influence layer reuse.
+
+## Registry Push vs Cache Usage
+
+| Metric | Count | Notes |
+|--------|-------|-------|
+| Layers reused (`Layer already exists`) | 20 | e.g., `8ccc0040e417`, `4ba56795173a`, `acf20588eb21` |
+| Layers pushed | 9 | `391a86ffd889`, `2afcea7e731b`, `9b627ecbe243`, `81be21e7f9db`, `8b8a89735a97`, etc. |
+
+The pushed layers correspond to the steps that download Claude Code artifacts and Playwright browser binaries, which change whenever upstream releases a new version. Everything else was served from the cache.
+
+## Follow-up Job (`resolve-issue`)
+
+The second job in the workflow rebuilt the same Dockerfile immediately after the first job. The script shows **14 cached steps** (#11–#24) and **no new layers pushed**, demonstrating that the cache becomes fully hot once one run completes.
+
+## Conclusion
+
+- The devcontainer workflow is functioning as intended: once the base layers are built, repeated runs reuse the cached image and skip uploading unchanged layers.
+- The nine pushed layers are attributable to nightly tool downloads (Claude CLI + Playwright). No action is required unless we decide to pin those assets or prebuild them into a separate layer.
+- Future investigations can reuse `tools/devcontainer_cache_report.py` to produce the same breakdown for other runs without manual parsing.

--- a/tools/devcontainer_cache_report.py
+++ b/tools/devcontainer_cache_report.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+devcontainer_cache_report.py
+
+Parses a GitHub Actions log for the devcontainer build step and summarizes how
+BuildKit and the registry cache were used. The script is intentionally small so
+it can be copied into future investigations without extra dependencies.
+
+Example:
+    gh run view 23728700999 --log > /tmp/run.log
+    python tools/devcontainer_cache_report.py --log /tmp/run.log \
+        --job build-devcontainer --markdown
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence
+
+
+STEP_LINE_RE = re.compile(r"#(?P<num>\d+)\s+\[(?P<stage>[^\]]+)\]\s+(?P<command>.+)")
+STEP_CACHED_RE = re.compile(r"#(?P<num>\d+)\s+CACHED\b")
+STEP_DONE_RE = re.compile(r"#(?P<num>\d+)\s+DONE\s+(?P<duration>[\d\.]+)(?P<unit>[a-z]+)", re.IGNORECASE)
+LAYER_EXISTS_RE = re.compile(r"(?P<digest>[0-9a-f]{12}):\s+Layer already exists")
+LAYER_PUSHED_RE = re.compile(r"(?P<digest>[0-9a-f]{12}):\s+Pushed")
+
+
+@dataclass
+class StepInfo:
+    num: int
+    stage: Optional[str] = None
+    command: Optional[str] = None
+    cached: bool = False
+    duration: Optional[float] = None
+    duration_unit: Optional[str] = None
+
+    def label(self) -> str:
+        if self.command:
+            # Trim excessive whitespace to keep tables readable.
+            cmd = re.sub(r"\s+", " ", self.command.strip())
+            return cmd
+        return self.stage or ""
+
+
+@dataclass
+class CacheReport:
+    job: str
+    cached_steps: List[StepInfo] = field(default_factory=list)
+    executed_steps: List[StepInfo] = field(default_factory=list)
+    existing_layers: List[str] = field(default_factory=list)
+    pushed_layers: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        def step_to_dict(step: StepInfo) -> dict:
+            return OrderedDict(
+                [
+                    ("step", step.num),
+                    ("cached", step.cached),
+                    ("stage", step.stage),
+                    ("command", step.command),
+                    ("duration", step.duration),
+                    ("duration_unit", step.duration_unit),
+                ]
+            )
+
+        return OrderedDict(
+            [
+                ("job", self.job),
+                ("cached_steps", [step_to_dict(s) for s in self.cached_steps]),
+                ("executed_steps", [step_to_dict(s) for s in self.executed_steps]),
+                ("existing_layers", self.existing_layers),
+                ("pushed_layers", self.pushed_layers),
+            ]
+        )
+
+    def to_markdown(self) -> str:
+        lines = [
+            f"### Job `{self.job}` cache summary",
+            "",
+            f"- BuildKit cache hits: {len(self.cached_steps)} steps ({', '.join(f'#{s.num}' for s in self.cached_steps) or 'none'})",
+            f"- BuildKit executed steps: {len(self.executed_steps)} ({', '.join(f'#{s.num}' for s in self.executed_steps) or 'none'})",
+            f"- Registry layers reused: {len(self.existing_layers)}",
+            f"- Registry layers pushed: {len(self.pushed_layers)}",
+            "",
+        ]
+
+        if self.cached_steps:
+            lines.append("| Step | Stage / Command |")
+            lines.append("|------|-----------------|")
+            for step in self.cached_steps:
+                lines.append(f"| #{step.num} | {step.label()} |")
+            lines.append("")
+
+        if self.executed_steps:
+            lines.append("| Step | Stage / Command | Duration |")
+            lines.append("|------|-----------------|----------|")
+            for step in self.executed_steps:
+                duration = (
+                    f"{step.duration:g}{step.duration_unit or ''}"
+                    if step.duration is not None
+                    else ""
+                )
+                lines.append(f"| #{step.num} | {step.label()} | {duration} |")
+            lines.append("")
+
+        if self.existing_layers:
+            lines.append(f"Reused layers ({len(self.existing_layers)}): `{', '.join(self.existing_layers)}`")
+            lines.append("")
+        if self.pushed_layers:
+            lines.append(f"Pushed layers ({len(self.pushed_layers)}): `{', '.join(self.pushed_layers)}`")
+            lines.append("")
+        return "\n".join(lines)
+
+
+def parse_lines(lines: Iterable[str], job: str) -> CacheReport:
+    steps: dict[int, StepInfo] = {}
+    existing_layers: List[str] = []
+    pushed_layers: List[str] = []
+
+    for raw_line in lines:
+        if not raw_line.startswith(job + "\t"):
+            continue
+
+        line = raw_line.split("\t", 2)[-1].strip()
+
+        match = STEP_LINE_RE.search(line)
+        if match:
+            num = int(match.group("num"))
+            info = steps.setdefault(num, StepInfo(num=num))
+            info.stage = match.group("stage")
+            info.command = match.group("command")
+            continue
+
+        match = STEP_CACHED_RE.search(line)
+        if match:
+            num = int(match.group("num"))
+            info = steps.setdefault(num, StepInfo(num=num))
+            info.cached = True
+            continue
+
+        match = STEP_DONE_RE.search(line)
+        if match:
+            num = int(match.group("num"))
+            info = steps.setdefault(num, StepInfo(num=num))
+            try:
+                info.duration = float(match.group("duration"))
+            except ValueError:
+                info.duration = None
+            info.duration_unit = match.group("unit")
+            continue
+
+        match = LAYER_EXISTS_RE.search(line)
+        if match:
+            digest = match.group("digest")
+            if digest not in existing_layers:
+                existing_layers.append(digest)
+            continue
+
+        match = LAYER_PUSHED_RE.search(line)
+        if match:
+            digest = match.group("digest")
+            if digest not in pushed_layers:
+                pushed_layers.append(digest)
+            continue
+
+    cached_steps = [info for info in sorted(steps.values(), key=lambda s: s.num) if info.cached]
+    executed_steps = [
+        info
+        for info in sorted(steps.values(), key=lambda s: s.num)
+        if not info.cached and info.command
+    ]
+
+    return CacheReport(
+        job=job,
+        cached_steps=cached_steps,
+        executed_steps=executed_steps,
+        existing_layers=existing_layers,
+        pushed_layers=pushed_layers,
+    )
+
+
+def load_lines(source: Optional[str]) -> Sequence[str]:
+    if source:
+        return Path(source).read_text(encoding="utf-8").splitlines()
+    return [line.rstrip("\n") for line in iter(input, "")]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Summarize devcontainer cache usage from a GitHub Actions log.")
+    parser.add_argument("--log", help="Path to the log file. Reads from stdin if omitted.")
+    parser.add_argument("--job", default="build-devcontainer", help="Job name prefix in the log (default: build-devcontainer).")
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of human-readable output.")
+    parser.add_argument("--markdown", action="store_true", help="Emit Markdown summary.")
+
+    args = parser.parse_args()
+
+    lines = load_lines(args.log)
+    report = parse_lines(lines, job=args.job)
+
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2))
+    elif args.markdown:
+        print(report.to_markdown())
+    else:
+        print(f"Job: {report.job}")
+        print(f"- BuildKit cache hits: {len(report.cached_steps)} ({', '.join(f'#{s.num}' for s in report.cached_steps) or 'none'})")
+        print(f"- BuildKit executed steps: {len(report.executed_steps)} ({', '.join(f'#{s.num}' for s in report.executed_steps) or 'none'})")
+        print(f"- Registry layers reused: {len(report.existing_layers)}")
+        print(f"- Registry layers pushed: {len(report.pushed_layers)}")
+        if report.cached_steps:
+            print("\nCached steps:")
+            for step in report.cached_steps:
+                print(f"  - #{step.num}: {step.label()}")
+        if report.executed_steps:
+            print("\nExecuted steps:")
+            for step in report.executed_steps:
+                duration = f"{step.duration:g}{step.duration_unit or ''}" if step.duration is not None else ""
+                print(f"  - #{step.num}: {step.label()} {duration}")
+        if report.existing_layers:
+            print("\nReused layers:")
+            print("  " + ", ".join(report.existing_layers))
+        if report.pushed_layers:
+            print("\nPushed layers:")
+            print("  " + ", ".join(report.pushed_layers))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/devcontainer_cache_report.py
+++ b/tools/devcontainer_cache_report.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import sys
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -187,7 +188,7 @@ def parse_lines(lines: Iterable[str], job: str) -> CacheReport:
 def load_lines(source: Optional[str]) -> Sequence[str]:
     if source:
         return Path(source).read_text(encoding="utf-8").splitlines()
-    return [line.rstrip("\n") for line in iter(input, "")]
+    return [line.rstrip("\n") for line in sys.stdin]
 
 
 def main() -> None:

--- a/tools/test_devcontainer_cache_report.py
+++ b/tools/test_devcontainer_cache_report.py
@@ -1,0 +1,38 @@
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("devcontainer_cache_report.py")
+
+
+class DevcontainerCacheReportCLITest(unittest.TestCase):
+    def test_reads_log_from_stdin(self) -> None:
+        log = "\n".join(
+            [
+                "build-devcontainer\tstep\t#11 [stage] RUN echo hi",
+                "build-devcontainer\tstep\t#11 DONE 1.2s",
+                "build-devcontainer\tstep\tabc123def456: Layer already exists",
+                "",
+            ]
+        )
+
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "--job", "build-devcontainer", "--json"],
+            input=log,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertEqual(report["job"], "build-devcontainer")
+        self.assertEqual([step["step"] for step in report["executed_steps"]], [11])
+        self.assertEqual(report["existing_layers"], ["abc123def456"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a small parser (tools/devcontainer_cache_report.py) for BuildKit cache hits and registry layer reuse
- document run 23728700999 showing 20 cached layers vs 9 pushes once Claude Code installs update
- link the helper from AI_GHA_PIPELINES so future investigations reuse the script

## Testing
- make pre-commit
- make unit-tests
- make integration-tests
