### PR TITLE
Fix #1000: unwrap response envelope in thermal battery forecast parsing

### DIFF
--- a/homeautomation-go/internal/plugins/loadshedding/thermal_battery.go
+++ b/homeautomation-go/internal/plugins/loadshedding/thermal_battery.go
@@ -18,12 +18,6 @@ type forecastEntry struct {
 	TempLow     float64 `json:"templow"`
 }
 
-// serviceResponseWrapper matches the HA WebSocket API envelope for call_service with return_response:true.
-// The actual entity data is nested under "response", not at the top level.
-type serviceResponseWrapper struct {
-	Response json.RawMessage `json:"response"`
-}
-
 // getForecastHighLow fetches the forecast daily high and low for today.
 // Returns (high, low, true) if forecast is available, or (0, 0, false) if unavailable.
 // Results are cached for forecastCacheDuration. Failures are negative-cached for
@@ -91,9 +85,16 @@ func (m *Manager) tryFetchForecast(entity string) (float64, float64, bool) {
 
 	// The HA WebSocket API wraps entity data under a "response" key when using
 	// call_service with return_response:true. Unwrap it before parsing entity data.
-	var wrapper serviceResponseWrapper
-	if err := json.Unmarshal(result, &wrapper); err != nil || wrapper.Response == nil {
-		m.logger.Warn("Weather forecast response missing 'response' wrapper",
+	var wrapper struct {
+		Response json.RawMessage `json:"response"`
+	}
+	if err := json.Unmarshal(result, &wrapper); err != nil {
+		m.logger.Warn("Weather forecast response JSON malformed",
+			zap.String("entity", entity), zap.Error(err))
+		return 0, 0, false
+	}
+	if wrapper.Response == nil {
+		m.logger.Warn("Weather forecast response missing 'response' key",
 			zap.String("entity", entity))
 		return 0, 0, false
 	}

--- a/homeautomation-go/internal/plugins/loadshedding/thermal_battery.go
+++ b/homeautomation-go/internal/plugins/loadshedding/thermal_battery.go
@@ -18,6 +18,12 @@ type forecastEntry struct {
 	TempLow     float64 `json:"templow"`
 }
 
+// serviceResponseWrapper matches the HA WebSocket API envelope for call_service with return_response:true.
+// The actual entity data is nested under "response", not at the top level.
+type serviceResponseWrapper struct {
+	Response json.RawMessage `json:"response"`
+}
+
 // getForecastHighLow fetches the forecast daily high and low for today.
 // Returns (high, low, true) if forecast is available, or (0, 0, false) if unavailable.
 // Results are cached for forecastCacheDuration. Failures are negative-cached for
@@ -83,10 +89,19 @@ func (m *Manager) tryFetchForecast(entity string) (float64, float64, bool) {
 		return 0, 0, false
 	}
 
+	// The HA WebSocket API wraps entity data under a "response" key when using
+	// call_service with return_response:true. Unwrap it before parsing entity data.
+	var wrapper serviceResponseWrapper
+	if err := json.Unmarshal(result, &wrapper); err != nil || wrapper.Response == nil {
+		m.logger.Warn("Weather forecast response missing 'response' wrapper",
+			zap.String("entity", entity))
+		return 0, 0, false
+	}
+
 	var parsed map[string]struct {
 		Forecast []forecastEntry `json:"forecast"`
 	}
-	if err := json.Unmarshal(result, &parsed); err != nil {
+	if err := json.Unmarshal(wrapper.Response, &parsed); err != nil {
 		m.logger.Warn("Failed to parse weather forecast response",
 			zap.String("entity", entity), zap.Error(err))
 		return 0, 0, false

--- a/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
+++ b/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
@@ -375,9 +375,9 @@ func TestThermalBattery_HeatingMode(t *testing.T) {
 }
 
 // makeForecastResponse builds a JSON forecast response for the mock HA client.
-// Uses the primary forecast entity (weather.strawberry_creek).
+// Uses the real HA WebSocket API envelope: entity data is nested under "response".
 func makeForecastResponse(high, low float64) json.RawMessage {
-	resp := fmt.Sprintf(`{"%s":{"forecast":[{"temperature":%v,"templow":%v}]}}`, forecastWeatherEntityPrimary, high, low)
+	resp := fmt.Sprintf(`{"context":{"id":"test"},"response":{"%s":{"forecast":[{"temperature":%v,"templow":%v}]}}}`, forecastWeatherEntityPrimary, high, low)
 	return json.RawMessage(resp)
 }
 


### PR DESCRIPTION
Resolves #1000

## Summary

The HA WebSocket API wraps `call_service` results (with `return_response:true`) in a `"response"` key:

```json
{
  "context": { "id": "..." },
  "response": {
    "weather.strawberry_creek": { "forecast": [...] }
  }
}
```

`tryFetchForecast` was unmarshalling the raw result directly, so `parsed[entity]` was never found. The code silently fell back to the outdoor temp sensor every single time, meaning the thermal battery has never used forecast-based logic since the feature was implemented.

**Changes:**
- `thermal_battery.go`: Add `serviceResponseWrapper` struct and unwrap the `"response"` key in `tryFetchForecast` before parsing entity data
- `thermal_battery_test.go`: Update `makeForecastResponse` to include the real HA API envelope so tests exercise the actual production code path

## Test Plan

- All existing thermal battery tests pass with the new response format in the mock
- `TestThermalBattery_HeatCoolMode_ColdForecast`, `_HotForecast`, and `_MildForecast_SkipsInSkipZone` now exercise the real unwrapping path
- Full test suite: `go test -race ./...` — all pass

🤖 Generated by the AI assistant