### PR TITLE
ci: skip devcontainer rebuild when image exists and files unchanged

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -446,34 +446,28 @@ jobs:
         with:
           ref: main
 
-      - name: Check if devcontainer files changed
-        id: check-changes
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Compute devcontainer tree hash
+        id: devcontainer-hash
         run: |
-          PR_NUMBER="${{ needs.get-context.outputs.pr_number }}"
-          # Get list of changed files in the PR
-          CHANGED_FILES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
-          if echo "$CHANGED_FILES" | grep -q "^\.devcontainer/"; then
-            DEVCONTAINER_CHANGED="true"
-          else
-            DEVCONTAINER_CHANGED="false"
-          fi
+          set -euo pipefail
+          TREE_HASH=$(git rev-parse HEAD:.devcontainer)
+          echo "tree_hash=$TREE_HASH" >> $GITHUB_OUTPUT
+          echo "Computed .devcontainer tree hash: $TREE_HASH"
 
-          # Check if the image exists in GHCR
-          if docker manifest inspect ${{ env.DEVCONTAINER_IMAGE }}:latest >/dev/null 2>&1; then
-            IMAGE_EXISTS="true"
-          else
-            IMAGE_EXISTS="false"
-            DEVCONTAINER_CHANGED="true"  # Force build if image doesn't exist
-          fi
+      - name: Check devcontainer cache
+        id: check-changes
+        run: |
+          set -euo pipefail
+          TREE_HASH="${{ steps.devcontainer-hash.outputs.tree_hash }}"
+          IMAGE="${{ env.DEVCONTAINER_IMAGE }}"
+          TREE_TAG="treehash-${TREE_HASH}"
 
-          if [ "$DEVCONTAINER_CHANGED" = "true" ] || [ "$IMAGE_EXISTS" = "false" ]; then
-            echo "should-build=true" >> $GITHUB_OUTPUT
-            echo "✅ Devcontainer will be built (changed=$DEVCONTAINER_CHANGED, exists=$IMAGE_EXISTS)"
-          else
+          if docker manifest inspect "${IMAGE}:${TREE_TAG}" >/dev/null 2>&1; then
             echo "should-build=false" >> $GITHUB_OUTPUT
-            echo "⏭️  Skipping devcontainer build (no changes detected)"
+            echo "⏭️  Skipping devcontainer build (found ${IMAGE}:${TREE_TAG})"
+          else
+            echo "should-build=true" >> $GITHUB_OUTPUT
+            echo "✅ Devcontainer will be built (missing ${IMAGE}:${TREE_TAG})"
           fi
 
       - name: Log in to GHCR
@@ -491,6 +485,17 @@ jobs:
           imageName: ${{ env.DEVCONTAINER_IMAGE }}
           cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
           push: always
+
+      - name: Tag devcontainer image with tree hash
+        if: steps.check-changes.outputs.should-build == 'true'
+        run: |
+          set -euo pipefail
+          TREE_HASH="${{ steps.devcontainer-hash.outputs.tree_hash }}"
+          IMAGE="${{ env.DEVCONTAINER_IMAGE }}"
+          TREE_TAG="treehash-${TREE_HASH}"
+
+          docker buildx imagetools create -t "${IMAGE}:${TREE_TAG}" "${IMAGE}:latest"
+          echo "📌 Pushed ${IMAGE}:${TREE_TAG} to record .devcontainer tree state"
 
   # Fix test failures - runs in a retry loop until tests pass (max 3 attempts)
   # Skips draft PRs to support TDD workflows where tests are intentionally failing

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -425,6 +425,7 @@ jobs:
   # SECURITY: Always build from main branch, NEVER from PR branches
   # This prevents malicious Dockerfile modifications from being used to build the container
   # SKIP for draft PRs (no reviews or fixes will run)
+  # Optimization: Skip build if .devcontainer/ files haven't changed and image exists
   build-devcontainer:
     runs-on: [self-hosted, homelab]
     needs: get-context
@@ -445,7 +446,38 @@ jobs:
         with:
           ref: main
 
+      - name: Check if devcontainer files changed
+        id: check-changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER="${{ needs.get-context.outputs.pr_number }}"
+          # Get list of changed files in the PR
+          CHANGED_FILES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+          if echo "$CHANGED_FILES" | grep -q "^\.devcontainer/"; then
+            DEVCONTAINER_CHANGED="true"
+          else
+            DEVCONTAINER_CHANGED="false"
+          fi
+
+          # Check if the image exists in GHCR
+          if docker manifest inspect ${{ env.DEVCONTAINER_IMAGE }}:latest >/dev/null 2>&1; then
+            IMAGE_EXISTS="true"
+          else
+            IMAGE_EXISTS="false"
+            DEVCONTAINER_CHANGED="true"  # Force build if image doesn't exist
+          fi
+
+          if [ "$DEVCONTAINER_CHANGED" = "true" ] || [ "$IMAGE_EXISTS" = "false" ]; then
+            echo "should-build=true" >> $GITHUB_OUTPUT
+            echo "✅ Devcontainer will be built (changed=$DEVCONTAINER_CHANGED, exists=$IMAGE_EXISTS)"
+          else
+            echo "should-build=false" >> $GITHUB_OUTPUT
+            echo "⏭️  Skipping devcontainer build (no changes detected)"
+          fi
+
       - name: Log in to GHCR
+        if: steps.check-changes.outputs.should-build == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -453,6 +485,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push devcontainer
+        if: steps.check-changes.outputs.should-build == 'true'
         uses: devcontainers/ci@v0.3
         with:
           imageName: ${{ env.DEVCONTAINER_IMAGE }}

--- a/.github/workflows/ai-diagnose-workflow-failure.yml
+++ b/.github/workflows/ai-diagnose-workflow-failure.yml
@@ -106,16 +106,31 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: main
 
-      - name: Check if devcontainer image exists
+      - name: Compute devcontainer tree hash
+        id: devcontainer-hash
+        run: |
+          set -euo pipefail
+          TREE_HASH=$(git rev-parse HEAD:.devcontainer)
+          echo "tree_hash=$TREE_HASH" >> $GITHUB_OUTPUT
+          echo "Computed .devcontainer tree hash: $TREE_HASH"
+
+      - name: Check devcontainer cache
         id: check-image
         run: |
-          if docker manifest inspect ${{ env.DEVCONTAINER_IMAGE }}:latest >/dev/null 2>&1; then
+          set -euo pipefail
+          TREE_HASH="${{ steps.devcontainer-hash.outputs.tree_hash }}"
+          IMAGE="${{ env.DEVCONTAINER_IMAGE }}"
+          TREE_TAG="treehash-${TREE_HASH}"
+
+          if docker manifest inspect "${IMAGE}:${TREE_TAG}" >/dev/null 2>&1; then
             echo "should-build=false" >> $GITHUB_OUTPUT
-            echo "⏭️  Skipping devcontainer build (image already exists)"
+            echo "⏭️  Skipping devcontainer build (found ${IMAGE}:${TREE_TAG})"
           else
             echo "should-build=true" >> $GITHUB_OUTPUT
-            echo "✅ Devcontainer will be built (image not found)"
+            echo "✅ Devcontainer will be built (missing ${IMAGE}:${TREE_TAG})"
           fi
 
       - name: Log in to GHCR
@@ -133,6 +148,17 @@ jobs:
           imageName: ${{ env.DEVCONTAINER_IMAGE }}
           cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
           push: always
+
+      - name: Tag devcontainer image with tree hash
+        if: steps.check-image.outputs.should-build == 'true'
+        run: |
+          set -euo pipefail
+          TREE_HASH="${{ steps.devcontainer-hash.outputs.tree_hash }}"
+          IMAGE="${{ env.DEVCONTAINER_IMAGE }}"
+          TREE_TAG="treehash-${TREE_HASH}"
+
+          docker buildx imagetools create -t "${IMAGE}:${TREE_TAG}" "${IMAGE}:latest"
+          echo "📌 Pushed ${IMAGE}:${TREE_TAG} to record .devcontainer tree state"
 
   # Run Codex to diagnose the failure
   diagnose-failure:

--- a/.github/workflows/ai-diagnose-workflow-failure.yml
+++ b/.github/workflows/ai-diagnose-workflow-failure.yml
@@ -94,6 +94,7 @@ jobs:
           echo "should_diagnose=true" >> $GITHUB_OUTPUT
 
   # Build devcontainer for Codex
+  # Optimization: Skip build if image already exists in GHCR
   build-devcontainer:
     runs-on: [self-hosted, homelab]
     needs: check-failure
@@ -106,7 +107,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Check if devcontainer image exists
+        id: check-image
+        run: |
+          if docker manifest inspect ${{ env.DEVCONTAINER_IMAGE }}:latest >/dev/null 2>&1; then
+            echo "should-build=false" >> $GITHUB_OUTPUT
+            echo "⏭️  Skipping devcontainer build (image already exists)"
+          else
+            echo "should-build=true" >> $GITHUB_OUTPUT
+            echo "✅ Devcontainer will be built (image not found)"
+          fi
+
       - name: Log in to GHCR
+        if: steps.check-image.outputs.should-build == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -114,6 +127,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push devcontainer
+        if: steps.check-image.outputs.should-build == 'true'
         uses: devcontainers/ci@v0.3
         with:
           imageName: ${{ env.DEVCONTAINER_IMAGE }}

--- a/docs/operations/AI_GHA_PIPELINES.md
+++ b/docs/operations/AI_GHA_PIPELINES.md
@@ -189,6 +189,8 @@ fix-test-failures                    ┌──────────┼──�
                                      (adds agent-reviews-passed label)
 ```
 
+**Devcontainer caching:** To keep Codex runs fast while still picking up infrastructure changes, the `build-devcontainer` job hashes the `.devcontainer/` directory on the `main` branch and publishes the build as both `latest` and `treehash-<hash>` in GHCR. If the tree hash tag already exists, the build is skipped and the existing image is reused.
+
 ### Draft PR Handling
 
 Draft PRs are completely skipped by the review pipeline to support TDD workflows where tests may intentionally fail during development.
@@ -509,7 +511,11 @@ concurrency:
 
 ### Jobs
 
-#### 4.1 `check-failure`
+#### 4.1 `build-devcontainer`
+
+Builds the Codex devcontainer from the `main` branch when needed, tagging the resulting image with both `latest` and `treehash-<hash>`. If a matching tree hash tag already exists in GHCR, the job skips the rebuild and reuses the cached image, keeping diagnosis runs fast while still updating whenever `.devcontainer/` changes land on `main`.
+
+#### 4.2 `check-failure`
 
 Pre-flight checks before running diagnosis.
 
@@ -520,7 +526,7 @@ Pre-flight checks before running diagnosis.
 
 **Outputs**: Workflow metadata for the diagnosis job
 
-#### 4.2 `diagnose-failure`
+#### 4.3 `diagnose-failure`
 
 Runs Codex to analyze the failure and classify it.
 


### PR DESCRIPTION
## Summary
- Adds devcontainer change detection to `ai-code-review.yml` — checks PR changed files via GitHub API and verifies GHCR image exists before building
- Adds GHCR image existence check to `ai-diagnose-workflow-failure.yml` — skips build when image already exists
- Adopts the same pattern already used in `ai-assistant.yml` (inspired by [hide-my-list](https://github.com/NickBorgers/hide-my-list))

## Test plan
- [ ] Verify ai-code-review workflow skips devcontainer build on a PR that doesn't touch `.devcontainer/`
- [ ] Verify ai-code-review workflow still builds when `.devcontainer/` files are in the PR diff
- [ ] Verify ai-diagnose-workflow-failure skips build when GHCR image exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)