### PR TITLE
ci: stage run-ci-agent bind-mount files in $RUNNER_TEMP, not /tmp

### DIFF
--- a/.github/actions/run-ci-agent/action.yml
+++ b/.github/actions/run-ci-agent/action.yml
@@ -74,8 +74,21 @@ runs:
         PRE_SCRIPT_INPUT: ${{ inputs.pre_script }}
       run: |
         set -euo pipefail
-        ENV_FILE="$(mktemp)"
-        PRE_SCRIPT_FILE="$(mktemp --suffix=.sh)"
+        # The pre-script file needs to be visible to the docker daemon that
+        # resolves the `-v` bind mount. On the self-hosted runner, that
+        # daemon runs on the host (dockergeneric), not inside the runner
+        # container — so files under /tmp (the runner's private /tmp) are
+        # NOT host-visible and bind-mounting them ends up materializing a
+        # root-owned empty directory at the mount target.
+        #
+        # $RUNNER_TEMP lives inside /tmp/runner-work-<repo>-<N>/_temp/,
+        # which IS bind-mounted from host → runner. Files written here are
+        # host-visible at the same absolute path. This is also why the
+        # workspace bind mount works end-to-end.
+        STAGING_DIR="${RUNNER_TEMP:-/tmp}/ci-agent"
+        mkdir -p "$STAGING_DIR"
+        ENV_FILE="$(mktemp "${STAGING_DIR}/env.XXXXXX")"
+        PRE_SCRIPT_FILE="$(mktemp "${STAGING_DIR}/pre-script.XXXXXX.sh")"
         # Filter blank lines and comment lines in env input; pass the rest through.
         printf '%s\n' "$ENV_INPUT" \
           | grep -Ev '^\s*(#|$)' \


### PR DESCRIPTION
## Summary
Third hotfix for the CI-split rollout. The multi-reviewer pipeline (#971) runs now but the `merge-decision` job crashes at [run 24293441691](https://github.com/NickBorgers/home-automation/actions/runs/24293441691):

```
/bin/bash: line 6: source: /tmp/ci-agent-pre-script.sh: is a directory
```

## Root cause
Self-hosted runner filesystem-namespace bug, same class as the original bind-mount issue.

`run-ci-agent/action.yml` was staging its pre-script file via bare `mktemp`, which drops it under the runner's `/tmp`. The runner is a container on dockergeneric using the host's docker daemon via shared socket — bind-mount sources resolve against the **host** filesystem. `/tmp` inside the runner container isn't visible to the host daemon, so `docker run -v /tmp/tmp.XXX:/tmp/ci-agent-pre-script.sh` silently materializes the target as a root-owned empty directory. Inside the container, `source` a directory → bash dies.

## Fix
Stage both the env file and the pre-script file under `$RUNNER_TEMP`:

```bash
STAGING_DIR="${RUNNER_TEMP:-/tmp}/ci-agent"
mkdir -p "$STAGING_DIR"
ENV_FILE="$(mktemp "${STAGING_DIR}/env.XXXXXX")"
PRE_SCRIPT_FILE="$(mktemp "${STAGING_DIR}/pre-script.XXXXXX.sh")"
```

`$RUNNER_TEMP` on the homelab runner is `/tmp/runner-work-<repo>-<N>/_temp/` — which **is** bind-mounted from host → runner, so files there are visible to both sides. This is the same property that makes the workspace bind mount work.

Added a long inline comment capturing the full class (host vs. runner fs namespace, why `/tmp` fails, why `$RUNNER_TEMP` works) so this doesn't get rediscovered a fourth time.

## Residual / deferred
Root-cause fix would be switching the runner to docker-in-docker so bind-mount sources resolve against the runner container's own filesystem instead of the host. That's a dockergeneric deployment change + Tailscale sidecar / image-cache design questions, parked for a separate design pass.

Three prior instances of this class in the last week:
1. `~/.claude` / `~/.bashrc` passthrough mounts (reverted via the devcontainer → CI split)
2. `/home/runner/.claude` placeholders from `initializeCommand` (became dead code after the split)
3. This one — workaround landed here

All three followed the same "source path inside runner, not host-visible" shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)