### PR TITLE
refactor: remove interactive AI job, keep only /autoresolve + /review

### DIFF
--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -1,22 +1,13 @@
-name: AI Assistant
+name: Issue Resolution Agent
 
 on:
   issue_comment:
     types: [created]
-  pull_request_review_comment:
-    types: [created]
   issues:
     types: [opened, assigned, unlabeled]
-  pull_request_review:
-    types: [submitted]
 
 concurrency:
-  group: >-
-    ai-interactive-${{
-      github.event_name == 'pull_request_review_comment' && github.event.pull_request.number ||
-      github.event_name == 'pull_request_review' && github.event.pull_request.number ||
-      github.event.issue.number
-    }}
+  group: ai-interactive-${{ github.event.issue.number }}
   cancel-in-progress: true
 
 # SECURITY NOTE: This workflow grants the AI assistant access to secrets and write permissions.
@@ -46,7 +37,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           COMMENT_BODY: ${{ github.event.comment.body || '' }}
-          REVIEW_BODY: ${{ github.event.review.body || '' }}
           LABEL_NAME: ${{ github.event.label.name || '' }}
           ISSUE_STATE: ${{ github.event.issue.state || '' }}
           ACTION_TYPE: ${{ github.event.action || '' }}
@@ -59,14 +49,6 @@ jobs:
             issue_comment)
               AUTHOR_ASSOC="${{ github.event.comment.author_association }}"
               ACTOR="${{ github.event.comment.user.login }}"
-              ;;
-            pull_request_review_comment)
-              AUTHOR_ASSOC="${{ github.event.comment.author_association }}"
-              ACTOR="${{ github.event.comment.user.login }}"
-              ;;
-            pull_request_review)
-              AUTHOR_ASSOC="${{ github.event.review.author_association }}"
-              ACTOR="${{ github.event.review.user.login }}"
               ;;
             issues)
               AUTHOR_ASSOC="${{ github.event.issue.author_association }}"
@@ -101,28 +83,17 @@ jobs:
               ;;
           esac
 
-          # Comment / review fallback path: require a plain-text /autoresolve
-          # mention and screen out auto-generated review comments to prevent
-          # feedback loops.
-          if [ "$SHOULD_RUN" = "true" ] && { [ "$EVENT_NAME" = "pull_request_review" ] || [ "$EVENT_NAME" = "pull_request_review_comment" ] || [ "$EVENT_NAME" = "issue_comment" ]; }; then
-            AUTO_REVIEW_PATTERNS="## Code Review|## Design Review|## Test Review|## Concurrency Review|## Documentation Review|## Fix Attempt|## 🚦 Merge Decision|## 📋 Agent Review Summary|## AI Code Review Skipped|## ❌ Automated Fix Failed"
-            case "$EVENT_NAME" in
-              pull_request_review)          BODY="$REVIEW_BODY" ;;
-              pull_request_review_comment)  BODY="$COMMENT_BODY" ;;
-              issue_comment)                BODY="$COMMENT_BODY" ;;
-              *)                            BODY="" ;;
-            esac
+          # issue_comment path: require a plain-text /autoresolve mention.
+          if [ "$SHOULD_RUN" = "true" ] && [ "$EVENT_NAME" = "issue_comment" ]; then
+            BODY="$COMMENT_BODY"
 
             if [ -z "$BODY" ]; then
-              echo "ℹ️ Empty comment/review body received. Skipping AI run."
-              SHOULD_RUN="false"
-            elif echo "$BODY" | grep -Eq "$AUTO_REVIEW_PATTERNS"; then
-              echo "🛑 Detected auto-generated review comment (matches known review headings). Skipping AI run to prevent feedback loop."
+              echo "ℹ️ Empty comment body received. Skipping AI run."
               SHOULD_RUN="false"
             else
               PLAIN_MENTION=$(printf %s "$BODY" | python3 .github/scripts/has_plain_token.py "$TRIGGER_TOKEN")
               if [ "$PLAIN_MENTION" != "true" ]; then
-                echo "ℹ️ No plain-text '$TRIGGER_TOKEN' found in comment/review body (ignoring code blocks and links). Skipping AI run."
+                echo "ℹ️ No plain-text '$TRIGGER_TOKEN' found in comment body (ignoring code blocks and links). Skipping AI run."
                 SHOULD_RUN="false"
               fi
             fi
@@ -157,245 +128,9 @@ jobs:
 
           echo "should_run_ai=$SHOULD_RUN" >> $GITHUB_OUTPUT
 
-  # Ensure the CI image exists in GHCR. If .github/ci/** changed in this
-  # PR or the image isn't yet published, rebuild. Otherwise the agent job
-  # just pulls the existing latest tag.
-  ensure-ci-image:
-    needs: authorize
-    if: |
-      needs.authorize.outputs.authorized == 'true' &&
-      needs.authorize.outputs.should_run_ai == 'true'
-    runs-on: [self-hosted, homelab]
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Check if CI image files changed
-        id: check-changes
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          if [ "${{ github.event_name }}" = "issues" ] && [ "${{ github.event.action }}" = "opened" ]; then
-            CI_FILES_CHANGED="false"
-          elif [ -n "${{ github.event.issue.pull_request || github.event.pull_request.number }}" ]; then
-            PR_NUMBER="${{ github.event.issue.number || github.event.pull_request.number }}"
-            CHANGED_FILES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
-            if echo "$CHANGED_FILES" | grep -qE "^\.github/ci/"; then
-              CI_FILES_CHANGED="true"
-            else
-              CI_FILES_CHANGED="false"
-            fi
-          else
-            CI_FILES_CHANGED="false"
-          fi
-
-          if docker manifest inspect "${{ env.CI_IMAGE }}" >/dev/null 2>&1; then
-            IMAGE_EXISTS="true"
-          else
-            IMAGE_EXISTS="false"
-          fi
-
-          if [ "$CI_FILES_CHANGED" = "true" ] || [ "$IMAGE_EXISTS" = "false" ]; then
-            echo "should_build=true" >> $GITHUB_OUTPUT
-            echo "✅ Will build CI image (ci_files_changed=$CI_FILES_CHANGED, image_exists=$IMAGE_EXISTS)"
-          else
-            echo "should_build=false" >> $GITHUB_OUTPUT
-            echo "⏭️  Skipping CI image build (image present, no CI files changed)"
-          fi
-
-      - name: Log in to GHCR
-        if: steps.check-changes.outputs.should_build == 'true'
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Buildx
-        if: steps.check-changes.outputs.should_build == 'true'
-        uses: docker/setup-buildx-action@v3
-
-      - name: Load pinned CLI versions
-        if: steps.check-changes.outputs.should_build == 'true'
-        run: |
-          # $GITHUB_ENV rejects comment lines and blank lines — strip them.
-          grep -Ev '^\s*(#|$)' .github/ci/versions.env >> "$GITHUB_ENV"
-
-      - name: Build and push CI image
-        if: steps.check-changes.outputs.should_build == 'true'
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: .github/ci/Dockerfile
-          push: true
-          tags: |
-            ${{ env.CI_IMAGE }}
-            ghcr.io/nickborgers/home-automation-ci:${{ github.sha }}
-          build-args: |
-            CLAUDE_CODE_VERSION=${{ env.CLAUDE_CODE_VERSION }}
-            CODEX_CLI_VERSION=${{ env.CODEX_CLI_VERSION }}
-            CRUSH_CLI_VERSION=${{ env.CRUSH_CLI_VERSION }}
-            NODE_MAJOR=${{ env.NODE_MAJOR }}
-          cache-from: |
-            type=gha
-            type=registry,ref=ghcr.io/nickborgers/home-automation-ci:buildcache
-          cache-to: |
-            type=gha,mode=max
-            type=registry,ref=ghcr.io/nickborgers/home-automation-ci:buildcache,mode=max
-
-  ai:
-    needs: [authorize, ensure-ci-image]
-    # The authorize job has already confirmed the actor is authorized and that
-    # a plain-text /autoresolve mention is present in the comment/review body
-    # (ignoring code blocks and links). This job handles the comment/review
-    # fallback path only — issues events are routed to resolve-issue below.
-    if: |
-      needs.authorize.outputs.authorized == 'true' &&
-      needs.authorize.outputs.should_run_ai == 'true' &&
-      (github.event_name == 'issue_comment' ||
-       github.event_name == 'pull_request_review_comment' ||
-       github.event_name == 'pull_request_review')
-    runs-on: [self-hosted, homelab]
-    timeout-minutes: 60
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-      actions: read
-      packages: read
-
-    steps:
-      - name: Get PR context
-        id: pr-context
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          IS_PR="false"
-          PR_HEAD_REF=""
-          PR_NUMBER=""
-
-          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
-            IS_PR="true"
-            PR_NUMBER="${{ github.event.pull_request.number }}"
-            PR_HEAD_REF="${{ github.event.pull_request.head.ref }}"
-          elif [ "${{ github.event_name }}" = "pull_request_review" ]; then
-            IS_PR="true"
-            PR_NUMBER="${{ github.event.pull_request.number }}"
-            PR_HEAD_REF="${{ github.event.pull_request.head.ref }}"
-          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
-            if [ -n "${{ github.event.issue.pull_request }}" ]; then
-              IS_PR="true"
-              PR_NUMBER="${{ github.event.issue.number }}"
-              PR_HEAD_REF=$(gh api repos/${{ github.repository }}/pulls/${PR_NUMBER} --jq '.head.ref')
-            fi
-          fi
-
-          echo "is_pr=$IS_PR" >> $GITHUB_OUTPUT
-          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-          echo "pr_head_ref=$PR_HEAD_REF" >> $GITHUB_OUTPUT
-          echo "Detected: IS_PR=$IS_PR, PR_NUMBER=$PR_NUMBER, PR_HEAD_REF=$PR_HEAD_REF"
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.WORKFLOW_PAT }}  # PAT required to push workflow file changes
-          ref: ${{ steps.pr-context.outputs.is_pr == 'true' && steps.pr-context.outputs.pr_head_ref || github.ref }}
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull CI image
-        run: docker pull "${CI_IMAGE}"
-
-      - name: Run AI assistant
-        env:
-          AI_API_KEY: ${{ vars.AI_API_KEY }}
-          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
-          EVENT_NAME: ${{ github.event_name }}
-          COMMENT_ID: ${{ github.event.comment.id }}
-          REVIEW_ID: ${{ github.event.review.id }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-          IS_PR: ${{ steps.pr-context.outputs.is_pr }}
-          PR_HEAD_REF: ${{ steps.pr-context.outputs.pr_head_ref }}
-        run: |
-          set -euo pipefail
-          mkdir -p /tmp/ai-output
-
-          docker run --rm \
-            --network host \
-            --workdir /workspace \
-            -v "${{ github.workspace }}:/workspace" \
-            -v /tmp/ai-output:/tmp/ai-output \
-            -e AI_API_KEY \
-            -e GH_TOKEN \
-            -e EVENT_NAME \
-            -e COMMENT_ID \
-            -e REVIEW_ID \
-            -e PR_NUMBER \
-            -e ISSUE_NUMBER \
-            -e REPO \
-            -e IS_PR \
-            -e PR_HEAD_REF \
-            "${CI_IMAGE}" \
-            -lc '
-              set -euo pipefail
-              source .devcontainer/configure-ai.sh
-
-              # Fetch comment/review/issue body via API to avoid docker env-var
-              # escaping issues for multi-line content with special characters.
-              case "$EVENT_NAME" in
-                issue_comment)
-                  COMMENT_BODY=$(gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" --jq ".body // \"\"")
-                  ;;
-                pull_request_review_comment)
-                  COMMENT_BODY=$(gh api "repos/${REPO}/pulls/comments/${COMMENT_ID}" --jq ".body // \"\"")
-                  ;;
-                pull_request_review)
-                  COMMENT_BODY=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews/${REVIEW_ID}" --jq ".body // \"\"")
-                  ;;
-                issues)
-                  COMMENT_BODY=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq ".body // \"\"")
-                  ;;
-              esac
-              export COMMENT_BODY
-
-              if [ "$IS_PR" = "true" ]; then
-                PROMPT_FILE=.github/ci/prompts/ai-comment-pr.md
-              else
-                PROMPT_FILE=.github/ci/prompts/ai-comment-issue.md
-              fi
-
-              PROMPT=$(envsubst < "$PROMPT_FILE")
-              bash .devcontainer/run-ai.sh "$PROMPT" 2>&1 \
-                | tee /tmp/ai-output/ai-conversation.jsonl
-            '
-
-      - name: Upload AI conversation log
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: ai-conversation-log
-          path: /tmp/ai-output/ai-conversation.jsonl
-          retention-days: 7
-
   # Auto-resolve new issues by opening a PR
   resolve-issue:
-    needs: [authorize, ensure-ci-image]
+    needs: [authorize]
     if: |
       needs.authorize.outputs.authorized == 'true' &&
       needs.authorize.outputs.should_run_ai == 'true' &&
@@ -413,6 +148,7 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+      actions: read
       packages: read
 
     steps:


### PR DESCRIPTION
## Summary
- Removes the interactive `ai` job that responded to PR/issue comments
- Keeps `resolve-issue` job for `/autoresolve` issue resolution
- Removes `pull_request_review_comment` and `pull_request_review` triggers (no longer needed)
- Simplifies authorize job (no longer needs review comment handling)
- Renames workflow to "Issue Resolution Agent"

Part of cross-repo alignment: standardizing on `/autoresolve` (issues) + `/review` (PRs) only. The interactive "respond to comments" feature may return later as `/ai`.

## Test plan
- [ ] `/autoresolve` on issues still triggers resolution
- [ ] Issue opened/assigned still triggers resolution
- [ ] Remove `ai-started` label still triggers retry
- [ ] PR comments no longer trigger any response from this workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)