### PR TITLE
ci: chmod 644 pre-script file so UID-1000 ci user can source it

### DIFF
--- a/.github/actions/run-ci-agent/action.yml
+++ b/.github/actions/run-ci-agent/action.yml
@@ -93,10 +93,17 @@ runs:
         printf '%s\n' "$ENV_INPUT" \
           | grep -Ev '^\s*(#|$)' \
           > "$ENV_FILE" || true
+        # --env-file is read client-side by `docker` on the runner, so it
+        # only needs to be readable by the runner user.
         chmod 600 "$ENV_FILE"
-        # The pre-script goes in verbatim (or empty).
+        # The pre-script goes in verbatim (or empty). It's mounted into the
+        # container and sourced as UID 1000 (`ci` user) — but created here
+        # by the runner user (typically UID 1001). Mode 644 lets the `ci`
+        # user read it despite the uid mismatch. Safe: the content is
+        # generated from workflow YAML and contains no secrets (credentials
+        # come in via `--env-file`, not the pre-script body).
         printf '%s\n' "$PRE_SCRIPT_INPUT" > "$PRE_SCRIPT_FILE"
-        chmod 600 "$PRE_SCRIPT_FILE"
+        chmod 644 "$PRE_SCRIPT_FILE"
         echo "env_file=$ENV_FILE" >> "$GITHUB_OUTPUT"
         echo "pre_script_file=$PRE_SCRIPT_FILE" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
Fourth and (hopefully) final hotfix in the run-ci-agent / bind-mount saga. After #976 moved staging files into `\$RUNNER_TEMP` so the docker daemon could see them, [run 24293558321](https://github.com/NickBorgers/home-automation/actions/runs/24293558321/job/70934711047) failed one step further:

```
/bin/bash: line 6: /tmp/ci-agent-pre-script.sh: Permission denied
```

## Root cause
UID mismatch between the runner container (which writes the pre-script file as the runner user, UID 1001, with mode 600) and the CI image (which sources it as the `ci` user, UID 1000). Mode 600 means owner-only — the uid mismatch blocks the read.

## Fix
`chmod 644` on the pre-script file. It's world-readable, which is fine because:

- The pre-script body is generated from workflow YAML — it's bash that decodes `PR_BODY_B64`, computes `PR_TYPE_DESC`, fetches issue comments, etc. No secrets.
- Credentials flow through `--env-file`, which is read **client-side** by docker on the runner and never mounted. That file stays at 600.

I added a comment explaining the split between `--env-file` (client-read, 600) and the pre-script (mounted, needs to be readable as the container's user, 644).

## Progress this session
```
#970  split CI agent container from devcontainer (foundation)  — merged
#971  refactor ai-code-review onto CI image                     — merged
#972  strip comment/blank lines from versions.env               — merged
#973  read AI_API_KEY from vars.AI_API_KEY not secrets.ANTHROPIC — merged
#976  stage bind-mount files in $RUNNER_TEMP not /tmp           — merged
#977  chmod 644 pre-script file                                 — this PR
```

Each hotfix has caught a distinct bug class. No regressions, just progressively peeling layers off the docker-socket-sharing topology. After this one merges, the expected failure modes on the next run narrow to "the actual agent prompt / LiteLLM path" — i.e., if anything still breaks, it's something we haven't tested locally yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)