### PR TITLE
fix(music): pre-mute followers when mute conditions met at playback start (#998)

### DIFF
--- a/docs/flows/MUSIC_PLAYBACK.md
+++ b/docs/flows/MUSIC_PLAYBACK.md
@@ -146,6 +146,9 @@ sequenceDiagram
 
     Music->>HA: Update currentlyPlayingMusicUri
 
+    Note over Music,Followers: Step 6.5 — Pre-mute followers whose mute<br/>conditions are already met (synchronous,<br/>before async join — issue #998)
+    Music->>Followers: Set target volume + mute (if leave_muted_if matches)
+
     par Async speaker group building
         loop For each follower
             Music->>Followers: Join to lead (with retries)
@@ -156,7 +159,7 @@ sequenceDiagram
                     Music->>Followers: Set target volume (stays muted)
                 end
             else Join failed (permanent error)
-                Note over Followers: Skip speaker
+                Note over Followers: Follower already pre-muted if<br/>mute condition was met; join<br/>failure leaves it silent
             end
         end
     end
@@ -168,7 +171,7 @@ The async approach provides faster perceived playback start:
 - **Before**: Wait for all speakers to join group → then start playback (slower)
 - **After**: Start playback on lead immediately → followers join in background (faster)
 
-Followers that fail to join (e.g., speaker offline) are logged but don't block playback.
+Followers that fail to join (e.g., speaker offline) are logged but don't block playback. Followers whose mute conditions were met at playback start are pre-silenced before the join attempt, so a join failure cannot leave them playing unmuted (issue #998).
 
 ## Post-Playback Health Monitoring
 

--- a/homeautomation-go/internal/plugins/music/manager_shadow_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_shadow_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"homeautomation/internal/ha"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
 	"homeautomation/pkg/plugin"
@@ -301,4 +302,58 @@ func TestMusicShadowState_InterfaceImplementation(t *testing.T) {
 	_ = shadowState.GetMetadata()
 
 	// If this compiles, the interface is implemented correctly
+}
+
+// TestMusicShadowState_CaptureInputs_IncludesMuteConditionVariables verifies that
+// captureCurrentInputs includes variables referenced in leave_muted_if conditions.
+//
+// Regression test for GitHub issue #998: when isTVPlaying=true, the shadow state
+// inputs did not include isTVPlaying, making it impossible to diagnose why speakers
+// with leave_muted_if: isTVPlaying=true were not being muted.
+func TestMusicShadowState_CaptureInputs_IncludesMuteConditionVariables(t *testing.T) {
+	t.Parallel()
+
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, zap.NewNop(), false)
+	_ = stateManager.SetBool("isTVPlaying", true)
+
+	// Config with isTVPlaying as a leave_muted_if condition
+	config := &MusicConfig{
+		Music: map[string]MusicMode{
+			"day": {
+				Participants: []Participant{
+					{
+						PlayerName:   "Front Room",
+						BaseVolume:   9,
+						LeaveMutedIf: []MuteCondition{},
+					},
+					{
+						PlayerName: "Kitchen",
+						BaseVolume: 9,
+						LeaveMutedIf: []MuteCondition{
+							{Variable: "isTVPlaying", Value: true},
+						},
+					},
+				},
+				PlaybackOptions: []PlaybackOption{
+					{URI: "https://tidal.com/browse/playlist/test", MediaType: "tidal", VolumeMultiplier: 1.0},
+				},
+			},
+		},
+	}
+
+	manager := NewManager(context.Background(), mockClient, stateManager, config, zap.NewNop(), true, nil, nil)
+
+	inputs := manager.captureCurrentInputs()
+
+	if _, exists := inputs["isTVPlaying"]; !exists {
+		t.Error("captureCurrentInputs() must include isTVPlaying when it is referenced in a leave_muted_if condition. " +
+			"Without this, shadow state inputs omit isTVPlaying and operators cannot diagnose muting failures (issue #998).")
+	}
+	if val, exists := inputs["isTVPlaying"]; exists {
+		boolVal, ok := val.(bool)
+		if !ok || !boolVal {
+			t.Errorf("Expected isTVPlaying=true in shadow inputs, got %v (type %T)", val, val)
+		}
+	}
 }

--- a/homeautomation-go/internal/plugins/music/occupancy_scenario_test.go
+++ b/homeautomation-go/internal/plugins/music/occupancy_scenario_test.go
@@ -50,6 +50,7 @@ import (
 	"homeautomation/pkg/plugin"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -568,10 +569,14 @@ func TestScenario_TVPlaying_PreMutesFollowers_EvenIfJoinFails(t *testing.T) {
 	}
 
 	_, _, err := manager.executePlayback("day", option, participants, "Kitchen")
-	assert.NoError(t, err, "executePlayback should succeed even when follower join fails")
+	require.NoError(t, err, "executePlayback should succeed even when follower join fails")
 
 	// Poll for pre-mute commands on Study. These must appear regardless of whether
 	// the group join succeeds, because pre-muting happens before the async join.
+	// Note: Even though pre-muting is synchronous in executePlayback(), the mock HTTP
+	// server handler runs in a separate goroutine (httptest.Server), so there is a
+	// propagation delay between the HTTP call completing and the path appearing in
+	// socoPaths. The poll ensures we don't race against that goroutine.
 	var allPaths []string
 	foundStudyVolumeSet := false
 	foundStudyMute := false

--- a/homeautomation-go/internal/plugins/music/occupancy_scenario_test.go
+++ b/homeautomation-go/internal/plugins/music/occupancy_scenario_test.go
@@ -480,6 +480,129 @@ func TestScenario_MutedSpeaker_GetsTargetVolumeSetDuringPlayback(t *testing.T) {
 }
 
 // =============================================================================
+// TEST: TV Playing - Followers Pre-Muted Even If Group Join Fails
+// =============================================================================
+//
+// WHAT THIS TEST VALIDATES:
+// When isTVPlaying=true before music starts, follower speakers with
+// leave_muted_if: isTVPlaying=true must be pre-muted SYNCHRONOUSLY inside
+// executePlayback(), BEFORE the async group join attempt.
+//
+// Without this pre-muting step (issue #998), a follower that fails to join the
+// Sonos group never has shouldUnmuteSpeaker() called (joinSpeakerWithRetry returns
+// early on failure), leaving the speaker playing audio unmuted as a standalone device.
+//
+// SCENARIO:
+// 1. isTVPlaying=true before music starts
+// 2. executePlayback() runs with Kitchen as a follower (leave_muted_if: isTVPlaying=true)
+// 3. The Sonos group join for Kitchen fails (simulated by custom SoCo mock)
+// 4. Kitchen must still receive volume+mute commands from the pre-muting step
+//
+// EXPECTED:
+// SoCo paths /Kitchen/volume/9 and /Kitchen/mute appear even though join fails.
+//
+// REGRESSION TEST FOR: https://github.com/NickBorgers/home-automation/issues/998
+func TestScenario_TVPlaying_PreMutesFollowers_EvenIfJoinFails(t *testing.T) {
+	t.Parallel()
+	logger := zap.NewNop()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	config := createOccupancyMusicConfig()
+
+	fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	timeProvider := plugin.FixedTimeProvider{FixedTime: fixedTime}
+
+	manager := NewManager(context.Background(), mockClient, stateManager, config, logger, false, timeProvider, nil)
+	manager.SetSleepFunc(func(d time.Duration) {}) // Skip all sleeps for fast test
+
+	// TV is playing BEFORE music starts — Kitchen must be muted.
+	_ = stateManager.SetBool("isTVPlaying", true)
+	_ = stateManager.SetString("dayPhase", "day")
+	_ = stateManager.SetBool("isAnyoneHome", true)
+	_ = stateManager.SetBool("isAnyoneAsleep", false)
+	_ = stateManager.SetBool("isMasterAsleep", false)
+	_ = stateManager.SetBool("isEveryoneAsleep", false)
+	_ = stateManager.SetBool("isNickOfficeOccupied", false)
+
+	// HA mock: lead speaker reports "playing" for verification step.
+	mockClient.SetMockState("media_player.kitchen", &ha.State{
+		EntityID: "media_player.kitchen",
+		State:    "playing",
+	})
+	mockClient.SetMockState("media_player.study", &ha.State{
+		EntityID: "media_player.study",
+		State:    "playing",
+	})
+
+	// SoCo mock: group join operations fail; all other operations succeed.
+	// This simulates the production scenario where Sonos group join is flaky.
+	socoPaths := setupFailingGroupJoinSoCo(t, manager)
+
+	// Kitchen is lead (no mute conditions), Study is follower muted if TV playing.
+	// Reuse the existing occupancy config participants but override the mute condition
+	// to test isTVPlaying specifically.
+	participants := []ParticipantWithVolume{
+		{
+			PlayerName:   "Kitchen",
+			BaseVolume:   9,
+			Volume:       9,
+			LeaveMutedIf: []MuteCondition{}, // Lead is always unmuted
+		},
+		{
+			PlayerName: "Study",
+			BaseVolume: 6,
+			Volume:     6,
+			LeaveMutedIf: []MuteCondition{
+				{
+					Variable: "isTVPlaying",
+					Value:    true, // Mute when TV is playing
+				},
+			},
+		},
+	}
+
+	option := PlaybackOption{
+		URI:              "https://example.com/music.mp3",
+		MediaType:        "music", // Non-tidal avoids SoCo sharelink path
+		VolumeMultiplier: 1.0,
+	}
+
+	_, _, err := manager.executePlayback("day", option, participants, "Kitchen")
+	assert.NoError(t, err, "executePlayback should succeed even when follower join fails")
+
+	// Poll for pre-mute commands on Study. These must appear regardless of whether
+	// the group join succeeds, because pre-muting happens before the async join.
+	var allPaths []string
+	foundStudyVolumeSet := false
+	foundStudyMute := false
+	for attempt := 0; attempt < 200; attempt++ {
+		allPaths = socoPaths.All()
+		for _, path := range allPaths {
+			if path == "/Study/volume/6" {
+				foundStudyVolumeSet = true
+			}
+			if path == "/Study/mute" {
+				foundStudyMute = true
+			}
+		}
+		if foundStudyVolumeSet && foundStudyMute {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	assert.True(t, foundStudyVolumeSet,
+		"Study speaker must be pre-muted with target volume even when group join fails (issue #998). "+
+			"Pre-muting happens synchronously in executePlayback() before the async join attempt. "+
+			"SoCo paths seen: %v", allPaths)
+
+	assert.True(t, foundStudyMute,
+		"Study speaker must receive mute command even when group join fails (issue #998). "+
+			"Without pre-muting, speakers play audio unmuted as standalone devices. "+
+			"SoCo paths seen: %v", allPaths)
+}
+
+// =============================================================================
 // TEST: Kitchen Speaker Always Unmuted
 // =============================================================================
 //

--- a/homeautomation-go/internal/plugins/music/orchestration.go
+++ b/homeautomation-go/internal/plugins/music/orchestration.go
@@ -311,6 +311,31 @@ func (m *Manager) executePlayback(musicType string, option PlaybackOption, parti
 		}
 	}
 
+	// Step 6.5: Pre-mute followers whose mute conditions are already met.
+	// This must happen BEFORE launching buildSpeakerGroupAsync so that speakers
+	// are silenced even if the async group join fails. Without this step, a follower
+	// that exhausts all join retries never has shouldUnmuteSpeaker() called
+	// (joinSpeakerWithRetry returns early on failure), leaving it playing audio
+	// unmuted as a standalone device after breakSpeakerGroups() unjoined it (issue #998).
+	for i := 1; i < len(participants); i++ {
+		p := participants[i]
+		if !m.shouldUnmuteSpeaker(p) {
+			m.logger.Info("Pre-muting follower (mute condition met before async join)",
+				zap.String("speaker", p.PlayerName),
+				zap.Int("volume", p.Volume))
+			if err := m.speakerSetVolume(p.PlayerName, p.Volume); err != nil {
+				m.logger.Warn("Failed to pre-set volume for muted follower",
+					zap.String("speaker", p.PlayerName),
+					zap.Error(err))
+			}
+			if err := m.speakerSetMute(p.PlayerName, true); err != nil {
+				m.logger.Warn("Failed to pre-mute follower speaker",
+					zap.String("speaker", p.PlayerName),
+					zap.Error(err))
+			}
+		}
+	}
+
 	// Step 7: Build speaker group ASYNCHRONOUSLY for followers
 	// Each speaker joins and starts its own fade-in without blocking the main flow
 	if len(participants) > 1 {

--- a/homeautomation-go/internal/plugins/music/orchestration.go
+++ b/homeautomation-go/internal/plugins/music/orchestration.go
@@ -317,6 +317,7 @@ func (m *Manager) executePlayback(musicType string, option PlaybackOption, parti
 	// that exhausts all join retries never has shouldUnmuteSpeaker() called
 	// (joinSpeakerWithRetry returns early on failure), leaving it playing audio
 	// unmuted as a standalone device after breakSpeakerGroups() unjoined it (issue #998).
+	// participants[0] is the lead speaker, already handled in Step 6 above.
 	for i := 1; i < len(participants); i++ {
 		p := participants[i]
 		if !m.shouldUnmuteSpeaker(p) {

--- a/homeautomation-go/internal/plugins/music/shadow.go
+++ b/homeautomation-go/internal/plugins/music/shadow.go
@@ -32,6 +32,19 @@ func (m *Manager) captureCurrentInputs() map[string]interface{} {
 		inputs["isWakeSequenceActive"] = val
 	}
 
+	// Capture variables referenced in leave_muted_if / exclude_if conditions across all
+	// music modes. These variables (e.g. isTVPlaying, isNickOfficeOccupied) control
+	// per-speaker muting and must appear in shadow inputs so operators can diagnose
+	// why speakers are or aren't muted (issue #998).
+	for _, varName := range m.collectMuteConditionVariables() {
+		if _, already := inputs[varName]; already {
+			continue // Already captured above
+		}
+		if val, err := m.getStateValue(varName); err == nil {
+			inputs[varName] = val
+		}
+	}
+
 	return inputs
 }
 

--- a/homeautomation-go/internal/plugins/music/speaker_commands_test.go
+++ b/homeautomation-go/internal/plugins/music/speaker_commands_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -137,30 +138,7 @@ func setupFailingGroupJoinSoCo(t *testing.T, manager *Manager) *threadSafePaths 
 // containsGroupJoin returns true for SoCo paths that represent a group join operation:
 // /{follower}/group/{lead} — e.g., /Kitchen/group/Front%20Room
 func containsGroupJoin(path string) bool {
-	// A group join path has at least two segments after the split, with "group" as the second
-	// segment and a third non-empty segment (the lead speaker name).
-	// Example: /Kitchen/group/Front%20Room → ["", "Kitchen", "group", "Front%20Room"]
-	parts := splitPath(path)
-	return len(parts) >= 3 && parts[1] == "group"
-}
-
-// splitPath splits a URL path by "/" and returns non-empty segments.
-// Input: /Kitchen/group/Front%20Room → ["Kitchen", "group", "Front%20Room"]
-func splitPath(path string) []string {
-	var segments []string
-	start := 0
-	for i, c := range path {
-		if c == '/' {
-			if i > start {
-				segments = append(segments, path[start:i])
-			}
-			start = i + 1
-		}
-	}
-	if start < len(path) {
-		segments = append(segments, path[start:])
-	}
-	return segments
+	return strings.Contains(path, "/group/")
 }
 
 // createTestManager creates a Manager wired up to a mock HA client for testing.

--- a/homeautomation-go/internal/plugins/music/speaker_commands_test.go
+++ b/homeautomation-go/internal/plugins/music/speaker_commands_test.go
@@ -97,6 +97,72 @@ func setupSoCoForTest(t *testing.T, manager *Manager, readOnly bool) *threadSafe
 	return paths
 }
 
+// setupFailingGroupJoinSoCo creates a mock SoCo-CLI server where group join operations
+// always fail (exit_code=1) while all other operations succeed. This is used to test
+// that pre-muting happens before the async join attempt (issue #998): if a follower
+// speaker fails to join the group, it should still have been pre-muted so it doesn't
+// play audio unmuted as a standalone speaker.
+func setupFailingGroupJoinSoCo(t *testing.T, manager *Manager) *threadSafePaths {
+	t.Helper()
+	recorded := &threadSafePaths{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recorded.Append(r.URL.Path)
+
+		resp := SoCoResponse{
+			Speaker: "test",
+			Action:  "test",
+		}
+
+		// Return error for group join operations: /{follower}/group/{lead}
+		if containsGroupJoin(r.URL.Path) {
+			resp.ExitCode = 1
+			resp.ErrorMsg = "forced group join failure (test)"
+			resp.Result = "error"
+		} else {
+			resp.ExitCode = 0
+			resp.Result = "success"
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			http.Error(w, "encode failed", http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(server.Close)
+	socoClient := NewSoCoClient(server.URL, zap.NewNop(), false)
+	manager.SetSoCoClient(socoClient)
+	return recorded
+}
+
+// containsGroupJoin returns true for SoCo paths that represent a group join operation:
+// /{follower}/group/{lead} — e.g., /Kitchen/group/Front%20Room
+func containsGroupJoin(path string) bool {
+	// A group join path has at least two segments after the split, with "group" as the second
+	// segment and a third non-empty segment (the lead speaker name).
+	// Example: /Kitchen/group/Front%20Room → ["", "Kitchen", "group", "Front%20Room"]
+	parts := splitPath(path)
+	return len(parts) >= 3 && parts[1] == "group"
+}
+
+// splitPath splits a URL path by "/" and returns non-empty segments.
+// Input: /Kitchen/group/Front%20Room → ["Kitchen", "group", "Front%20Room"]
+func splitPath(path string) []string {
+	var segments []string
+	start := 0
+	for i, c := range path {
+		if c == '/' {
+			if i > start {
+				segments = append(segments, path[start:i])
+			}
+			start = i + 1
+		}
+	}
+	if start < len(path) {
+		segments = append(segments, path[start:])
+	}
+	return segments
+}
+
 // createTestManager creates a Manager wired up to a mock HA client for testing.
 func createTestManager(t *testing.T) (*Manager, *ha.MockClient) {
 	t.Helper()


### PR DESCRIPTION
## Summary

Resolves #998: Music speakers not muting when `isTVPlaying=true`.

Two root causes identified and fixed:

**Bug 1 — Shadow state missing mute condition variables (`shadow.go`)**

`captureCurrentInputs()` captured a fixed set of variables (`dayPhase`, `isAnyoneAsleep`, etc.) but not variables referenced in `leave_muted_if` conditions such as `isTVPlaying`. The shadow state's `inputs.current` was therefore missing `isTVPlaying`, making it impossible to diagnose why speakers were not muting.

*Fix:* Call `collectMuteConditionVariables()` (already used for subscriptions) to dynamically include all condition variables — including `isTVPlaying`, `isNickOfficeOccupied`, etc. — in the captured inputs.

**Bug 2 — Followers not pre-muted before async group join (`orchestration.go`)**

`executePlayback()` applied mute conditions to the lead speaker (Step 6) and to followers only *after* a successful async group join (`joinSpeakerWithRetry`). If all 6 join retries were exhausted, `shouldUnmuteSpeaker()` was never called for that follower. After `breakSpeakerGroups()` unjoins all speakers, a failed-join follower resumes its own audio queue as a standalone device at non-zero volume.

*Fix:* Added Step 6.5 in `executePlayback()`: synchronously pre-mutes any follower whose mute conditions are already met, **before** launching `buildSpeakerGroupAsync()`. This ensures muting is applied even if the async join subsequently fails. When the join succeeds, `joinSpeakerWithRetry` re-applies the mute (idempotent — harmless double-mute).

## Tests added

- `TestMusicShadowState_CaptureInputs_IncludesMuteConditionVariables`: verifies `captureCurrentInputs()` includes `isTVPlaying` when referenced by a `leave_muted_if` condition. Fails without Bug 1 fix.
- `TestScenario_TVPlaying_PreMutesFollowers_EvenIfJoinFails`: uses a custom SoCo mock (`setupFailingGroupJoinSoCo`) that always returns `exit_code=1` for group join operations, forcing the "join fails" scenario. Verifies that `volume/N` and `mute` commands still appear for the follower via pre-muting. Fails without Bug 2 fix.

## Test plan

- [x] `TestMusicShadowState_CaptureInputs_IncludesMuteConditionVariables` passes
- [x] `TestScenario_TVPlaying_PreMutesFollowers_EvenIfJoinFails` passes
- [x] All existing music plugin tests pass (`ok homeautomation/internal/plugins/music 4.553s coverage: 85.0%`)
- [x] Full unit test suite passes (`Total coverage: 75.1% ≥ 65%`)
- [x] `go vet` passes, `gofmt` shows no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)