### PR TITLE
Fix #950: fetch comment body via API instead of Docker env var

### DIFF
--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -255,16 +255,16 @@ jobs:
             # (see https://github.com/NickBorgers/home-automation/issues/950)
             case "$EVENT_NAME" in
               issue_comment)
-                COMMENT_BODY=$(gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" --jq '.body')
+                COMMENT_BODY=$(gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" --jq '.body // ""')
                 ;;
               pull_request_review_comment)
-                COMMENT_BODY=$(gh api "repos/${REPO}/pulls/comments/${COMMENT_ID}" --jq '.body')
+                COMMENT_BODY=$(gh api "repos/${REPO}/pulls/comments/${COMMENT_ID}" --jq '.body // ""')
                 ;;
               pull_request_review)
-                COMMENT_BODY=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews/${REVIEW_ID}" --jq '.body')
+                COMMENT_BODY=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews/${REVIEW_ID}" --jq '.body // ""')
                 ;;
               issues)
-                COMMENT_BODY=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '.body')
+                COMMENT_BODY=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '.body // ""')
                 ;;
             esac
 

--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -222,27 +222,6 @@ jobs:
           token: ${{ secrets.WORKFLOW_PAT }}  # PAT required to push workflow file changes
           ref: ${{ steps.pr-context.outputs.is_pr == 'true' && steps.pr-context.outputs.pr_head_ref || github.ref }}
 
-      - name: Extract comment body
-        id: comment
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
-          REVIEW_BODY: ${{ github.event.review.body }}
-          ISSUE_BODY: ${{ github.event.issue.body }}
-        run: |
-          # Use environment variables to avoid shell escaping issues with special characters
-          echo "body<<EOF" >> $GITHUB_OUTPUT
-          if [ "$EVENT_NAME" = "issue_comment" ]; then
-            echo "$COMMENT_BODY" >> $GITHUB_OUTPUT
-          elif [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
-            echo "$COMMENT_BODY" >> $GITHUB_OUTPUT
-          elif [ "$EVENT_NAME" = "pull_request_review" ]; then
-            echo "$REVIEW_BODY" >> $GITHUB_OUTPUT
-          else
-            echo "$ISSUE_BODY" >> $GITHUB_OUTPUT
-          fi
-          echo "EOF" >> $GITHUB_OUTPUT
-
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -260,13 +239,34 @@ jobs:
           env: |
             OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
-            COMMENT_BODY=${{ steps.comment.outputs.body }}
+            EVENT_NAME=${{ github.event_name }}
+            COMMENT_ID=${{ github.event.comment.id }}
+            REVIEW_ID=${{ github.event.review.id }}
+            PR_NUMBER=${{ github.event.pull_request.number }}
             ISSUE_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
             REPO=${{ github.repository }}
             IS_PR=${{ steps.pr-context.outputs.is_pr }}
             PR_HEAD_REF=${{ steps.pr-context.outputs.pr_head_ref }}
           runCmd: |
             source .devcontainer/configure-codex.sh
+
+            # Fetch comment/review/issue body via API to avoid Docker env escaping issues
+            # Multi-line content with special characters breaks docker exec -e args
+            # (see https://github.com/NickBorgers/home-automation/issues/950)
+            case "$EVENT_NAME" in
+              issue_comment)
+                COMMENT_BODY=$(gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" --jq '.body')
+                ;;
+              pull_request_review_comment)
+                COMMENT_BODY=$(gh api "repos/${REPO}/pulls/comments/${COMMENT_ID}" --jq '.body')
+                ;;
+              pull_request_review)
+                COMMENT_BODY=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews/${REVIEW_ID}" --jq '.body')
+                ;;
+              issues)
+                COMMENT_BODY=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '.body')
+                ;;
+            esac
 
             # Build the prompt based on whether this is a PR or issue comment
             if [ "$IS_PR" = "true" ]; then


### PR DESCRIPTION
## Summary
- Removes the "Extract comment body" step that put multi-line content into a GitHub output
- Passes safe identifier env vars (`EVENT_NAME`, `COMMENT_ID`, `REVIEW_ID`) instead of raw `COMMENT_BODY`
- Fetches comment/review/issue body inside the container via `gh api`, matching the pattern already used by the `resolve-issue` job

Fixes #950

## Test plan
- [ ] Trigger the Codex workflow with a comment containing `====` separator lines (the exact failure case from the issue)
- [ ] Verify `issue_comment`, `pull_request_review_comment`, and `pull_request_review` event types all fetch the body correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)