### PR TITLE
chore: update AI CLIs in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,9 +38,9 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     && rm -rf /var/lib/apt/lists/*
 
 # Pin AI CLI versions so Dockerfile, post-create script, and updater workflow stay in sync
-ARG CLAUDE_CODE_VERSION=2.1.87
-ARG CODEX_CLI_VERSION=0.117.0
-ARG CRUSH_CLI_VERSION=0.53.0
+ARG CLAUDE_CODE_VERSION=2.1.92
+ARG CODEX_CLI_VERSION=0.118.0
+ARG CRUSH_CLI_VERSION=0.55.0
 
 # Install Node.js LTS (needed for Claude Code plugins and Playwright build step)
 ARG NODE_VERSION=20


### PR DESCRIPTION
Automated weekly update of the AI CLIs bundled in the devcontainer.

- **Claude Code:** 2.1.87 → 2.1.92
- **Crush:** 0.53.0 → 0.55.0
- **Codex:** 0.117.0 → 0.118.0

🤖 Generated automatically by the `update-ai-clis` workflow.