### PR TITLE
Fix #991: spurious lockdown during owner handoff

### DIFF
--- a/docs/flows/SECURITY.md
+++ b/docs/flows/SECURITY.md
@@ -21,6 +21,11 @@ flowchart TD
         everyoneAsleep["isEveryoneAsleep = true"]
     end
 
+    subgraph GraceCheck["Arrival Grace Period (issue #991)"]
+        checkGrace{"Owner arrived within\nArrivalLockdownGracePeriod?"}
+        suppress["Suppress lockdown\n(log and return)"]
+    end
+
     subgraph Sequence["Activation Sequence"]
         turnOff["Turn lockdown OFF"]
         wait["Wait 30 seconds"]
@@ -33,7 +38,9 @@ flowchart TD
         reset["Turn lockdown OFF"]
     end
 
-    noOneHome --> turnOff
+    noOneHome --> checkGrace
+    checkGrace -->|Yes| suppress
+    checkGrace -->|No| turnOff
     everyoneAsleep --> turnOff
     turnOff --> wait
     wait --> turnOn
@@ -195,6 +202,7 @@ flowchart TD
 |----------|----------|---------|
 | Lockdown clear delay | 30 seconds | Time to wait before re-activating lockdown |
 | Lockdown reset delay | 5 seconds | Time before auto-resetting lockdown |
+| `ArrivalLockdownGracePeriod` | 5 minutes | Suppress "no one home" lockdown after recent owner arrival |
 | Doorbell rate limit | 20 seconds | Minimum time between doorbell notifications |
 | Doorbell flash delay | 2 seconds | Delay between light flashes |
 | Vehicle rate limit | 20 seconds | Minimum time between vehicle notifications |

--- a/docs/flows/STATE_TRACKING.md
+++ b/docs/flows/STATE_TRACKING.md
@@ -83,6 +83,7 @@ flowchart TD
 
     lightsOff --> start
     start -->|Lights turn on| cancel
+    start -->|Owner arrives home| cancel
     start -->|1 minute passes| expire
     expire --> checkHome
     checkHome -->|No| skip
@@ -93,6 +94,8 @@ flowchart TD
     style setAsleep fill:#6c5ce7,color:#fff
     style cancel fill:#e74c3c,color:#fff
 ```
+
+The timer cancels on two events: lights turning back on (normal wake-up) and an owner arriving home (issue #991 — prevents false sleep detection when lights turn off during away/lockdown behavior and an owner subsequently walks in).
 
 ### Master Awake Detection
 

--- a/homeautomation-go/internal/plugins/security/manager.go
+++ b/homeautomation-go/internal/plugins/security/manager.go
@@ -31,6 +31,10 @@ const (
 
 	// VehicleArrivalRateLimit is the minimum time between vehicle arrival notifications
 	VehicleArrivalRateLimit = 20 * time.Second
+
+	// ArrivalLockdownGracePeriod is how long after an owner arrives home to suppress
+	// "no one home" lockdown activations, guarding against brief presence flaps (issue #991).
+	ArrivalLockdownGracePeriod = 5 * time.Minute
 )
 
 // Manager handles security-related automation
@@ -49,7 +53,12 @@ type Manager struct {
 	// Rate limiting for notifications
 	lastDoorbellNotification       time.Time
 	lastVehicleArrivalNotification time.Time
-	mu                             sync.Mutex
+
+	// lastOwnerArrivalTime records when didOwnerJustReturnHome last became true.
+	// Used to suppress lockdown during brief presence flaps after an owner arrives (issue #991).
+	lastOwnerArrivalTime time.Time
+
+	mu sync.Mutex
 }
 
 // NewManager creates a new Security manager
@@ -153,6 +162,20 @@ func (m *Manager) handleAnyoneHomeChange(key string, oldValue, newValue interfac
 	}
 
 	if !anyoneHome {
+		// Suppress lockdown if an owner arrived recently — guards against brief presence
+		// flaps that cause isAnyoneHome to momentarily go false (issue #991).
+		m.mu.Lock()
+		timeSinceArrival := m.clock.Since(m.lastOwnerArrivalTime)
+		withinGrace := !m.lastOwnerArrivalTime.IsZero() && timeSinceArrival < ArrivalLockdownGracePeriod
+		m.mu.Unlock()
+
+		if withinGrace {
+			m.logger.Info("No one home but owner arrived recently — suppressing lockdown (arrival grace period)",
+				zap.Duration("timeSinceArrival", timeSinceArrival),
+				zap.Duration("gracePeriod", ArrivalLockdownGracePeriod))
+			return
+		}
+
 		m.logger.Info("No one is home, activating lockdown")
 		m.activateLockdown("No one is home", key)
 	}
@@ -236,6 +259,14 @@ func (m *Manager) handleOwnerReturnHome(key string, oldValue, newValue interface
 	if !returned {
 		return
 	}
+
+	// Record arrival time for lockdown grace period (issue #991).
+	// This timestamp persists even after didOwnerJustReturnHome is cleared (e.g. on
+	// departure or flap), so we can suppress lockdown for ArrivalLockdownGracePeriod
+	// minutes after the owner physically arrived.
+	m.mu.Lock()
+	m.lastOwnerArrivalTime = m.clock.Now()
+	m.mu.Unlock()
 
 	m.logger.Info("Owner just returned home, checking garage status")
 

--- a/homeautomation-go/internal/plugins/statetracking/manager.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager.go
@@ -373,6 +373,18 @@ func (m *Manager) handleNickHomeChange(entityID string, oldState, newState *ha.S
 			zap.String("old_state", oldState.State),
 			zap.String("new_state", newState.State))
 
+		// Cancel any pending sleep detection timer when an owner arrives home (issue #991).
+		// The timer may have been started when lights went off during away/lockdown behavior
+		// for the departing owner, and must not fire now that someone has returned.
+		m.timerMutex.Lock()
+		if m.masterSleepTimer != nil {
+			m.logger.Info("Owner arrived home - cancelling pending sleep detection timer")
+			m.masterSleepTimer.Stop()
+			m.masterSleepTimer = nil
+			m.shadowTracker.UpdateSleepDetectionTimer(false)
+		}
+		m.timerMutex.Unlock()
+
 		// Check arrival debounce to suppress presence sensor bounce (issue #922)
 		m.timerMutex.Lock()
 		timeSinceDeparture := m.clock.Now().Sub(m.nickDepartureTime)
@@ -434,6 +446,18 @@ func (m *Manager) handleCarolineHomeChange(entityID string, oldState, newState *
 			zap.String("entity_id", entityID),
 			zap.String("old_state", oldState.State),
 			zap.String("new_state", newState.State))
+
+		// Cancel any pending sleep detection timer when an owner arrives home (issue #991).
+		// The timer may have been started when lights went off during away/lockdown behavior
+		// for the departing owner, and must not fire now that someone has returned.
+		m.timerMutex.Lock()
+		if m.masterSleepTimer != nil {
+			m.logger.Info("Owner arrived home - cancelling pending sleep detection timer")
+			m.masterSleepTimer.Stop()
+			m.masterSleepTimer = nil
+			m.shadowTracker.UpdateSleepDetectionTimer(false)
+		}
+		m.timerMutex.Unlock()
 
 		// Check arrival debounce to suppress presence sensor bounce (issue #922)
 		m.timerMutex.Lock()

--- a/homeautomation-go/test/integration/scenario_owner_handoff_test.go
+++ b/homeautomation-go/test/integration/scenario_owner_handoff_test.go
@@ -1,0 +1,156 @@
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// Owner Handoff Scenario Tests (issue #991)
+//
+// These tests cover the bug where lockdown fires spuriously during a normal
+// owner handoff (one leaving as another arrives). Two root causes:
+//
+//  1. Sleep detection false positive: the 1-minute sleep timer started when
+//     lights went off (lockdown/away behavior) was not cancelled when another
+//     owner arrived. Timer would fire and mark master as asleep even though
+//     someone had just walked in.
+//
+//  2. No lockdown grace period after arrival: a brief presence flap (8 seconds)
+//     immediately triggered full lockdown even though an owner had just arrived.
+// ============================================================================
+
+// findLockdownCall returns the first lockdown service call (either turn_on or turn_off)
+// found in calls since the given snapshot, or nil if none found.
+func findLockdownCall(server *MockHAServer, since int) *ServiceCall {
+	calls := server.GetServiceCallsSince(since)
+	for i := range calls {
+		call := &calls[i]
+		if call.Domain == "input_boolean" {
+			if entityID, ok := call.ServiceData["entity_id"].(string); ok && entityID == "input_boolean.lockdown" {
+				return call
+			}
+		}
+	}
+	return nil
+}
+
+// TestScenario_OwnerHandoff_SleepTimerCancelledOnArrival verifies that the sleep
+// detection timer (started when primary suite lights go off during away/lockdown
+// behavior) is cancelled when an owner arrives home, preventing a false
+// isMasterAsleep=true detection (issue #991 fix 1).
+//
+// Invariant: arriving home MUST cancel any pending sleep detection timer.
+func TestScenario_OwnerHandoff_SleepTimerCancelledOnArrival(t *testing.T) {
+	t.Parallel()
+	server, _, _, manager, mockClock, cleanup := setupSecurityScenarioTestWithMockClock(t)
+	defer cleanup()
+
+	t.Log("GIVEN: No one is home and master is not marked asleep")
+	server.SetState("input_boolean.nick_home", "off", nil)
+	server.SetState("input_boolean.caroline_home", "off", nil)
+	require.NoError(t, manager.SetBool("isMasterAsleep", false))
+	waitForBoolState(t, manager, "isAnyoneHome", false, "isAnyoneHome should be false initially")
+	waitForProcessing(t, manager)
+
+	t.Log("WHEN: Primary suite lights turn off (simulating lockdown/away behavior)")
+	server.SetState("light.primary_suite", "off", nil)
+	waitForProcessing(t, manager)
+	// The 1-minute sleep detection timer has now started.
+
+	t.Log("AND: Nick arrives 54 seconds later (before the 1-minute sleep timer fires)")
+	mockClock.AdvanceAndProcess(54 * time.Second)
+
+	server.SetState("input_boolean.nick_home", "on", nil)
+	waitForBoolState(t, manager, "isNickHome", true, "isNickHome should be true after arrival")
+	waitForProcessing(t, manager)
+	// Fix 1: arrival should have cancelled the sleep detection timer.
+
+	t.Log("WHEN: The 1-minute sleep detection window expires (timer should have been cancelled)")
+	mockClock.AdvanceAndProcess(10 * time.Second) // total ~64s from lights off, past the 1-minute mark
+
+	t.Log("THEN: isMasterAsleep must remain false (sleep timer was cancelled by Nick's arrival)")
+	isMasterAsleep, err := manager.GetBool("isMasterAsleep")
+	require.NoError(t, err)
+	assert.False(t, isMasterAsleep,
+		"isMasterAsleep should be false — sleep timer must be cancelled when owner arrives home")
+
+	t.Log("✓ Sleep timer correctly cancelled on owner arrival during handoff")
+}
+
+// TestScenario_OwnerHandoff_LockdownSuppressedDuringGracePeriod verifies that a
+// brief presence sensor flap does NOT trigger lockdown when an owner recently
+// arrived home (issue #991 fix 2).
+//
+// Invariant: "no one home" lockdown must NOT activate if an owner arrived within
+// the last ArrivalLockdownGracePeriod minutes.
+func TestScenario_OwnerHandoff_LockdownSuppressedDuringGracePeriod(t *testing.T) {
+	t.Parallel()
+	server, _, _, manager, mockClock, cleanup := setupSecurityScenarioTestWithMockClock(t)
+	defer cleanup()
+
+	t.Log("GIVEN: Nick is not home initially")
+	server.SetState("input_boolean.nick_home", "off", nil)
+	waitForBoolState(t, manager, "isNickHome", false, "isNickHome should be false initially")
+	waitForProcessing(t, manager)
+	// Advance clock so there is no lingering state from startup.
+	mockClock.AdvanceAndProcess(10 * time.Minute)
+
+	t.Log("WHEN: Nick arrives home (sets didOwnerJustReturnHome=true)")
+	server.SetState("input_boolean.nick_home", "on", nil)
+	waitForBoolState(t, manager, "isNickHome", true, "isNickHome should be true after arrival")
+	waitForBoolState(t, manager, "didOwnerJustReturnHome", true, "didOwnerJustReturnHome should be true")
+	waitForProcessing(t, manager)
+
+	snapshot := server.ServiceCallCount()
+
+	t.Log("AND: Nick's presence briefly flaps false (simulating 8-second sensor glitch)")
+	server.SetState("input_boolean.nick_home", "off", nil)
+	waitForBoolState(t, manager, "isNickHome", false, "isNickHome should be false during flap")
+	waitForServiceCallQuiescenceSince(t, server, snapshot, 200*time.Millisecond)
+
+	t.Log("THEN: Lockdown must NOT be activated (owner just arrived — within grace period)")
+	lockdownCall := findLockdownCall(server, snapshot)
+	assert.Nil(t, lockdownCall,
+		"Lockdown must not be triggered during brief presence flap within grace period after owner arrival")
+
+	t.Log("✓ Lockdown correctly suppressed during presence flap within arrival grace period")
+}
+
+// TestScenario_OwnerHandoff_LockdownAllowedAfterGracePeriod verifies that a genuine
+// departure (after the grace period expires) still triggers lockdown normally.
+func TestScenario_OwnerHandoff_LockdownAllowedAfterGracePeriod(t *testing.T) {
+	t.Parallel()
+	server, _, _, manager, mockClock, cleanup := setupSecurityScenarioTestWithMockClock(t)
+	defer cleanup()
+
+	t.Log("GIVEN: Nick is not home initially")
+	server.SetState("input_boolean.nick_home", "off", nil)
+	waitForBoolState(t, manager, "isNickHome", false, "isNickHome should be false initially")
+	waitForProcessing(t, manager)
+	mockClock.AdvanceAndProcess(10 * time.Minute)
+
+	t.Log("AND: Nick arrives home")
+	server.SetState("input_boolean.nick_home", "on", nil)
+	waitForBoolState(t, manager, "isNickHome", true, "isNickHome should be true after arrival")
+	waitForBoolState(t, manager, "didOwnerJustReturnHome", true, "didOwnerJustReturnHome should be true")
+	waitForProcessing(t, manager)
+
+	t.Log("WHEN: The arrival grace period expires (6 minutes pass)")
+	mockClock.AdvanceAndProcess(6 * time.Minute)
+
+	snapshot := server.ServiceCallCount()
+
+	t.Log("AND: Nick genuinely departs")
+	server.SetState("input_boolean.nick_home", "off", nil)
+	waitForBoolState(t, manager, "isNickHome", false, "isNickHome should be false after departure")
+
+	t.Log("THEN: Lockdown MUST be activated (grace period has expired)")
+	waitForServiceCallWithEntitySince(t, server, snapshot, "input_boolean", "turn_off", "input_boolean.lockdown",
+		"Lockdown should be activated when owner genuinely departs after grace period")
+
+	t.Log("✓ Lockdown correctly activated after grace period on genuine departure")
+}


### PR DESCRIPTION
Resolves #991

## Summary

Two root causes fixed for the spurious lockdown that fired 3 times during a normal owner handoff (Caroline leaving as Nick arrived):

### Fix 1 — Cancel sleep detection timer on owner arrival (`statetracking/manager.go`)

When Caroline left, `isAnyoneHome` went false and HA turned off lights, starting the 1-minute sleep detection timer. Nick arrived 54 seconds later (lights came back on), but the sleep timer kept running. It fired at T+1min, saw `isAnyoneHome=true` (Nick was home), and falsely marked master as asleep → triggered lockdown via `isEveryoneAsleep=true`.

**Fix**: Cancel `masterSleepTimer` in `handleNickHomeChange` and `handleCarolineHomeChange` whenever an owner arrives home.

### Fix 2 — Lockdown grace period after owner arrival (`security/manager.go`)

Nick's presence briefly flapped false (8 seconds), causing `isAnyoneHome → false → lockdown` even though he had just walked in 3 minutes earlier.

**Fix**: Track `lastOwnerArrivalTime` (set when `didOwnerJustReturnHome` becomes true). When `isAnyoneHome` goes false, suppress lockdown if the most recent owner arrival was within `ArrivalLockdownGracePeriod` (5 minutes). Genuine departures after the grace period still lock down normally.

## Test Plan

Three new integration tests in `scenario_owner_handoff_test.go`:

- `TestScenario_OwnerHandoff_SleepTimerCancelledOnArrival` — verifies `isMasterAsleep` stays false when lights go off and owner arrives before the 1-minute timer fires
- `TestScenario_OwnerHandoff_LockdownSuppressedDuringGracePeriod` — verifies lockdown is NOT activated during brief presence flap within 5 minutes of owner arrival
- `TestScenario_OwnerHandoff_LockdownAllowedAfterGracePeriod` — verifies lockdown IS activated on genuine departure after the 5-minute grace period expires

All tests pass (`make unit-tests && make integration-tests` ✅).

🤖 Generated by the AI assistant