### PR TITLE
Fix #996: Sleep schedule step 4/4 — shift 1 hour earlier (final target)

### DIFF
--- a/configs/schedule_config.yaml
+++ b/configs/schedule_config.yaml
@@ -1,57 +1,57 @@
 schedule:
-  - begin_backup_wake: 09:50
-    backup_wake_time: 10:15
+  - begin_backup_wake: 08:50
+    backup_wake_time: 09:15
     dusk: '19:30'
-    go_to_bed: '23:30'
+    go_to_bed: '22:30'
     name: Sunday
-    night: '23:00'
-    stop_screens: '22:30'
-    winddown: '22:15'
-  - begin_backup_wake: 08:50
-    backup_wake_time: 09:15
+    night: '22:00'
+    stop_screens: '21:30'
+    winddown: '21:15'
+  - begin_backup_wake: 07:50
+    backup_wake_time: 08:15
     dusk: '19:30'
-    go_to_bed: '23:30'
+    go_to_bed: '22:30'
     name: Monday
-    night: '23:00'
-    stop_screens: '22:30'
-    winddown: '22:15'
-  - begin_backup_wake: 08:50
-    backup_wake_time: 09:15
+    night: '22:00'
+    stop_screens: '21:30'
+    winddown: '21:15'
+  - begin_backup_wake: 07:50
+    backup_wake_time: 08:15
     dusk: '19:30'
-    go_to_bed: '23:30'
+    go_to_bed: '22:30'
     name: Tuesday
-    night: '23:00'
-    stop_screens: '22:30'
-    winddown: '22:15'
-  - begin_backup_wake: 08:50
-    backup_wake_time: 09:15
+    night: '22:00'
+    stop_screens: '21:30'
+    winddown: '21:15'
+  - begin_backup_wake: 07:50
+    backup_wake_time: 08:15
     dusk: '19:30'
-    go_to_bed: '23:30'
+    go_to_bed: '22:30'
     name: Wednesday
-    night: '23:00'
-    stop_screens: '22:30'
-    winddown: '22:15'
-  - begin_backup_wake: 08:50
-    backup_wake_time: 09:15
+    night: '22:00'
+    stop_screens: '21:30'
+    winddown: '21:15'
+  - begin_backup_wake: 07:50
+    backup_wake_time: 08:15
     dusk: '19:30'
-    go_to_bed: '23:30'
+    go_to_bed: '22:30'
     name: Thursday
-    night: '23:00'
-    stop_screens: '22:30'
-    winddown: '22:15'
+    night: '22:00'
+    stop_screens: '21:30'
+    winddown: '21:15'
+  - begin_backup_wake: 07:50
+    backup_wake_time: 08:15
+    dusk: '19:30'
+    go_to_bed: '22:59'
+    name: Friday
+    night: '22:59'
+    stop_screens: '22:00'
+    winddown: '21:00'
   - begin_backup_wake: 08:50
     backup_wake_time: 09:15
     dusk: '19:30'
-    go_to_bed: '23:59'
-    name: Friday
-    night: '23:59'
-    stop_screens: '23:00'
-    winddown: '22:00'
-  - begin_backup_wake: 09:50
-    backup_wake_time: 10:15
-    dusk: '19:30'
-    go_to_bed: '23:59'
+    go_to_bed: '22:59'
     name: Saturday
-    night: '23:59'
-    stop_screens: '23:00'
-    winddown: '22:00'
+    night: '22:59'
+    stop_screens: '22:00'
+    winddown: '21:00'


### PR DESCRIPTION
Resolves #996

## Summary

- Updated `configs/schedule_config.yaml` to the final target sleep schedule, shifting all times 1 hour earlier from the original baseline (4 steps × 15 minutes each)
- Weekday/Sunday evening: winddown 21:15, stop_screens 21:30, night 22:00, bed 22:30, wake 07:50/08:15
- Weekend (Fri-Sat): winddown 21:00, stop_screens 22:00, night 22:59, bed 22:59, wake 07:50/08:15 (Fri) / 08:50/09:15 (Sat)
- Sunday morning: wake 08:50/09:15

> **Note:** Eight Sleep alarm times should also be shifted 15 minutes earlier in the Eight Sleep app to match (manual step per issue instructions).

## Test Plan

- Unit tests pass (`make unit-tests` — 75.4% coverage ✅)
- Config is YAML-valid (schedule entries verified against existing schema)
- No code changes — config-only update, no logic affected

🤖 Generated by the AI assistant