### PR TITLE
test: fix snapshot/waitForServiceCallSince races in 3 integration tests

### DIFF
--- a/homeautomation-go/test/integration/scenario_lighting_test.go
+++ b/homeautomation-go/test/integration/scenario_lighting_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"homeautomation/internal/plugins/lighting"
 	"homeautomation/internal/state"
@@ -68,12 +69,14 @@ func TestScenario_DayPhaseEvening_ActivatesCorrectScenes(t *testing.T) {
 	// scene activations to leak past the snapshot into the post-setup assertion window.
 	//
 	// Polling isAnyoneHome/isAnyoneHomeAndAwake drains at least two of the three event handlers,
-	// reducing the window of in-flight morning activations. The actual synchronization guarantee
-	// comes from the final waitForProcessing() call, which flushes any remaining in-flight work.
+	// reducing the window of in-flight morning activations. The final waitForProcessing() flushes
+	// any remaining in-flight work, and waitForServiceCallsToStabilize ensures fire-and-forget
+	// scene goroutines have fully completed before the snapshot is taken.
 	waitForBoolState(t, stateManager, "isAnyoneHome", true, "isAnyoneHome should be true after setup")
 	waitForBoolState(t, stateManager, "isAnyoneHomeAndAwake", true, "isAnyoneHomeAndAwake should be true after setup")
-	// Final flush for any remaining in-flight work
+	// Final flush and wait for fire-and-forget scene goroutines to finish
 	waitForProcessing(t, stateManager)
+	waitForServiceCallsToStabilize(t, server, 200*time.Millisecond)
 
 	snapshot := server.ServiceCallCount()
 
@@ -462,7 +465,11 @@ func TestScenario_PersonDetectionOverridesSuneventTurnOff(t *testing.T) {
 	server.SetState("input_boolean.front_of_house_person_present", "off", map[string]interface{}{})
 	server.SetState("input_text.day_phase", "evening", map[string]interface{}{})
 	server.SetState("input_text.sun_event", "sunset", map[string]interface{}{})
+	// Wait for initial scene activations (and any sunset-triggered retry loops)
+	// to stabilize before snapshotting — otherwise they land in the "since" window
+	// and can be mistaken for the later dusk/person-detection actions.
 	waitForProcessing(t, stateManager)
+	waitForServiceCallsToStabilize(t, server, 200*time.Millisecond)
 	snapshot := server.ServiceCallCount()
 
 	// WHEN: Sunevent changes (triggers evaluation for all rooms, including Front of House)

--- a/homeautomation-go/test/integration/scenario_wake_music_fade_test.go
+++ b/homeautomation-go/test/integration/scenario_wake_music_fade_test.go
@@ -169,8 +169,12 @@ func TestScenario_WakeSequence_BedroomFadeIsGradualNotAbrupt(t *testing.T) {
 	currentMusicJSON := `{"participants":[{"player_name":"media_player.bedroom","volume":14}]}`
 	env.server.SetState("input_text.currently_playing_music", currentMusicJSON, map[string]interface{}{})
 
-	// Allow all plugins to process the initial state
+	// Allow all plugins to process the initial state. Use a stabilization window
+	// in addition to waitForProcessing because zone orchestration spawns
+	// fire-and-forget goroutines (volume_set for bedroom seeding) that would
+	// otherwise land post-snapshot and pollute the bedroom fade-out measurement.
 	waitForProcessing(t, env.stateManager)
+	waitForServiceCallQuiescenceSince(t, env.server, 0, 200*time.Millisecond)
 	snapshot := env.server.ServiceCallCount()
 
 	// ========== WHEN ==========


### PR DESCRIPTION
## Summary

Three integration tests took `ServiceCallCount()` snapshots after `waitForProcessing()`, but `waitForProcessing()` only drains `state.Manager` handlers — not the fire-and-forget service-call goroutines plugins spawn (scene activation, zone orchestration, sunevent retry loops). Stale calls from initial state setup could land post-snapshot and satisfy `waitForServiceCallSince` before the actual action-under-test fired.

Flake seen on PR #1014: `TestScenario_DayPhaseEvening_ActivatesCorrectScenes` matched two leftover morning scene calls before the evening scene ever ran, and the `foundEveningScene` assertion failed.

## Tests fixed

- `TestScenario_DayPhaseEvening_ActivatesCorrectScenes` — confirmed CI flake
- `TestScenario_PersonDetectionOverridesSuneventTurnOff` — last-action assertion vulnerable to sunevent retry loop lag
- `TestScenario_WakeSequence_BedroomFadeIsGradualNotAbrupt` — initial zone orchestration `volume_set` on bedroom could pollute the fade-out measurement window

## Fix

Add `waitForServiceCallsToStabilize` / `waitForServiceCallQuiescenceSince` (200ms quiet window) before each snapshot so pending goroutines drain first.

## Scope note

An agent audit flagged 11 candidates. 8 were verified as false positives (assertions always true, entity-specific waits, or already-stabilized). Only the three above have content-dependent assertions that can actually fail from the race.

## Test plan

- [x] Each fixed test passes 5x under `-race`
- [x] Full integration suite green locally (`make integration-tests`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)