### PR TITLE
ci: mkdir -p output staging root before mktemp -d

### DIFF
--- a/.github/actions/run-ci-agent/action.yml
+++ b/.github/actions/run-ci-agent/action.yml
@@ -134,6 +134,7 @@ runs:
         # output_file path so their upload-artifact step (which expects
         # that path) keeps working.
         OUTPUT_STAGING_ROOT="${RUNNER_TEMP:-/tmp}/ci-agent-output"
+        mkdir -p "$OUTPUT_STAGING_ROOT"
         OUTPUT_STAGING_DIR="$(mktemp -d "${OUTPUT_STAGING_ROOT}/XXXXXX")"
         chmod 777 "$OUTPUT_STAGING_DIR"
         STAGED_OUTPUT_FILE="${OUTPUT_STAGING_DIR}/$(basename "$CI_AGENT_OUTPUT_FILE")"


### PR DESCRIPTION
One-line follow-up to #982. \`mktemp -d\` was trying to create a directory under \`\$RUNNER_TEMP/ci-agent-output/\` on a fresh runner where that parent didn't exist yet. Add \`mkdir -p\` before the \`mktemp -d\`.

Seen in run 24293746038:
\`\`\`
mktemp: failed to create directory via template
'/tmp/runner-work-home-automation-5/_temp/ci-agent-output/XXXXXX':
No such file or directory
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)