### PR TITLE
fix(devcontainer): drop ANTHROPIC_API_KEY=fake-key so Claude OAuth works

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,7 +44,6 @@
   "remoteEnv": {
     "SSH_AUTH_SOCK": "",
     "OPENAI_API_KEY": "fake-key",
-    "ANTHROPIC_API_KEY": "fake-key",
     "TERM": "xterm-256color",
     "LANG": "en_US.UTF-8",
     "CLAUDE_HOST_CONFIG_DIR": "${localEnv:HOME}/.claude",


### PR DESCRIPTION
## Summary
- Removes `ANTHROPIC_API_KEY: "fake-key"` from `.devcontainer/devcontainer.json` `remoteEnv`.
- The placeholder value overrode the real OAuth credentials that `post-create.sh` copies from the host into `~/.claude/.credentials.json`, so interactive `claude` / `claude-yolo` inside the devcontainer failed with HTTP 401 ("Invalid authentication credentials").
- Workflow runs (`run-ai.sh:29`) overwrite `ANTHROPIC_API_KEY` with the real `AI_API_KEY` before invoking `claude`, so non-interactive use was unaffected — the bug only hit contributors using Claude Code interactively.
- CI no longer shares this Dockerfile (pipelines moved to `.github/ci/Dockerfile` in #970), so this change is scoped to local dev.
- `OPENAI_API_KEY=fake-key` is intentionally retained — codex/crush expect it set.

## Reproduction (before fix)
1. `dcs` into devcontainer
2. Run `claude-yolo`
3. Send any message → `API Error: 401 {"type":"authentication_error","message":"Invalid authentication credentials"}`

## Test plan
- [ ] Rebuild devcontainer
- [ ] Verify `~/.claude/.credentials.json` exists and is populated by `post-create.sh`
- [ ] Run `claude-yolo`, confirm successful auth (no 401)
- [ ] Confirm `printenv ANTHROPIC_API_KEY` is empty inside the container
- [ ] Existing AI workflow runs (ai-code-review, ai-assistant, etc.) still succeed — they set the env var explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)