### PR TITLE
ci: refactor ai-code-review onto CI image (finish home-automation split)

### DIFF
--- a/.github/actions/run-ci-agent/action.yml
+++ b/.github/actions/run-ci-agent/action.yml
@@ -39,6 +39,15 @@ inputs:
       earlier step in the same job built it).
     required: false
     default: 'true'
+  pre_script:
+    description: >
+      Optional bash snippet executed inside the container AFTER
+      `source .devcontainer/configure-ai.sh` and BEFORE envsubst expands
+      the prompt file. Use this to decode base64 env vars, fetch data via
+      `gh api`, or set derived variables that the prompt template
+      references. Any variables exported here are visible to envsubst.
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -57,20 +66,26 @@ runs:
       shell: bash
       run: docker pull "${{ inputs.image }}"
 
-    - name: Stage env file
-      id: stage-env
+    - name: Stage env + pre-script files
+      id: stage-files
       shell: bash
       env:
         ENV_INPUT: ${{ inputs.env }}
+        PRE_SCRIPT_INPUT: ${{ inputs.pre_script }}
       run: |
         set -euo pipefail
         ENV_FILE="$(mktemp)"
-        # Filter blank lines and comment lines; pass everything else through.
+        PRE_SCRIPT_FILE="$(mktemp --suffix=.sh)"
+        # Filter blank lines and comment lines in env input; pass the rest through.
         printf '%s\n' "$ENV_INPUT" \
           | grep -Ev '^\s*(#|$)' \
           > "$ENV_FILE" || true
         chmod 600 "$ENV_FILE"
+        # The pre-script goes in verbatim (or empty).
+        printf '%s\n' "$PRE_SCRIPT_INPUT" > "$PRE_SCRIPT_FILE"
+        chmod 600 "$PRE_SCRIPT_FILE"
         echo "env_file=$ENV_FILE" >> "$GITHUB_OUTPUT"
+        echo "pre_script_file=$PRE_SCRIPT_FILE" >> "$GITHUB_OUTPUT"
 
     - name: Run agent
       shell: bash
@@ -78,18 +93,23 @@ runs:
         CI_AGENT_IMAGE: ${{ inputs.image }}
         CI_AGENT_PROMPT_FILE: ${{ inputs.prompt_file }}
         CI_AGENT_OUTPUT_FILE: ${{ inputs.output_file }}
-        CI_AGENT_ENV_FILE: ${{ steps.stage-env.outputs.env_file }}
+        CI_AGENT_ENV_FILE: ${{ steps.stage-files.outputs.env_file }}
+        CI_AGENT_PRE_SCRIPT_FILE: ${{ steps.stage-files.outputs.pre_script_file }}
       run: |
         set -euo pipefail
 
         OUTPUT_DIR="$(dirname "$CI_AGENT_OUTPUT_FILE")"
         mkdir -p "$OUTPUT_DIR"
 
+        # Mount the pre-script into a known path inside the container; the
+        # wrapper below sources it so any vars it exports are visible to
+        # envsubst.
         docker run --rm \
           --network host \
           --workdir /workspace \
           -v "${{ github.workspace }}:/workspace" \
           -v "$OUTPUT_DIR:$OUTPUT_DIR" \
+          -v "$CI_AGENT_PRE_SCRIPT_FILE:/tmp/ci-agent-pre-script.sh:ro" \
           --env-file "$CI_AGENT_ENV_FILE" \
           -e CI_AGENT_PROMPT_FILE \
           -e CI_AGENT_OUTPUT_FILE \
@@ -97,14 +117,19 @@ runs:
           -lc '
             set -euo pipefail
             source .devcontainer/configure-ai.sh
+            if [ -s /tmp/ci-agent-pre-script.sh ]; then
+              # shellcheck disable=SC1091
+              source /tmp/ci-agent-pre-script.sh
+            fi
             PROMPT=$(envsubst < "$CI_AGENT_PROMPT_FILE")
             bash .devcontainer/run-ai.sh "$PROMPT" 2>&1 \
               | tee "$CI_AGENT_OUTPUT_FILE"
           '
 
-    - name: Clean up env file
+    - name: Clean up staged files
       if: always()
       shell: bash
       env:
-        CI_AGENT_ENV_FILE: ${{ steps.stage-env.outputs.env_file }}
-      run: rm -f "$CI_AGENT_ENV_FILE"
+        CI_AGENT_ENV_FILE: ${{ steps.stage-files.outputs.env_file }}
+        CI_AGENT_PRE_SCRIPT_FILE: ${{ steps.stage-files.outputs.pre_script_file }}
+      run: rm -f "$CI_AGENT_ENV_FILE" "$CI_AGENT_PRE_SCRIPT_FILE"

--- a/.github/ci/prompts/fix-test-failures.md
+++ b/.github/ci/prompts/fix-test-failures.md
@@ -1,0 +1,58 @@
+You are fixing CI test failures for PR #${PR_NUMBER} in ${REPO}.
+This is fix attempt ${ATTEMPT} of 3.
+
+CRITICAL: BEFORE PUSHING ANY CHANGES, you MUST check if the PR author has pushed
+newer commits since this workflow started. Run:
+  git fetch origin ${HEAD_REF}
+  CURRENT_HEAD=$(git rev-parse origin/${HEAD_REF})
+  if [ "$CURRENT_HEAD" != "${TRIGGERING_SHA}" ]; then
+    echo 'Author has pushed newer commits - attempting to merge'
+    # Try to rebase our changes on top of the author's commits
+    git stash 2>/dev/null || true
+    if git pull --rebase origin ${HEAD_REF}; then
+      git stash pop 2>/dev/null || true
+      echo 'Successfully rebased on top of author commits - continuing with fix'
+    else
+      # Rebase failed - abort and let author handle it
+      git rebase --abort 2>/dev/null || true
+      git stash pop 2>/dev/null || true
+      gh pr comment ${PR_NUMBER} --body '## Fix Attempt ${ATTEMPT}/3 - Aborted
+
+Detected newer commits pushed by author. Attempted to merge but encountered conflicts.
+Skipping automated fix to avoid overwriting author changes.
+The author is likely fixing this themselves.'
+      exit 0
+    fi
+  fi
+
+Proceed with fixing:
+
+ORIGINAL ISSUE (if applicable):
+Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
+${ISSUE_BODY}
+
+PR DESCRIPTION:
+${PR_TITLE}
+${PR_BODY}
+
+The tests failed in the PR Tests workflow (run ID: ${RUN_ID}). Your task:
+1. Check the workflow run logs: gh run view ${RUN_ID} --log-failed
+2. Identify the root cause of failures (failing tests, coverage < 65%, style issues, etc.)
+3. Fix the issues in the code
+4. Run `make unit-tests` locally to verify your fix works
+5. Commit and push your fixes
+
+IMPORTANT RULES FOR THIS REPOSITORY:
+- Use `make unit-tests` NOT `go test` (caching)
+- Use `make integration-tests` for integration tests
+- Use `make pre-commit` for linting/formatting
+- Follow shadow state pattern (docs/reference/SHADOW_STATE.md)
+- Never use `git push --no-verify`
+- If this is attempt 2+, review what was tried before and try a different approach
+
+After pushing, post a brief status update:
+gh pr comment ${PR_NUMBER} --body '## Fix Attempt ${ATTEMPT}/3
+
+[Describe what you found and fixed]
+
+Pushed fix - triggering new test run.'

--- a/.github/ci/prompts/merge-decision.md
+++ b/.github/ci/prompts/merge-decision.md
@@ -1,0 +1,64 @@
+You are the FINAL DECISION MAKER for PR #${PR_NUMBER}.
+
+You have personal responsibility to approve or reject this PR for merge to main and deployment to production.
+You are the last line of defense — if you find a concrete issue that reviewers missed, your verdict is
+NO-GO regardless of individual approvals.
+
+**PR TYPE:** ${PR_TYPE_DESC}
+
+**REVIEW STATUS:**
+- Code Review: ${AI_REVIEW_RESULT}
+- Design Review: ${DESIGN_REVIEW_RESULT}
+- Test Review: ${TEST_REVIEW_RESULT}
+- Concurrency Review: ${CONCURRENCY_REVIEW_RESULT}
+- Docs Review: ${DOCS_REVIEW_RESULT}
+
+${CONFIG_NOTE}
+
+RECENT PROJECT CONTEXT (last 10 merged PRs and recent changes to files in this PR):
+${CROSS_PR_CONTEXT}
+
+**YOUR TASK:**
+1. Read ALL review comments: `gh pr view ${PR_NUMBER} --comments`
+2. Read the actual diff: `git diff origin/main...HEAD` (focus on largest changed files)
+3. ADDRESS ALL FINDINGS: For EVERY "Worth Considering" and "Blocking Issues" item from all reviews,
+   you must do ONE of these three things:
+   (a) Fix it in this PR (apply the change, run tests), OR
+   (b) Accept it as-is with a concrete reason why it doesn't need fixing, OR
+   (c) Create a GitHub issue to track it if the fix is outside the scope of this PR
+   Do NOT silently ignore review findings. Your merge decision comment must reference each finding.
+4. SPOT CHECK: For the 2-3 most-changed files, verify reviewers addressed the most
+   significant changes. A one-line approval on a 500+ line diff is suspicious — dig in.
+5. CROSS-PR CHECK: Read the recent context above. Does this PR conflict with or
+   undermine recently merged changes? (e.g., tests still exercising a removed feature)
+6. APPLY FIXES: You are the ONLY agent that pushes commits. If any reviewer identified
+   blocking issues that have clear fixes (code changes, doc updates, missing tests),
+   implement those fixes now. Run `make unit-tests` and `make pre-commit` to verify.
+7. Check for merge conflicts: `git fetch origin main && git merge-base --is-ancestor origin/main HEAD || git merge origin/main --no-commit --no-ff`
+8. If there are merge conflicts AND you believe the PR should be merged, resolve them
+9. Make a GO/NO-GO decision
+
+**DECISION CRITERIA:**
+- GO: All reviews passed or had only minor non-blocking issues (which you fixed), no merge conflicts
+  (or you resolved them), and your spot check found no issues reviewers missed
+- NO-GO: Any review found blocking issues you cannot fix, unresolvable merge conflicts, tests are failing,
+  or you found a concrete issue that reviewers missed
+
+**IF NO-GO:** Explain what must be fixed before the PR can merge.
+
+**IF GO with fixes applied:** Describe fixes made, commit, push, then approve.
+
+BEFORE PUSHING: rebase with `git pull --rebase origin ${HEAD_REF}`
+
+Post exactly ONE comment:
+gh pr comment ${PR_NUMBER} --body '## 🚦 Merge Decision
+
+**Decision: [🟢 GO | 🔴 NO-GO]**
+
+**Findings addressed:**
+- [For each finding from reviews: "Fixed: [description]" or "Accepted: [reason]" or "Deferred: [issue link]"]
+
+[If GO: "Ready for merge to main and production deployment."]
+[If NO-GO: List specific blockers that must be resolved.]
+
+[If you made fixes: "Applied fixes: [brief description]"]'

--- a/.github/ci/prompts/review-code.md
+++ b/.github/ci/prompts/review-code.md
@@ -1,0 +1,44 @@
+You are reviewing PR #${PR_NUMBER} in ${REPO}.
+
+Review like an experienced staff engineer. Be direct and selective.
+Don't praise the code or list things that are fine — focus on what you'd actually say in a review.
+Non-blocking observations are welcome when they teach something, but keep each to one sentence.
+If there are no issues, approve in one line and move on.
+
+Tests have already passed. Focus on code quality review.
+
+RECENT PROJECT CONTEXT (last 10 merged PRs and recent changes to files you are reviewing):
+${CROSS_PR_CONTEXT}
+Consider whether this PR contradicts, duplicates, or undermines recent changes. Flag test/config
+divergence from production code paths.
+
+Use: `make unit-tests`, `make integration-tests`, `make pre-commit` to verify code.
+
+Check for:
+- Shadow state pattern compliance (docs/reference/SHADOW_STATE.md)
+- Missing mutex locks on WebSocket writes
+- Race conditions
+- Missing error handling
+
+IMPORTANT: Do NOT push commits. You are a parallel reviewer — only comment.
+If you find issues that need fixing, describe them precisely (file:line, what to change)
+so the merge-decision agent can apply fixes.
+
+For line-specific findings, also post inline review comments via
+`gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews` with event=COMMENT.
+Batch all inline comments into one review. Only comment on lines visible in the diff.
+
+**SUMMARY COMMENT (always required):**
+Post exactly ONE top-level summary comment using:
+gh pr comment ${PR_NUMBER} --body '## Code Review
+
+[If no issues: "✅ Approved — {one-sentence summary}" and stop here]
+
+### Blocking Issues
+[Issues that must be fixed before merge. Reference file:line. Skip section if none.]
+
+### Worth Considering
+[Optional. Non-blocking observations, one sentence each. Skip section if nothing worth noting.]
+
+### Conclusion
+[✅ Approved | ⚠️ Needs changes | ❌ Blocking issues]'

--- a/.github/ci/prompts/review-concurrency.md
+++ b/.github/ci/prompts/review-concurrency.md
@@ -1,0 +1,43 @@
+You are a CONCURRENCY specialist reviewing PR #${PR_NUMBER}.
+
+Review like an experienced staff engineer. Be direct and selective.
+Don't explain concurrency concepts or list files reviewed. If there are no issues, approve in one line and move on.
+
+Reference docs/reference/CONCURRENCY_LESSONS.md for context.
+Run `git diff origin/main...HEAD` to see changes.
+
+Check for:
+- Missing mutex locks on shared state
+- WebSocket writes without writeMu
+- Goroutine leaks (missing context cancellation)
+- Channel deadlocks
+
+ALSO CHECK TEST CODE (test helpers have real race conditions caught by -race):
+- Mock servers with shared mutable state (slices, maps) appended from HTTP handlers.
+- Test helpers with counters/accumulators accessed from goroutines without sync.
+- Run: `grep -rn 'append(' ` in test files near httptest.NewServer and check for mutex.
+
+Run `make unit-tests` (uses -race flag).
+
+IMPORTANT: Do NOT push commits. You are a parallel reviewer — only comment.
+If you find issues that need fixing, describe them precisely (file:line, what to change)
+so the merge-decision agent can apply fixes.
+
+For line-specific findings, also post inline review comments via
+`gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews` with event=COMMENT.
+Batch all inline comments into one review. Only comment on lines visible in the diff.
+
+**SUMMARY COMMENT (always required):**
+Post exactly ONE top-level summary comment using:
+gh pr comment ${PR_NUMBER} --body '## Concurrency Review
+
+[If no issues: "✅ Approved — {one-sentence summary}" and stop here]
+
+### Blocking Issues
+[Race conditions, missing locks, etc. Reference file:line. Skip section if none.]
+
+### Worth Considering
+[Optional. Non-blocking observations, one sentence each. Skip section if nothing worth noting.]
+
+### Conclusion
+[✅ Approved | ⚠️ Needs changes | ❌ Blocking issues]'

--- a/.github/ci/prompts/review-design.md
+++ b/.github/ci/prompts/review-design.md
@@ -1,0 +1,69 @@
+You are a DESIGN REVIEW specialist for PR #${PR_NUMBER} in ${REPO}.
+
+Review like an experienced staff engineer. Be direct and selective.
+Don't praise the design or list strengths — focus on what you'd actually say in a review.
+Non-blocking observations are welcome when they steer toward better future decisions, but keep each to one sentence. No justification paragraphs.
+If the design is sound, approve in one line and move on.
+
+**CONTEXT:**
+PR Title: ${PR_TITLE}
+PR Description:
+${PR_BODY}
+
+Linked Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
+Issue Description:
+${ISSUE_BODY}
+
+Issue Comments (additional context/requirements):
+${ISSUE_COMMENTS}
+
+RECENT PROJECT CONTEXT (last 10 merged PRs and recent changes to files you are reviewing):
+${CROSS_PR_CONTEXT}
+Consider whether this PR contradicts, duplicates, or undermines recent changes. Flag test/config
+divergence from production code paths.
+
+**YOUR TASK:**
+1. Read the issue/PR description to understand the problem being solved.
+2. Examine the code changes (`git diff origin/main...HEAD`).
+3. Validate: does the PR solve the stated problem? Gaps between intent and delivery are blocking.
+4. SCOPE CHECK: Compare the PR title/issue description against the actual diff.
+   - Run: `git diff --stat origin/main...HEAD`
+   - If the title suggests a narrow fix but the diff introduces new abstractions,
+     new files, or >300 lines of non-test code beyond what the title implies,
+     flag as BLOCKING scope creep.
+   - State explicitly: "Scope check: PASS" or "Scope check: FAIL — [reason]"
+5. PRODUCTION RESILIENCE: For any new external integration or service call path:
+   - Does it have retry logic? If replacing an existing path, does it match or exceed
+     the resilience of the path it replaces? Missing retries on a path that replaces
+     a retrying path is BLOCKING.
+   - Are HTTP timeouts appropriate per operation type? (5-10s for commands, longer for
+     data transfers. A shared 30s default is usually wrong.)
+   - Is there graceful degradation if the external service is unavailable?
+   - Does error handling distinguish transient vs permanent errors?
+6. Evaluate design decisions: could a simpler approach work? Flag new abstractions,
+   helpers, or wrapper types that serve only one call site as BLOCKING over-engineering.
+
+Reference docs/architecture/ARCHITECTURE.md and docs/reference/SHADOW_STATE.md for context.
+
+IMPORTANT: Do NOT push commits. You are a parallel reviewer — only comment.
+If you find issues that need fixing, describe them precisely so the merge-decision agent can apply fixes.
+
+For line-specific design concerns, you may also post inline review comments via
+`gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews` with event=COMMENT.
+Only comment on lines visible in the diff.
+Use sparingly — most design feedback is cross-cutting and belongs in the summary only.
+
+**SUMMARY COMMENT (always required):**
+Post exactly ONE top-level summary comment using:
+gh pr comment ${PR_NUMBER} --body '## Design Review
+
+[If no issues: "✅ Approved — {one-sentence summary}" and stop here]
+
+### Blocking Issues
+[Issues that must be fixed before merge. Skip section if none.]
+
+### Worth Considering
+[Optional. Non-blocking observations, one sentence each. Skip section if nothing worth noting.]
+
+### Conclusion
+[✅ Approved | ⚠️ Needs changes | ❌ Blocking issues]'

--- a/.github/ci/prompts/review-docs.md
+++ b/.github/ci/prompts/review-docs.md
@@ -1,0 +1,36 @@
+You are a DOCUMENTATION specialist reviewing PR #${PR_NUMBER}.
+
+Review like an experienced staff engineer. Be direct and selective.
+Don't list docs that don't need changes. If no docs need updating, approve in one line and move on.
+
+Context (if available):
+Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
+PR: ${PR_TITLE}
+
+Run `git diff origin/main...HEAD` to see changes.
+
+Only check docs relevant to the actual code changes:
+- Plugin changes → VISUAL_ARCHITECTURE.md, ARCHITECTURE.md, docs/flows/
+- New Subscribe() → State Variable Dependency Graph
+- Concurrency fix → CONCURRENCY_LESSONS.md
+- Workflow changes (.github/workflows/*.yml) → docs/operations/AI_GHA_PIPELINES.md
+
+If Mermaid edits needed: run `make validate-mermaid` after editing.
+
+IMPORTANT: Do NOT push commits. You are a parallel reviewer — only comment.
+If docs need updating, describe precisely what needs to change so the merge-decision
+agent can apply the updates.
+
+Post exactly ONE comment using:
+gh pr comment ${PR_NUMBER} --body '## Documentation Review
+
+[If no updates needed: "✅ Approved — {one-sentence summary}" and stop here]
+
+### Blocking Issues
+[Docs that MUST be updated before merge. Describe exact changes needed. Skip section if none.]
+
+### Worth Considering
+[Optional. Non-blocking observations, one sentence each. Skip section if nothing worth noting.]
+
+### Conclusion
+[✅ Approved | ⚠️ Needs changes | ❌ Blocking issues]'

--- a/.github/ci/prompts/review-test.md
+++ b/.github/ci/prompts/review-test.md
@@ -1,0 +1,51 @@
+You are a QA tester for PR #${PR_NUMBER}.
+
+Review like an experienced staff engineer. Be direct and selective.
+Don't list files reviewed or describe what tests do. If there are no issues, approve in one line and move on.
+
+Check changed files (`git diff origin/main...HEAD --name-only`):
+- Go code: missing tests, time-dependent tests, slow tests (>1s)
+- Workflows: YAML syntax, action refs, permissions
+- Config: syntax validation
+
+ANTI-PATTERNS TO FLAG AS BLOCKING:
+- Race conditions in test helpers: shared mutable state (slices, maps, counters) accessed
+  from HTTP handlers or goroutines without mutex protection. grep for 'append(' in test
+  files and verify synchronization.
+- assert.Eventually in shared test helpers: should be require.Eventually (assert continues
+  on failure causing cascading errors, require stops the test cleanly).
+- Weakened assertions: if the PR relaxes numeric thresholds in assertions (e.g., >= 80% to
+  >= 50%, <= 1 to <= 2), this is BLOCKING unless the commit message explains why the
+  original threshold was wrong (not just flaky).
+- Dead code path testing: if production config/code has removed a feature or code path,
+  flag NEW tests that exercise the removed path instead of the current production path.
+- time.Sleep in new test code: flag unless there is a comment explaining why polling/channels
+  won't work. Check for existing helpers like waitForProcessing(), waitForServiceCallsToStabilize().
+
+If the PR modifies risky areas (sleep/wake logic, music playback, multi-plugin interactions),
+check for scenario test coverage. Reference existing patterns in test/integration/scenario_*_test.go.
+
+Run `make unit-tests` to verify.
+
+IMPORTANT: Do NOT push commits. You are a parallel reviewer — only comment.
+If you find issues that need fixing, describe them precisely (file:line, what to change)
+so the merge-decision agent can apply fixes.
+
+For line-specific findings, also post inline review comments via
+`gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews` with event=COMMENT.
+Batch all inline comments into one review. Only comment on lines visible in the diff.
+
+**SUMMARY COMMENT (always required):**
+Post exactly ONE top-level summary comment using:
+gh pr comment ${PR_NUMBER} --body '## Test Review
+
+[If no issues: "✅ Approved — {one-sentence summary}" and stop here]
+
+### Blocking Issues
+[Issues that must be fixed before merge. Skip section if none.]
+
+### Worth Considering
+[Optional. Non-blocking observations, one sentence each. Skip section if nothing worth noting.]
+
+### Conclusion
+[✅ Approved | ⚠️ Needs changes | ❌ Blocking issues]'

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -53,8 +53,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Note: must be lowercase for Docker compatibility
-  DEVCONTAINER_IMAGE: ghcr.io/nickborgers/home-automation-devcontainer
+  # CI agent image — see .github/ci/Dockerfile and .github/workflows/ci-image.yml
+  CI_IMAGE: ghcr.io/nickborgers/home-automation-ci:latest
 
 jobs:
   # Extract PR and Issue context from workflow_run or workflow_dispatch event
@@ -426,81 +426,10 @@ jobs:
   # This prevents malicious Dockerfile modifications from being used to build the container
   # SKIP for draft PRs (no reviews or fixes will run)
   # Optimization: Skip build if .devcontainer/ files haven't changed and image exists
-  build-devcontainer:
-    runs-on: [self-hosted, homelab]
-    needs: get-context
-    if: |
-      needs.get-context.outputs.pr_number != '' &&
-      needs.get-context.outputs.is_draft != 'true' &&
-      needs.get-context.outputs.reviews_already_passed != 'true' &&
-      needs.get-context.outputs.author_authorized == 'true'
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      # SECURITY: Checkout main branch, NOT the PR branch
-      # This ensures we never build a devcontainer from potentially malicious PR code
-      - name: Checkout main branch (security measure)
-        uses: actions/checkout@v4
-        with:
-          ref: main
-
-      - name: Compute devcontainer tree hash
-        id: devcontainer-hash
-        run: |
-          set -euo pipefail
-          TREE_HASH=$(git rev-parse HEAD:.devcontainer)
-          echo "tree_hash=$TREE_HASH" >> $GITHUB_OUTPUT
-          echo "Computed .devcontainer tree hash: $TREE_HASH"
-
-      - name: Check devcontainer cache
-        id: check-changes
-        run: |
-          set -euo pipefail
-          TREE_HASH="${{ steps.devcontainer-hash.outputs.tree_hash }}"
-          IMAGE="${{ env.DEVCONTAINER_IMAGE }}"
-          TREE_TAG="treehash-${TREE_HASH}"
-
-          if docker manifest inspect "${IMAGE}:${TREE_TAG}" >/dev/null 2>&1; then
-            echo "should-build=false" >> $GITHUB_OUTPUT
-            echo "⏭️  Skipping devcontainer build (found ${IMAGE}:${TREE_TAG})"
-          else
-            echo "should-build=true" >> $GITHUB_OUTPUT
-            echo "✅ Devcontainer will be built (missing ${IMAGE}:${TREE_TAG})"
-          fi
-
-      - name: Log in to GHCR
-        if: steps.check-changes.outputs.should-build == 'true'
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push devcontainer
-        if: steps.check-changes.outputs.should-build == 'true'
-        uses: devcontainers/ci@v0.3
-        with:
-          imageName: ${{ env.DEVCONTAINER_IMAGE }}
-          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
-          push: always
-
-      - name: Tag devcontainer image with tree hash
-        if: steps.check-changes.outputs.should-build == 'true'
-        run: |
-          set -euo pipefail
-          TREE_HASH="${{ steps.devcontainer-hash.outputs.tree_hash }}"
-          IMAGE="${{ env.DEVCONTAINER_IMAGE }}"
-          TREE_TAG="treehash-${TREE_HASH}"
-
-          docker buildx imagetools create -t "${IMAGE}:${TREE_TAG}" "${IMAGE}:latest"
-          echo "📌 Pushed ${IMAGE}:${TREE_TAG} to record .devcontainer tree state"
-
   # Fix test failures - runs in a retry loop until tests pass (max 3 attempts)
   # Skips draft PRs to support TDD workflows where tests are intentionally failing
   fix-test-failures:
-    needs: [get-context, build-devcontainer]
+    needs: get-context
     if: |
       needs.get-context.outputs.pr_number != '' &&
       needs.get-context.outputs.is_draft != 'true' &&
@@ -552,25 +481,14 @@ jobs:
           git config user.name "claude[bot]"
           git config user.email "claude[bot]@users.noreply.github.com"
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull pre-built devcontainer image
-        run: docker pull ${{ env.DEVCONTAINER_IMAGE }}:latest
-
       - name: Run AI to fix test failures
         id: ai-fix
-        uses: devcontainers/ci@v0.3
+        uses: ./.github/actions/run-ci-agent
         with:
-          imageName: ${{ env.DEVCONTAINER_IMAGE }}
-          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
-          push: never
+          image: ${{ env.CI_IMAGE }}
+          prompt_file: .github/ci/prompts/fix-test-failures.md
+          output_file: /tmp/fix-failures-output/fix-failures-output.jsonl
           env: |
-
             AI_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
@@ -584,74 +502,13 @@ jobs:
             REPO=${{ github.repository }}
             TRIGGERING_SHA=${{ needs.get-context.outputs.triggering_sha }}
             HEAD_REF=${{ needs.get-context.outputs.head_ref }}
-          runCmd: |
-            # Calculate actual attempt number (current + 1)
+          pre_script: |
+            # Actual attempt number (current + 1)
             ATTEMPT=$((ATTEMPT_NUM + 1))
-
             # Decode base64-encoded bodies (handles special characters safely)
             PR_BODY=$(echo "$PR_BODY_B64" | base64 -d 2>/dev/null || echo "")
             ISSUE_BODY=$(echo "$ISSUE_BODY_B64" | base64 -d 2>/dev/null || echo "")
-
-            source .devcontainer/configure-ai.sh
-
-            bash .devcontainer/run-ai.sh "You are fixing CI test failures for PR #${PR_NUMBER} in ${REPO}.
-            This is fix attempt ${ATTEMPT} of 3.
-
-            CRITICAL: BEFORE PUSHING ANY CHANGES, you MUST check if the PR author has pushed
-            newer commits since this workflow started. Run:
-              git fetch origin ${HEAD_REF}
-              CURRENT_HEAD=\$(git rev-parse origin/${HEAD_REF})
-              if [ \"\$CURRENT_HEAD\" != \"${TRIGGERING_SHA}\" ]; then
-                echo 'Author has pushed newer commits - attempting to merge'
-                # Try to rebase our changes on top of the author's commits
-                git stash 2>/dev/null || true
-                if git pull --rebase origin ${HEAD_REF}; then
-                  git stash pop 2>/dev/null || true
-                  echo 'Successfully rebased on top of author commits - continuing with fix'
-                else
-                  # Rebase failed - abort and let author handle it
-                  git rebase --abort 2>/dev/null || true
-                  git stash pop 2>/dev/null || true
-                  gh pr comment ${PR_NUMBER} --body '## Fix Attempt ${ATTEMPT}/3 - Aborted
-
-            Detected newer commits pushed by author. Attempted to merge but encountered conflicts.
-            Skipping automated fix to avoid overwriting author changes.
-            The author is likely fixing this themselves.'
-                  exit 0
-                fi
-              fi
-
-            Proceed with fixing:
-
-            ORIGINAL ISSUE (if applicable):
-            Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
-            ${ISSUE_BODY}
-
-            PR DESCRIPTION:
-            ${PR_TITLE}
-            ${PR_BODY}
-
-            The tests failed in the PR Tests workflow (run ID: ${RUN_ID}). Your task:
-            1. Check the workflow run logs: gh run view ${RUN_ID} --log-failed
-            2. Identify the root cause of failures (failing tests, coverage < 65%, style issues, etc.)
-            3. Fix the issues in the code
-            4. Run \`make unit-tests\` locally to verify your fix works
-            5. Commit and push your fixes
-
-            IMPORTANT RULES FOR THIS REPOSITORY:
-            - Use \`make unit-tests\` NOT \`go test\` (caching)
-            - Use \`make integration-tests\` for integration tests
-            - Use \`make pre-commit\` for linting/formatting
-            - Follow shadow state pattern (docs/reference/SHADOW_STATE.md)
-            - Never use \`git push --no-verify\`
-            - If this is attempt 2+, review what was tried before and try a different approach
-
-            After pushing, post a brief status update:
-            gh pr comment ${PR_NUMBER} --body '## Fix Attempt ${ATTEMPT}/3
-
-            [Describe what you found and fixed]
-
-            Pushed fix - triggering new test run.'" 2>&1 | tee /tmp/fix-failures-output.jsonl
+            export ATTEMPT PR_BODY ISSUE_BODY
 
       - name: Trigger PR Tests and reviews after fix
         if: success()
@@ -760,14 +617,14 @@ jobs:
         if: always()
         with:
           name: fix-failures-output-attempt-${{ needs.get-context.outputs.fix_attempts }}
-          path: /tmp/fix-failures-output.jsonl
+          path: /tmp/fix-failures-output/fix-failures-output.jsonl
           retention-days: 7
 
   # AI review (code review) - runs after design-review
   # SKIP for config-only PRs (no code to review)
   # SKIP for draft PRs (work in progress)
   ai-review:
-    needs: [get-context, build-devcontainer]
+    needs: get-context
     if: |
       needs.get-context.outputs.pr_number != '' &&
       needs.get-context.outputs.is_draft != 'true' &&
@@ -826,89 +683,30 @@ jobs:
           fetch-depth: 0
           token: ${{ github.token }}  # Read-only: parallel reviewers must not push
 
-      - name: Log in to GHCR
+      - name: Run code review
         if: steps.verify-tests.outputs.verified == 'true'
-        uses: docker/login-action@v3
+        uses: ./.github/actions/run-ci-agent
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull pre-built devcontainer image
-        if: steps.verify-tests.outputs.verified == 'true'
-        run: docker pull ${{ env.DEVCONTAINER_IMAGE }}:latest
-
-      - name: Run AI review in devcontainer
-        if: steps.verify-tests.outputs.verified == 'true'
-        uses: devcontainers/ci@v0.3
-        with:
-          imageName: ${{ env.DEVCONTAINER_IMAGE }}
-          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
-          push: never
+          image: ${{ env.CI_IMAGE }}
+          prompt_file: .github/ci/prompts/review-code.md
+          output_file: /tmp/ai-review-output/ai-review-output.jsonl
           env: |
-
             AI_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             REPO=${{ github.repository }}
             HEAD_REF=${{ needs.get-context.outputs.head_ref }}
             CROSS_PR_CONTEXT_B64=${{ needs.get-context.outputs.cross_pr_context_b64 }}
-          runCmd: |
+          pre_script: |
             CROSS_PR_CONTEXT=$(echo "$CROSS_PR_CONTEXT_B64" | base64 -d 2>/dev/null || echo "")
+            export CROSS_PR_CONTEXT
 
-            source .devcontainer/configure-ai.sh
-
-            bash .devcontainer/run-ai.sh "You are reviewing PR #${PR_NUMBER} in ${REPO}.
-
-            Review like an experienced staff engineer. Be direct and selective.
-            Don't praise the code or list things that are fine — focus on what you'd actually say in a review.
-            Non-blocking observations are welcome when they teach something, but keep each to one sentence.
-            If there are no issues, approve in one line and move on.
-
-            Tests have already passed. Focus on code quality review.
-
-            RECENT PROJECT CONTEXT (last 10 merged PRs and recent changes to files you are reviewing):
-            ${CROSS_PR_CONTEXT}
-            Consider whether this PR contradicts, duplicates, or undermines recent changes. Flag test/config
-            divergence from production code paths.
-
-            Use: \`make unit-tests\`, \`make integration-tests\`, \`make pre-commit\` to verify code.
-
-            Check for:
-            - Shadow state pattern compliance (docs/reference/SHADOW_STATE.md)
-            - Missing mutex locks on WebSocket writes
-            - Race conditions
-            - Missing error handling
-
-            IMPORTANT: Do NOT push commits. You are a parallel reviewer — only comment.
-            If you find issues that need fixing, describe them precisely (file:line, what to change)
-            so the merge-decision agent can apply fixes.
-
-            For line-specific findings, also post inline review comments via
-            \`gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews\` with event=COMMENT.
-            Batch all inline comments into one review. Only comment on lines visible in the diff.
-
-            **SUMMARY COMMENT (always required):**
-            Post exactly ONE top-level summary comment using:
-            gh pr comment ${PR_NUMBER} --body '## Code Review
-
-            [If no issues: \"✅ Approved — {one-sentence summary}\" and stop here]
-
-            ### Blocking Issues
-            [Issues that must be fixed before merge. Reference file:line. Skip section if none.]
-
-            ### Worth Considering
-            [Optional. Non-blocking observations, one sentence each. Skip section if nothing worth noting.]
-
-            ### Conclusion
-            [✅ Approved | ⚠️ Needs changes | ❌ Blocking issues]'" 2>&1 | tee /tmp/ai-review-output.jsonl
-
-      - name: Upload AI review output
+      - name: Upload code review output
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: ai-review-output
-          path: /tmp/ai-review-output.jsonl
+          path: /tmp/ai-review-output/ai-review-output.jsonl
           retention-days: 7
 
   # Design review specialist - validates PR implements issue intent and reviews design quality
@@ -916,7 +714,7 @@ jobs:
   # SKIP for config-only PRs (no design decisions to review)
   # SKIP for draft PRs (work in progress)
   design-review:
-    needs: [get-context, build-devcontainer]
+    needs: get-context
     if: |
       needs.get-context.outputs.pr_number != '' &&
       needs.get-context.outputs.is_draft != 'true' &&
@@ -979,27 +777,14 @@ jobs:
         if: steps.verify-tests.outputs.verified == 'true'
         run: git pull origin ${{ needs.get-context.outputs.head_ref }} || true
 
-      - name: Log in to GHCR
+      - name: Run design review
         if: steps.verify-tests.outputs.verified == 'true'
-        uses: docker/login-action@v3
+        uses: ./.github/actions/run-ci-agent
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull pre-built devcontainer image
-        if: steps.verify-tests.outputs.verified == 'true'
-        run: docker pull ${{ env.DEVCONTAINER_IMAGE }}:latest
-
-      - name: Design review in devcontainer
-        if: steps.verify-tests.outputs.verified == 'true'
-        uses: devcontainers/ci@v0.3
-        with:
-          imageName: ${{ env.DEVCONTAINER_IMAGE }}
-          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
-          push: never
+          image: ${{ env.CI_IMAGE }}
+          prompt_file: .github/ci/prompts/review-design.md
+          output_file: /tmp/design-review-output/design-review-output.jsonl
           env: |
-
             AI_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
@@ -1011,103 +796,29 @@ jobs:
             HEAD_REF=${{ needs.get-context.outputs.head_ref }}
             REPO=${{ github.repository }}
             CROSS_PR_CONTEXT_B64=${{ needs.get-context.outputs.cross_pr_context_b64 }}
-          runCmd: |
-            # Decode base64-encoded bodies (handles special characters safely)
+          pre_script: |
             PR_BODY=$(echo "$PR_BODY_B64" | base64 -d 2>/dev/null || echo "")
             ISSUE_BODY=$(echo "$ISSUE_BODY_B64" | base64 -d 2>/dev/null || echo "")
             CROSS_PR_CONTEXT=$(echo "$CROSS_PR_CONTEXT_B64" | base64 -d 2>/dev/null || echo "")
-
-            # Fetch all comments on the linked issue (may contain additional context/requirements)
             ISSUE_COMMENTS=""
             if [ -n "$ISSUE_NUMBER" ]; then
               ISSUE_COMMENTS=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" --jq '.[] | "---\n**\(.user.login)** commented at \(.created_at):\n\(.body)\n"' 2>/dev/null | head -c 50000 || echo "")
             fi
-
-            source .devcontainer/configure-ai.sh
-
-            bash .devcontainer/run-ai.sh "You are a DESIGN REVIEW specialist for PR #${PR_NUMBER} in ${REPO}.
-
-            Review like an experienced staff engineer. Be direct and selective.
-            Don't praise the design or list strengths — focus on what you'd actually say in a review.
-            Non-blocking observations are welcome when they steer toward better future decisions, but keep each to one sentence. No justification paragraphs.
-            If the design is sound, approve in one line and move on.
-
-            **CONTEXT:**
-            PR Title: ${PR_TITLE}
-            PR Description:
-            ${PR_BODY}
-
-            Linked Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
-            Issue Description:
-            ${ISSUE_BODY}
-
-            Issue Comments (additional context/requirements):
-            ${ISSUE_COMMENTS}
-
-            RECENT PROJECT CONTEXT (last 10 merged PRs and recent changes to files you are reviewing):
-            ${CROSS_PR_CONTEXT}
-            Consider whether this PR contradicts, duplicates, or undermines recent changes. Flag test/config
-            divergence from production code paths.
-
-            **YOUR TASK:**
-            1. Read the issue/PR description to understand the problem being solved.
-            2. Examine the code changes (\`git diff origin/main...HEAD\`).
-            3. Validate: does the PR solve the stated problem? Gaps between intent and delivery are blocking.
-            4. SCOPE CHECK: Compare the PR title/issue description against the actual diff.
-               - Run: \`git diff --stat origin/main...HEAD\`
-               - If the title suggests a narrow fix but the diff introduces new abstractions,
-                 new files, or >300 lines of non-test code beyond what the title implies,
-                 flag as BLOCKING scope creep.
-               - State explicitly: \"Scope check: PASS\" or \"Scope check: FAIL — [reason]\"
-            5. PRODUCTION RESILIENCE: For any new external integration or service call path:
-               - Does it have retry logic? If replacing an existing path, does it match or exceed
-                 the resilience of the path it replaces? Missing retries on a path that replaces
-                 a retrying path is BLOCKING.
-               - Are HTTP timeouts appropriate per operation type? (5-10s for commands, longer for
-                 data transfers. A shared 30s default is usually wrong.)
-               - Is there graceful degradation if the external service is unavailable?
-               - Does error handling distinguish transient vs permanent errors?
-            6. Evaluate design decisions: could a simpler approach work? Flag new abstractions,
-               helpers, or wrapper types that serve only one call site as BLOCKING over-engineering.
-
-            Reference docs/architecture/ARCHITECTURE.md and docs/reference/SHADOW_STATE.md for context.
-
-            IMPORTANT: Do NOT push commits. You are a parallel reviewer — only comment.
-            If you find issues that need fixing, describe them precisely so the merge-decision agent can apply fixes.
-
-            For line-specific design concerns, you may also post inline review comments via
-            \`gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews\` with event=COMMENT.
-            Only comment on lines visible in the diff.
-            Use sparingly — most design feedback is cross-cutting and belongs in the summary only.
-
-            **SUMMARY COMMENT (always required):**
-            Post exactly ONE top-level summary comment using:
-            gh pr comment ${PR_NUMBER} --body '## Design Review
-
-            [If no issues: \"✅ Approved — {one-sentence summary}\" and stop here]
-
-            ### Blocking Issues
-            [Issues that must be fixed before merge. Skip section if none.]
-
-            ### Worth Considering
-            [Optional. Non-blocking observations, one sentence each. Skip section if nothing worth noting.]
-
-            ### Conclusion
-            [✅ Approved | ⚠️ Needs changes | ❌ Blocking issues]'" 2>&1 | tee /tmp/design-review-output.jsonl
+            export PR_BODY ISSUE_BODY CROSS_PR_CONTEXT ISSUE_COMMENTS
 
       - name: Upload design review output
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: design-review-output
-          path: /tmp/design-review-output.jsonl
+          path: /tmp/design-review-output/design-review-output.jsonl
           retention-days: 7
 
   # Test-focused reviewer - runs in parallel with other reviews
   # SKIP for config-only PRs (no tests to review for config changes)
   # SKIP for draft PRs (work in progress)
   test-review:
-    needs: [get-context, build-devcontainer]
+    needs: get-context
     if: |
       needs.get-context.outputs.pr_number != '' &&
       needs.get-context.outputs.is_draft != 'true' &&
@@ -1170,100 +881,33 @@ jobs:
         if: steps.verify-tests.outputs.verified == 'true'
         run: git pull origin ${{ needs.get-context.outputs.head_ref }} || true
 
-      - name: Log in to GHCR
+      - name: Run test review
         if: steps.verify-tests.outputs.verified == 'true'
-        uses: docker/login-action@v3
+        uses: ./.github/actions/run-ci-agent
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull pre-built devcontainer image
-        if: steps.verify-tests.outputs.verified == 'true'
-        run: docker pull ${{ env.DEVCONTAINER_IMAGE }}:latest
-
-      - name: Test review in devcontainer
-        if: steps.verify-tests.outputs.verified == 'true'
-        uses: devcontainers/ci@v0.3
-        with:
-          imageName: ${{ env.DEVCONTAINER_IMAGE }}
-          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
-          push: never
+          image: ${{ env.CI_IMAGE }}
+          prompt_file: .github/ci/prompts/review-test.md
+          output_file: /tmp/test-review-output/test-review-output.jsonl
           env: |
-
             AI_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             HEAD_REF=${{ needs.get-context.outputs.head_ref }}
             REPO=${{ github.repository }}
-          runCmd: |
-            source .devcontainer/configure-ai.sh
-
-            bash .devcontainer/run-ai.sh "You are a QA tester for PR #${PR_NUMBER}.
-
-            Review like an experienced staff engineer. Be direct and selective.
-            Don't list files reviewed or describe what tests do. If there are no issues, approve in one line and move on.
-
-            Check changed files (\`git diff origin/main...HEAD --name-only\`):
-            - Go code: missing tests, time-dependent tests, slow tests (>1s)
-            - Workflows: YAML syntax, action refs, permissions
-            - Config: syntax validation
-
-            ANTI-PATTERNS TO FLAG AS BLOCKING:
-            - Race conditions in test helpers: shared mutable state (slices, maps, counters) accessed
-              from HTTP handlers or goroutines without mutex protection. grep for 'append(' in test
-              files and verify synchronization.
-            - assert.Eventually in shared test helpers: should be require.Eventually (assert continues
-              on failure causing cascading errors, require stops the test cleanly).
-            - Weakened assertions: if the PR relaxes numeric thresholds in assertions (e.g., >= 80% to
-              >= 50%, <= 1 to <= 2), this is BLOCKING unless the commit message explains why the
-              original threshold was wrong (not just flaky).
-            - Dead code path testing: if production config/code has removed a feature or code path,
-              flag NEW tests that exercise the removed path instead of the current production path.
-            - time.Sleep in new test code: flag unless there is a comment explaining why polling/channels
-              won't work. Check for existing helpers like waitForProcessing(), waitForServiceCallsToStabilize().
-
-            If the PR modifies risky areas (sleep/wake logic, music playback, multi-plugin interactions),
-            check for scenario test coverage. Reference existing patterns in test/integration/scenario_*_test.go.
-
-            Run \`make unit-tests\` to verify.
-
-            IMPORTANT: Do NOT push commits. You are a parallel reviewer — only comment.
-            If you find issues that need fixing, describe them precisely (file:line, what to change)
-            so the merge-decision agent can apply fixes.
-
-            For line-specific findings, also post inline review comments via
-            \`gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews\` with event=COMMENT.
-            Batch all inline comments into one review. Only comment on lines visible in the diff.
-
-            **SUMMARY COMMENT (always required):**
-            Post exactly ONE top-level summary comment using:
-            gh pr comment ${PR_NUMBER} --body '## Test Review
-
-            [If no issues: \"✅ Approved — {one-sentence summary}\" and stop here]
-
-            ### Blocking Issues
-            [Issues that must be fixed before merge. Skip section if none.]
-
-            ### Worth Considering
-            [Optional. Non-blocking observations, one sentence each. Skip section if nothing worth noting.]
-
-            ### Conclusion
-            [✅ Approved | ⚠️ Needs changes | ❌ Blocking issues]'" 2>&1 | tee /tmp/test-review-output.jsonl
 
       - name: Upload test review output
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-review-output
-          path: /tmp/test-review-output.jsonl
+          path: /tmp/test-review-output/test-review-output.jsonl
           retention-days: 7
 
   # Concurrency/race condition specialist - runs in parallel with other reviews
   # SKIP for config-only PRs (no Go code to analyze)
   # SKIP for draft PRs (work in progress)
   concurrency-review:
-    needs: [get-context, build-devcontainer]
+    needs: get-context
     if: |
       needs.get-context.outputs.pr_number != '' &&
       needs.get-context.outputs.is_draft != 'true' &&
@@ -1326,92 +970,33 @@ jobs:
         if: steps.verify-tests.outputs.verified == 'true'
         run: git pull origin ${{ needs.get-context.outputs.head_ref }} || true
 
-      - name: Log in to GHCR
+      - name: Run concurrency review
         if: steps.verify-tests.outputs.verified == 'true'
-        uses: docker/login-action@v3
+        uses: ./.github/actions/run-ci-agent
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull pre-built devcontainer image
-        if: steps.verify-tests.outputs.verified == 'true'
-        run: docker pull ${{ env.DEVCONTAINER_IMAGE }}:latest
-
-      - name: Concurrency review in devcontainer
-        if: steps.verify-tests.outputs.verified == 'true'
-        uses: devcontainers/ci@v0.3
-        with:
-          imageName: ${{ env.DEVCONTAINER_IMAGE }}
-          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
-          push: never
+          image: ${{ env.CI_IMAGE }}
+          prompt_file: .github/ci/prompts/review-concurrency.md
+          output_file: /tmp/concurrency-review-output/concurrency-review-output.jsonl
           env: |
-
             AI_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
             HEAD_REF=${{ needs.get-context.outputs.head_ref }}
             REPO=${{ github.repository }}
-          runCmd: |
-            source .devcontainer/configure-ai.sh
-
-            bash .devcontainer/run-ai.sh "You are a CONCURRENCY specialist reviewing PR #${PR_NUMBER}.
-
-            Review like an experienced staff engineer. Be direct and selective.
-            Don't explain concurrency concepts or list files reviewed. If there are no issues, approve in one line and move on.
-
-            Reference docs/reference/CONCURRENCY_LESSONS.md for context.
-            Run \`git diff origin/main...HEAD\` to see changes.
-
-            Check for:
-            - Missing mutex locks on shared state
-            - WebSocket writes without writeMu
-            - Goroutine leaks (missing context cancellation)
-            - Channel deadlocks
-
-            ALSO CHECK TEST CODE (test helpers have real race conditions caught by -race):
-            - Mock servers with shared mutable state (slices, maps) appended from HTTP handlers.
-            - Test helpers with counters/accumulators accessed from goroutines without sync.
-            - Run: \`grep -rn 'append(' \` in test files near httptest.NewServer and check for mutex.
-
-            Run \`make unit-tests\` (uses -race flag).
-
-            IMPORTANT: Do NOT push commits. You are a parallel reviewer — only comment.
-            If you find issues that need fixing, describe them precisely (file:line, what to change)
-            so the merge-decision agent can apply fixes.
-
-            For line-specific findings, also post inline review comments via
-            \`gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews\` with event=COMMENT.
-            Batch all inline comments into one review. Only comment on lines visible in the diff.
-
-            **SUMMARY COMMENT (always required):**
-            Post exactly ONE top-level summary comment using:
-            gh pr comment ${PR_NUMBER} --body '## Concurrency Review
-
-            [If no issues: \"✅ Approved — {one-sentence summary}\" and stop here]
-
-            ### Blocking Issues
-            [Race conditions, missing locks, etc. Reference file:line. Skip section if none.]
-
-            ### Worth Considering
-            [Optional. Non-blocking observations, one sentence each. Skip section if nothing worth noting.]
-
-            ### Conclusion
-            [✅ Approved | ⚠️ Needs changes | ❌ Blocking issues]'" 2>&1 | tee /tmp/concurrency-review-output.jsonl
 
       - name: Upload concurrency review output
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: concurrency-review-output
-          path: /tmp/concurrency-review-output.jsonl
+          path: /tmp/concurrency-review-output/concurrency-review-output.jsonl
           retention-days: 7
 
   # Documentation update specialist - runs in parallel with other reviews
   # SKIP for config-only PRs (config changes don't need doc updates)
   # SKIP for draft PRs (work in progress)
   docs-review:
-    needs: [get-context, build-devcontainer]
+    needs: get-context
     if: |
       needs.get-context.outputs.pr_number != '' &&
       needs.get-context.outputs.is_draft != 'true' &&
@@ -1474,27 +1059,14 @@ jobs:
         if: steps.verify-tests.outputs.verified == 'true'
         run: git pull origin ${{ needs.get-context.outputs.head_ref }} || true
 
-      - name: Log in to GHCR
+      - name: Run docs review
         if: steps.verify-tests.outputs.verified == 'true'
-        uses: docker/login-action@v3
+        uses: ./.github/actions/run-ci-agent
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull pre-built devcontainer image
-        if: steps.verify-tests.outputs.verified == 'true'
-        run: docker pull ${{ env.DEVCONTAINER_IMAGE }}:latest
-
-      - name: Documentation review in devcontainer
-        if: steps.verify-tests.outputs.verified == 'true'
-        uses: devcontainers/ci@v0.3
-        with:
-          imageName: ${{ env.DEVCONTAINER_IMAGE }}
-          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
-          push: never
+          image: ${{ env.CI_IMAGE }}
+          prompt_file: .github/ci/prompts/review-docs.md
+          output_file: /tmp/docs-review-output/docs-review-output.jsonl
           env: |
-
             AI_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
@@ -1504,62 +1076,23 @@ jobs:
             ISSUE_TITLE=${{ needs.get-context.outputs.issue_title }}
             ISSUE_BODY_B64=${{ needs.get-context.outputs.issue_body_b64 }}
             HEAD_REF=${{ needs.get-context.outputs.head_ref }}
-          runCmd: |
-            # Decode base64-encoded bodies (handles special characters safely)
+          pre_script: |
             PR_BODY=$(echo "$PR_BODY_B64" | base64 -d 2>/dev/null || echo "")
             ISSUE_BODY=$(echo "$ISSUE_BODY_B64" | base64 -d 2>/dev/null || echo "")
-
-            source .devcontainer/configure-ai.sh
-
-            bash .devcontainer/run-ai.sh "You are a DOCUMENTATION specialist reviewing PR #${PR_NUMBER}.
-
-            Review like an experienced staff engineer. Be direct and selective.
-            Don't list docs that don't need changes. If no docs need updating, approve in one line and move on.
-
-            Context (if available):
-            Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
-            PR: ${PR_TITLE}
-
-            Run \`git diff origin/main...HEAD\` to see changes.
-
-            Only check docs relevant to the actual code changes:
-            - Plugin changes → VISUAL_ARCHITECTURE.md, ARCHITECTURE.md, docs/flows/
-            - New Subscribe() → State Variable Dependency Graph
-            - Concurrency fix → CONCURRENCY_LESSONS.md
-            - Workflow changes (.github/workflows/*.yml) → docs/operations/AI_GHA_PIPELINES.md
-
-            If Mermaid edits needed: run \`make validate-mermaid\` after editing.
-
-            IMPORTANT: Do NOT push commits. You are a parallel reviewer — only comment.
-            If docs need updating, describe precisely what needs to change so the merge-decision
-            agent can apply the updates.
-
-            Post exactly ONE comment using:
-            gh pr comment ${PR_NUMBER} --body '## Documentation Review
-
-            [If no updates needed: \"✅ Approved — {one-sentence summary}\" and stop here]
-
-            ### Blocking Issues
-            [Docs that MUST be updated before merge. Describe exact changes needed. Skip section if none.]
-
-            ### Worth Considering
-            [Optional. Non-blocking observations, one sentence each. Skip section if nothing worth noting.]
-
-            ### Conclusion
-            [✅ Approved | ⚠️ Needs changes | ❌ Blocking issues]'" 2>&1 | tee /tmp/docs-review-output.jsonl
+            export PR_BODY ISSUE_BODY
 
       - name: Upload documentation review output
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: docs-review-output
-          path: /tmp/docs-review-output.jsonl
+          path: /tmp/docs-review-output/docs-review-output.jsonl
           retention-days: 7
 
   # Final decision maker - synthesizes all reviews and makes go/no-go call
   # SKIP for draft PRs (work in progress)
   merge-decision:
-    needs: [get-context, build-devcontainer, ai-review, design-review, test-review, concurrency-review, docs-review]
+    needs: [get-context, ai-review, design-review, test-review, concurrency-review, docs-review]
     if: |
       always() &&
       needs.get-context.outputs.pr_number != '' &&
@@ -1628,27 +1161,14 @@ jobs:
           git config user.name "claude[bot]"
           git config user.email "claude[bot]@users.noreply.github.com"
 
-      - name: Log in to GHCR
+      - name: Run merge decision
         if: steps.verify-tests.outputs.verified == 'true'
-        uses: docker/login-action@v3
+        uses: ./.github/actions/run-ci-agent
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull pre-built devcontainer image
-        if: steps.verify-tests.outputs.verified == 'true'
-        run: docker pull ${{ env.DEVCONTAINER_IMAGE }}:latest
-
-      - name: Make merge decision in devcontainer
-        if: steps.verify-tests.outputs.verified == 'true'
-        uses: devcontainers/ci@v0.3
-        with:
-          imageName: ${{ env.DEVCONTAINER_IMAGE }}
-          cacheFrom: ${{ env.DEVCONTAINER_IMAGE }}
-          push: never
+          image: ${{ env.CI_IMAGE }}
+          prompt_file: .github/ci/prompts/merge-decision.md
+          output_file: /tmp/merge-decision-output/merge-decision-output.jsonl
           env: |
-
             AI_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
             PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
@@ -1660,9 +1180,7 @@ jobs:
             DOCS_REVIEW_RESULT=${{ needs.docs-review.result }}
             CONFIG_ONLY=${{ needs.get-context.outputs.config_only }}
             CROSS_PR_CONTEXT_B64=${{ needs.get-context.outputs.cross_pr_context_b64 }}
-          runCmd: |
-            # Pre-compute conditional values to avoid $() inside double-quoted claude argument
-            # (bash -c wrapping by devcontainers/ci breaks $() inside escaped quotes)
+          pre_script: |
             if [ "${CONFIG_ONLY}" = "true" ]; then
               PR_TYPE_DESC="Config-only (reviews were streamlined)"
               CONFIG_NOTE="NOTE: This is a config-only PR. Most reviews were skipped as they don't apply to configuration changes. Focus on validating the config changes are correct and safe."
@@ -1670,82 +1188,15 @@ jobs:
               PR_TYPE_DESC="Standard"
               CONFIG_NOTE=""
             fi
-
             CROSS_PR_CONTEXT=$(echo "$CROSS_PR_CONTEXT_B64" | base64 -d 2>/dev/null || echo "")
-
-            source .devcontainer/configure-ai.sh
-
-            bash .devcontainer/run-ai.sh "You are the FINAL DECISION MAKER for PR #${PR_NUMBER}.
-
-            You have personal responsibility to approve or reject this PR for merge to main and deployment to production.
-            You are the last line of defense — if you find a concrete issue that reviewers missed, your verdict is
-            NO-GO regardless of individual approvals.
-
-            **PR TYPE:** ${PR_TYPE_DESC}
-
-            **REVIEW STATUS:**
-            - Code Review: ${AI_REVIEW_RESULT}
-            - Design Review: ${DESIGN_REVIEW_RESULT}
-            - Test Review: ${TEST_REVIEW_RESULT}
-            - Concurrency Review: ${CONCURRENCY_REVIEW_RESULT}
-            - Docs Review: ${DOCS_REVIEW_RESULT}
-
-            ${CONFIG_NOTE}
-
-            RECENT PROJECT CONTEXT (last 10 merged PRs and recent changes to files in this PR):
-            ${CROSS_PR_CONTEXT}
-
-            **YOUR TASK:**
-            1. Read ALL review comments: \`gh pr view ${PR_NUMBER} --comments\`
-            2. Read the actual diff: \`git diff origin/main...HEAD\` (focus on largest changed files)
-            3. ADDRESS ALL FINDINGS: For EVERY \"Worth Considering\" and \"Blocking Issues\" item from all reviews,
-               you must do ONE of these three things:
-               (a) Fix it in this PR (apply the change, run tests), OR
-               (b) Accept it as-is with a concrete reason why it doesn't need fixing, OR
-               (c) Create a GitHub issue to track it if the fix is outside the scope of this PR
-               Do NOT silently ignore review findings. Your merge decision comment must reference each finding.
-            4. SPOT CHECK: For the 2-3 most-changed files, verify reviewers addressed the most
-               significant changes. A one-line approval on a 500+ line diff is suspicious — dig in.
-            5. CROSS-PR CHECK: Read the recent context above. Does this PR conflict with or
-               undermine recently merged changes? (e.g., tests still exercising a removed feature)
-            6. APPLY FIXES: You are the ONLY agent that pushes commits. If any reviewer identified
-               blocking issues that have clear fixes (code changes, doc updates, missing tests),
-               implement those fixes now. Run \`make unit-tests\` and \`make pre-commit\` to verify.
-            7. Check for merge conflicts: \`git fetch origin main && git merge-base --is-ancestor origin/main HEAD || git merge origin/main --no-commit --no-ff\`
-            8. If there are merge conflicts AND you believe the PR should be merged, resolve them
-            9. Make a GO/NO-GO decision
-
-            **DECISION CRITERIA:**
-            - GO: All reviews passed or had only minor non-blocking issues (which you fixed), no merge conflicts
-              (or you resolved them), and your spot check found no issues reviewers missed
-            - NO-GO: Any review found blocking issues you cannot fix, unresolvable merge conflicts, tests are failing,
-              or you found a concrete issue that reviewers missed
-
-            **IF NO-GO:** Explain what must be fixed before the PR can merge.
-
-            **IF GO with fixes applied:** Describe fixes made, commit, push, then approve.
-
-            BEFORE PUSHING: rebase with \`git pull --rebase origin ${HEAD_REF}\`
-
-            Post exactly ONE comment:
-            gh pr comment ${PR_NUMBER} --body '## 🚦 Merge Decision
-
-            **Decision: [🟢 GO | 🔴 NO-GO]**
-
-            **Findings addressed:**
-            - [For each finding from reviews: \"Fixed: [description]\" or \"Accepted: [reason]\" or \"Deferred: [issue link]\"]
-
-            [If GO: \"Ready for merge to main and production deployment.\"]
-            [If NO-GO: List specific blockers that must be resolved.]
-
-            [If you made fixes: \"Applied fixes: [brief description]\"]'" 2>&1 | tee /tmp/merge-decision-output.jsonl
+            export PR_TYPE_DESC CONFIG_NOTE CROSS_PR_CONTEXT
 
       - name: Upload merge decision output
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: merge-decision-output
-          path: /tmp/merge-decision-output.jsonl
+          path: /tmp/merge-decision-output/merge-decision-output.jsonl
           retention-days: 7
 
       - name: Parse merge decision from PR comments
@@ -1787,7 +1238,7 @@ jobs:
   all-reviews-passed:
     name: All Required Agent Reviews
     runs-on: [self-hosted, homelab]
-    needs: [get-context, build-devcontainer, fix-test-failures, ai-review, design-review, test-review, concurrency-review, docs-review, merge-decision]
+    needs: [get-context, fix-test-failures, ai-review, design-review, test-review, concurrency-review, docs-review, merge-decision]
     if: always() && needs.get-context.outputs.author_authorized == 'true'
     permissions:
       statuses: write  # Required to create commit status on PR
@@ -1868,10 +1319,6 @@ jobs:
 
           # If tests passed, check review results
           if [ "$TESTS_PASSED" = "true" ]; then
-            if ! check_result "${{ needs.build-devcontainer.result }}"; then
-              echo "Build Devcontainer: ${{ needs.build-devcontainer.result }}"
-              failed=true
-            fi
             if ! check_result "${{ needs.ai-review.result }}"; then
               echo "AI Review: ${{ needs.ai-review.result }}"
               failed=true
@@ -1930,7 +1377,6 @@ jobs:
           echo "Review Results:"
           echo "  Tests Passed: ${{ needs.get-context.outputs.tests_passed }}"
           echo "  Fix Attempts: ${{ needs.get-context.outputs.fix_attempts }}"
-          echo "  Build Devcontainer: ${{ needs.build-devcontainer.result }}"
           echo "  Fix Test Failures: ${{ needs.fix-test-failures.result }}"
           echo "  AI Review: ${{ needs.ai-review.result }}"
           echo "  Design Review: ${{ needs.design-review.result }}"
@@ -2009,7 +1455,6 @@ jobs:
           PR_NUMBER: ${{ needs.get-context.outputs.pr_number }}
           TESTS_PASSED: ${{ needs.get-context.outputs.tests_passed }}
           FIX_ATTEMPTS: ${{ needs.get-context.outputs.fix_attempts }}
-          BUILD_RESULT: ${{ needs.build-devcontainer.result }}
           FIX_RESULT: ${{ needs.fix-test-failures.result }}
           AI_RESULT: ${{ needs.ai-review.result }}
           DESIGN_RESULT: ${{ needs.design-review.result }}


### PR DESCRIPTION
## Summary

Finishes the CI agent split for home-automation. PR #970 handled the simpler workflows (`ai-assistant`, `ai-diagnose-workflow-failure`, `ha-deprecation-check`, `update-ai-clis`); this one tackles the 2107-line multi-agent review pipeline that was still on `devcontainers/ci@v0.3`.

## What's in it

### Composite action enhancement
`.github/actions/run-ci-agent/action.yml` gains a `pre_script` input. Runs bash inside the CI container **after** `source .devcontainer/configure-ai.sh` but **before** envsubst expands the prompt file. Use case: decode base64 env vars and fetch issue comments via `gh api`. The pre-script is written to a host temp file, mounted in at `/tmp/ci-agent-pre-script.sh`, and sourced by the wrapper so any variables it exports are visible to envsubst.

Verified end-to-end locally: base64-encoded `PR_BODY` decoded in pre_script → exported → envsubst expanded template referencing both `${PR_NUMBER}` and decoded `${PR_BODY}` → run-ai.sh → LiteLLM on Tailscale → Claude returned the exact expected line.

### 7 prompt extractions
One file per reviewer role:
- `fix-test-failures.md`
- `review-code.md`
- `review-design.md`
- `review-test.md`
- `review-concurrency.md`
- `review-docs.md`
- `merge-decision.md`

Each is a verbatim extraction of the inline heredoc that lived inside the `devcontainers/ci` `runCmd` block, with `\"` → `"`, `\$` → `$`, `` \` `` → `` ` `` de-escaped (those escapes were only needed because the prompt was wrapped in devcontainers/ci's own shell quoting).

### ai-code-review.yml — 530 lines of net deletion
- **`DEVCONTAINER_IMAGE` → `CI_IMAGE`** (the new `ghcr.io/nickborgers/home-automation-ci:latest`).
- **`build-devcontainer` job deleted** (~100 lines). The CI image lives in its own build pipeline at `.github/workflows/ci-image.yml`.
- Every `needs: [get-context, build-devcontainer]` → `needs: get-context`.
- Each of the 7 reviewer jobs replaces its `Log in to GHCR` + `Pull pre-built devcontainer image` + `Run X in devcontainer (devcontainers/ci@v0.3)` sequence with a single `uses: ./.github/actions/run-ci-agent` step. Login, pull, workspace mount, env forwarding, envsubst, and run-ai.sh piping all happen inside the composite action.
- Base64 decodes (`PR_BODY_B64` → `PR_BODY`, etc.) and `gh api` fetches (ISSUE_COMMENTS in design-review) move into each job's `pre_script`.
- `merge-decision`'s `CONFIG_ONLY → PR_TYPE_DESC / CONFIG_NOTE` conditional moves into its `pre_script` so the prompt template can just envsubst-reference `${PR_TYPE_DESC}`.
- `all-reviews-passed` aggregator cleanup: drops the `build-devcontainer` reference in `needs:`, in the check-results loop, in the echo trace, and in the summary comment's `BUILD_RESULT` env var.

Diff stat:
```
 .github/actions/run-ci-agent/action.yml |  39 +-
 .github/workflows/ai-code-review.yml    | 681 +++-----------------------------
 2 files changed, 95 insertions(+), 625 deletions(-)
```
Plus 7 new prompt files (one per reviewer).

## Verification

Locally:
- `yaml.safe_load` on `ai-code-review.yml` → clean
- `actionlint` clean (only 2 pre-existing `SC2034` warnings in shell blocks I didn't touch + the `homelab` self-hosted runner label)
- Composite action's new `pre_script` feature exercised end-to-end against real home-automation workspace and real Claude invocation via LiteLLM/Tailscale
- `grep` for stragglers: no remaining `devcontainers/ci`, `DEVCONTAINER_IMAGE`, or `build-devcontainer` references in the workflow

Not locally tested (needs GitHub):
- Real `workflow_run` trigger on a test PR
- The `review-coverage-evaluator.yml` interaction (unchanged, but it depends on get-context outputs that are unchanged)
- Real Codex / fix-test-failures loop

## Compatibility

Every reviewer job continues to:
- Use the same `runs-on: [self-hosted, homelab]`
- Hold the same `permissions:` block
- Run the same `Verify tests passed on current commit` gate
- Checkout the same PR branch
- Upload the same-named artifact
- Use the same secrets (`ANTHROPIC_API_KEY`, `WORKFLOW_PAT`)

The change is entirely container-invocation plumbing. Prompt contents are unchanged. Agent behavior should be identical to before.

## Follow-ups (this PR does NOT include)

- `hide-my-list` CI refactor — same pattern, needs its own branch + PR
- `home-automation-plus-security` CI refactor — same pattern, needs its own branch + PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)