### PR TITLE
ci: strip comments/blank lines when loading versions.env into $GITHUB_ENV

### DIFF
--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -225,7 +225,8 @@ jobs:
       - name: Load pinned CLI versions
         if: steps.check-changes.outputs.should_build == 'true'
         run: |
-          cat .github/ci/versions.env >> "$GITHUB_ENV"
+          # $GITHUB_ENV rejects comment lines and blank lines — strip them.
+          grep -Ev '^\s*(#|$)' .github/ci/versions.env >> "$GITHUB_ENV"
 
       - name: Build and push CI image
         if: steps.check-changes.outputs.should_build == 'true'

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -58,7 +58,8 @@ jobs:
       - name: Load pinned CLI versions
         run: |
           set -eux
-          cat .github/ci/versions.env >> "$GITHUB_ENV"
+          # $GITHUB_ENV rejects comment lines and blank lines — strip them.
+          grep -Ev '^\s*(#|$)' .github/ci/versions.env >> "$GITHUB_ENV"
 
       - name: Resolve tag
         id: tag


### PR DESCRIPTION
## Summary
Hotfix for [run #24293048158](https://github.com/NickBorgers/home-automation/actions/runs/24293048158/job/70933449563) which failed with:

```
Run cat .github/ci/versions.env >> "$GITHUB_ENV"
Error: Unable to process file command 'env' successfully.
Error: Invalid format '# CI agent image pinned versions.'
```

`$GITHUB_ENV`'s file-command parser rejects both comment lines (`#…`) and blank lines — the header comments I put in `.github/ci/versions.env` for humans were being piped through and blowing up the env load.

## Fix
Pipe through `grep -Ev '^\s*(#|$)'` in both call sites so only the actual `KEY=VALUE` lines reach `$GITHUB_ENV`:

- `.github/workflows/ci-image.yml` — main "Load pinned CLI versions" step
- `.github/workflows/ai-assistant.yml` — the same step inside the `ensure-ci-image` pre-job

Verified locally — grep output is clean four-line key=value:
```
CLAUDE_CODE_VERSION=2.1.92
CODEX_CLI_VERSION=0.118.0
CRUSH_CLI_VERSION=0.55.0
NODE_MAJOR=20
```

## Residual risk
Minimal — same two-file change, `yaml.safe_load` passes on both.

## Impact
Unblocks the CI image build, which is what the refactored agent workflows pull from. Needs to land before the new `ai-diagnose-workflow-failure` / `ai-assistant` / `ha-deprecation-check` runs will actually succeed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)