### PR TITLE
Fix #1003: delay AI issue ingestion 5 minutes after open

### DIFF
--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -165,6 +165,12 @@ jobs:
           gh label create "ai-started" --color "7057ff" --description "AI assistant is working on this issue" --repo ${{ github.repository }} 2>/dev/null || true
           gh issue edit ${{ github.event.issue.number }} --add-label "ai-started" --repo ${{ github.repository }}
 
+      - name: Wait for issue refinement
+        if: github.event.action == 'opened'
+        run: |
+          echo "Waiting 5 minutes for issue to be refined before ingesting..."
+          sleep 300
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Resolves #1003

## Summary
- Added a **Wait for issue refinement** step in the `resolve-issue` job that sleeps 300 seconds (5 minutes) before the AI reads the issue body and comments
- The step is conditioned on `github.event.action == 'opened'` so it only fires for newly created issues — not for `assigned` or the unlabeled retry gesture, where the issue is already refined

The delay is inserted after labeling the issue as `ai-started` (so the user sees immediate feedback) but before the Docker container is started, ensuring the AI reads the fully refined issue and all comments.

## Test Plan
- Open a new issue as an authorized user → the `resolve-issue` job should start, label the issue `ai-started` immediately, then wait 5 minutes before the AI container starts
- Assign an existing issue → no delay (step is skipped)
- Remove `ai-started` label (retry gesture) → no delay (step is skipped)

🤖 Generated by the AI assistant