### PR TITLE
ci: stage run-ci-agent output directory in $RUNNER_TEMP

### DIFF
--- a/.github/actions/run-ci-agent/action.yml
+++ b/.github/actions/run-ci-agent/action.yml
@@ -118,8 +118,25 @@ runs:
       run: |
         set -euo pipefail
 
-        OUTPUT_DIR="$(dirname "$CI_AGENT_OUTPUT_FILE")"
-        mkdir -p "$OUTPUT_DIR"
+        # The output directory needs two properties:
+        #   1. Host-visible to the docker daemon (same constraint as the
+        #      pre-script — see the stage-files step for the full rationale).
+        #   2. Writable as the container's non-root `ci` user (UID 1000).
+        #
+        # Path (1) means the mount source must live under $RUNNER_TEMP so
+        # the daemon on dockergeneric can resolve it. Property (2) means
+        # the directory must be world-writable, because it's created by
+        # the runner user (UID 1001) and then written by a different uid
+        # inside the container.
+        #
+        # We stage into $RUNNER_TEMP/ci-agent-output/<unique>/, then after
+        # the container exits we copy the result to the caller's requested
+        # output_file path so their upload-artifact step (which expects
+        # that path) keeps working.
+        OUTPUT_STAGING_ROOT="${RUNNER_TEMP:-/tmp}/ci-agent-output"
+        OUTPUT_STAGING_DIR="$(mktemp -d "${OUTPUT_STAGING_ROOT}/XXXXXX")"
+        chmod 777 "$OUTPUT_STAGING_DIR"
+        STAGED_OUTPUT_FILE="${OUTPUT_STAGING_DIR}/$(basename "$CI_AGENT_OUTPUT_FILE")"
 
         # Mount the pre-script into a known path inside the container; the
         # wrapper below sources it so any vars it exports are visible to
@@ -128,11 +145,11 @@ runs:
           --network host \
           --workdir /workspace \
           -v "${{ github.workspace }}:/workspace" \
-          -v "$OUTPUT_DIR:$OUTPUT_DIR" \
+          -v "$OUTPUT_STAGING_DIR:$OUTPUT_STAGING_DIR" \
           -v "$CI_AGENT_PRE_SCRIPT_FILE:/tmp/ci-agent-pre-script.sh:ro" \
           --env-file "$CI_AGENT_ENV_FILE" \
           -e CI_AGENT_PROMPT_FILE \
-          -e CI_AGENT_OUTPUT_FILE \
+          -e "CI_AGENT_OUTPUT_FILE=$STAGED_OUTPUT_FILE" \
           "$CI_AGENT_IMAGE" \
           -lc '
             set -euo pipefail
@@ -145,6 +162,17 @@ runs:
             bash .devcontainer/run-ai.sh "$PROMPT" 2>&1 \
               | tee "$CI_AGENT_OUTPUT_FILE"
           '
+
+        # Copy the staged output back to the caller-requested path so
+        # their upload-artifact step reads it from the same path they
+        # wrote when declaring the step. The staged path lives inside
+        # $RUNNER_TEMP which is ephemeral; the caller's path is typically
+        # /tmp/<name>-output/<name>-output.jsonl on the runner fs.
+        mkdir -p "$(dirname "$CI_AGENT_OUTPUT_FILE")"
+        if [ -f "$STAGED_OUTPUT_FILE" ]; then
+          cp "$STAGED_OUTPUT_FILE" "$CI_AGENT_OUTPUT_FILE"
+        fi
+        rm -rf "$OUTPUT_STAGING_DIR"
 
     - name: Clean up staged files
       if: always()


### PR DESCRIPTION
## Summary
Fifth hotfix. **The good news**: run [24293638548](https://github.com/NickBorgers/home-automation/actions/runs/24293638548/job/70934903214) shows the agent path is actually working end-to-end. Claude connected to LiteLLM through the nested `docker run`, reasoned, and posted the merge-decision comment on the PR. You can see the PR comment.

**The bug**: `tee` blew up capturing the agent's stdout stream for the artifact upload:

```
tee: /tmp/merge-decision-output/merge-decision-output.jsonl: Permission denied
```

Same topology class as #976, one layer deeper. #976 fixed the pre-script staging path but the **output directory** is still being created at the caller-requested path (typically `/tmp/<name>-output/`) which lives inside the runner container's private `/tmp`. When `docker run` tries to bind-mount it, the host daemon materializes it as root-owned on the host fs, and the non-root `ci` user (UID 1000) inside the container can't write into a root-owned mount.

## Fix
Stage the output dir under `$RUNNER_TEMP/ci-agent-output/<unique>/` (host-visible + runner-writable), chmod 777 so the inner UID can write, override `CI_AGENT_OUTPUT_FILE` to point at the staging path for the inner `tee`, and copy the staged file back to the caller-requested path after `docker run` exits. The caller's `upload-artifact` step still finds the file at the path it declared — this is purely internal plumbing.

## Caller API
`run-ci-agent` inputs (image, prompt_file, output_file, env, pre_script) are unchanged. No workflow changes needed.

## Saga status
```
#970  foundation (split + 4 workflows)              merged
#971  refactor ai-code-review.yml                   merged
#972  strip comments when loading versions.env      merged
#973  read AI_API_KEY from vars not secrets         merged
#976  stage pre-script in $RUNNER_TEMP              merged
#979  chmod 644 the pre-script file                 merged
#NNN  stage output dir in $RUNNER_TEMP              THIS PR
```

We've been systematically peeling layers off the shared-docker-socket topology. Each bug so far has been a distinct manifestation of "thing that worked under devcontainers/ci now visible under raw `docker run` with a non-root user". The positive signal is that the agent invocation **itself** now works — the remaining bugs have all been at the IO boundary (loading env, writing output). After this merges, the next expected failure mode is "there isn't one" — but if there is, it'll be something new, not another permutation of the topology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)