### PR TITLE
config: move Piano Guys playlist from evening to day rotation

### DIFF
--- a/configs/music_config.yaml
+++ b/configs/music_config.yaml
@@ -231,6 +231,11 @@ music:
           https://tidal.com/browse/playlist/89b0c117-c11b-46fc-9ef9-766c2701f73e
         media_type: tidal
         volume_multiplier: 1.0
+      # The Piano Guys (moved from evening — better fit for afternoon)
+      # yamllint disable-line rule:line-length
+      - uri: http://rain-sounds.nickborgers.net:8080/playlists/evening-piano-guys.m3u
+        media_type: music
+        volume_multiplier: 1.8
   evening:
     participants:
       - player_name: "Front Room"
@@ -363,11 +368,6 @@ music:
       - uri: http://rain-sounds.nickborgers.net:8080/playlists/evening-levit-beethoven-cd9.m3u
         media_type: music
         volume_multiplier: 2.5
-      # The Piano Guys
-      # yamllint disable-line rule:line-length
-      - uri: http://rain-sounds.nickborgers.net:8080/playlists/evening-piano-guys.m3u
-        media_type: music
-        volume_multiplier: 1.8
   winddown:
     participants:
       - player_name: "Front Room"


### PR DESCRIPTION
## Summary

- Removes The Piano Guys playlist (`evening-piano-guys.m3u`) from `evening.playback_options`
- Adds it to `day.playback_options` (after the last Tidal entry)
- Same URI and `volume_multiplier: 1.8` — just a rotation change

Closes #961

## Test plan
- [x] yamllint passes on `music_config.yaml`
- [x] Unit tests pass (75.5% coverage)
- [x] Integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)