### PR TITLE
ci(review): add Alignment Check to catch scope-miss in Design Reviewer

### DIFF
--- a/.github/ci/prompts/review-design.md
+++ b/.github/ci/prompts/review-design.md
@@ -3,7 +3,7 @@ You are a DESIGN REVIEW specialist for PR #${PR_NUMBER} in ${REPO}.
 Review like an experienced staff engineer. Be direct and selective.
 Don't praise the design or list strengths — focus on what you'd actually say in a review.
 Non-blocking observations are welcome when they steer toward better future decisions, but keep each to one sentence. No justification paragraphs.
-If the design is sound, approve in one line and move on.
+If the design is sound, keep the review terse — but the two top-line verdicts (Alignment check and Scope check) must still always appear.
 
 **CONTEXT:**
 PR Title: ${PR_TITLE}
@@ -26,13 +26,33 @@ divergence from production code paths.
 1. Read the issue/PR description to understand the problem being solved.
 2. Examine the code changes (`git diff origin/main...HEAD`).
 3. Validate: does the PR solve the stated problem? Gaps between intent and delivery are blocking.
-4. SCOPE CHECK: Compare the PR title/issue description against the actual diff.
+4. ALIGNMENT CHECK: Compare the issue's proposed solution against the PR's implementation strategy.
+   - Quote (verbatim) the issue's proposed algorithm, data sources, or config keys. If the
+     issue has a "Proposed Solution" / "Algorithm" / "Approach" section, use that. Otherwise
+     extract the specific sensors, entities, config keys, or decision rules the issue names.
+   - Quote the PR's actual implementation strategy (from PR body + diff): what data sources
+     does it read, what decision rule does it apply, what config does it expose?
+   - State explicitly: "Alignment check: PASS" or "Alignment check: FAIL — [one-line reason]"
+   - FAIL when: the PR solves an adjacent/simpler problem (e.g., issue asks for solar-curve
+     timing, PR implements weather-forecast-only timing); the PR ignores specific entities
+     or data sources the issue names as load-bearing; the PR's config keys diverge from the
+     issue's proposed keys without explanation in the PR body.
+   - PASS when: the implementation reads the same inputs and applies a decision rule
+     equivalent to what the issue proposed, OR the PR body explicitly justifies a
+     deliberate divergence (e.g., "issue proposed X but X is infeasible because Y,
+     doing Z instead").
+   - FAIL is BLOCKING. Do not issue a FAIL for pure style / naming divergence; only for
+     strategy or data-source divergence.
+5. SCOPE CHECK (did the PR do too MUCH?): Compare the PR title/issue description against
+   the actual diff.
    - Run: `git diff --stat origin/main...HEAD`
    - If the title suggests a narrow fix but the diff introduces new abstractions,
      new files, or >300 lines of non-test code beyond what the title implies,
      flag as BLOCKING scope creep.
    - State explicitly: "Scope check: PASS" or "Scope check: FAIL — [reason]"
-5. PRODUCTION RESILIENCE: For any new external integration or service call path:
+   - Note: Scope check catches scope CREEP. Alignment check (step 4) catches scope MISS
+     (solved adjacent problem).
+6. PRODUCTION RESILIENCE: For any new external integration or service call path:
    - Does it have retry logic? If replacing an existing path, does it match or exceed
      the resilience of the path it replaces? Missing retries on a path that replaces
      a retrying path is BLOCKING.
@@ -40,7 +60,7 @@ divergence from production code paths.
      data transfers. A shared 30s default is usually wrong.)
    - Is there graceful degradation if the external service is unavailable?
    - Does error handling distinguish transient vs permanent errors?
-6. Evaluate design decisions: could a simpler approach work? Flag new abstractions,
+7. Evaluate design decisions: could a simpler approach work? Flag new abstractions,
    helpers, or wrapper types that serve only one call site as BLOCKING over-engineering.
 
 Reference docs/architecture/ARCHITECTURE.md and docs/reference/SHADOW_STATE.md for context.
@@ -57,7 +77,8 @@ Use sparingly — most design feedback is cross-cutting and belongs in the summa
 Post exactly ONE top-level summary comment using:
 gh pr comment ${PR_NUMBER} --body '## Design Review
 
-[If no issues: "✅ Approved — {one-sentence summary}" and stop here]
+**Alignment check:** PASS | FAIL — [one-line reason if FAIL]
+**Scope check:** PASS | FAIL — [one-line reason if FAIL]
 
 ### Blocking Issues
 [Issues that must be fixed before merge. Skip section if none.]
@@ -67,3 +88,7 @@ gh pr comment ${PR_NUMBER} --body '## Design Review
 
 ### Conclusion
 [✅ Approved | ⚠️ Needs changes | ❌ Blocking issues]'
+
+Both verdicts must always appear at the top of the comment, even on a clean approval.
+If both are PASS and there are no Blocking Issues, the Conclusion is ✅ Approved and
+Worth Considering may be omitted.

--- a/.github/ci/prompts/review-design.md
+++ b/.github/ci/prompts/review-design.md
@@ -41,8 +41,11 @@ divergence from production code paths.
      equivalent to what the issue proposed, OR the PR body explicitly justifies a
      deliberate divergence (e.g., "issue proposed X but X is infeasible because Y,
      doing Z instead").
+   - If the issue specifies no algorithm or data sources (e.g., a simple bug report),
+     note that and mark PASS (N/A) — do not fabricate a quote.
    - FAIL is BLOCKING. Do not issue a FAIL for pure style / naming divergence; only for
-     strategy or data-source divergence.
+     strategy or data-source divergence. When issuing a FAIL, also list it under
+     ### Blocking Issues so reviewers scanning that section cannot miss it.
 5. SCOPE CHECK (did the PR do too MUCH?): Compare the PR title/issue description against
    the actual diff.
    - Run: `git diff --stat origin/main...HEAD`

--- a/docs/operations/AI_GHA_PIPELINES.md
+++ b/docs/operations/AI_GHA_PIPELINES.md
@@ -325,13 +325,16 @@ Design validation and critical design review specialist. Runs in parallel with o
 **Pre-Flight Check**: Before running the review, verifies that "All Required Tests" commit status is `success` on the current HEAD. If tests haven't passed, the review is skipped to avoid reviewing broken code that can't be merged anyway.
 
 **Purpose**: This reviewer serves two functions:
-1. **Intent Validation**: Ensures the PR actually implements what was requested in the linked issue and/or PR description (including **all comments** on the linked issue)
+1. **Intent Validation**: Two mandatory checks run on every PR:
+   - **Alignment check** — did the PR solve the same problem the issue proposed (scope miss)? FAIL is blocking. Both `Alignment check:` and `Scope check:` verdicts always appear at the top of every review comment.
+   - **Scope check** — did the PR do too much beyond what was asked (scope creep)?
 2. **Design Critique**: Critically reviews the design decisions for quality, trade-offs, and potential issues
 
 **Focus Areas**:
 - Does the PR solve the stated problem?
 - Are there gaps between requirements and implementation?
-- **Scope check**: Does the diff match the PR title/issue scope? Flags >300 lines of non-test code beyond what the title implies as BLOCKING scope creep
+- **Alignment check**: Does the PR implement the same algorithm/data sources the linked issue proposed, or does it solve an adjacent/simpler problem? FAIL is blocking. Both `Alignment check:` and `Scope check:` verdicts always appear at the top of every review comment.
+- **Scope check** (scope creep): Does the diff match the PR title/issue scope? Flags >300 lines of non-test code beyond what the title implies as BLOCKING scope creep.
 - **Production resilience**: New external integrations must have retry logic, appropriate timeouts, and graceful degradation
 - **Cross-PR context**: Considers whether the PR contradicts or undermines recently merged changes
 - Is this a good design for the problem?


### PR DESCRIPTION
## Summary

The Design Reviewer approved PR #1007 despite a material mismatch with its linked issue #1002. The issue proposed **solar-curve-based timing** for thermal battery activation (using `sensor.energy_production_today_remaining` + `sensor.energy_next_hour` to target the solar tail). The PR implemented **weather-forecast-only timing** with a fixed 3-hour lead time — a different algorithm that misses the issue's core insight ("charge thermal battery with solar, not battery"). The reviewer wrote \"Scope check: PASS\" without comparing the implementation strategy against the issue's proposed solution.

The existing **Scope Check** catches scope *creep* (did the PR do too much?). This PR adds an **Alignment Check** that catches scope *miss* (did the PR solve an adjacent/simpler problem?).

## Changes

- Insert `ALIGNMENT CHECK` as task 4 in `.github/ci/prompts/review-design.md`; renumber subsequent steps 5-7.
- Require the reviewer to quote (verbatim) the issue's proposed algorithm / data sources / config keys and the PR's actual implementation strategy, then render an explicit `PASS | FAIL` verdict.
- **FAIL conditions:** PR ignores issue-named load-bearing data sources/entities, OR diverges from proposed config keys without justification in the PR body, OR solves an adjacent/simpler problem. FAIL is blocking.
- **PASS conditions:** implementation reads the same inputs and applies an equivalent decision rule, OR the PR body explicitly justifies a deliberate divergence.
- Surface both `Alignment check:` and `Scope check:` verdicts at the top of every review comment (not only on failures) so silent omission is impossible.

## Why no workflow changes

`get-context` already injects `\${ISSUE_BODY}` and `\${ISSUE_COMMENTS}` into the design-review prompt. The reviewer correctly operates on the issue as of review-start time; post-PR-creation edits to the issue body are outside the reviewer's contract and not what this PR addresses.

## Regression check against #1007

The new FAIL conditions directly describe the #1007 failure mode:
- PR ignores `sensor.energy_production_today_remaining` and `sensor.energy_next_hour` — the sensors issue #1002 names as load-bearing. ✅ Triggers FAIL.
- PR exposes `thermalBatteryLeadTime` / `thermalBatteryHourlyComfortMargin` instead of the issue's proposed `solar_tail_threshold_kwh` / `solar_tail_fraction`, with no justification in the PR body. ✅ Triggers FAIL.

## Test plan

- [ ] Trigger `/review` on an intentionally-misaligned test PR (issue names sensor X, PR uses sensor Y). Confirm `Alignment check: FAIL` appears at the top of the Design Reviewer comment and merge-decision blocks.
- [ ] Trigger `/review` on a recent well-aligned PR (e.g. #1004). Confirm `Alignment check: PASS` and no spurious block.
- [ ] Confirm the summary comment still posts successfully (markdown renders correctly, shell-quoting of the template is unaffected).

## Follow-up (separate PR)

- Re-open #1002 or open a corrective PR that actually implements solar-curve timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)