### PR TITLE
devcontainer: pass host ~/.bashrc through + drop unintended zsh default

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,11 +23,11 @@ RUN rm -f /etc/apt/sources.list.d/yarn.list \
     bc ripgrep fzf tmux \
     # YAML validation
     yamllint \
-    && rm -rf /var/lib/apt/lists/* \
-    # Set zsh as default shell for vscode user
-    && chsh -s /usr/bin/zsh vscode
+    && rm -rf /var/lib/apt/lists/*
 
-# Note: oh-my-zsh is already included in the base Go devcontainer image
+# Note: zsh is still installed above and oh-my-zsh ships in the base Go
+# devcontainer image; users who want zsh can invoke it explicitly. The
+# vscode user keeps the base image default login shell (bash).
 
 # Install GitHub CLI (from github-cli feature)
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,16 @@
     // as on the host so absolute paths inside settings.json resolve verbatim.
     // On CI runners without ~/.claude, Docker creates an empty directory and
     // post-create.sh no-ops.
-    "source=${localEnv:HOME}/.claude,target=${localEnv:HOME}/.claude,type=bind,readonly,consistency=cached"
+    "source=${localEnv:HOME}/.claude,target=${localEnv:HOME}/.claude,type=bind,readonly,consistency=cached",
+    // Same pattern for the developer's host ~/.bashrc and the external
+    // util/profile file it sources (shell functions, mise activation, the
+    // claude-yolo alias, etc.). Mounting at the same absolute path lets the
+    // source line inside ~/.bashrc resolve verbatim inside the container.
+    // post-create.sh appends a source line to the container user's .bashrc
+    // rather than overlaying it, so the container's baseline PS1 /
+    // bash-completion are preserved.
+    "source=${localEnv:HOME}/.bashrc,target=${localEnv:HOME}/.bashrc,type=bind,readonly,consistency=cached",
+    "source=${localEnv:HOME}/code/util/profile,target=${localEnv:HOME}/code/util/profile,type=bind,readonly,consistency=cached"
   ],
   "initializeCommand": "bash .devcontainer/init-host-credentials.sh",
   "remoteEnv": {
@@ -37,7 +46,8 @@
     "OPENAI_API_KEY": "fake-key",
     "TERM": "xterm-256color",
     "LANG": "en_US.UTF-8",
-    "CLAUDE_HOST_CONFIG_DIR": "${localEnv:HOME}/.claude"
+    "CLAUDE_HOST_CONFIG_DIR": "${localEnv:HOME}/.claude",
+    "HOST_BASHRC": "${localEnv:HOME}/.bashrc"
   },
   "updateRemoteUserUID": true,
   "remoteUser": "vscode"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -170,6 +170,24 @@ if [ -n "${CLAUDE_HOST_CONFIG_DIR:-}" ] \
     done
 fi
 
+# Append a source line to the container user's .bashrc so the host ~/.bashrc
+# (bind-mounted read-only at the same absolute path) is loaded on top of the
+# container's baseline. Idempotent: re-running post-create won't duplicate
+# the line. The host .bashrc's internal `source .../code/util/profile` line
+# resolves via the matching bind mount.
+if [ -n "${HOST_BASHRC:-}" ] \
+   && [ -f "$HOST_BASHRC" ] \
+   && [ "$HOST_BASHRC" != "$HOME/.bashrc" ]; then
+    bashrc_mark="# host-bashrc-passthrough: $HOST_BASHRC"
+    if [ ! -f "$HOME/.bashrc" ] || ! grep -qF "$bashrc_mark" "$HOME/.bashrc"; then
+        {
+            printf '\n%s\n' "$bashrc_mark"
+            printf '[ -r "%s" ] && . "%s"\n' "$HOST_BASHRC" "$HOST_BASHRC"
+        } >> "$HOME/.bashrc"
+        echo "Wired host .bashrc passthrough into $HOME/.bashrc"
+    fi
+fi
+
 # Helper to read pinned versions from the Dockerfile (single source of truth)
 DEVCONTAINER_DOCKERFILE="$SCRIPT_DIR/Dockerfile"
 get_arg_version() {


### PR DESCRIPTION
## Summary
Mirrors the `~/.claude` passthrough pattern (#962 / #398 / #205) for the developer's host `~/.bashrc` and the single external file it sources, `~/code/util/profile`.

- **Read-only bind mount** of both files at the **same absolute path** inside the container, so the `source "/.../code/util/profile"` line inside the host `.bashrc` resolves verbatim — no path rewriting, no marker, no copy.
- **Idempotent append** to the container user's `$HOME/.bashrc` that loads the host file **on top of** the container's baseline. The baseline PS1 / bash-completion / history config is preserved; host customizations layer on top.
- **Live sync:** edits to `~/.bashrc` or `~/code/util/profile` on the host are reflected in new shells inside the container on next source.

## Files changed
- `.devcontainer/devcontainer.json` — adds two `mounts` entries (`~/.bashrc`, `~/code/util/profile`) and a `HOST_BASHRC` entry under `remoteEnv`.
- `.devcontainer/post-create.sh` — adds a ~15-line idempotent block after the existing `CLAUDE_HOST_CONFIG_DIR` block that appends `[ -r "$HOST_BASHRC" ] && . "$HOST_BASHRC"` to `$HOME/.bashrc` guarded by a marker comment so rebuilds don't duplicate.

## CI safety
- On runners without `~/.bashrc` or `~/code/util/profile`, Docker materializes the bind sources as empty directories on the runner host (ephemeral no-op). The per-file `-f` checks in post-create fail and nothing is appended. Automated pipelines see **no** behavior change.
- No Dockerfile change in this repo → no devcontainer image cache invalidation.

## Test plan
- [x] `bash -n .devcontainer/post-create.sh`
- [x] `devcontainer.json` parses as JSONC with 3 mounts and `HOST_BASHRC` in `remoteEnv`
- [ ] Rebuild-from-scratch on a dev machine: verify `tail ~/.bashrc` inside the container ends with the `# host-bashrc-passthrough: ...` marker + the source line, and `bash -ic 'declare -f mov_to_gif'` prints the function body (proving `util/profile` loaded through the host `.bashrc`)
- [ ] Idempotency: re-run `devcontainer up` without `--remove-existing-container`; `grep -c host-bashrc-passthrough ~/.bashrc` inside the container must return `1`
- [ ] Simulate CI by temporarily renaming `~/.bashrc` on host; rebuild; confirm container's `.bashrc` doesn't contain the marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Additional change in this PR (home-automation only)

This PR also removes a one-line unintended Dockerfile setting:

```diff
     yamllint \
-    && rm -rf /var/lib/apt/lists/* \
-    # Set zsh as default shell for vscode user
-    && chsh -s /usr/bin/zsh vscode
+    && rm -rf /var/lib/apt/lists/*
```

The `chsh -s /usr/bin/zsh vscode` was set unintentionally; the other two sister repos (`hide-my-list`, `home-automation-plus-security`) never chsh and already default to bash. With this fix, the vscode user uses the base image's default bash shell, which means the new `.bashrc` passthrough actually takes effect in the default VS Code / `devcontainer exec` shell instead of only when the user explicitly runs `bash`.

The zsh package stays installed, so users who want `zsh` can still invoke it explicitly. oh-my-zsh is still present from the base Go devcontainer image.

**Cache impact:** editing this existing `RUN` layer invalidates the build cache for every layer downstream of it (gh, nodejs, Claude Code, Codex, playwright-skill, playwright browsers). First rebuild in CI (`ai-assistant`, `ai-code-review`, `devcontainer-cache`) will be slower; subsequent builds are cached normally.