### PR TITLE
Fix #1013: Increase thermal battery solar tail threshold to 28 kWh

### DIFF
--- a/docs/flows/LOAD_SHEDDING.md
+++ b/docs/flows/LOAD_SHEDDING.md
@@ -137,7 +137,7 @@ flowchart TD
     checkMode{"heat_cool<br/>mode?"}
     checkHourly{"Hourly forecast<br/>available?"}
     checkStress{"Stress event<br/>in window?"}
-    checkSolarTail{"Solar tail reached?<br/>(remaining &lt; 15 kWh<br/>or free energy?)"}
+    checkSolarTail{"Solar tail reached?<br/>(remaining &lt; 28 kWh<br/>or free energy?)"}
     deferred["Defer activation<br/>Re-check every 15 min"]
     checkDaily{"Daily forecast<br/>available?"}
     checkOutdoor{"Outdoor temp<br/>within ±20°F of<br/>comfort band?"}
@@ -225,8 +225,8 @@ flowchart TD
 
 1. **Hourly forecast** (primary) — `weather.get_forecasts` with `type=hourly`. Scans forward from now for the first hour where outdoor temp falls outside the comfort band ± 5°F margin.
    - **No stress in window** → skip entirely.
-   - **Stress found, remaining solar > 15 kWh and free energy not active** → defer activation; re-check every 15 min until solar tail is reached.
-   - **Solar tail reached (remaining ≤ 15 kWh) or free energy in effect** → activate now.
+   - **Stress found, remaining solar > 28 kWh and free energy not active** → defer activation; re-check every 15 min until solar tail is reached.
+   - **Solar tail reached (remaining ≤ 28 kWh) or free energy in effect** → activate now.
    - Direction: temp below band → pre-heat (shift **up**); temp above band → pre-cool (shift **down**).
    - Note: the hourly comfort margin (±5°F) is intentionally tighter than the daily skip margin (±20°F); the two paths use different thresholds by design.
 
@@ -239,7 +239,7 @@ flowchart TD
 | Parameter | Value | Description |
 |-----------|-------|-------------|
 | Hourly comfort margin | 5°F | Outside comfort band to consider "stress" (hourly path) |
-| Solar tail threshold | 15 kWh | Activate when remaining solar forecast drops below this |
+| Solar tail threshold | 28 kWh | Activate when remaining solar forecast drops below this |
 | Deferral recheck interval | 15 min | How often to re-evaluate while deferred |
 | Daily skip margin | 20°F | Comfort band expansion for daily skip logic |
 

--- a/homeautomation-go/internal/plugins/loadshedding/manager.go
+++ b/homeautomation-go/internal/plugins/loadshedding/manager.go
@@ -77,7 +77,7 @@ const (
 	// Note: thermalBatteryHourlyComfortMargin (5°F) is intentionally tighter than
 	// thermalBatterySkipMargin (20°F). The hourly path triggers on genuine near-term
 	// stress; the daily path uses a wide band to skip only on truly mild days.
-	thermalBatteryDefaultSolarTailThresholdKWh = 15.0             // activate when remaining solar forecast drops below this
+	thermalBatteryDefaultSolarTailThresholdKWh = 28.0             // activate when remaining solar forecast drops below this (~3hr window before solar ends)
 	thermalBatteryHourlyComfortMargin          = 5.0              // °F outside comfort band to consider "stress" (hourly)
 	thermalBatteryDeferredRecheckDefault       = 15 * time.Minute // how often to re-evaluate while deferred
 )

--- a/homeautomation-go/test/integration/scenario_lighting_test.go
+++ b/homeautomation-go/test/integration/scenario_lighting_test.go
@@ -60,7 +60,19 @@ func TestScenario_DayPhaseEvening_ActivatesCorrectScenes(t *testing.T) {
 	server.SetState("input_text.day_phase", "morning", map[string]interface{}{})
 	server.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	server.SetState("input_boolean.anyone_home_and_awake", "on", map[string]interface{}{})
-	// Brief delay to let initialization complete before taking snapshot
+
+	// Wait for state changes to fully propagate through state manager AND lighting plugin handlers.
+	// waitForProcessing() alone is unreliable here: WaitForHandlers Phase 2 only waits for one
+	// event notification, so when multiple events are queued (morning, anyone_home,
+	// anyone_home_and_awake), it may return before all handlers have run. This causes morning
+	// scene activations to leak past the snapshot into the post-setup assertion window.
+	//
+	// Polling isAnyoneHomeAndAwake=true is reliable: the state manager updates cache and calls
+	// notifySubscribers synchronously in the same goroutine, so when GetBool returns true, the
+	// lighting plugin's handleOccupancyChange (and its scene activations) have already completed.
+	waitForBoolState(t, stateManager, "isAnyoneHome", true, "isAnyoneHome should be true after setup")
+	waitForBoolState(t, stateManager, "isAnyoneHomeAndAwake", true, "isAnyoneHomeAndAwake should be true after setup")
+	// Additional flush for any remaining in-flight work
 	waitForProcessing(t, stateManager)
 
 	snapshot := server.ServiceCallCount()

--- a/homeautomation-go/test/integration/scenario_lighting_test.go
+++ b/homeautomation-go/test/integration/scenario_lighting_test.go
@@ -67,12 +67,12 @@ func TestScenario_DayPhaseEvening_ActivatesCorrectScenes(t *testing.T) {
 	// anyone_home_and_awake), it may return before all handlers have run. This causes morning
 	// scene activations to leak past the snapshot into the post-setup assertion window.
 	//
-	// Polling isAnyoneHomeAndAwake=true is reliable: the state manager updates cache and calls
-	// notifySubscribers synchronously in the same goroutine, so when GetBool returns true, the
-	// lighting plugin's handleOccupancyChange (and its scene activations) have already completed.
+	// Polling isAnyoneHome/isAnyoneHomeAndAwake drains at least two of the three event handlers,
+	// reducing the window of in-flight morning activations. The actual synchronization guarantee
+	// comes from the final waitForProcessing() call, which flushes any remaining in-flight work.
 	waitForBoolState(t, stateManager, "isAnyoneHome", true, "isAnyoneHome should be true after setup")
 	waitForBoolState(t, stateManager, "isAnyoneHomeAndAwake", true, "isAnyoneHomeAndAwake should be true after setup")
-	// Additional flush for any remaining in-flight work
+	// Final flush for any remaining in-flight work
 	waitForProcessing(t, stateManager)
 
 	snapshot := server.ServiceCallCount()


### PR DESCRIPTION
Resolves #1013

## Summary

- Increased `thermalBatteryDefaultSolarTailThresholdKWh` from **15.0** to **28.0** kWh in `homeautomation-go/internal/plugins/loadshedding/manager.go`

The previous 15 kWh threshold triggered activation too late (April 19: only ~1h 12m runtime vs. the ~3 hours needed for meaningful thermal mass charging). At 28 kWh, activation should occur mid-afternoon when sufficient solar remains to run HVAC for ~3 hours before solar fades.

## Test Plan

- All unit tests pass (`make unit-tests`) — existing tests explicitly set the threshold via `SetThermalBatterySolarTailThresholdForTesting()` so they're unaffected by this constant change
- Monitor production: next sunny spring day (~50+ kWh production), confirm activation starts ~3 hours before solar ends rather than ~1 hour before

🤖 Generated by the AI assistant