### PR TITLE
Fix #1017: Re-validate trigger conditions before delayed-action timers fire

### DIFF
--- a/docs/flows/STATE_TRACKING.md
+++ b/docs/flows/STATE_TRACKING.md
@@ -74,6 +74,7 @@ flowchart TD
     subgraph Check["Condition Check"]
         checkHome{"isAnyoneHome?"}
         checkAsleep{"Already<br/>isMasterAsleep?"}
+        checkLights{"Lights still off?<br/>(re-validate #1017)"}
     end
 
     subgraph Action["Action"]
@@ -89,7 +90,9 @@ flowchart TD
     checkHome -->|No| skip
     checkHome -->|Yes| checkAsleep
     checkAsleep -->|Yes| skip
-    checkAsleep -->|No| setAsleep
+    checkAsleep -->|No| checkLights
+    checkLights -->|No| skip
+    checkLights -->|Yes| setAsleep
 
     style setAsleep fill:#6c5ce7,color:#fff
     style cancel fill:#e74c3c,color:#fff
@@ -111,14 +114,21 @@ flowchart TD
         expire["Timer expires"]
     end
 
+    subgraph Check["Condition Check"]
+        checkDoor{"Door still open?<br/>(re-validate #1017)"}
+    end
+
     subgraph Action["Action"]
         setAwake["Set isMasterAsleep = false"]
+        skipWake["No action"]
     end
 
     doorOpen --> start
     start -->|Door closes| cancel
     start -->|20 seconds pass| expire
-    expire --> setAwake
+    expire --> checkDoor
+    checkDoor -->|No| skipWake
+    checkDoor -->|Yes| setAwake
 
     style setAwake fill:#ffd93d,color:#000
     style cancel fill:#e74c3c,color:#fff

--- a/homeautomation-go/internal/plugins/statetracking/manager.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager.go
@@ -293,6 +293,20 @@ func (m *Manager) detectMasterAsleep() {
 		return
 	}
 
+	// Re-validate trigger condition: confirm lights are still off before marking asleep.
+	// During the 1-minute delay the scene may have been activated (e.g. owner arrived home),
+	// so we must re-read the current entity state rather than assuming it hasn't changed. (#1017)
+	lightState, err := m.haClient.GetState("light.primary_suite")
+	if err != nil {
+		m.logger.Warn("Failed to re-read light.primary_suite, aborting sleep detection", zap.Error(err))
+		return
+	}
+	if lightState.State != "off" {
+		m.logger.Debug("Primary suite lights no longer off, aborting sleep detection",
+			zap.String("light_state", lightState.State))
+		return
+	}
+
 	// All checks passed, mark master as asleep
 	m.logger.Info("Marking master as asleep (lights off for 1 minute)")
 	if err := m.stateManager.SetBool("isMasterAsleep", true); err != nil {
@@ -346,6 +360,19 @@ func (m *Manager) handlePrimaryBedroomDoorChange(entityID string, oldState, newS
 
 // detectMasterAwake runs after door has been open for 20 seconds
 func (m *Manager) detectMasterAwake() {
+	// Re-validate trigger condition: confirm the bedroom door is still open before marking awake.
+	// The door may have been closed again during the 20-second delay. (#1017)
+	doorState, err := m.haClient.GetState("input_boolean.primary_bedroom_door_open")
+	if err != nil {
+		m.logger.Warn("Failed to re-read primary_bedroom_door_open, aborting wake detection", zap.Error(err))
+		return
+	}
+	if doorState.State != "on" {
+		m.logger.Debug("Primary bedroom door no longer open, aborting wake detection",
+			zap.String("door_state", doorState.State))
+		return
+	}
+
 	m.logger.Info("Marking master as awake (bedroom door open for 20 seconds)")
 
 	if err := m.stateManager.SetBool("isMasterAsleep", false); err != nil {

--- a/homeautomation-go/internal/plugins/statetracking/sleep_detection_test.go
+++ b/homeautomation-go/internal/plugins/statetracking/sleep_detection_test.go
@@ -124,29 +124,40 @@ func TestWakeDetection_DoorTimerControl(t *testing.T) {
 func TestDetectMasterAsleep_Conditions(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name           string
-		isNickHome     bool
-		setAnyoneHome  bool // if true, sets isAnyoneHome directly instead of isNickHome
-		isMasterAsleep bool
-		expectedAsleep bool
+		name              string
+		isNickHome        bool
+		setAnyoneHome     bool   // if true, sets isAnyoneHome directly instead of isNickHome
+		isMasterAsleep    bool
+		primarySuiteState string // HA entity state for light.primary_suite; empty = not set (early-return tests)
+		expectedAsleep    bool
 	}{
 		{
 			name:           "Skips when nobody home",
 			setAnyoneHome:  true, // sets isAnyoneHome=false directly
 			isMasterAsleep: false,
+			// primarySuiteState not set - function returns early before the light re-check
 			expectedAsleep: false,
 		},
 		{
 			name:           "Skips when already asleep",
 			isNickHome:     true,
 			isMasterAsleep: true,
+			// primarySuiteState not set - function returns early before the light re-check
 			expectedAsleep: true,
 		},
 		{
-			name:           "Sets sleep when conditions met",
-			isNickHome:     true,
-			isMasterAsleep: false,
-			expectedAsleep: true,
+			name:              "Sets sleep when conditions met and lights still off",
+			isNickHome:        true,
+			isMasterAsleep:    false,
+			primarySuiteState: "off",
+			expectedAsleep:    true,
+		},
+		{
+			name:              "Aborts if lights turned on during delay",
+			isNickHome:        true,
+			isMasterAsleep:    false,
+			primarySuiteState: "on",
+			expectedAsleep:    false,
 		},
 	}
 
@@ -167,6 +178,9 @@ func TestDetectMasterAsleep_Conditions(t *testing.T) {
 			}
 			if err := stateMgr.SetBool("isMasterAsleep", tt.isMasterAsleep); err != nil {
 				t.Fatalf("Failed to set isMasterAsleep: %v", err)
+			}
+			if tt.primarySuiteState != "" {
+				mockHA.SetState("light.primary_suite", tt.primarySuiteState, nil)
 			}
 
 			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
@@ -189,35 +203,62 @@ func TestDetectMasterAsleep_Conditions(t *testing.T) {
 }
 
 func TestDetectMasterAwake_SetsAwake(t *testing.T) {
-	t.Parallel(
-	// Create mock HA client and state manager
-	)
+	t.Parallel()
 
 	mockHA := ha.NewMockClient()
 	logger := zap.NewNop()
 	stateMgr := state.NewManager(mockHA, logger, false)
 
-	// Set initial state - asleep
+	// Set initial state - asleep, door still open
 	if err := stateMgr.SetBool("isMasterAsleep", true); err != nil {
 		t.Fatalf("Failed to set isMasterAsleep: %v", err)
 	}
+	mockHA.SetState("input_boolean.primary_bedroom_door_open", "on", nil)
 
-	// Create manager
 	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
 	if err := manager.Start(); err != nil {
 		t.Fatalf("Failed to start manager: %v", err)
 	}
 	defer manager.Stop()
 
-	// Call detectMasterAwake directly
 	manager.detectMasterAwake()
 
-	// Verify master IS marked as awake
 	isMasterAsleep, err := stateMgr.GetBool("isMasterAsleep")
 	if err != nil {
 		t.Fatalf("Failed to get isMasterAsleep: %v", err)
 	}
 	if isMasterAsleep {
 		t.Error("Expected isMasterAsleep to be false after wake detection")
+	}
+}
+
+func TestDetectMasterAwake_AbortsIfDoorClosed(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	logger := zap.NewNop()
+	stateMgr := state.NewManager(mockHA, logger, false)
+
+	// Set initial state - asleep, but door closed again during the delay
+	if err := stateMgr.SetBool("isMasterAsleep", true); err != nil {
+		t.Fatalf("Failed to set isMasterAsleep: %v", err)
+	}
+	mockHA.SetState("input_boolean.primary_bedroom_door_open", "off", nil)
+
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+	if err := manager.Start(); err != nil {
+		t.Fatalf("Failed to start manager: %v", err)
+	}
+	defer manager.Stop()
+
+	manager.detectMasterAwake()
+
+	// Door closed during delay - master should remain asleep
+	isMasterAsleep, err := stateMgr.GetBool("isMasterAsleep")
+	if err != nil {
+		t.Fatalf("Failed to get isMasterAsleep: %v", err)
+	}
+	if !isMasterAsleep {
+		t.Error("Expected isMasterAsleep to remain true when door closed during wake delay")
 	}
 }

--- a/homeautomation-go/internal/plugins/statetracking/sleep_detection_test.go
+++ b/homeautomation-go/internal/plugins/statetracking/sleep_detection_test.go
@@ -126,7 +126,7 @@ func TestDetectMasterAsleep_Conditions(t *testing.T) {
 	tests := []struct {
 		name              string
 		isNickHome        bool
-		setAnyoneHome     bool   // if true, sets isAnyoneHome directly instead of isNickHome
+		setAnyoneHome     bool // if true, sets isAnyoneHome directly instead of isNickHome
 		isMasterAsleep    bool
 		primarySuiteState string // HA entity state for light.primary_suite; empty = not set (early-return tests)
 		expectedAsleep    bool


### PR DESCRIPTION
Resolves #1017

## Summary

- **`detectMasterAsleep()`**: After the 1-minute sleep detection timer fires, re-reads `light.primary_suite` from HA. If the lights are no longer off (e.g. arrival-home scene was activated during the delay), the sleep detection is aborted.
- **`detectMasterAwake()`**: After the 20-second wake detection timer fires, re-reads `input_boolean.primary_bedroom_door_open`. If the door is no longer open (closed again during the delay), wake detection is aborted.
- Added two new test cases: `Aborts if lights turned on during delay` and `TestDetectMasterAwake_AbortsIfDoorClosed`.

This directly prevents the 2026-04-20 1:49 PM false sleep incident: Nick arrived home, the day scene commanded Primary Suite lights on, but the HA entity still reported "off" at the time the 1-minute timer started. When the timer fired, the old code only checked guard conditions (`isAnyoneHome`, `isMasterAsleep`) — not whether the lights were still off. The new code re-reads the entity state at fire time and aborts if it has changed.

## Test Plan

- `make unit-tests` passes (75.0% coverage, all statetracking tests green)
- New test `Aborts if lights turned on during delay`: sets `light.primary_suite` to "on" before calling `detectMasterAsleep()` → verifies `isMasterAsleep` remains false
- New test `TestDetectMasterAwake_AbortsIfDoorClosed`: sets door to "off" before calling `detectMasterAwake()` → verifies `isMasterAsleep` remains true

🤖 Generated by the AI assistant