### PR TITLE
fix(devcontainer): handle ~/.claude bind-mount collision in post-create

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -102,11 +102,23 @@ fi
 CLAUDE_CREDS_FILE="$SCRIPT_DIR/.claude-credentials"
 if [ -s "$CLAUDE_CREDS_FILE" ]; then
     echo "Setting up Claude Code credentials..."
-    mkdir -p "$HOME/.claude"
-    cp "$CLAUDE_CREDS_FILE" "$HOME/.claude/.credentials.json"
-    chmod 600 "$HOME/.claude/.credentials.json"
-    echo "Claude Code credentials configured."
-    rm -f "$CLAUDE_CREDS_FILE"
+    if [ "${CLAUDE_HOST_CONFIG_DIR:-}" = "$HOME/.claude" ]; then
+        # Host ~/.claude is bind-mounted read-only on top of the container's
+        # $HOME/.claude (happens when devcontainer up is invoked with
+        # HOME=/home/vscode, e.g., from inside another devcontainer). We can't
+        # write credentials here, but the host's .credentials.json is already
+        # visible via the mount. OAuth token refresh will not work while the
+        # credentials file is read-only; re-run `claude login` on the host if
+        # the token expires.
+        echo "Host ~/.claude shadows \$HOME/.claude (read-only mount). Using host credentials in place; token refresh disabled."
+        rm -f "$CLAUDE_CREDS_FILE"
+    else
+        mkdir -p "$HOME/.claude"
+        cp "$CLAUDE_CREDS_FILE" "$HOME/.claude/.credentials.json"
+        chmod 600 "$HOME/.claude/.credentials.json"
+        echo "Claude Code credentials configured."
+        rm -f "$CLAUDE_CREDS_FILE"
+    fi
 else
     echo "Warning: No Claude credentials found; Claude Code credentials not available."
 fi


### PR DESCRIPTION
## Summary
- Fix `postCreateCommand` failure (`cp: ... Read-only file system`) that aborted devcontainer start when the host `~/.claude` bind mount shadowed the container user's writable `~/.claude`.
- Detect the collision (`CLAUDE_HOST_CONFIG_DIR == $HOME/.claude`) and skip the credentials copy — host creds are already visible via the read-only mount.

## Why it happened
The mount is defined as:
```
source=${localEnv:HOME}/.claude,target=${localEnv:HOME}/.claude,readonly
```
When `devcontainer up` runs with `HOME=/home/vscode` (nested devcontainer, wrapper script, or a host user literally named `vscode`), both sides resolve to `/home/vscode/.claude`. The read-only mount then lands on top of the container's writable `~/.claude`, and `cp` into `$HOME/.claude/.credentials.json` fails with EROFS.

Other post-create steps (host `.claude` symlink block, `.bashrc` passthrough) already guarded against the same-path case, so only the credentials copy needed to be fixed.

## Behavior after fix
- **No collision** (normal case, host HOME ≠ `/home/vscode`): unchanged — credentials copied to a writable `$HOME/.claude/.credentials.json`.
- **Collision**: skip the copy, log a clear message. Host's `.credentials.json` is already visible via the bind mount so interactive auth works. OAuth token refresh won't work while the file is read-only; re-run `claude login` on the host if the token expires.

## Test plan
- [x] Fresh `devcontainer up --workspace-folder .` on this repo succeeds (`postCreateCommand` completes, credentials copied).
- [ ] Repro the collision scenario (`HOME=/home/vscode devcontainer up …` or equivalent nested-container invocation) and confirm `postCreateCommand` now completes with the informative message instead of aborting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)