### PR TITLE
Fix #1002: Defer thermal battery activation using hourly forecast timing

### DIFF
--- a/docs/flows/LOAD_SHEDDING.md
+++ b/docs/flows/LOAD_SHEDDING.md
@@ -135,6 +135,11 @@ flowchart TD
     checkSleep{"Everyone<br/>asleep?"}
     checkHVAC{"Thermostats<br/>on?"}
     checkMode{"heat_cool<br/>mode?"}
+    checkHourly{"Hourly forecast<br/>available?"}
+    checkStress{"Stress event<br/>in window?"}
+    checkLeadTime{"Stress within<br/>lead time (3h)?"}
+    deferred["Defer activation<br/>Re-check every 15 min"]
+    checkDaily{"Daily forecast<br/>available?"}
     checkOutdoor{"Outdoor temp<br/>within ±20°F of<br/>comfort band?"}
     activate["Activate thermal battery<br/>Apply first 1°F step"]
     skip["Skip activation"]
@@ -152,12 +157,22 @@ flowchart TD
     checkHVAC -->|Off| skip
     checkHVAC -->|On| checkMode
     checkMode -->|No| activate
-    checkMode -->|Yes| checkOutdoor
+    checkMode -->|Yes| checkHourly
+    checkHourly -->|Yes| checkStress
+    checkStress -->|No stress| skip
+    checkStress -->|Stress found| checkLeadTime
+    checkLeadTime -->|No: too far away| deferred
+    checkLeadTime -->|Yes: within 3h| activate
+    checkHourly -->|No| checkDaily
+    checkDaily -->|Yes: mild forecast| skip
+    checkDaily -->|Yes: hot/cold forecast| activate
+    checkDaily -->|No| checkOutdoor
     checkOutdoor -->|Yes: mild| skip
     checkOutdoor -->|No: hot/cold| activate
 
     style activate fill:#3498db,color:#fff
     style skip fill:#95a5a6,color:#fff
+    style deferred fill:#f39c12,color:#fff
     style revertHolds fill:#f39c12,color:#fff
 ```
 
@@ -206,23 +221,38 @@ flowchart TD
 | `heat` | Setpoint **up** 2°F | Pre-heat the house |
 | `heat_cool`/`auto` | Entire band shifts based on weather forecast (or outdoor temp fallback) | See below |
 
-**`heat_cool`/`auto` mode** uses the daily weather forecast to determine shift direction:
-- **Primary**: Fetches daily forecast high/low via `weather.get_forecasts` service call (cached 1 hour). Tries `weather.strawberry_creek` (WeatherFlow Tempest API) first, then `weather.forecast_home_2` (Met.no) as secondary.
-- **Fallback**: If all forecast sources are unavailable, falls back to current outdoor temp sensor (`sensor.weather_station_temperature`) with single-point logic.
-- **Skip logic (forecast)**: Skip only if **both** forecast high AND low fall within the comfort band ± 20°F margin — truly mild day.
-- **Direction (forecast)**: If forecast high exceeds the skip zone → pre-cool (shift **down**). If forecast low falls below → pre-heat (shift **up**).
-- **Direction (fallback)**: Cold outside (below comfort band - 20°F) → shift **up**. Hot outside (above comfort band + 20°F) → shift **down**. Mild → **skipped**.
+**`heat_cool`/`auto` mode** uses a three-level forecast cascade to determine shift direction and timing:
+
+1. **Hourly forecast** (primary) — `weather.get_forecasts` with `type=hourly`. Scans forward from now for the first hour where outdoor temp falls outside the comfort band ± 5°F margin.
+   - **No stress in window** → skip entirely.
+   - **Stress found, > 3h away** → defer activation; re-check every 15 min until within lead time.
+   - **Stress found, ≤ 3h away** → activate now.
+   - Direction: temp below band → pre-heat (shift **up**); temp above band → pre-cool (shift **down**).
+   - Note: the hourly comfort margin (±5°F) is intentionally tighter than the daily skip margin (±20°F); the two paths use different thresholds by design.
+
+2. **Daily forecast** (fallback when hourly unavailable) — `weather.get_forecasts` with `type=daily`. Tries `weather.strawberry_creek` first, then `weather.forecast_home_2`.
+   - **Skip logic**: Skip only if **both** forecast high AND low fall within the comfort band ± 20°F margin.
+   - **Direction**: If forecast high exceeds the skip zone → pre-cool (shift **down**). If forecast low falls below → pre-heat (shift **up**).
+
+3. **Outdoor temp sensor** (tertiary fallback) — `sensor.weather_station_temperature`. Single-point logic: cold (below comfort band - 20°F) → shift **up**; hot (above + 20°F) → shift **down**; mild → **skipped**.
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| Hourly comfort margin | 5°F | Outside comfort band to consider "stress" (hourly path) |
+| Hourly lead time | 3h | Hours before forecast stress event to activate |
+| Deferral recheck interval | 15 min | How often to re-evaluate while deferred |
+| Daily skip margin | 20°F | Comfort band expansion for daily skip logic |
 
 Original setpoints are saved and restored on deactivation.
 
 ### Deactivation Triggers
 
-Thermal battery deactivates (reverting to original setpoints) when:
+Thermal battery deactivates — or, if deferred, the pending activation is cancelled — when:
 - Energy level drops below white (green, yellow, red, or black)
 - Nobody is home (`isAnyoneHome` → false)
 - Everyone falls asleep (`isEveryoneAsleep` → true)
 
-Any in-progress stepping goroutine is cancelled on deactivation.
+Any in-progress stepping goroutine and any deferred-activation recheck timer are cancelled on deactivation.
 
 ## Yellow State — Partial Load Shedding
 

--- a/homeautomation-go/internal/plugins/loadshedding/manager.go
+++ b/homeautomation-go/internal/plugins/loadshedding/manager.go
@@ -67,6 +67,11 @@ const (
 
 	// Restart safety: delay after reverting stale holds to let thermostat schedule take effect
 	thermalBatteryDefaultHoldRevertDelay = 5 * time.Second
+
+	// Thermal battery: hourly forecast timing
+	thermalBatteryDefaultLeadTimeHours   = 3.0              // hours before forecast stress to activate
+	thermalBatteryHourlyComfortMargin    = 5.0              // °F outside comfort band to consider "stress" (hourly)
+	thermalBatteryDeferredRecheckDefault = 15 * time.Minute // how often to re-evaluate while deferred
 )
 
 // deferredAction represents a pending action that was rate-limited
@@ -116,6 +121,13 @@ type Manager struct {
 	thermalBatteryStepStart       time.Time     // when the current step began (for safety timeout)
 	thermalBatteryMaxStepWaitDur  time.Duration // configurable max wait per step (defaults to thermalBatteryMaxStepWait)
 
+	// Hourly forecast timing: deferred activation state (guarded by thermalBatteryMu)
+	thermalBatteryLeadTimeHours           float64       // hours before stress to activate (configurable for tests)
+	thermalBatteryDeferredRecheckInterval time.Duration // how often to re-evaluate while deferred
+	thermalBatteryDeferred                bool          // true when activation is deferred due to timing
+	thermalBatteryPlannedActivation       time.Time     // when we plan to activate (stress_time - lead_time)
+	thermalBatteryDeferCancel             chan struct{}  // signal to stop deferred timer goroutine
+
 	// Forecast cache for thermal battery.
 	// forecastMu is intentionally held across the network call in getForecastHighLow.
 	// This is acceptable because: (1) callers are serialized via state-change handlers,
@@ -125,6 +137,11 @@ type Manager struct {
 	forecastCachedAt time.Time
 	forecastFailedAt time.Time // negative cache: last forecast fetch failure time
 	forecastMu       sync.Mutex
+
+	// Hourly forecast cache (guarded by forecastMu)
+	hourlyForecastEntries  []hourlyForecastEntry
+	hourlyForecastAt       time.Time
+	hourlyForecastFailedAt time.Time
 
 	// Push notifications
 	ntfyClient ntfy.Notifier
@@ -150,9 +167,11 @@ func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.M
 		rateLimitInterval:             minActionInterval,
 		deferredStopChan:              make(chan struct{}),
 		ntfyClient:                    ntfyClient,
-		thermalBatteryPollInt:         thermalBatteryDefaultPollInt,
-		thermalBatteryHoldRevertDelay: thermalBatteryDefaultHoldRevertDelay,
-		thermalBatteryMaxStepWaitDur:  thermalBatteryMaxStepWait,
+		thermalBatteryPollInt:                thermalBatteryDefaultPollInt,
+		thermalBatteryHoldRevertDelay:        thermalBatteryDefaultHoldRevertDelay,
+		thermalBatteryMaxStepWaitDur:         thermalBatteryMaxStepWait,
+		thermalBatteryLeadTimeHours:          thermalBatteryDefaultLeadTimeHours,
+		thermalBatteryDeferredRecheckInterval: thermalBatteryDeferredRecheckDefault,
 	}
 }
 
@@ -186,6 +205,16 @@ func (m *Manager) SetThermalBatteryHoldRevertDelayForTesting(d time.Duration) {
 // SetThermalBatteryMaxStepWaitForTesting allows tests to use a shorter safety timeout per step.
 func (m *Manager) SetThermalBatteryMaxStepWaitForTesting(d time.Duration) {
 	m.thermalBatteryMaxStepWaitDur = d
+}
+
+// SetThermalBatteryLeadTimeHoursForTesting allows tests to override the default lead time.
+func (m *Manager) SetThermalBatteryLeadTimeHoursForTesting(h float64) {
+	m.thermalBatteryLeadTimeHours = h
+}
+
+// SetThermalBatteryDeferredRecheckIntervalForTesting allows tests to use a shorter recheck interval.
+func (m *Manager) SetThermalBatteryDeferredRecheckIntervalForTesting(d time.Duration) {
+	m.thermalBatteryDeferredRecheckInterval = d
 }
 
 // IsLoadSheddingOn returns whether load shedding is currently active (thread-safe)
@@ -242,9 +271,10 @@ func (m *Manager) Stop() {
 
 	m.logger.Info("Stopping Load Shedding Manager")
 
-	// Stop any thermal battery stepping goroutine
+	// Stop any thermal battery stepping or deferred timer goroutines
 	m.thermalBatteryMu.Lock()
 	m.stopThermalBatteryStepping()
+	m.stopDeferredActivationTimer()
 	m.thermalBatteryMu.Unlock()
 
 	// Cancel any pending deferred action

--- a/homeautomation-go/internal/plugins/loadshedding/manager.go
+++ b/homeautomation-go/internal/plugins/loadshedding/manager.go
@@ -126,7 +126,7 @@ type Manager struct {
 	thermalBatteryDeferredRecheckInterval time.Duration // how often to re-evaluate while deferred
 	thermalBatteryDeferred                bool          // true when activation is deferred due to timing
 	thermalBatteryPlannedActivation       time.Time     // when we plan to activate (stress_time - lead_time)
-	thermalBatteryDeferCancel             chan struct{}  // signal to stop deferred timer goroutine
+	thermalBatteryDeferCancel             chan struct{} // signal to stop deferred timer goroutine
 
 	// Forecast cache for thermal battery.
 	// forecastMu is intentionally held across the network call in getForecastHighLow.
@@ -156,21 +156,21 @@ func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.M
 	shadowTracker := shadowstate.NewLoadSheddingTracker()
 
 	return &Manager{
-		ctx:                           ctx,
-		haClient:                      haClient,
-		stateManager:                  stateManager,
-		logger:                        logger.Named("loadshedding"),
-		readOnly:                      readOnly,
-		enabled:                       false,
-		shadowTracker:                 shadowTracker,
-		subHelper:                     shadowstate.NewSubscriptionHelper(haClient, stateManager, registry, shadowTracker, "loadshedding", logger.Named("loadshedding")),
-		rateLimitInterval:             minActionInterval,
-		deferredStopChan:              make(chan struct{}),
-		ntfyClient:                    ntfyClient,
-		thermalBatteryPollInt:                thermalBatteryDefaultPollInt,
-		thermalBatteryHoldRevertDelay:        thermalBatteryDefaultHoldRevertDelay,
-		thermalBatteryMaxStepWaitDur:         thermalBatteryMaxStepWait,
-		thermalBatteryLeadTimeHours:          thermalBatteryDefaultLeadTimeHours,
+		ctx:                                   ctx,
+		haClient:                              haClient,
+		stateManager:                          stateManager,
+		logger:                                logger.Named("loadshedding"),
+		readOnly:                              readOnly,
+		enabled:                               false,
+		shadowTracker:                         shadowTracker,
+		subHelper:                             shadowstate.NewSubscriptionHelper(haClient, stateManager, registry, shadowTracker, "loadshedding", logger.Named("loadshedding")),
+		rateLimitInterval:                     minActionInterval,
+		deferredStopChan:                      make(chan struct{}),
+		ntfyClient:                            ntfyClient,
+		thermalBatteryPollInt:                 thermalBatteryDefaultPollInt,
+		thermalBatteryHoldRevertDelay:         thermalBatteryDefaultHoldRevertDelay,
+		thermalBatteryMaxStepWaitDur:          thermalBatteryMaxStepWait,
+		thermalBatteryLeadTimeHours:           thermalBatteryDefaultLeadTimeHours,
 		thermalBatteryDeferredRecheckInterval: thermalBatteryDeferredRecheckDefault,
 	}
 }

--- a/homeautomation-go/internal/plugins/loadshedding/manager.go
+++ b/homeautomation-go/internal/plugins/loadshedding/manager.go
@@ -68,7 +68,10 @@ const (
 	// Restart safety: delay after reverting stale holds to let thermostat schedule take effect
 	thermalBatteryDefaultHoldRevertDelay = 5 * time.Second
 
-	// Thermal battery: hourly forecast timing
+	// Thermal battery: hourly forecast timing.
+	// Note: thermalBatteryHourlyComfortMargin (5°F) is intentionally tighter than thermalBatterySkipMargin
+	// (20°F). The hourly path triggers on genuine near-term stress; the daily path uses a wide band
+	// to skip only on truly mild days. Normalizing them would break the intended behavior of each path.
 	thermalBatteryDefaultLeadTimeHours   = 3.0              // hours before forecast stress to activate
 	thermalBatteryHourlyComfortMargin    = 5.0              // °F outside comfort band to consider "stress" (hourly)
 	thermalBatteryDeferredRecheckDefault = 15 * time.Minute // how often to re-evaluate while deferred

--- a/homeautomation-go/internal/plugins/loadshedding/thermal_battery.go
+++ b/homeautomation-go/internal/plugins/loadshedding/thermal_battery.go
@@ -18,6 +18,13 @@ type forecastEntry struct {
 	TempLow     float64 `json:"templow"`
 }
 
+// hourlyForecastEntry represents a single hourly forecast entry from HA.
+// Only Temperature and DateTime are used; other fields are ignored.
+type hourlyForecastEntry struct {
+	DateTime    string  `json:"datetime"`
+	Temperature float64 `json:"temperature"`
+}
+
 // getForecastHighLow fetches the forecast daily high and low for today.
 // Returns (high, low, true) if forecast is available, or (0, 0, false) if unavailable.
 // Results are cached for forecastCacheDuration. Failures are negative-cached for
@@ -117,6 +124,182 @@ func (m *Manager) tryFetchForecast(entity string) (float64, float64, bool) {
 
 	today := entityData.Forecast[0]
 	return today.Temperature, today.TempLow, true
+}
+
+// getHourlyForecast fetches hourly forecast entries for thermal battery timing.
+// Only entries with non-empty datetimes are returned; entries without datetimes
+// (e.g., daily forecast data mistakenly fetched as hourly) are filtered out.
+// Cached for forecastCacheDuration; failures negatively cached separately from daily.
+// Shares forecastMu with getForecastHighLow.
+func (m *Manager) getHourlyForecast() ([]hourlyForecastEntry, bool) {
+	m.forecastMu.Lock()
+	defer m.forecastMu.Unlock()
+
+	// Return cached entries if still fresh
+	if !m.hourlyForecastAt.IsZero() && time.Since(m.hourlyForecastAt) < forecastCacheDuration {
+		return m.hourlyForecastEntries, true
+	}
+
+	// Negative cache: don't retry if we failed recently
+	if !m.hourlyForecastFailedAt.IsZero() && time.Since(m.hourlyForecastFailedAt) < forecastNegativeCacheDuration {
+		m.logger.Debug("Skipping hourly forecast fetch: within negative cache window",
+			zap.Duration("since_failure", time.Since(m.hourlyForecastFailedAt)))
+		return nil, false
+	}
+
+	entities := []string{forecastWeatherEntityPrimary, forecastWeatherEntitySecondary}
+	for _, entity := range entities {
+		entries, ok := m.tryFetchHourlyForecast(entity)
+		if ok {
+			m.hourlyForecastEntries = entries
+			m.hourlyForecastAt = time.Now()
+			m.hourlyForecastFailedAt = time.Time{} // clear negative cache on success
+			m.logger.Info("Fetched hourly forecast for thermal battery timing",
+				zap.String("source", entity),
+				zap.Int("entries", len(entries)))
+			return entries, true
+		}
+	}
+
+	m.hourlyForecastFailedAt = time.Now()
+	m.logger.Warn("All hourly forecast sources failed, cannot check timing")
+	return nil, false
+}
+
+// tryFetchHourlyForecast fetches hourly forecast entries from a single weather entity.
+// Filters out entries with empty datetimes (e.g., malformed or daily data served as hourly).
+func (m *Manager) tryFetchHourlyForecast(entity string) ([]hourlyForecastEntry, bool) {
+	result, err := m.haClient.CallServiceWithResponse(m.ctx, "weather", "get_forecasts", map[string]interface{}{
+		"entity_id": entity,
+		"type":      "hourly",
+	})
+	if err != nil {
+		m.logger.Warn("Failed to fetch hourly weather forecast",
+			zap.String("entity", entity), zap.Error(err))
+		return nil, false
+	}
+	if result == nil {
+		m.logger.Warn("Hourly weather forecast returned nil response",
+			zap.String("entity", entity))
+		return nil, false
+	}
+
+	var wrapper struct {
+		Response json.RawMessage `json:"response"`
+	}
+	if err := json.Unmarshal(result, &wrapper); err != nil || wrapper.Response == nil {
+		m.logger.Warn("Hourly weather forecast response malformed",
+			zap.String("entity", entity))
+		return nil, false
+	}
+
+	var parsed map[string]struct {
+		Forecast []hourlyForecastEntry `json:"forecast"`
+	}
+	if err := json.Unmarshal(wrapper.Response, &parsed); err != nil {
+		m.logger.Warn("Failed to parse hourly forecast response",
+			zap.String("entity", entity), zap.Error(err))
+		return nil, false
+	}
+
+	entityData, ok := parsed[entity]
+	if !ok || len(entityData.Forecast) == 0 {
+		m.logger.Warn("No hourly forecast entries found",
+			zap.String("entity", entity))
+		return nil, false
+	}
+
+	// Filter out entries without parseable datetimes
+	var valid []hourlyForecastEntry
+	for _, e := range entityData.Forecast {
+		if e.DateTime == "" {
+			continue
+		}
+		valid = append(valid, e)
+	}
+	if len(valid) == 0 {
+		m.logger.Warn("Hourly forecast has no entries with valid datetimes",
+			zap.String("entity", entity))
+		return nil, false
+	}
+	return valid, true
+}
+
+// findHourlyStressEvent scans hourly forecast entries (forward from now) to find the first
+// hour where outdoor temp crosses outside the comfort band: below targetLow-margin or above
+// targetHigh+margin. Returns (stressTime, direction, true) if found, or (zero,"",false) if not.
+// direction is "up" (pre-heat) or "down" (pre-cool).
+func findHourlyStressEvent(entries []hourlyForecastEntry, targetLow, targetHigh, margin float64) (time.Time, string, bool) {
+	stressLow := targetLow - margin
+	stressHigh := targetHigh + margin
+	now := time.Now()
+
+	for _, entry := range entries {
+		// Parse datetime (RFC3339 with timezone, or without)
+		t, err := time.Parse(time.RFC3339, entry.DateTime)
+		if err != nil {
+			t, err = time.Parse("2006-01-02T15:04:05", entry.DateTime)
+			if err != nil {
+				continue
+			}
+		}
+		// Skip past entries
+		if !t.After(now) {
+			continue
+		}
+		if entry.Temperature < stressLow {
+			return t, "up", true // cold stress — pre-heat
+		}
+		if entry.Temperature > stressHigh {
+			return t, "down", true // hot stress — pre-cool
+		}
+	}
+	return time.Time{}, "", false
+}
+
+// stopDeferredActivationTimer cancels the deferred activation goroutine if running.
+// Must be called with thermalBatteryMu held.
+func (m *Manager) stopDeferredActivationTimer() {
+	if m.thermalBatteryDeferCancel != nil {
+		close(m.thermalBatteryDeferCancel)
+		m.thermalBatteryDeferCancel = nil
+	}
+}
+
+// runDeferredActivationTimer periodically re-evaluates whether it is time to activate
+// the thermal battery. It exits when the cancel channel is closed or context is done.
+// cancelCh is a local copy of the cancel channel, safe to read without holding the lock.
+func (m *Manager) runDeferredActivationTimer(cancelCh <-chan struct{}) {
+	ticker := time.NewTicker(m.thermalBatteryDeferredRecheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-cancelCh:
+			m.logger.Info("Deferred thermal battery timer cancelled")
+			return
+		case <-m.ctx.Done():
+			return
+		case <-ticker.C:
+			// Check if still deferred before re-evaluating.
+			// deactivateThermalBattery() may have cleared the deferred state and closed
+			// cancelCh between our last select and now; the isDeferred guard handles it.
+			m.thermalBatteryMu.Lock()
+			isDeferred := m.thermalBatteryDeferred
+			m.thermalBatteryMu.Unlock()
+
+			if !isDeferred {
+				return
+			}
+
+			// Invalidate the hourly cache so activation re-fetches fresh forecast data.
+			m.forecastMu.Lock()
+			m.hourlyForecastAt = time.Time{}
+			m.forecastMu.Unlock()
+
+			m.activateThermalBattery()
+		}
+	}
 }
 
 // activateThermalBattery shifts HVAC setpoints to pre-condition the house when energy is abundant (white level).
@@ -251,80 +434,143 @@ func (m *Manager) activateThermalBattery() {
 	}
 
 	if hasHeatCool {
-		// Try forecast first, fall back to current outdoor temp
-		fHigh, fLow, hasForecast := m.getForecastHighLow()
-
-		if hasForecast {
-			usedForecast = true
-			forecastHigh = fHigh
-			forecastLow = fLow
-
-			// Use the first heat_cool thermostat's setpoints to define the skip zone
+		// Try hourly forecast first for precise timing (issue #1002).
+		// If hourly data is available, use it to both determine direction AND decide whether
+		// to defer activation until the stress event is within the lead time window.
+		// Falls back to daily forecast / outdoor temp when hourly is unavailable.
+		hourlyEntries, hasHourly := m.getHourlyForecast()
+		if hasHourly {
+			// Use the first heat_cool thermostat's setpoints for the stress scan
 			for _, sp := range savedSetpoints {
-				if sp.HVACMode == "heat_cool" || sp.HVACMode == "auto" {
-					skipLow := sp.TargetLow - thermalBatterySkipMargin
-					skipHigh := sp.TargetHigh + thermalBatterySkipMargin
-
-					// Skip only if both forecast high AND low are within the comfort band + margin
-					if forecastHigh <= skipHigh && forecastLow >= skipLow {
-						m.logger.Info("Skipping thermal battery: forecast within skip zone",
-							zap.Float64("forecast_high", forecastHigh),
-							zap.Float64("forecast_low", forecastLow),
-							zap.Float64("skip_low", skipLow),
-							zap.Float64("skip_high", skipHigh))
-						m.shadowTracker.RecordThermalBatterySkipped(
-							fmt.Sprintf("forecast high %.1f°F/low %.1f°F within skip zone (%.0f-%.0f°F)", forecastHigh, forecastLow, skipLow, skipHigh))
-						return
-					}
-
-					// Direction based on which extreme is outside the comfort band
-					if forecastHigh > skipHigh {
-						direction = "down" // hot day coming, pre-cool
-					} else {
-						direction = "up" // cold night coming, pre-heat
-					}
-					break
+				if sp.HVACMode != "heat_cool" && sp.HVACMode != "auto" {
+					continue
 				}
+
+				stressTime, stressDir, hasStress := findHourlyStressEvent(
+					hourlyEntries, sp.TargetLow, sp.TargetHigh, thermalBatteryHourlyComfortMargin)
+
+				if !hasStress {
+					// No stress in forecast window — thermal battery not needed
+					m.logger.Info("Skipping thermal battery: no thermal stress in hourly forecast window",
+						zap.Float64("comfort_margin_f", thermalBatteryHourlyComfortMargin))
+					m.shadowTracker.RecordThermalBatterySkipped("no thermal stress in hourly forecast window")
+					return
+				}
+
+				hoursUntilStress := time.Until(stressTime).Hours()
+				direction = stressDir
+
+				if hoursUntilStress > m.thermalBatteryLeadTimeHours {
+					// Stress is too far away — defer activation
+					plannedActivation := stressTime.Add(
+						-time.Duration(m.thermalBatteryLeadTimeHours * float64(time.Hour)))
+					m.thermalBatteryDeferred = true
+					m.thermalBatteryPlannedActivation = plannedActivation
+
+					// Start re-evaluation timer if not already running
+					if m.thermalBatteryDeferCancel == nil {
+						cancelCh := make(chan struct{})
+						m.thermalBatteryDeferCancel = cancelCh
+						go m.runDeferredActivationTimer(cancelCh)
+					}
+
+					m.shadowTracker.RecordThermalBatteryDeferred(plannedActivation, stressDir)
+					m.logger.Info("Thermal battery deferred: stress not yet within lead time",
+						zap.Float64("hours_until_stress", hoursUntilStress),
+						zap.Float64("lead_time_hours", m.thermalBatteryLeadTimeHours),
+						zap.Time("planned_activation", plannedActivation),
+						zap.String("stress_direction", stressDir))
+					return
+				}
+
+				// Within lead time — proceed to activate now.
+				// Clear any deferred state (timer goroutine will see deferred=false and exit).
+				if m.thermalBatteryDeferred {
+					m.stopDeferredActivationTimer()
+					m.thermalBatteryDeferred = false
+					m.thermalBatteryPlannedActivation = time.Time{}
+				}
+
+				m.logger.Info("Thermal battery: stress within lead time, activating now",
+					zap.Float64("hours_until_stress", hoursUntilStress),
+					zap.String("stress_direction", stressDir))
+				break
 			}
 		} else {
-			// Fallback: use current outdoor temperature (existing behavior)
-			m.logger.Warn("Using current outdoor temp as fallback for thermal battery direction")
+			// Hourly forecast unavailable — fall back to daily forecast / outdoor temp
+			fHigh, fLow, hasForecast := m.getForecastHighLow()
 
-			outdoorState, err := m.haClient.GetState(outdoorTempSensor)
-			if err != nil {
-				m.logger.Warn("Skipping thermal battery: outdoor temp sensor unavailable",
-					zap.String("sensor", outdoorTempSensor), zap.Error(err))
-				m.shadowTracker.RecordThermalBatterySkipped("outdoor temp sensor unavailable")
-				return
-			}
-			parsed, err := strconv.ParseFloat(outdoorState.State, 64)
-			if err != nil {
-				m.logger.Warn("Skipping thermal battery: could not parse outdoor temp",
-					zap.String("sensor", outdoorTempSensor), zap.String("value", outdoorState.State), zap.Error(err))
-				m.shadowTracker.RecordThermalBatterySkipped("outdoor temp not parseable")
-				return
-			}
-			outdoorTemp = parsed
+			if hasForecast {
+				usedForecast = true
+				forecastHigh = fHigh
+				forecastLow = fLow
 
-			for _, sp := range savedSetpoints {
-				if sp.HVACMode == "heat_cool" || sp.HVACMode == "auto" {
-					skipLow := sp.TargetLow - thermalBatterySkipMargin
-					skipHigh := sp.TargetHigh + thermalBatterySkipMargin
-					if outdoorTemp >= skipLow && outdoorTemp <= skipHigh {
-						m.logger.Info("Skipping thermal battery: outdoor temp within skip zone (fallback)",
-							zap.Float64("outdoor_temp", outdoorTemp),
-							zap.Float64("skip_low", skipLow),
-							zap.Float64("skip_high", skipHigh))
-						m.shadowTracker.RecordThermalBatterySkipped(
-							fmt.Sprintf("outdoor temp %.1f°F within skip zone (%.0f-%.0f°F) (fallback)", outdoorTemp, skipLow, skipHigh))
-						return
+				for _, sp := range savedSetpoints {
+					if sp.HVACMode == "heat_cool" || sp.HVACMode == "auto" {
+						skipLow := sp.TargetLow - thermalBatterySkipMargin
+						skipHigh := sp.TargetHigh + thermalBatterySkipMargin
+
+						if forecastHigh <= skipHigh && forecastLow >= skipLow {
+							m.logger.Info("Skipping thermal battery: forecast within skip zone",
+								zap.Float64("forecast_high", forecastHigh),
+								zap.Float64("forecast_low", forecastLow),
+								zap.Float64("skip_low", skipLow),
+								zap.Float64("skip_high", skipHigh))
+							m.shadowTracker.RecordThermalBatterySkipped(
+								fmt.Sprintf("forecast high %.1f°F/low %.1f°F within skip zone (%.0f-%.0f°F)",
+									forecastHigh, forecastLow, skipLow, skipHigh))
+							return
+						}
+
+						if forecastHigh > skipHigh {
+							direction = "down" // hot day coming, pre-cool
+						} else {
+							direction = "up" // cold night coming, pre-heat
+						}
+						break
 					}
-					if outdoorTemp < skipLow {
-						direction = "up"
-					} else {
-						direction = "down"
+				}
+			} else {
+				// Fallback: use current outdoor temperature
+				m.logger.Warn("Using current outdoor temp as fallback for thermal battery direction")
+
+				outdoorState, err := m.haClient.GetState(outdoorTempSensor)
+				if err != nil {
+					m.logger.Warn("Skipping thermal battery: outdoor temp sensor unavailable",
+						zap.String("sensor", outdoorTempSensor), zap.Error(err))
+					m.shadowTracker.RecordThermalBatterySkipped("outdoor temp sensor unavailable")
+					return
+				}
+				parsed, err := strconv.ParseFloat(outdoorState.State, 64)
+				if err != nil {
+					m.logger.Warn("Skipping thermal battery: could not parse outdoor temp",
+						zap.String("sensor", outdoorTempSensor), zap.String("value", outdoorState.State), zap.Error(err))
+					m.shadowTracker.RecordThermalBatterySkipped("outdoor temp not parseable")
+					return
+				}
+				outdoorTemp = parsed
+
+				for _, sp := range savedSetpoints {
+					if sp.HVACMode == "heat_cool" || sp.HVACMode == "auto" {
+						skipLow := sp.TargetLow - thermalBatterySkipMargin
+						skipHigh := sp.TargetHigh + thermalBatterySkipMargin
+						if outdoorTemp >= skipLow && outdoorTemp <= skipHigh {
+							m.logger.Info("Skipping thermal battery: outdoor temp within skip zone (fallback)",
+								zap.Float64("outdoor_temp", outdoorTemp),
+								zap.Float64("skip_low", skipLow),
+								zap.Float64("skip_high", skipHigh))
+							m.shadowTracker.RecordThermalBatterySkipped(
+								fmt.Sprintf("outdoor temp %.1f°F within skip zone (%.0f-%.0f°F) (fallback)",
+									outdoorTemp, skipLow, skipHigh))
+							return
+						}
+						if outdoorTemp < skipLow {
+							direction = "up"
+						} else {
+							direction = "down"
+						}
+						break
 					}
-					break
 				}
 			}
 		}
@@ -636,10 +882,20 @@ func (m *Manager) stopThermalBatteryStepping() {
 	}
 }
 
-// deactivateThermalBattery reverts HVAC setpoints to their original values.
+// deactivateThermalBattery reverts HVAC setpoints to their original values and clears
+// any deferred activation state. Safe to call when not active (no-op) or when deferred.
 func (m *Manager) deactivateThermalBattery(reason string) {
 	m.thermalBatteryMu.Lock()
 	defer m.thermalBatteryMu.Unlock()
+
+	// Clear deferred state if present (even when not yet active)
+	if m.thermalBatteryDeferred {
+		m.logger.Info("Clearing deferred thermal battery activation", zap.String("reason", reason))
+		m.stopDeferredActivationTimer()
+		m.thermalBatteryDeferred = false
+		m.thermalBatteryPlannedActivation = time.Time{}
+		m.shadowTracker.RecordThermalBatteryDeferredCleared()
+	}
 
 	if !m.thermalBatteryActive {
 		return
@@ -716,13 +972,14 @@ func (m *Manager) deactivateThermalBattery(reason string) {
 }
 
 // handlePresenceChange handles changes to presence/sleep states.
-// If thermal battery is active and conditions no longer apply, deactivate it.
+// If thermal battery is active or deferred and conditions no longer apply, deactivate it.
 func (m *Manager) handlePresenceChange(key string, oldValue, newValue interface{}) {
 	m.thermalBatteryMu.Lock()
 	isActive := m.thermalBatteryActive
+	isDeferred := m.thermalBatteryDeferred
 	m.thermalBatteryMu.Unlock()
 
-	if !isActive {
+	if !isActive && !isDeferred {
 		return
 	}
 

--- a/homeautomation-go/internal/plugins/loadshedding/thermal_battery.go
+++ b/homeautomation-go/internal/plugins/loadshedding/thermal_battery.go
@@ -283,7 +283,10 @@ func (m *Manager) runDeferredActivationTimer(cancelCh <-chan struct{}) {
 		case <-ticker.C:
 			// Check if still deferred before re-evaluating.
 			// deactivateThermalBattery() may have cleared the deferred state and closed
-			// cancelCh between our last select and now; the isDeferred guard handles it.
+			// cancelCh between our last select and now. Note: this guard alone does not
+			// prevent activateThermalBattery() from running if deactivateThermalBattery()
+			// races in after we release the lock below. activateThermalBattery() itself
+			// re-checks the energy level under thermalBatteryMu, which closes that window.
 			m.thermalBatteryMu.Lock()
 			isDeferred := m.thermalBatteryDeferred
 			m.thermalBatteryMu.Unlock()
@@ -313,6 +316,19 @@ func (m *Manager) activateThermalBattery() {
 
 	if m.thermalBatteryActive {
 		m.logger.Info("Thermal battery already active, skipping activation")
+		return
+	}
+
+	// Guard: energy must still be white. This is the primary trigger condition; if energy
+	// dropped between the caller's check and acquiring the lock (TOCTOU), abort safely.
+	// This also defends against the deferred-timer race: deactivateThermalBattery() may
+	// run after the timer goroutine releases thermalBatteryMu but before we re-acquire it,
+	// so energy may no longer be white by the time we get here.
+	energyLevel, err := m.stateManager.GetString("currentEnergyLevel")
+	if err != nil || energyLevel != "white" {
+		m.logger.Info("Skipping thermal battery: energy no longer white",
+			zap.String("energy_level", energyLevel))
+		m.shadowTracker.RecordThermalBatterySkipped("energy not white")
 		return
 	}
 

--- a/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
+++ b/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1140,4 +1141,264 @@ func TestThermalBattery_SafetyTimeoutForcesStepAdvancement(t *testing.T) {
 	assert.Equal(t, 2, shadow.Outputs.ThermalBattery.StepsCompleted)
 	assert.Equal(t, 2, shadow.Outputs.ThermalBattery.TotalSteps)
 	assert.False(t, shadow.Outputs.ThermalBattery.Stepping, "Should not be stepping (all steps done)")
+}
+
+// =============================================================================
+// Hourly forecast timing tests (issue #1002)
+// =============================================================================
+
+// makeHourlyStressForecast creates an hourly forecast with a single stress event
+// at stressTime at stressTemp. Used for testing hourly timing deferral.
+// The response uses the real HA WebSocket API envelope format.
+func makeHourlyStressForecast(stressTemp float64, stressTime time.Time) json.RawMessage {
+	resp := fmt.Sprintf(
+		`{"context":{"id":"test"},"response":{"%s":{"forecast":[{"datetime":"%s","temperature":%.1f}]}}}`,
+		forecastWeatherEntityPrimary,
+		stressTime.UTC().Format(time.RFC3339),
+		stressTemp,
+	)
+	return json.RawMessage(resp)
+}
+
+// makeHourlyNoStressForecast creates an hourly forecast with mild temperatures
+// that stay within the comfort zone (69/72 ±5°F = 64-77°F) for 24 hours.
+func makeHourlyNoStressForecast() json.RawMessage {
+	now := time.Now().Truncate(time.Hour)
+	parts := make([]string, 0, 24)
+	for h := 1; h <= 24; h++ {
+		t := now.Add(time.Duration(h) * time.Hour)
+		parts = append(parts, fmt.Sprintf(`{"datetime":"%s","temperature":70.0}`, t.UTC().Format(time.RFC3339)))
+	}
+	resp := fmt.Sprintf(`{"context":{"id":"test"},"response":{"%s":{"forecast":[%s]}}}`,
+		forecastWeatherEntityPrimary, strings.Join(parts, ","))
+	return json.RawMessage(resp)
+}
+
+// setupHeatCoolEnvWithHourlyForecast creates a heat_cool test environment with an
+// hourly forecast for timing tests. stressTemp below 64°F triggers "up" (pre-heat),
+// above 77°F triggers "down" (pre-cool). stressTime is when the stress event occurs.
+func setupHeatCoolEnvWithHourlyForecast(t *testing.T, stressTemp float64, stressTime time.Time) *testutil.Env {
+	t.Helper()
+	env := testutil.NewEnv(t)
+	env.MockHA.SetState(thermostatHoldHouse, "off", nil)
+	env.MockHA.SetState(thermostatHoldSuite, "off", nil)
+
+	env.MockHA.SetState(climateHouse, "heat_cool", map[string]interface{}{
+		"target_temp_low":     69.0,
+		"target_temp_high":    72.0,
+		"current_temperature": 70.0,
+		"hvac_action":         "idle",
+	})
+	env.MockHA.SetState(climateSuite, "heat_cool", map[string]interface{}{
+		"target_temp_low":     69.0,
+		"target_temp_high":    72.0,
+		"current_temperature": 71.0,
+		"hvac_action":         "idle",
+	})
+
+	env.MockHA.SetServiceResponse("weather", "get_forecasts", makeHourlyStressForecast(stressTemp, stressTime))
+
+	require.NoError(t, env.StateMgr.SetBool("isAnyoneHome", true))
+	require.NoError(t, env.StateMgr.SetBool("isEveryoneAsleep", false))
+	require.NoError(t, env.StateMgr.SyncFromHA())
+	return env
+}
+
+func TestThermalBattery_HourlyForecast_DeferredWhenStressFarAway(t *testing.T) {
+	t.Parallel()
+	// Comfort band: 69/72. Margin: 5°F. Stress threshold: < 64°F (cold).
+	// Stress event: cold (50°F) 8 hours away. Lead time: 3 hours.
+	// Expected: deferred (8h > 3h lead time), shadow state shows deferred=true.
+	stressTime := time.Now().Add(8 * time.Hour)
+	env := setupHeatCoolEnvWithHourlyForecast(t, 50.0, stressTime) // 50°F < 64°F = cold stress
+
+	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, nil)
+	ls.SetThermalBatteryLeadTimeHoursForTesting(3.0)
+	require.NoError(t, ls.Start())
+	defer ls.Stop()
+
+	_ = env.MockHA.ServiceCallCount()
+
+	require.NoError(t, env.StateMgr.SetString("currentEnergyLevel", "white"))
+
+	// Should be deferred, not active
+	assert.False(t, ls.IsThermalBatteryActive(), "Thermal battery should be deferred, not active")
+
+	// No climate service calls should be made
+	calls := env.MockHA.GetServiceCallsSince(0)
+	for _, call := range calls {
+		if call.Domain == "climate" {
+			t.Error("No climate.set_temperature calls should be made when thermal battery is deferred")
+		}
+	}
+
+	// Shadow state should show deferred
+	shadow := ls.GetShadowState()
+	assert.True(t, shadow.Outputs.ThermalBattery.Deferred, "Shadow state should show deferred=true")
+	assert.False(t, shadow.Outputs.ThermalBattery.PlannedActivation.IsZero(), "PlannedActivation should be set")
+	assert.Equal(t, "up", shadow.Outputs.ThermalBattery.StressDirection, "Cold stress should be 'up' direction")
+}
+
+func TestThermalBattery_HourlyForecast_ActivatesImmediatelyWhenStressImminent(t *testing.T) {
+	t.Parallel()
+	// Stress event: cold (50°F) 1 hour away. Lead time: 3 hours.
+	// Expected: activates immediately (1h < 3h lead time).
+	stressTime := time.Now().Add(1 * time.Hour)
+	env := setupHeatCoolEnvWithHourlyForecast(t, 50.0, stressTime)
+
+	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, nil)
+	ls.SetThermalBatteryLeadTimeHoursForTesting(3.0)
+	require.NoError(t, ls.Start())
+	defer ls.Stop()
+
+	require.NoError(t, env.StateMgr.SetString("currentEnergyLevel", "white"))
+
+	// Should activate immediately (stress within lead time)
+	assert.True(t, ls.IsThermalBatteryActive(), "Thermal battery should activate when stress is within lead time")
+
+	// Shadow state should NOT be deferred
+	shadow := ls.GetShadowState()
+	assert.False(t, shadow.Outputs.ThermalBattery.Deferred, "Shadow state should not be deferred")
+	assert.True(t, shadow.Outputs.ThermalBattery.Active, "Shadow state should show active=true")
+}
+
+func TestThermalBattery_HourlyForecast_SkipsWhenNoStress(t *testing.T) {
+	t.Parallel()
+	// Hourly forecast with mild temps (70°F, within 64-77°F comfort zone).
+	// Expected: skip (no thermal stress in window).
+	env := testutil.NewEnv(t)
+	env.MockHA.SetState(thermostatHoldHouse, "off", nil)
+	env.MockHA.SetState(thermostatHoldSuite, "off", nil)
+	env.MockHA.SetState(climateHouse, "heat_cool", map[string]interface{}{
+		"target_temp_low": 69.0, "target_temp_high": 72.0, "current_temperature": 70.0,
+	})
+	env.MockHA.SetState(climateSuite, "heat_cool", map[string]interface{}{
+		"target_temp_low": 69.0, "target_temp_high": 72.0, "current_temperature": 70.0,
+	})
+	env.MockHA.SetServiceResponse("weather", "get_forecasts", makeHourlyNoStressForecast())
+	require.NoError(t, env.StateMgr.SetBool("isAnyoneHome", true))
+	require.NoError(t, env.StateMgr.SetBool("isEveryoneAsleep", false))
+	require.NoError(t, env.StateMgr.SyncFromHA())
+
+	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, nil)
+	require.NoError(t, ls.Start())
+	defer ls.Stop()
+
+	require.NoError(t, env.StateMgr.SetString("currentEnergyLevel", "white"))
+
+	assert.False(t, ls.IsThermalBatteryActive(), "Thermal battery should skip when no stress in forecast")
+
+	shadow := ls.GetShadowState()
+	assert.Contains(t, shadow.Outputs.ThermalBattery.SkipReason, "no thermal stress")
+}
+
+func TestThermalBattery_HourlyForecast_DeferredClearedOnEnergyDrop(t *testing.T) {
+	t.Parallel()
+	// Set up deferred state, then drop energy level. Deferred state should clear.
+	stressTime := time.Now().Add(8 * time.Hour)
+	env := setupHeatCoolEnvWithHourlyForecast(t, 50.0, stressTime)
+
+	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, nil)
+	ls.SetThermalBatteryLeadTimeHoursForTesting(3.0)
+	ls.lastAction = time.Now().Add(-2 * time.Hour) // avoid rate limiting
+	require.NoError(t, ls.Start())
+	defer ls.Stop()
+
+	// Activate to white → should defer
+	require.NoError(t, env.StateMgr.SetString("currentEnergyLevel", "white"))
+	assert.False(t, ls.IsThermalBatteryActive())
+	shadow := ls.GetShadowState()
+	assert.True(t, shadow.Outputs.ThermalBattery.Deferred, "Should be deferred initially")
+
+	// Drop to yellow → deferred state should clear
+	require.NoError(t, env.StateMgr.SetString("currentEnergyLevel", "yellow"))
+
+	assert.False(t, ls.IsThermalBatteryActive(), "Should not be active after energy drop")
+	shadow = ls.GetShadowState()
+	assert.False(t, shadow.Outputs.ThermalBattery.Deferred, "Deferred state should be cleared after energy drop")
+	assert.True(t, shadow.Outputs.ThermalBattery.PlannedActivation.IsZero(), "PlannedActivation should be cleared")
+}
+
+func TestThermalBattery_HourlyForecast_DeferredClearedWhenNoOneHome(t *testing.T) {
+	t.Parallel()
+	// Set up deferred state, then mark no one home. Deferred state should clear.
+	stressTime := time.Now().Add(8 * time.Hour)
+	env := setupHeatCoolEnvWithHourlyForecast(t, 50.0, stressTime)
+
+	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, nil)
+	ls.SetThermalBatteryLeadTimeHoursForTesting(3.0)
+	require.NoError(t, ls.Start())
+	defer ls.Stop()
+
+	// Activate to white → should defer
+	require.NoError(t, env.StateMgr.SetString("currentEnergyLevel", "white"))
+	assert.False(t, ls.IsThermalBatteryActive())
+	shadow := ls.GetShadowState()
+	assert.True(t, shadow.Outputs.ThermalBattery.Deferred, "Should be deferred initially")
+
+	// Everyone leaves → deferred state should clear
+	require.NoError(t, env.StateMgr.SetBool("isAnyoneHome", false))
+
+	shadow = ls.GetShadowState()
+	assert.False(t, shadow.Outputs.ThermalBattery.Deferred, "Deferred state should be cleared when no one is home")
+	assert.True(t, shadow.Outputs.ThermalBattery.PlannedActivation.IsZero(), "PlannedActivation should be cleared")
+}
+
+func TestThermalBattery_HourlyForecast_DeferredTimerActivatesWhenWithinLeadTime(t *testing.T) {
+	t.Parallel()
+	// Use a very short lead time and recheck interval so the timer fires quickly.
+	// Stress event is 200ms away. Lead time is 100ms (in hours). Recheck is 20ms.
+	// Initial check: 200ms > 100ms → defers.
+	// After ~100ms: recheck timer fires, stress is ~100ms away ≤ lead_time → activates.
+	recheckInterval := 20 * time.Millisecond
+	leadTimeDuration := 100 * time.Millisecond
+	leadTimeHours := float64(leadTimeDuration) / float64(time.Hour)
+
+	stressTime := time.Now().Add(200 * time.Millisecond)
+	env := setupHeatCoolEnvWithHourlyForecast(t, 50.0, stressTime)
+
+	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, nil)
+	ls.SetThermalBatteryLeadTimeHoursForTesting(leadTimeHours)
+	ls.SetThermalBatteryDeferredRecheckIntervalForTesting(recheckInterval)
+	require.NoError(t, ls.Start())
+	defer ls.Stop()
+
+	require.NoError(t, env.StateMgr.SetString("currentEnergyLevel", "white"))
+
+	// Initially deferred
+	assert.False(t, ls.IsThermalBatteryActive(), "Should be deferred initially")
+	shadow := ls.GetShadowState()
+	assert.True(t, shadow.Outputs.ThermalBattery.Deferred, "Should show deferred in shadow state")
+
+	// Wait for the timer to re-evaluate and activate (up to 500ms)
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if ls.IsThermalBatteryActive() {
+			break
+		}
+		time.Sleep(recheckInterval)
+	}
+
+	assert.True(t, ls.IsThermalBatteryActive(), "Thermal battery should activate after stress enters lead-time window")
+	shadow = ls.GetShadowState()
+	assert.False(t, shadow.Outputs.ThermalBattery.Deferred, "Shadow state should not be deferred after activation")
+	assert.True(t, shadow.Outputs.ThermalBattery.Active, "Shadow state should show active=true")
+}
+
+func TestThermalBattery_HourlyForecast_FallsBackToDailyWhenHourlyUnavailable(t *testing.T) {
+	t.Parallel()
+	// No hourly forecast configured (daily format returned = no valid datetimes).
+	// Fall back to daily forecast logic. Cold daily forecast → activates.
+	env := setupHeatCoolEnvWithForecast(t, "", 45.0, 25.0) // daily forecast only
+
+	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, nil)
+	require.NoError(t, ls.Start())
+	defer ls.Stop()
+
+	require.NoError(t, env.StateMgr.SetString("currentEnergyLevel", "white"))
+
+	// Should activate using daily forecast fallback (not deferred)
+	assert.True(t, ls.IsThermalBatteryActive(), "Should activate using daily forecast when hourly unavailable")
+	shadow := ls.GetShadowState()
+	assert.False(t, shadow.Outputs.ThermalBattery.Deferred, "Should not be deferred when using daily fallback")
 }

--- a/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
+++ b/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
@@ -1347,14 +1347,16 @@ func TestThermalBattery_HourlyForecast_DeferredClearedWhenNoOneHome(t *testing.T
 func TestThermalBattery_HourlyForecast_DeferredTimerActivatesWhenWithinLeadTime(t *testing.T) {
 	t.Parallel()
 	// Use a very short lead time and recheck interval so the timer fires quickly.
-	// Stress event is 200ms away. Lead time is 100ms (in hours). Recheck is 20ms.
-	// Initial check: 200ms > 100ms → defers.
-	// After ~100ms: recheck timer fires, stress is ~100ms away ≤ lead_time → activates.
-	recheckInterval := 20 * time.Millisecond
-	leadTimeDuration := 100 * time.Millisecond
+	// Stress event is 2s away. Lead time is 500ms (in hours). Recheck is 50ms.
+	// Initial check: 2s > 500ms → defers.
+	// After ~1.5s: recheck timer fires, stress is ≤500ms away → activates.
+	recheckInterval := 50 * time.Millisecond
+	leadTimeDuration := 500 * time.Millisecond
 	leadTimeHours := float64(leadTimeDuration) / float64(time.Hour)
 
-	stressTime := time.Now().Add(200 * time.Millisecond)
+	// Use a 2-second stress window so test setup overhead (~200ms) stays well within
+	// the deferral window (2s - 0.5s lead = 1.5s), giving robust initial deferral.
+	stressTime := time.Now().Add(2 * time.Second)
 	env := setupHeatCoolEnvWithHourlyForecast(t, 50.0, stressTime)
 
 	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, nil)
@@ -1370,8 +1372,8 @@ func TestThermalBattery_HourlyForecast_DeferredTimerActivatesWhenWithinLeadTime(
 	shadow := ls.GetShadowState()
 	assert.True(t, shadow.Outputs.ThermalBattery.Deferred, "Should show deferred in shadow state")
 
-	// Wait for the timer to re-evaluate and activate (up to 500ms)
-	deadline := time.Now().Add(500 * time.Millisecond)
+	// Wait for the timer to re-evaluate and activate (up to 4s)
+	deadline := time.Now().Add(4 * time.Second)
 	for time.Now().Before(deadline) {
 		if ls.IsThermalBatteryActive() {
 			break

--- a/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
+++ b/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
@@ -1372,16 +1372,9 @@ func TestThermalBattery_HourlyForecast_DeferredTimerActivatesWhenWithinLeadTime(
 	shadow := ls.GetShadowState()
 	assert.True(t, shadow.Outputs.ThermalBattery.Deferred, "Should show deferred in shadow state")
 
-	// Wait for the timer to re-evaluate and activate (up to 4s)
-	deadline := time.Now().Add(4 * time.Second)
-	for time.Now().Before(deadline) {
-		if ls.IsThermalBatteryActive() {
-			break
-		}
-		time.Sleep(recheckInterval)
-	}
-
-	assert.True(t, ls.IsThermalBatteryActive(), "Thermal battery should activate after stress enters lead-time window")
+	// Wait for the timer to re-evaluate and activate (up to 4s).
+	require.Eventually(t, ls.IsThermalBatteryActive, 4*time.Second, recheckInterval,
+		"Thermal battery should activate after stress enters lead-time window")
 	shadow = ls.GetShadowState()
 	assert.False(t, shadow.Outputs.ThermalBattery.Deferred, "Shadow state should not be deferred after activation")
 	assert.True(t, shadow.Outputs.ThermalBattery.Active, "Shadow state should show active=true")

--- a/homeautomation-go/internal/shadowstate/tracker.go
+++ b/homeautomation-go/internal/shadowstate/tracker.go
@@ -405,13 +405,17 @@ func (lst *LoadSheddingTracker) RecordThermalBatteryStepProgress(stepsCompleted,
 	lst.State().Metadata.LastUpdated = now
 }
 
-// RecordThermalBatterySkipped records that thermal battery activation was skipped
+// RecordThermalBatterySkipped records that thermal battery activation was skipped.
+// Also clears any deferred state so the dashboard does not show deferred=true
+// alongside a skip reason simultaneously (e.g. when a guard fires during a timer re-check).
 func (lst *LoadSheddingTracker) RecordThermalBatterySkipped(reason string) {
 	lst.Lock()
 	defer lst.Unlock()
 
 	now := time.Now()
 	lst.State().Outputs.ThermalBattery.SkipReason = reason
+	lst.State().Outputs.ThermalBattery.Deferred = false
+	lst.State().Outputs.ThermalBattery.PlannedActivation = time.Time{}
 	lst.State().Metadata.LastUpdated = now
 }
 

--- a/homeautomation-go/internal/shadowstate/tracker.go
+++ b/homeautomation-go/internal/shadowstate/tracker.go
@@ -415,6 +415,32 @@ func (lst *LoadSheddingTracker) RecordThermalBatterySkipped(reason string) {
 	lst.State().Metadata.LastUpdated = now
 }
 
+// RecordThermalBatteryDeferred records that thermal battery activation has been deferred
+// because the forecast stress event is not yet within the lead time window.
+func (lst *LoadSheddingTracker) RecordThermalBatteryDeferred(plannedActivation time.Time, direction string) {
+	lst.Lock()
+	defer lst.Unlock()
+
+	now := time.Now()
+	lst.State().Outputs.ThermalBattery.Deferred = true
+	lst.State().Outputs.ThermalBattery.PlannedActivation = plannedActivation
+	lst.State().Outputs.ThermalBattery.StressDirection = direction
+	lst.State().Metadata.LastUpdated = now
+}
+
+// RecordThermalBatteryDeferredCleared records that the deferred thermal battery state
+// was cleared (e.g., because energy dropped below white or presence conditions changed).
+func (lst *LoadSheddingTracker) RecordThermalBatteryDeferredCleared() {
+	lst.Lock()
+	defer lst.Unlock()
+
+	now := time.Now()
+	lst.State().Outputs.ThermalBattery.Deferred = false
+	lst.State().Outputs.ThermalBattery.PlannedActivation = time.Time{}
+	lst.State().Outputs.ThermalBattery.StressDirection = ""
+	lst.State().Metadata.LastUpdated = now
+}
+
 // GetState returns the current shadow state (thread-safe copy)
 func (lst *LoadSheddingTracker) GetState() *LoadSheddingShadowState {
 	lst.RLock()

--- a/homeautomation-go/internal/shadowstate/types.go
+++ b/homeautomation-go/internal/shadowstate/types.go
@@ -471,16 +471,19 @@ type ThermostatSettings struct {
 
 // ThermalBatteryState tracks the thermal battery pre-conditioning state
 type ThermalBatteryState struct {
-	Active         bool                     `json:"active"`
-	OffsetApplied  float64                  `json:"offsetApplied,omitempty"` // Degrees F shifted so far
-	ActivatedAt    time.Time                `json:"activatedAt,omitempty"`
-	DeactivatedAt  time.Time                `json:"deactivatedAt,omitempty"`
-	SkipReason     string                   `json:"skipReason,omitempty"` // Why activation was skipped
-	SavedSetpoints map[string]SavedSetpoint `json:"savedSetpoints,omitempty"`
-	StepsCompleted int                      `json:"stepsCompleted,omitempty"`
-	TotalSteps     int                      `json:"totalSteps,omitempty"`
-	StepSize       float64                  `json:"stepSize,omitempty"`
-	Stepping       bool                     `json:"stepping,omitempty"` // true while steps remain
+	Active           bool                     `json:"active"`
+	OffsetApplied    float64                  `json:"offsetApplied,omitempty"`    // Degrees F shifted so far
+	ActivatedAt      time.Time                `json:"activatedAt,omitempty"`
+	DeactivatedAt    time.Time                `json:"deactivatedAt,omitempty"`
+	SkipReason       string                   `json:"skipReason,omitempty"`       // Why activation was skipped
+	SavedSetpoints   map[string]SavedSetpoint `json:"savedSetpoints,omitempty"`
+	StepsCompleted   int                      `json:"stepsCompleted,omitempty"`
+	TotalSteps       int                      `json:"totalSteps,omitempty"`
+	StepSize         float64                  `json:"stepSize,omitempty"`
+	Stepping         bool                     `json:"stepping,omitempty"`         // true while steps remain
+	Deferred         bool                     `json:"deferred,omitempty"`         // true when activation is deferred due to timing
+	PlannedActivation time.Time               `json:"plannedActivation,omitempty"` // when we plan to activate
+	StressDirection  string                   `json:"stressDirection,omitempty"`  // "up" or "down"
 }
 
 // SavedSetpoint records the original thermostat setpoint before thermal battery offset was applied

--- a/homeautomation-go/internal/shadowstate/types.go
+++ b/homeautomation-go/internal/shadowstate/types.go
@@ -471,19 +471,19 @@ type ThermostatSettings struct {
 
 // ThermalBatteryState tracks the thermal battery pre-conditioning state
 type ThermalBatteryState struct {
-	Active           bool                     `json:"active"`
-	OffsetApplied    float64                  `json:"offsetApplied,omitempty"`    // Degrees F shifted so far
-	ActivatedAt      time.Time                `json:"activatedAt,omitempty"`
-	DeactivatedAt    time.Time                `json:"deactivatedAt,omitempty"`
-	SkipReason       string                   `json:"skipReason,omitempty"`       // Why activation was skipped
-	SavedSetpoints   map[string]SavedSetpoint `json:"savedSetpoints,omitempty"`
-	StepsCompleted   int                      `json:"stepsCompleted,omitempty"`
-	TotalSteps       int                      `json:"totalSteps,omitempty"`
-	StepSize         float64                  `json:"stepSize,omitempty"`
-	Stepping         bool                     `json:"stepping,omitempty"`         // true while steps remain
-	Deferred         bool                     `json:"deferred,omitempty"`         // true when activation is deferred due to timing
-	PlannedActivation time.Time               `json:"plannedActivation,omitempty"` // when we plan to activate
-	StressDirection  string                   `json:"stressDirection,omitempty"`  // "up" or "down"
+	Active            bool                     `json:"active"`
+	OffsetApplied     float64                  `json:"offsetApplied,omitempty"` // Degrees F shifted so far
+	ActivatedAt       time.Time                `json:"activatedAt,omitempty"`
+	DeactivatedAt     time.Time                `json:"deactivatedAt,omitempty"`
+	SkipReason        string                   `json:"skipReason,omitempty"` // Why activation was skipped
+	SavedSetpoints    map[string]SavedSetpoint `json:"savedSetpoints,omitempty"`
+	StepsCompleted    int                      `json:"stepsCompleted,omitempty"`
+	TotalSteps        int                      `json:"totalSteps,omitempty"`
+	StepSize          float64                  `json:"stepSize,omitempty"`
+	Stepping          bool                     `json:"stepping,omitempty"`          // true while steps remain
+	Deferred          bool                     `json:"deferred,omitempty"`          // true when activation is deferred due to timing
+	PlannedActivation time.Time                `json:"plannedActivation,omitempty"` // when we plan to activate
+	StressDirection   string                   `json:"stressDirection,omitempty"`   // "up" or "down"
 }
 
 // SavedSetpoint records the original thermostat setpoint before thermal battery offset was applied


### PR DESCRIPTION
## Summary

Implements hourly forecast timing for the thermal battery pre-conditioning system (issue #1002).

Previously, the thermal battery activated immediately when energy reached the "white" level and shifted HVAC setpoints based on the **daily** forecast. This PR adds hourly forecast awareness so activation is deferred until a configurable lead-time window before the actual thermal stress event arrives.

- **Fetch hourly forecast** from same weather entities (Met.no / WeatherFlow) using `type: "hourly"`
- **Scan forward** through hourly entries to find the first hour where outdoor temp crosses outside the comfort band (±5°F margin around current setpoints)
- **Defer** if `hours_until_stress > lead_time_hours` (default 3h); start a background re-evaluation timer
- **Activate immediately** once stress is within the lead-time window
- **Clear deferred state** when energy drops below white or presence conditions change
- **Fall back** gracefully to daily forecast / outdoor temp when hourly data is unavailable (backwards compatible — existing tests unaffected)

### Files Changed

| File | Change |
|------|--------|
| `manager.go` | 3 new constants, 5 new fields (deferred state + hourly cache), 2 test setters, update `Stop()` |
| `thermal_battery.go` | New `hourlyForecastEntry` struct, `getHourlyForecast()`, `tryFetchHourlyForecast()`, `findHourlyStressEvent()`, `stopDeferredActivationTimer()`, `runDeferredActivationTimer()`; restructured heat_cool block; updated `deactivateThermalBattery()` and `handlePresenceChange()` |
| `shadowstate/types.go` | Added `Deferred`, `PlannedActivation`, `StressDirection` to `ThermalBatteryState` |
| `shadowstate/tracker.go` | Added `RecordThermalBatteryDeferred()` and `RecordThermalBatteryDeferredCleared()` |
| `thermal_battery_test.go` | 7 new test cases covering deferral, immediate activation, no-stress skip, deferred-cleared-on-energy-drop, deferred-cleared-on-no-one-home, timer-triggers-activation, and daily-fallback |

## Test plan

- [x] `make unit-tests` — all tests pass (75.1% coverage, above 65% threshold)
- [x] `make pre-commit` — gofmt, goimports, go vet, staticcheck, build all pass
- [x] New tests cover: deferral when stress far away, immediate activation when stress imminent, no-stress skip, deferred state cleared on energy drop, deferred state cleared when no one home, timer correctly transitions deferred→active, daily forecast fallback when hourly unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)