### PR TITLE
ci: factor ai pipeline invocation through run-ai.sh wrapper

### DIFF
--- a/.devcontainer/ai-tool.env
+++ b/.devcontainer/ai-tool.env
@@ -1,0 +1,25 @@
+# Tool-agnostic AI pipeline configuration.
+#
+# Change AI_TOOL below to swap the CLI the review pipelines invoke. Sourced by
+# configure-ai.sh (setup) and run-ai.sh (runtime invocation), so a swap ripples
+# automatically: binary check, bot git identity, tool-specific env var mapping,
+# and CLI flags all follow.
+#
+# Supported values: claude | codex
+
+# The ${AI_TOOL:-claude} form lets developers override at invocation time for
+# local testing (e.g. `AI_TOOL=codex bash .devcontainer/run-ai.sh ...`) without
+# editing this file.
+export AI_TOOL="${AI_TOOL:-claude}"
+
+# Tool-specific LiteLLM base URL. The proxy exposes distinct paths for the
+# Anthropic-compatible and OpenAI-compatible shapes, so the right one must be
+# selected alongside AI_TOOL.
+case "$AI_TOOL" in
+  claude)
+    export AI_BASE_URL="https://llm.featherback-mermaid.ts.net/anthropic/"
+    ;;
+  codex)
+    export AI_BASE_URL="https://llm.featherback-mermaid.ts.net/v1"
+    ;;
+esac

--- a/.devcontainer/configure-ai.sh
+++ b/.devcontainer/configure-ai.sh
@@ -2,20 +2,50 @@
 
 set -euo pipefail
 
+# Load shared tool selection: sets AI_TOOL and AI_BASE_URL.
+source "$(dirname "${BASH_SOURCE[0]}")/ai-tool.env"
+
 export PATH="$HOME/.local/bin:$PATH"
 
-# Claude Code CLI is baked into the devcontainer image. Verify it's available.
-if ! command -v claude &>/dev/null; then
-  echo "ERROR: claude not found — expected it baked into the devcontainer image" >&2
-  exit 1
-fi
+# Dispatch per selected tool: verify the binary is available, pick a bot git
+# identity that matches the tool actually running, and write any on-disk config
+# the CLI requires.
+case "$AI_TOOL" in
+  claude)
+    if ! command -v claude &>/dev/null; then
+      echo "ERROR: claude not found — expected it baked into the devcontainer image" >&2
+      exit 1
+    fi
+    AI_GIT_NAME_DEFAULT="claude[bot]"
+    AI_GIT_EMAIL_DEFAULT="claude[bot]@users.noreply.github.com"
+    # Claude Code reads ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL straight from the
+    # environment — run-ai.sh sets those at invocation time. Nothing to write here.
+    ;;
+  codex)
+    if ! command -v codex &>/dev/null; then
+      echo "ERROR: codex not found — expected it baked into the devcontainer image" >&2
+      exit 1
+    fi
+    AI_GIT_NAME_DEFAULT="codex[bot]"
+    AI_GIT_EMAIL_DEFAULT="codex[bot]@users.noreply.github.com"
+    # Codex reads its provider config from ~/.codex/config.toml.
+    mkdir -p "$HOME/.codex"
+    cat > "$HOME/.codex/config.toml" <<EOF
+model = "gpt-5-codex"
+model_provider = "litellm"
 
-# Claude Code reads ANTHROPIC_API_KEY and ANTHROPIC_BASE_URL straight from the
-# environment — no on-disk config file needed. The workflow env block is
-# responsible for setting those values; this script only handles git identity.
+[model_providers.litellm]
+name = "LiteLLM"
+base_url = "${AI_BASE_URL}"
+env_key = "OPENAI_API_KEY"
+EOF
+    ;;
+  *)
+    echo "ERROR: unknown AI_TOOL='${AI_TOOL}' (expected 'claude' or 'codex')" >&2
+    exit 1
+    ;;
+esac
 
-AI_GIT_NAME_DEFAULT="claude[bot]"
-AI_GIT_EMAIL_DEFAULT="claude[bot]@users.noreply.github.com"
 AI_GIT_NAME="${AI_GIT_NAME:-$AI_GIT_NAME_DEFAULT}"
 AI_GIT_EMAIL="${AI_GIT_EMAIL:-$AI_GIT_EMAIL_DEFAULT}"
 
@@ -29,4 +59,4 @@ if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
   export GIT_COMMITTER_EMAIL="${AI_GIT_EMAIL}"
 fi
 
-echo "Claude Code configured for LiteLLM proxy."
+echo "AI pipeline configured: AI_TOOL=${AI_TOOL} (bot identity: ${AI_GIT_NAME})"

--- a/.devcontainer/run-ai.sh
+++ b/.devcontainer/run-ai.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Tool-agnostic wrapper around whichever AI CLI the pipelines are configured
+# to use. Called from every workflow invocation site:
+#
+#   bash .devcontainer/run-ai.sh "$PROMPT" 2>&1 | tee /tmp/ai-conversation.jsonl
+#
+# The workflow env block passes a single generic AI_API_KEY; this script
+# translates it into whatever env var name the selected CLI reads.
+
+set -euo pipefail
+
+# Load shared tool selection: sets AI_TOOL and AI_BASE_URL.
+source "$(dirname "${BASH_SOURCE[0]}")/ai-tool.env"
+
+export PATH="$HOME/.local/bin:$PATH"
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $0 <prompt>" >&2
+  exit 2
+fi
+
+PROMPT="$1"
+
+: "${AI_API_KEY:?AI_API_KEY must be set in the workflow env block (maps to the active tools API key)}"
+
+case "$AI_TOOL" in
+  claude)
+    export ANTHROPIC_API_KEY="$AI_API_KEY"
+    export ANTHROPIC_BASE_URL="$AI_BASE_URL"
+    # --dangerously-skip-permissions + --permission-mode=bypassPermissions are
+    # required for Claude Code in non-interactive mode to edit files / run
+    # commands without prompting.
+    exec claude -p \
+      --dangerously-skip-permissions \
+      --permission-mode=bypassPermissions \
+      --model claude-sonnet-4-6 \
+      "$PROMPT"
+    ;;
+  codex)
+    export OPENAI_API_KEY="$AI_API_KEY"
+    # Codex reads base URL from ~/.codex/config.toml (written by configure-ai.sh).
+    exec codex exec --json --dangerously-bypass-approvals-and-sandbox "$PROMPT"
+    ;;
+  *)
+    echo "ERROR: unknown AI_TOOL='${AI_TOOL}' (expected 'claude' or 'codex')" >&2
+    exit 1
+    ;;
+esac

--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -432,8 +432,7 @@ PY
           cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
           push: never
           env: |
-            ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-            ANTHROPIC_BASE_URL=https://llm.featherback-mermaid.ts.net/anthropic/
+            AI_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             EVENT_NAME=${{ github.event_name }}
             COMMENT_ID=${{ github.event.comment.id }}
@@ -522,7 +521,7 @@ PY
             Reply to the user using: gh issue comment ${ISSUE_NUMBER} --body 'YOUR_RESPONSE'"
             fi
 
-            claude -p --dangerously-skip-permissions --permission-mode=bypassPermissions --model claude-sonnet-4-6 "$PROMPT" 2>&1 | tee /tmp/ai-conversation.jsonl
+            bash .devcontainer/run-ai.sh "$PROMPT" 2>&1 | tee /tmp/ai-conversation.jsonl
 
       - name: Upload AI conversation log
         uses: actions/upload-artifact@v4
@@ -579,8 +578,7 @@ PY
           cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
           push: never
           env: |
-            ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-            ANTHROPIC_BASE_URL=https://llm.featherback-mermaid.ts.net/anthropic/
+            AI_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             ISSUE_NUMBER=${{ github.event.issue.number }}
             ISSUE_TITLE=${{ github.event.issue.title }}
@@ -595,7 +593,7 @@ PY
             # Fetch all comments on the issue (may contain additional context/requirements)
             ISSUE_COMMENTS=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" --jq '.[] | "---\n**\(.user.login)** commented at \(.created_at):\n\(.body)\n"' 2>/dev/null | head -c 50000 || echo "")
 
-            claude -p --dangerously-skip-permissions --permission-mode=bypassPermissions --model claude-sonnet-4-6 "You are an autonomous agent tasked with resolving GitHub issue #${ISSUE_NUMBER}.
+            bash .devcontainer/run-ai.sh "You are an autonomous agent tasked with resolving GitHub issue #${ISSUE_NUMBER}.
 
             ISSUE TITLE: ${ISSUE_TITLE}
 

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -571,8 +571,7 @@ jobs:
           push: never
           env: |
 
-            ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-            ANTHROPIC_BASE_URL=https://llm.featherback-mermaid.ts.net/anthropic/
+            AI_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             PR_TITLE=${{ needs.get-context.outputs.pr_title }}
@@ -595,7 +594,7 @@ jobs:
 
             source .devcontainer/configure-ai.sh
 
-            claude -p --dangerously-skip-permissions --permission-mode=bypassPermissions --model claude-sonnet-4-6 "You are fixing CI test failures for PR #${PR_NUMBER} in ${REPO}.
+            bash .devcontainer/run-ai.sh "You are fixing CI test failures for PR #${PR_NUMBER} in ${REPO}.
             This is fix attempt ${ATTEMPT} of 3.
 
             CRITICAL: BEFORE PUSHING ANY CHANGES, you MUST check if the PR author has pushed
@@ -848,8 +847,7 @@ jobs:
           push: never
           env: |
 
-            ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-            ANTHROPIC_BASE_URL=https://llm.featherback-mermaid.ts.net/anthropic/
+            AI_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             REPO=${{ github.repository }}
@@ -860,7 +858,7 @@ jobs:
 
             source .devcontainer/configure-ai.sh
 
-            claude -p --dangerously-skip-permissions --permission-mode=bypassPermissions --model claude-sonnet-4-6 "You are reviewing PR #${PR_NUMBER} in ${REPO}.
+            bash .devcontainer/run-ai.sh "You are reviewing PR #${PR_NUMBER} in ${REPO}.
 
             Review like an experienced staff engineer. Be direct and selective.
             Don't praise the code or list things that are fine — focus on what you'd actually say in a review.
@@ -1002,8 +1000,7 @@ jobs:
           push: never
           env: |
 
-            ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-            ANTHROPIC_BASE_URL=https://llm.featherback-mermaid.ts.net/anthropic/
+            AI_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             PR_TITLE=${{ needs.get-context.outputs.pr_title }}
@@ -1028,7 +1025,7 @@ jobs:
 
             source .devcontainer/configure-ai.sh
 
-            claude -p --dangerously-skip-permissions --permission-mode=bypassPermissions --model claude-sonnet-4-6 "You are a DESIGN REVIEW specialist for PR #${PR_NUMBER} in ${REPO}.
+            bash .devcontainer/run-ai.sh "You are a DESIGN REVIEW specialist for PR #${PR_NUMBER} in ${REPO}.
 
             Review like an experienced staff engineer. Be direct and selective.
             Don't praise the design or list strengths — focus on what you'd actually say in a review.
@@ -1194,8 +1191,7 @@ jobs:
           push: never
           env: |
 
-            ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-            ANTHROPIC_BASE_URL=https://llm.featherback-mermaid.ts.net/anthropic/
+            AI_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             HEAD_REF=${{ needs.get-context.outputs.head_ref }}
@@ -1203,7 +1199,7 @@ jobs:
           runCmd: |
             source .devcontainer/configure-ai.sh
 
-            claude -p --dangerously-skip-permissions --permission-mode=bypassPermissions --model claude-sonnet-4-6 "You are a QA tester for PR #${PR_NUMBER}.
+            bash .devcontainer/run-ai.sh "You are a QA tester for PR #${PR_NUMBER}.
 
             Review like an experienced staff engineer. Be direct and selective.
             Don't list files reviewed or describe what tests do. If there are no issues, approve in one line and move on.
@@ -1351,8 +1347,7 @@ jobs:
           push: never
           env: |
 
-            ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-            ANTHROPIC_BASE_URL=https://llm.featherback-mermaid.ts.net/anthropic/
+            AI_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             HEAD_REF=${{ needs.get-context.outputs.head_ref }}
@@ -1360,7 +1355,7 @@ jobs:
           runCmd: |
             source .devcontainer/configure-ai.sh
 
-            claude -p --dangerously-skip-permissions --permission-mode=bypassPermissions --model claude-sonnet-4-6 "You are a CONCURRENCY specialist reviewing PR #${PR_NUMBER}.
+            bash .devcontainer/run-ai.sh "You are a CONCURRENCY specialist reviewing PR #${PR_NUMBER}.
 
             Review like an experienced staff engineer. Be direct and selective.
             Don't explain concurrency concepts or list files reviewed. If there are no issues, approve in one line and move on.
@@ -1500,8 +1495,7 @@ jobs:
           push: never
           env: |
 
-            ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-            ANTHROPIC_BASE_URL=https://llm.featherback-mermaid.ts.net/anthropic/
+            AI_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             PR_TITLE=${{ needs.get-context.outputs.pr_title }}
@@ -1517,7 +1511,7 @@ jobs:
 
             source .devcontainer/configure-ai.sh
 
-            claude -p --dangerously-skip-permissions --permission-mode=bypassPermissions --model claude-sonnet-4-6 "You are a DOCUMENTATION specialist reviewing PR #${PR_NUMBER}.
+            bash .devcontainer/run-ai.sh "You are a DOCUMENTATION specialist reviewing PR #${PR_NUMBER}.
 
             Review like an experienced staff engineer. Be direct and selective.
             Don't list docs that don't need changes. If no docs need updating, approve in one line and move on.
@@ -1655,8 +1649,7 @@ jobs:
           push: never
           env: |
 
-            ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-            ANTHROPIC_BASE_URL=https://llm.featherback-mermaid.ts.net/anthropic/
+            AI_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             HEAD_REF=${{ needs.get-context.outputs.head_ref }}
@@ -1682,7 +1675,7 @@ jobs:
 
             source .devcontainer/configure-ai.sh
 
-            claude -p --dangerously-skip-permissions --permission-mode=bypassPermissions --model claude-sonnet-4-6 "You are the FINAL DECISION MAKER for PR #${PR_NUMBER}.
+            bash .devcontainer/run-ai.sh "You are the FINAL DECISION MAKER for PR #${PR_NUMBER}.
 
             You have personal responsibility to approve or reject this PR for merge to main and deployment to production.
             You are the last line of defense — if you find a concrete issue that reviewers missed, your verdict is

--- a/.github/workflows/ai-diagnose-workflow-failure.yml
+++ b/.github/workflows/ai-diagnose-workflow-failure.yml
@@ -192,8 +192,7 @@ jobs:
           cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
           push: never
           env: |
-            ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-            ANTHROPIC_BASE_URL=https://llm.featherback-mermaid.ts.net/anthropic/
+            AI_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
             GH_TOKEN=${{ github.token }}
             WORKFLOW_NAME=${{ needs.check-failure.outputs.workflow_name }}
             RUN_ID=${{ needs.check-failure.outputs.run_id }}
@@ -204,7 +203,7 @@ jobs:
           runCmd: |
             source .devcontainer/configure-ai.sh
 
-            claude -p --dangerously-skip-permissions --permission-mode=bypassPermissions --model claude-sonnet-4-6 "You are a GitHub Actions diagnostician. A workflow has failed and you need to determine
+            bash .devcontainer/run-ai.sh "You are a GitHub Actions diagnostician. A workflow has failed and you need to determine
             if it's a GitHub Actions configuration problem or a normal test/code failure.
 
             WORKFLOW INFORMATION:

--- a/.github/workflows/ha-deprecation-check.yml
+++ b/.github/workflows/ha-deprecation-check.yml
@@ -115,15 +115,14 @@ jobs:
           cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
           push: never
           env: |
-            ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-            ANTHROPIC_BASE_URL=https://llm.featherback-mermaid.ts.net/anthropic/
+            AI_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             REPO=${{ github.repository }}
             HA_VERSION=${{ inputs.ha_version || '' }}
           runCmd: |
             source .devcontainer/configure-ai.sh
 
-            claude -p --dangerously-skip-permissions --permission-mode=bypassPermissions --model claude-sonnet-4-6 "You are a Home Assistant deprecation checker. Your job is to find deprecated HA APIs
+            bash .devcontainer/run-ai.sh "You are a Home Assistant deprecation checker. Your job is to find deprecated HA APIs
             that this codebase still uses, and create GitHub issues so they get fixed proactively.
 
             PHASE 1: GATHER DEPRECATIONS

--- a/docs/operations/AI_GHA_PIPELINES.md
+++ b/docs/operations/AI_GHA_PIPELINES.md
@@ -127,10 +127,10 @@ Responds to `@ai` mentions in comments.
 
 **Key Configuration**:
 ```yaml
-claude -p --dangerously-skip-permissions --permission-mode=bypassPermissions --model claude-sonnet-4-6 "$PROMPT"
+bash .devcontainer/run-ai.sh "$PROMPT"
 ```
 
-The CLI reads `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL` (pointing at the self-hosted LiteLLM proxy) from the environment — see `.devcontainer/configure-ai.sh`.
+`run-ai.sh` is a tool-agnostic wrapper that dispatches to whichever CLI is currently configured. It reads `.devcontainer/ai-tool.env` to decide which tool to invoke and translates the generic `AI_API_KEY` env var into the tool-specific name (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.). See [Swapping the Backing AI Tool](#swapping-the-backing-ai-tool) below.
 
 #### 1.3 `resolve-issue`
 
@@ -724,6 +724,22 @@ The pipelines currently invoke Claude Code CLI with `claude-sonnet-4-6` via the 
 | `ha-deprecation-check.yml` | `claude-sonnet-4-6` | Release-note scanning and issue creation |
 
 The workflow display names are `AI Assistant`, `AI Code Review`, and `AI Diagnose Workflow Failure`, with filenames `ai-assistant.yml`, `ai-code-review.yml`, and `ai-diagnose-workflow-failure.yml`. Plumbing is tool-agnostic so the underlying CLI can be swapped without renaming anything.
+
+### Swapping the Backing AI Tool
+
+The pipelines route every CLI invocation through `.devcontainer/run-ai.sh`, which reads `.devcontainer/ai-tool.env` to decide which tool to actually run. Swapping between supported tools is a one-file change:
+
+1. Edit `.devcontainer/ai-tool.env` and change `AI_TOOL` to the desired value (currently `claude` or `codex`). The `AI_BASE_URL` for that tool is selected automatically by the `case` block in the same file.
+2. If the new tool needs a different API key, update the `ANTHROPIC_API_KEY` secret value in GitHub Actions settings — the secret name is kept for historical reasons, but the value can hold whatever key the new tool needs. (Workflow env blocks map it to a generic `AI_API_KEY` that `run-ai.sh` re-exports under the tool-specific env var name.)
+3. Rebuild the devcontainer image once so the next CI run picks up the new `ai-tool.env`.
+
+What each script does on a swap:
+
+- **`ai-tool.env`** — Single source of truth for `AI_TOOL` + `AI_BASE_URL`. Sourced by both scripts below.
+- **`configure-ai.sh`** — Verifies the selected tool's binary is in the devcontainer image, picks a matching bot git identity (`claude[bot]` / `codex[bot]`), and writes any on-disk config the CLI requires (e.g. `~/.codex/config.toml`).
+- **`run-ai.sh`** — Takes `$PROMPT` as `$1`, exports the right tool-specific env vars (`ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` for Claude, `OPENAI_API_KEY` for Codex), and `exec`s the CLI with the right flags.
+
+Adding a new tool (e.g. a different backend) requires adding a `case` arm to both `configure-ai.sh` and `run-ai.sh`, plus baking the tool's binary into the devcontainer Dockerfile. Workflow YAML files do **not** need to change.
 
 ### Why Devcontainers?
 


### PR DESCRIPTION
## Summary

Follow-up to #964. Every workflow CLI call now goes through `.devcontainer/run-ai.sh`, which reads `.devcontainer/ai-tool.env` to decide which tool to invoke and translates a generic `AI_API_KEY` env var into the tool-specific name. **Swapping the backing AI tool is now a one-line change in `ai-tool.env`.**

## How it works

Three files form the dispatch layer:

| File | Role |
|---|---|
| `.devcontainer/ai-tool.env` | Single source of truth — `AI_TOOL=claude` (+ tool-specific `AI_BASE_URL`). Sourced by both scripts below. Uses `${AI_TOOL:-claude}` so developers can override at invocation time without editing. |
| `.devcontainer/configure-ai.sh` | Setup-time dispatch: verifies the selected tool's binary is in the devcontainer image, picks a matching bot git identity (`claude[bot]` / `codex[bot]`), and writes any on-disk config the CLI needs (e.g. `~/.codex/config.toml`). |
| `.devcontainer/run-ai.sh` | Runtime dispatch: takes `$PROMPT` as `$1`, exports the right tool-specific env vars (`ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` for Claude, `OPENAI_API_KEY` for Codex), and `exec`s the CLI with the right flags. |

All 11 `claude -p` call sites across 4 workflows now invoke `bash .devcontainer/run-ai.sh "$PROMPT"`. All `env:` blocks collapsed from `ANTHROPIC_API_KEY + ANTHROPIC_BASE_URL` to a single generic `AI_API_KEY`.

Claude permission flags (`--dangerously-skip-permissions --permission-mode=bypassPermissions`) live inside `run-ai.sh` — the one place that knows they're Claude-specific. A Codex swap wouldn't need them.

## Swap procedure (Claude → Codex or vice versa)

1. Edit **one line** in `.devcontainer/ai-tool.env`: change `AI_TOOL="claude"` to `AI_TOOL="codex"` (or back).
2. If the new tool needs a different API key, update the `ANTHROPIC_API_KEY` secret value in GitHub Actions settings — the secret *name* is kept for historical reasons, but the value can hold whatever key the new tool needs.
3. Rebuild the devcontainer image once so the next CI run picks up the new `ai-tool.env`.

Adding a whole new tool (not just swapping the two already supported) means adding a `case` arm to both `configure-ai.sh` and `run-ai.sh`, plus baking the binary into the Dockerfile. Workflow YAML still doesn't need to change.

## Test plan

- [x] `bash -n` on all three new/modified scripts
- [x] `make pre-commit` (gofmt, goimports, vet, staticcheck, build)
- [x] `make pre-push` (unit + integration tests)
- [x] Smoke-tested `ai-tool.env` override: `AI_TOOL=codex bash -c 'source .devcontainer/ai-tool.env; echo $AI_TOOL $AI_BASE_URL'` correctly dispatches to the codex base URL; default (no override) stays on claude
- [x] Verified all 11 workflow invocation sites now call `bash .devcontainer/run-ai.sh`
- [ ] End-to-end CI run on a real PR — trigger `HA Deprecation Check` via `workflow_dispatch` to exercise the full devcontainer → `configure-ai.sh` → `run-ai.sh` → LiteLLM path
- [ ] Manual swap test: flip `AI_TOOL=codex` in `ai-tool.env` on a throwaway branch, push, verify the `Codex[bot]` identity + `codex exec` invocation works end-to-end, then flip back

🤖 Generated with [Claude Code](https://claude.com/claude-code)