### PR TITLE
Fix #951: Expose WaitForProcessing on state manager interface

### DIFF
--- a/homeautomation-go/pkg/state/adapter.go
+++ b/homeautomation-go/pkg/state/adapter.go
@@ -73,3 +73,7 @@ func (a *ManagerAdapter) Subscribe(key string, handler StateChangeHandler) (Subs
 func (a *ManagerAdapter) GetAllValues() map[string]interface{} {
 	return a.internal.GetAllValues()
 }
+
+func (a *ManagerAdapter) WaitForProcessing() {
+	a.internal.WaitForProcessing()
+}

--- a/homeautomation-go/pkg/state/interfaces.go
+++ b/homeautomation-go/pkg/state/interfaces.go
@@ -42,4 +42,7 @@ type Manager interface {
 
 	// Query
 	GetAllValues() map[string]interface{}
+
+	// WaitForProcessing blocks until all in-flight event handler goroutines complete.
+	WaitForProcessing()
 }


### PR DESCRIPTION
Resolves #951

## Summary
- add WaitForProcessing to the pkg/state.Manager interface so downstream tests can synchronize deterministically
- ensure ManagerAdapter forwards WaitForProcessing to the internal implementation

## Test Plan
- make unit-tests
- make integration-tests

🤖 Generated with Codex