### PR TITLE
Fix #1011: show hourly forecast stress info in thermal battery notification

### DIFF
--- a/homeautomation-go/internal/plugins/loadshedding/thermal_battery.go
+++ b/homeautomation-go/internal/plugins/loadshedding/thermal_battery.go
@@ -447,7 +447,10 @@ func (m *Manager) activateThermalBattery() {
 	var outdoorTemp float64
 	hasHeatCool := false
 	usedForecast := false
+	usedHourlyForecast := false
 	var forecastHigh, forecastLow float64
+	var hourlyStressTime time.Time
+	var hourlyStressTemp float64
 	for _, sp := range savedSetpoints {
 		if sp.HVACMode == "heat_cool" || sp.HVACMode == "auto" {
 			hasHeatCool = true
@@ -530,6 +533,10 @@ func (m *Manager) activateThermalBattery() {
 					m.stopDeferredActivationTimer()
 					m.thermalBatteryDeferred = false
 				}
+
+				usedHourlyForecast = true
+				hourlyStressTime = stressTime
+				hourlyStressTemp = stressTemp
 
 				m.logger.Info("Thermal battery: solar tail reached, activating now",
 					zap.String("stress_direction", stressDir),
@@ -687,7 +694,15 @@ func (m *Manager) activateThermalBattery() {
 	// Send push notification
 	if m.ntfyClient != nil && directionLabel != "" {
 		body := fmt.Sprintf("Shifting HVAC %s by %.0f°F (step 1/%d)", directionLabel, thermalBatteryOffset, totalSteps)
-		if hasHeatCool && usedForecast {
+		if hasHeatCool && usedHourlyForecast {
+			tempLabel := "low"
+			if direction == "down" {
+				tempLabel = "high"
+			}
+			body = fmt.Sprintf("Shifting HVAC %s by %.0f°F (step 1/%d, stress at %s, %s %.0f°F)",
+				directionLabel, thermalBatteryOffset, totalSteps,
+				hourlyStressTime.Local().Format("3:04 PM"), tempLabel, hourlyStressTemp)
+		} else if hasHeatCool && usedForecast {
 			body = fmt.Sprintf("Shifting HVAC %s by %.0f°F (step 1/%d, forecast high: %.0f°F, low: %.0f°F)", directionLabel, thermalBatteryOffset, totalSteps, forecastHigh, forecastLow)
 		} else if hasHeatCool {
 			body = fmt.Sprintf("Shifting HVAC %s by %.0f°F (step 1/%d, outdoor: %.1f°F)", directionLabel, thermalBatteryOffset, totalSteps, outdoorTemp)

--- a/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
+++ b/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
@@ -664,6 +664,7 @@ func TestThermalBattery_NtfyNotificationOnActivation_HourlyPath(t *testing.T) {
 	assert.Equal(t, "Thermal Battery Activated", ntfyCalls[0].Title)
 	assert.Contains(t, ntfyCalls[0].Body, "UP (pre-heat)")
 	assert.Contains(t, ntfyCalls[0].Body, "stress at")
+	assert.Contains(t, ntfyCalls[0].Body, stressTime.Local().Format("3:04 PM"))
 	assert.Contains(t, ntfyCalls[0].Body, "37")
 	// Must NOT show zeroed-out outdoor temp (the bug)
 	assert.NotContains(t, ntfyCalls[0].Body, "outdoor: 0.0°F")

--- a/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
+++ b/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
@@ -642,6 +642,33 @@ func TestThermalBattery_NtfyNotificationOnActivation(t *testing.T) {
 	assert.Contains(t, ntfyCalls[0].Body, "low: 25")
 }
 
+func TestThermalBattery_NtfyNotificationOnActivation_HourlyPath(t *testing.T) {
+	t.Parallel()
+	// Regression test for issue #1011: hourly-forecast path showed "outdoor: 0.0°F" in notification.
+	// Verify that when activated via hourly forecast (solar tail reached), the notification
+	// includes stress time and temperature instead of zeroed-out outdoor temp.
+	stressTime := time.Now().Add(8 * time.Hour)
+	env := setupHeatCoolEnvWithHourlyForecast(t, 37.0, stressTime, 6.0) // 6 kWh < threshold → activates
+
+	mockNtfy := ntfy.NewMockClient()
+	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, mockNtfy)
+	ls.SetThermalBatterySolarTailThresholdForTesting(15.0)
+	require.NoError(t, ls.Start())
+	defer ls.Stop()
+
+	require.NoError(t, env.StateMgr.SetString("currentEnergyLevel", "white"))
+	assert.True(t, ls.IsThermalBatteryActive(), "Thermal battery should activate when solar tail is reached")
+
+	ntfyCalls := mockNtfy.GetCalls()
+	require.Len(t, ntfyCalls, 1, "Should have sent exactly one ntfy notification")
+	assert.Equal(t, "Thermal Battery Activated", ntfyCalls[0].Title)
+	assert.Contains(t, ntfyCalls[0].Body, "UP (pre-heat)")
+	assert.Contains(t, ntfyCalls[0].Body, "stress at")
+	assert.Contains(t, ntfyCalls[0].Body, "37")
+	// Must NOT show zeroed-out outdoor temp (the bug)
+	assert.NotContains(t, ntfyCalls[0].Body, "outdoor: 0.0°F")
+}
+
 func TestThermalBattery_SkipsWhenThermostatOff(t *testing.T) {
 	t.Parallel()
 	env := setupThermalBatteryEnv(t)


### PR DESCRIPTION
Resolves #1011

## Summary

- Added `usedHourlyForecast bool`, `hourlyStressTime time.Time`, and `hourlyStressTemp float64` variables in `activateThermalBattery()` to capture stress event details from the hourly forecast path
- Set these variables when the hourly path proceeds to activation (after the solar-tail gate passes)
- Added a new notification branch for the hourly path that formats the stress event: e.g. `Shifting HVAC UP (pre-heat) by 2°F (step 1/2, stress at 10:00 PM, low 37°F)`
- Added regression test `TestThermalBattery_NtfyNotificationOnActivation_HourlyPath` that verifies the notification contains stress info and NOT the zeroed-out outdoor temp

**Before:** `Shifting HVAC UP (pre-heat) by 2°F (step 1/2, outdoor: 0.0°F)`  
**After:** `Shifting HVAC UP (pre-heat) by 2°F (step 1/2, stress at 5:00 PM, low 37°F)`

## Test Plan

- `make unit-tests` — all 11 integration tests and all unit tests pass ✅
- New test `TestThermalBattery_NtfyNotificationOnActivation_HourlyPath` specifically covers the bug scenario: hourly path, solar tail reached, checks notification contains `"stress at"` and stress temp, and does NOT contain `"outdoor: 0.0°F"`

🤖 Generated by the AI assistant