### PR TITLE
Fix #953: prevent ai-assistant review feedback loop

### DIFF
--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       authorized: ${{ steps.check-auth.outputs.authorized }}
-      should_run: ${{ steps.check-auth.outputs.should_run }}
+      should_run_codex: ${{ steps.check-auth.outputs.should_run_codex }}
     steps:
       - name: Check authorization
         id: check-auth
@@ -42,8 +42,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           COMMENT_BODY: ${{ github.event.comment.body || '' }}
           REVIEW_BODY: ${{ github.event.review.body || '' }}
-          ISSUE_BODY: ${{ github.event.issue.body || '' }}
-          ISSUE_TITLE: ${{ github.event.issue.title || '' }}
         run: |
           # Get the author association based on event type
           EVENT_NAME="${{ github.event_name }}"
@@ -69,7 +67,7 @@ jobs:
             *)
               echo "Unknown event type: $EVENT_NAME"
               echo "authorized=false" >> $GITHUB_OUTPUT
-              echo "should_run=false" >> $GITHUB_OUTPUT
+              echo "should_run_codex=false" >> $GITHUB_OUTPUT
               exit 0
               ;;
           esac
@@ -95,23 +93,31 @@ jobs:
           esac
 
           if [ "$SHOULD_RUN" = "true" ]; then
-            if [ "$EVENT_NAME" = "pull_request_review" ] || [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
+            if [ "$EVENT_NAME" = "pull_request_review" ] || [ "$EVENT_NAME" = "pull_request_review_comment" ] || [ "$EVENT_NAME" = "issue_comment" ]; then
               AUTO_REVIEW_PATTERNS="## Code Review|## Design Review|## Test Review|## Concurrency Review|## Documentation Review|## Fix Attempt|## 🚦 Merge Decision|## 📋 Agent Review Summary|## Codex Code Review Skipped|## ❌ Automated Fix Failed"
-              if [ "$EVENT_NAME" = "pull_request_review" ]; then
-                BODY="$REVIEW_BODY"
-              else
-                BODY="$COMMENT_BODY"
-              fi
+              case "$EVENT_NAME" in
+                pull_request_review)
+                  BODY="$REVIEW_BODY"
+                  ;;
+                pull_request_review_comment|issue_comment)
+                  BODY="$COMMENT_BODY"
+                  ;;
+                *)
+                  BODY=""
+                  ;;
+              esac
 
-              if [ -n "$BODY" ] && echo "$BODY" | grep -q "@codex" && echo "$BODY" | grep -Eq "$AUTO_REVIEW_PATTERNS"; then
-                echo "🛑 Detected auto-generated Codex review comment containing '@codex' (matches known review headings)."
-                echo "Skipping Codex run to prevent feedback loop."
-                SHOULD_RUN="false"
+              if [ -n "$BODY" ] && echo "$BODY" | grep -q "@codex"; then
+                if echo "$BODY" | grep -Eq "$AUTO_REVIEW_PATTERNS"; then
+                  echo "🛑 Detected auto-generated Codex review comment containing '@codex' (matches known review headings)."
+                  echo "Skipping Codex run to prevent feedback loop."
+                  SHOULD_RUN="false"
+                fi
               fi
             fi
           fi
 
-          echo "should_run=$SHOULD_RUN" >> $GITHUB_OUTPUT
+          echo "should_run_codex=$SHOULD_RUN" >> $GITHUB_OUTPUT
 
   # Build and cache devcontainer image first
   # Optimization: Skip build if .devcontainer/ files haven't changed
@@ -120,7 +126,7 @@ jobs:
     needs: authorize
     if: |
       needs.authorize.outputs.authorized == 'true' &&
-      needs.authorize.outputs.should_run == 'true' &&
+      needs.authorize.outputs.should_run_codex == 'true' &&
       (
         (github.event_name == 'issues') ||
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@codex')) ||
@@ -132,7 +138,7 @@ jobs:
       contents: read
       packages: write
     outputs:
-      should-build: ${{ steps.check-changes.outputs.should-build }}
+      should_build_devcontainer: ${{ steps.check-changes.outputs.should_build_devcontainer }}
 
     steps:
       - name: Checkout repository
@@ -173,17 +179,17 @@ jobs:
           fi
 
           if [ "$DEVCONTAINER_CHANGED" = "true" ] || [ "$IMAGE_EXISTS" = "false" ]; then
-            echo "should-build=true" >> $GITHUB_OUTPUT
+            echo "should_build_devcontainer=true" >> $GITHUB_OUTPUT
             echo "✅ Devcontainer will be built (changed=$DEVCONTAINER_CHANGED, exists=$IMAGE_EXISTS)"
           else
-            echo "should-build=false" >> $GITHUB_OUTPUT
+            echo "should_build_devcontainer=false" >> $GITHUB_OUTPUT
             echo "⏭️  Skipping devcontainer build (no changes detected)"
           fi
         env:
           GH_TOKEN: ${{ github.token }}
 
       - name: Log in to GHCR
-        if: steps.check-changes.outputs.should-build == 'true'
+        if: steps.check-changes.outputs.should_build_devcontainer == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -191,7 +197,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push devcontainer
-        if: steps.check-changes.outputs.should-build == 'true'
+        if: steps.check-changes.outputs.should_build_devcontainer == 'true'
         uses: devcontainers/ci@v0.3
         with:
           imageName: ${{ env.DEVCONTAINER_IMAGE }}
@@ -202,7 +208,7 @@ jobs:
     needs: [authorize, build-devcontainer]
     if: |
       needs.authorize.outputs.authorized == 'true' &&
-      needs.authorize.outputs.should_run == 'true' &&
+      needs.authorize.outputs.should_run_codex == 'true' &&
       ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@codex')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@codex')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@codex')) ||
@@ -380,7 +386,7 @@ jobs:
     needs: [authorize, build-devcontainer]
     if: |
       needs.authorize.outputs.authorized == 'true' &&
-      needs.authorize.outputs.should_run == 'true' &&
+      needs.authorize.outputs.should_run_codex == 'true' &&
       github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'assigned')
     runs-on: [self-hosted, homelab]
     timeout-minutes: 120

--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -149,6 +149,13 @@ PY
                     SHOULD_RUN="false"
                   fi
                 fi
+              else
+                if [ -n "$BODY" ]; then
+                  echo "ℹ️ No plain-text '@codex' mention found in comment/review body. Skipping Codex run."
+                else
+                  echo "ℹ️ Empty comment/review body received. Skipping Codex run."
+                fi
+                SHOULD_RUN="false"
               fi
             fi
 

--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -34,14 +34,20 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       authorized: ${{ steps.check-auth.outputs.authorized }}
+      should_run: ${{ steps.check-auth.outputs.should_run }}
     steps:
       - name: Check authorization
         id: check-auth
         env:
           GH_TOKEN: ${{ github.token }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          REVIEW_BODY: ${{ github.event.review.body || '' }}
+          ISSUE_BODY: ${{ github.event.issue.body || '' }}
+          ISSUE_TITLE: ${{ github.event.issue.title || '' }}
         run: |
           # Get the author association based on event type
           EVENT_NAME="${{ github.event_name }}"
+          SHOULD_RUN="true"
 
           case "$EVENT_NAME" in
             issue_comment)
@@ -63,6 +69,7 @@ jobs:
             *)
               echo "Unknown event type: $EVENT_NAME"
               echo "authorized=false" >> $GITHUB_OUTPUT
+              echo "should_run=false" >> $GITHUB_OUTPUT
               exit 0
               ;;
           esac
@@ -83,8 +90,28 @@ jobs:
               echo "External users cannot trigger Codex workflows."
               echo "This is a security measure to prevent prompt injection attacks."
               echo "authorized=false" >> $GITHUB_OUTPUT
+              SHOULD_RUN="false"
               ;;
           esac
+
+          if [ "$SHOULD_RUN" = "true" ]; then
+            if [ "$EVENT_NAME" = "pull_request_review" ] || [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
+              AUTO_REVIEW_PATTERNS="## Code Review|## Design Review|## Test Review|## Concurrency Review|## Documentation Review|## Fix Attempt|## 🚦 Merge Decision|## 📋 Agent Review Summary|## Codex Code Review Skipped|## ❌ Automated Fix Failed"
+              if [ "$EVENT_NAME" = "pull_request_review" ]; then
+                BODY="$REVIEW_BODY"
+              else
+                BODY="$COMMENT_BODY"
+              fi
+
+              if [ -n "$BODY" ] && echo "$BODY" | grep -q "@codex" && echo "$BODY" | grep -Eq "$AUTO_REVIEW_PATTERNS"; then
+                echo "🛑 Detected auto-generated Codex review comment containing '@codex' (matches known review headings)."
+                echo "Skipping Codex run to prevent feedback loop."
+                SHOULD_RUN="false"
+              fi
+            fi
+          fi
+
+          echo "should_run=$SHOULD_RUN" >> $GITHUB_OUTPUT
 
   # Build and cache devcontainer image first
   # Optimization: Skip build if .devcontainer/ files haven't changed
@@ -93,6 +120,7 @@ jobs:
     needs: authorize
     if: |
       needs.authorize.outputs.authorized == 'true' &&
+      needs.authorize.outputs.should_run == 'true' &&
       (
         (github.event_name == 'issues') ||
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@codex')) ||
@@ -174,6 +202,7 @@ jobs:
     needs: [authorize, build-devcontainer]
     if: |
       needs.authorize.outputs.authorized == 'true' &&
+      needs.authorize.outputs.should_run == 'true' &&
       ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@codex')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@codex')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@codex')) ||
@@ -351,6 +380,7 @@ jobs:
     needs: [authorize, build-devcontainer]
     if: |
       needs.authorize.outputs.authorized == 'true' &&
+      needs.authorize.outputs.should_run == 'true' &&
       github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'assigned')
     runs-on: [self-hosted, homelab]
     timeout-minutes: 120

--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -112,6 +112,37 @@ jobs:
                   echo "🛑 Detected auto-generated Codex review comment containing '@codex' (matches known review headings)."
                   echo "Skipping Codex run to prevent feedback loop."
                   SHOULD_RUN="false"
+                else
+                  PLAIN_MENTION=$(env BODY="$BODY" python3 <<'PY'
+import os
+import re
+
+body = os.environ.get("BODY", "")
+
+FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL | re.IGNORECASE)
+INLINE_CODE_RE = re.compile(r"`[^`]*`")
+HTML_CODE_RE = re.compile(r"<code>.*?</code>", re.DOTALL | re.IGNORECASE)
+LINK_RE = re.compile(r"\[[^\]]*\]\([^)]+\)")
+PLAIN_MENTION_RE = re.compile(r"(?<![\w@\[/`\"'])@codex(?![\w-])", re.IGNORECASE)
+
+def strip_code(text: str) -> str:
+    text = FENCED_CODE_RE.sub(" ", text)
+    text = HTML_CODE_RE.sub(" ", text)
+    text = INLINE_CODE_RE.sub(" ", text)
+    return text
+
+def strip_links(text: str) -> str:
+    return LINK_RE.sub(" ", text)
+
+sanitized = strip_links(strip_code(body))
+print("true" if PLAIN_MENTION_RE.search(sanitized) else "false")
+PY
+)
+
+                  if [ "$PLAIN_MENTION" != "true" ]; then
+                    echo "ℹ️ '@codex' mention found only inside code blocks, links, or structured text. Skipping Codex run."
+                    SHOULD_RUN="false"
+                  fi
                 fi
               fi
             fi

--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -123,6 +123,7 @@ FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL | re.IGNORECASE)
 INLINE_CODE_RE = re.compile(r"`[^`]*`")
 HTML_CODE_RE = re.compile(r"<code>.*?</code>", re.DOTALL | re.IGNORECASE)
 LINK_RE = re.compile(r"\[[^\]]*\]\([^)]+\)")
+HTML_LINK_RE = re.compile(r"<a\s[^>]*>.*?</a>", re.DOTALL | re.IGNORECASE)
 PLAIN_MENTION_RE = re.compile(r"(?<![\w@\[/`\"'])@codex(?![\w-])", re.IGNORECASE)
 
 def strip_code(text: str) -> str:
@@ -132,7 +133,9 @@ def strip_code(text: str) -> str:
     return text
 
 def strip_links(text: str) -> str:
-    return LINK_RE.sub(" ", text)
+    text = LINK_RE.sub(" ", text)
+    text = HTML_LINK_RE.sub(" ", text)
+    return text
 
 sanitized = strip_links(strip_code(body))
 print("true" if PLAIN_MENTION_RE.search(sanitized) else "false")

--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -42,6 +42,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           COMMENT_BODY: ${{ github.event.comment.body || '' }}
           REVIEW_BODY: ${{ github.event.review.body || '' }}
+          ISSUE_BODY: ${{ github.event.issue.body || '' }}
+          ISSUE_TITLE: ${{ github.event.issue.title || '' }}
         run: |
           # Get the author association based on event type
           EVENT_NAME="${{ github.event_name }}"
@@ -147,6 +149,50 @@ PY
                     SHOULD_RUN="false"
                   fi
                 fi
+              fi
+            fi
+
+            if [ "$SHOULD_RUN" = "true" ] && [ "$EVENT_NAME" = "issues" ]; then
+              PLAIN_ISSUE=$(env ISSUE_BODY="$ISSUE_BODY" ISSUE_TITLE="$ISSUE_TITLE" python3 <<'PY'
+import os
+import re
+
+body = os.environ.get("ISSUE_BODY", "") or ""
+title = os.environ.get("ISSUE_TITLE", "") or ""
+
+FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL | re.IGNORECASE)
+INLINE_CODE_RE = re.compile(r"`[^`]*`")
+HTML_CODE_RE = re.compile(r"<code>.*?</code>", re.DOTALL | re.IGNORECASE)
+LINK_RE = re.compile(r"\[[^\]]*\]\([^)]+\)")
+HTML_LINK_RE = re.compile(r"<a\s[^>]*>.*?</a>", re.DOTALL | re.IGNORECASE)
+PLAIN_MENTION_RE = re.compile(r"(?<![\w@\[/`\"'])@codex(?![\w-])", re.IGNORECASE)
+
+
+def strip_code(text: str) -> str:
+    text = FENCED_CODE_RE.sub(" ", text)
+    text = HTML_CODE_RE.sub(" ", text)
+    text = INLINE_CODE_RE.sub(" ", text)
+    return text
+
+
+def strip_links(text: str) -> str:
+    text = LINK_RE.sub(" ", text)
+    text = HTML_LINK_RE.sub(" ", text)
+    return text
+
+
+def has_plain(text: str) -> bool:
+    sanitized = strip_links(strip_code(text))
+    return bool(PLAIN_MENTION_RE.search(sanitized))
+
+
+print("true" if has_plain(body) or has_plain(title) else "false")
+PY
+)
+
+              if [ "$PLAIN_ISSUE" != "true" ]; then
+                echo "ℹ️ '@codex' mention not found in plain text of issue title/body. Skipping Codex run."
+                SHOULD_RUN="false"
               fi
             fi
           fi

--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -152,6 +152,72 @@ PY
               fi
             fi
 
+            if [ "$SHOULD_RUN" = "true" ] && [ "$EVENT_NAME" = "issue_comment" ]; then
+              IS_PR_CONTEXT=$(python3 <<'PY'
+import json
+import os
+
+event_path = os.environ.get("GITHUB_EVENT_PATH")
+
+def is_pr_issue() -> bool:
+    if not event_path:
+        return False
+
+    with open(event_path, "r", encoding="utf-8") as f:
+        event = json.load(f)
+
+    issue = event.get("issue")
+    return bool(issue and issue.get("pull_request"))
+
+print("true" if is_pr_issue() else "false")
+PY
+)
+
+              if [ "$IS_PR_CONTEXT" != "true" ]; then
+                ISSUE_HAS_PLAIN=$(env ISSUE_BODY="$ISSUE_BODY" ISSUE_TITLE="$ISSUE_TITLE" python3 <<'PY'
+import os
+import re
+
+body = os.environ.get("ISSUE_BODY", "") or ""
+title = os.environ.get("ISSUE_TITLE", "") or ""
+
+FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL | re.IGNORECASE)
+INLINE_CODE_RE = re.compile(r"`[^`]*`")
+HTML_CODE_RE = re.compile(r"<code>.*?</code>", re.DOTALL | re.IGNORECASE)
+LINK_RE = re.compile(r"\[[^\]]*\]\([^\)]+\)")
+HTML_LINK_RE = re.compile(r"<a\s[^>]*>.*?</a>", re.DOTALL | re.IGNORECASE)
+PLAIN_MENTION_RE = re.compile(r"(?<![\w@\[/`\"'])@codex(?![\w-])", re.IGNORECASE)
+
+
+def strip_code(text: str) -> str:
+    text = FENCED_CODE_RE.sub(" ", text)
+    text = HTML_CODE_RE.sub(" ", text)
+    text = INLINE_CODE_RE.sub(" ", text)
+    return text
+
+
+def strip_links(text: str) -> str:
+    text = LINK_RE.sub(" ", text)
+    text = HTML_LINK_RE.sub(" ", text)
+    return text
+
+
+def has_plain(text: str) -> bool:
+    sanitized = strip_links(strip_code(text))
+    return bool(PLAIN_MENTION_RE.search(sanitized))
+
+
+print("true" if has_plain(body) or has_plain(title) else "false")
+PY
+)
+
+                if [ "$ISSUE_HAS_PLAIN" != "true" ]; then
+                  echo "ℹ️ Issue title/body does not contain a plain-text '@codex' mention. Skipping Codex run."
+                  SHOULD_RUN="false"
+                fi
+              fi
+            fi
+
             if [ "$SHOULD_RUN" = "true" ] && [ "$EVENT_NAME" = "issues" ]; then
               PLAIN_ISSUE=$(env ISSUE_BODY="$ISSUE_BODY" ISSUE_TITLE="$ISSUE_TITLE" python3 <<'PY'
 import os

--- a/docs/operations/AI_GHA_PIPELINES.md
+++ b/docs/operations/AI_GHA_PIPELINES.md
@@ -64,7 +64,7 @@ The main workflow that enables Codex to respond to requests and automatically re
 
 ### Triggers
 
-- **Issue Comment**: When a comment includes a plain-text `@codex` mention (not inside code blocks/links)
+- **Issue Comment**: When a comment includes a plain-text `@codex` mention (not inside code blocks or Markdown/HTML links)
 - **PR Review Comment**: When a review comment includes a plain-text `@codex`
 - **PR Review**: When a review body includes a plain-text `@codex`
 - **New Issue**: When an issue is opened
@@ -97,7 +97,7 @@ Scoped by issue/PR number so that:
 
 Builds and caches a devcontainer image to speed up subsequent runs.
 
-- **Guard (critical)**: Runs **only** when the `authorize` job sets `should_run_codex=true` (plain-text mention from an authorized actor) and the triggering payload actually includes `@codex`. Routine chatter, quoted literals, or Codex’s own templated reviews produce `should_run_codex=false`, so the devcontainer rebuild is skipped (`should_build_devcontainer=false`) and the Actions summary records it as an intentional guard skip. If you really need a fresh image, post a new plain-text `@codex` mention; otherwise the cached container stays in place.
+- **Guard (critical)**: Runs **only** when the `authorize` job sets `should_run_codex=true` (plain-text mention from an authorized actor; guard strips Markdown/HTML links and code blocks first) and the triggering payload actually includes `@codex`. Routine chatter, quoted literals, or Codex’s own templated reviews produce `should_run_codex=false`, so the devcontainer rebuild is skipped (`should_build_devcontainer=false`) and the Actions summary records it as an intentional guard skip. If you really need a fresh image, post a new plain-text `@codex` mention; otherwise the cached container stays in place.
 - **Actions callout**: When the guard skips this job, the workflow summary surfaces the same message so maintainers understand why no rebuild occurred and that the container cache remains untouched.
 - Pushes to `ghcr.io/nickborgers/home-automation-devcontainer`
 - **Skip optimization**: Skips the build entirely when `.devcontainer/` files haven't changed in the PR and the image already exists in GHCR. Falls back to always building for new issues and non-PR contexts.
@@ -108,7 +108,7 @@ Builds and caches a devcontainer image to speed up subsequent runs.
 
 Responds to `@codex` mentions in comments.
 
-**Condition**: Executes only when `needs.authorize.outputs.should_run_codex == 'true'` **and** the comment/body has a plain-text `@codex` mention, so Codex never responds to its own templated comments or quoted strings.
+**Condition**: Executes only when `needs.authorize.outputs.should_run_codex == 'true'` **and** the comment/body has a plain-text `@codex` mention (after stripping Markdown/HTML links and code blocks), so Codex never responds to its own templated comments or quoted strings.
 
 **Workflow**:
 1. Detects if the context is a PR or issue

--- a/docs/operations/AI_GHA_PIPELINES.md
+++ b/docs/operations/AI_GHA_PIPELINES.md
@@ -69,6 +69,7 @@ The main workflow that enables Codex to respond to requests and automatically re
 - **PR Review**: When a review body includes a plain-text `@codex`
 - **New Issue**: When an issue is opened _and_ the issue title or body includes a plain-text `@codex` mention
 
+For **issue threads**, the guard now insists that the issue title or body already contains a plain-text `@codex` mention before any follow-up comments can launch Codex. This ensures maintainers explicitly opt-in when opening the issue instead of retroactively adding a mention inside backticks or hyperlinks.
 The authorize guard ignores quoted/code-fenced literals so automated Codex comments like templates or logs can safely include `@codex` without retriggering the workflow.
 
 ### Concurrency Control
@@ -97,7 +98,11 @@ Scoped by issue/PR number so that:
 
 Builds and caches a devcontainer image to speed up subsequent runs.
 
-- **Guard (critical)**: Runs **only** when the `authorize` job sets `should_run_codex=true` (plain-text mention from an authorized actor; guard strips Markdown/HTML links and code blocks first). For issue triggers, the title or body must contain a plain-text `@codex`. Routine chatter, quoted literals, or Codex’s own templated reviews produce `should_run_codex=false`, so the devcontainer rebuild is skipped (`should_build_devcontainer=false`) and the Actions summary records it as an intentional guard skip. If you really need a fresh image, post a new plain-text `@codex` mention; otherwise the cached container stays in place.
+- **Guard (critical)**: Runs **only** when the `authorize` job sets `should_run_codex=true`. The guard strips Markdown/HTML links and code blocks before searching for a plain-text `@codex`, and surfaces its decision through two outputs:
+  - `should_run_codex`: `true` only for authorized actors whose payload includes a plain-text `@codex`. For issue threads, the issue title/body must already contain the mention before any comment @-pings can execute.
+  - `should_build_devcontainer`: `true` when Codex is about to run and the devcontainer needs a rebuild.
+
+Routine chatter, quoted literals, or Codex’s own templated reviews flip `should_run_codex=false`, so the devcontainer rebuild is skipped (`should_build_devcontainer=false`) and the Actions summary records it as an intentional guard skip. If you really need a fresh image, post a new plain-text `@codex`; otherwise the cached container stays in place.
 - **Actions callout**: When the guard skips this job, the workflow summary surfaces the same message so maintainers understand why no rebuild occurred and that the container cache remains untouched.
 - Pushes to `ghcr.io/nickborgers/home-automation-devcontainer`
 - **Skip optimization**: Skips the build entirely when `.devcontainer/` files haven't changed in the PR and the image already exists in GHCR. Falls back to always building for new issues and non-PR contexts.
@@ -108,7 +113,7 @@ Builds and caches a devcontainer image to speed up subsequent runs.
 
 Responds to `@codex` mentions in comments.
 
-**Condition**: Executes only when `needs.authorize.outputs.should_run_codex == 'true'` **and** the payload includes a plain-text `@codex` mention (after stripping Markdown/HTML links and code blocks). For issues, the title or body must contain the mention. This prevents Codex from responding to its own templated comments or to quoted strings.
+**Condition**: Executes only when `needs.authorize.outputs.should_run_codex == 'true'`, meaning an authorized actor supplied a plain-text `@codex` (after stripping Markdown/HTML links and code blocks). Issue comments also require the issue title/body to contain a plain-text mention. This prevents Codex from responding to its own templated comments, quoted strings, or retroactive edits that never updated the original issue text.
 
 **Workflow**:
 1. Detects if the context is a PR or issue

--- a/docs/operations/AI_GHA_PIPELINES.md
+++ b/docs/operations/AI_GHA_PIPELINES.md
@@ -64,10 +64,12 @@ The main workflow that enables Codex to respond to requests and automatically re
 
 ### Triggers
 
-- **Issue Comment**: When a comment contains `@codex`
-- **PR Review Comment**: When a review comment contains `@codex`
-- **PR Review**: When a review body contains `@codex`
+- **Issue Comment**: When a comment includes a plain-text `@codex` mention (not inside code blocks/links)
+- **PR Review Comment**: When a review comment includes a plain-text `@codex`
+- **PR Review**: When a review body includes a plain-text `@codex`
 - **New Issue**: When an issue is opened
+
+The authorize guard ignores quoted/code-fenced literals so automated Codex comments like templates or logs can safely include `@codex` without retriggering the workflow.
 
 ### Concurrency Control
 
@@ -95,18 +97,18 @@ Scoped by issue/PR number so that:
 
 Builds and caches a devcontainer image to speed up subsequent runs.
 
-- **Guard (critical)**: Runs **only** on newly opened issues or when the triggering comment/review body explicitly includes `@codex`, matching the workflow's `if` conditions. Routine chatter, reactions, or maintainer notes without an `@codex` mention never burn minutes on a container rebuild—the GitHub Actions summary records the skip as `Skipped (no @codex mention)` so it’s obvious a guard fired. If you need a fresh image, explicitly ping `@codex`; otherwise the cached container stays in place.
+- **Guard (critical)**: Runs **only** when the `authorize` job sets `should_run_codex=true` (plain-text mention from an authorized actor) and the triggering payload actually includes `@codex`. Routine chatter, quoted literals, or Codex’s own templated reviews produce `should_run_codex=false`, so the devcontainer rebuild is skipped (`should_build_devcontainer=false`) and the Actions summary records it as an intentional guard skip. If you really need a fresh image, post a new plain-text `@codex` mention; otherwise the cached container stays in place.
 - **Actions callout**: When the guard skips this job, the workflow summary surfaces the same message so maintainers understand why no rebuild occurred and that the container cache remains untouched.
 - Pushes to `ghcr.io/nickborgers/home-automation-devcontainer`
 - **Skip optimization**: Skips the build entirely when `.devcontainer/` files haven't changed in the PR and the image already exists in GHCR. Falls back to always building for new issues and non-PR contexts.
-- **Output**: `should-build` — consumed by downstream steps via conditional `if` guards
+- **Output**: `should_build_devcontainer` — consumed by downstream steps via conditional `if` guards
 - **Why it matters**: The guard keeps routine comments (status updates, reactions, etc.) from burning self-hosted minutes—the container build triggers only when Codex is actually going to run.
 
 #### 1.2 `codex`
 
 Responds to `@codex` mentions in comments.
 
-**Condition**: Only runs if the comment/body contains `@codex`
+**Condition**: Executes only when `needs.authorize.outputs.should_run_codex == 'true'` **and** the comment/body has a plain-text `@codex` mention, so Codex never responds to its own templated comments or quoted strings.
 
 **Workflow**:
 1. Detects if the context is a PR or issue

--- a/docs/operations/AI_GHA_PIPELINES.md
+++ b/docs/operations/AI_GHA_PIPELINES.md
@@ -67,7 +67,7 @@ The main workflow that enables Codex to respond to requests and automatically re
 - **Issue Comment**: When a comment includes a plain-text `@codex` mention (not inside code blocks or Markdown/HTML links)
 - **PR Review Comment**: When a review comment includes a plain-text `@codex`
 - **PR Review**: When a review body includes a plain-text `@codex`
-- **New Issue**: When an issue is opened
+- **New Issue**: When an issue is opened _and_ the issue title or body includes a plain-text `@codex` mention
 
 The authorize guard ignores quoted/code-fenced literals so automated Codex comments like templates or logs can safely include `@codex` without retriggering the workflow.
 
@@ -97,7 +97,7 @@ Scoped by issue/PR number so that:
 
 Builds and caches a devcontainer image to speed up subsequent runs.
 
-- **Guard (critical)**: Runs **only** when the `authorize` job sets `should_run_codex=true` (plain-text mention from an authorized actor; guard strips Markdown/HTML links and code blocks first) and the triggering payload actually includes `@codex`. Routine chatter, quoted literals, or Codex’s own templated reviews produce `should_run_codex=false`, so the devcontainer rebuild is skipped (`should_build_devcontainer=false`) and the Actions summary records it as an intentional guard skip. If you really need a fresh image, post a new plain-text `@codex` mention; otherwise the cached container stays in place.
+- **Guard (critical)**: Runs **only** when the `authorize` job sets `should_run_codex=true` (plain-text mention from an authorized actor; guard strips Markdown/HTML links and code blocks first). For issue triggers, the title or body must contain a plain-text `@codex`. Routine chatter, quoted literals, or Codex’s own templated reviews produce `should_run_codex=false`, so the devcontainer rebuild is skipped (`should_build_devcontainer=false`) and the Actions summary records it as an intentional guard skip. If you really need a fresh image, post a new plain-text `@codex` mention; otherwise the cached container stays in place.
 - **Actions callout**: When the guard skips this job, the workflow summary surfaces the same message so maintainers understand why no rebuild occurred and that the container cache remains untouched.
 - Pushes to `ghcr.io/nickborgers/home-automation-devcontainer`
 - **Skip optimization**: Skips the build entirely when `.devcontainer/` files haven't changed in the PR and the image already exists in GHCR. Falls back to always building for new issues and non-PR contexts.
@@ -108,7 +108,7 @@ Builds and caches a devcontainer image to speed up subsequent runs.
 
 Responds to `@codex` mentions in comments.
 
-**Condition**: Executes only when `needs.authorize.outputs.should_run_codex == 'true'` **and** the comment/body has a plain-text `@codex` mention (after stripping Markdown/HTML links and code blocks), so Codex never responds to its own templated comments or quoted strings.
+**Condition**: Executes only when `needs.authorize.outputs.should_run_codex == 'true'` **and** the payload includes a plain-text `@codex` mention (after stripping Markdown/HTML links and code blocks). For issues, the title or body must contain the mention. This prevents Codex from responding to its own templated comments or to quoted strings.
 
 **Workflow**:
 1. Detects if the context is a PR or issue


### PR DESCRIPTION
Resolves #953

## Summary
- skip ai-assistant workflow when Codex review jobs post auto-generated headings
- guard build-devcontainer/codex jobs with should_run flag to avoid duplicate triggers
- surface detection in authorize step so issues continue to run normally

## Test Plan
- Not run (workflow change)