### PR TITLE
ci: prevent AI bot commits from tripping first-time contributor gate

### DIFF
--- a/.devcontainer/configure-ai.sh
+++ b/.devcontainer/configure-ai.sh
@@ -16,8 +16,14 @@ case "$AI_TOOL" in
       echo "ERROR: claude not found — expected it baked into the devcontainer image" >&2
       exit 1
     fi
+    # Author name preserves tool branding for `git log --author`.
+    # Email intentionally uses the RFC 6761 `.invalid` TLD so it cannot map to
+    # any GitHub account — if it did (e.g. `claude[bot]@users.noreply.github.com`
+    # maps to the claude[bot] GitHub App), then every AI-authored commit would
+    # trip GitHub's "require approval for first-time contributors" gate and
+    # block PR Tests from running until a maintainer manually approves.
     AI_GIT_NAME_DEFAULT="claude[bot]"
-    AI_GIT_EMAIL_DEFAULT="claude[bot]@users.noreply.github.com"
+    AI_GIT_EMAIL_DEFAULT="claude-bot@ci.invalid"
     # Claude Code reads ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL straight from the
     # environment — run-ai.sh sets those at invocation time. Nothing to write here.
     ;;
@@ -26,8 +32,10 @@ case "$AI_TOOL" in
       echo "ERROR: codex not found — expected it baked into the devcontainer image" >&2
       exit 1
     fi
+    # See claude arm above for why the email uses `.invalid` instead of
+    # `@users.noreply.github.com`.
     AI_GIT_NAME_DEFAULT="codex[bot]"
-    AI_GIT_EMAIL_DEFAULT="codex[bot]@users.noreply.github.com"
+    AI_GIT_EMAIL_DEFAULT="codex-bot@ci.invalid"
     # Codex reads its provider config from ~/.codex/config.toml.
     mkdir -p "$HOME/.codex"
     cat > "$HOME/.codex/config.toml" <<EOF

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -583,8 +583,8 @@ jobs:
 
       - name: Configure git identity for commits
         run: |
-          git config user.name "claude[bot]"
-          git config user.email "claude[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Run AI to fix test failures
         id: ai-fix
@@ -1263,8 +1263,8 @@ jobs:
       - name: Configure git identity for commits
         if: steps.verify-tests.outputs.verified == 'true'
         run: |
-          git config user.name "claude[bot]"
-          git config user.email "claude[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Run merge decision
         if: steps.verify-tests.outputs.verified == 'true'

--- a/docs/operations/AI_GHA_PIPELINES.md
+++ b/docs/operations/AI_GHA_PIPELINES.md
@@ -2,7 +2,7 @@
 
 This document describes the AI-assistant-backed GitHub Actions pipelines in this repository. These pipelines enable AI-powered issue resolution, PR creation, code review, and automated test failure fixes.
 
-The pipeline plumbing (file names, job names, labels, mention tag, secret name, branch prefix) is tool-agnostic: the underlying AI tool can be swapped without renaming anything. The commit author identity, however, names whichever tool is actually running — currently `claude[bot]`.
+The pipeline plumbing (file names, job names, labels, mention tag, secret name, branch prefix) is tool-agnostic: the underlying AI tool can be swapped without renaming anything. Commits from the interactive assistant (`ai-assistant.yml`) are attributed to the tool currently configured (e.g. `claude[bot]`). Commits from the review pipeline (`ai-code-review.yml`) are attributed to `github-actions[bot]` — this avoids mapping to the claude[bot] GitHub App, which would otherwise trip GitHub's "require approval for first-time contributors" gate and block PR Tests from running until a maintainer manually approves.
 
 ## Overview
 
@@ -761,7 +761,7 @@ The pipelines route every CLI invocation through `.devcontainer/run-ai.sh`, whic
 What each script does on a swap:
 
 - **`ai-tool.env`** — Single source of truth for `AI_TOOL` + `AI_BASE_URL`. Sourced by both scripts below.
-- **`configure-ai.sh`** — Verifies the selected tool's binary is in the devcontainer image, picks a matching bot git identity (`claude[bot]` / `codex[bot]`), and writes any on-disk config the CLI requires (e.g. `~/.codex/config.toml`).
+- **`configure-ai.sh`** — Verifies the selected tool's binary is in the devcontainer image, picks a matching bot git identity (`claude[bot]` / `codex[bot]`) with an email using the RFC 6761 `.invalid` TLD (e.g. `claude-bot@ci.invalid`) so it cannot map to any GitHub account and avoids tripping the first-time contributor gate, and writes any on-disk config the CLI requires (e.g. `~/.codex/config.toml`).
 - **`run-ai.sh`** — Takes `$PROMPT` as `$1`, exports the right tool-specific env vars (`ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` for Claude, `OPENAI_API_KEY` for Codex), and `exec`s the CLI with the right flags.
 
 Adding a new tool (e.g. a different backend) requires adding a `case` arm to both `configure-ai.sh` and `run-ai.sh`, plus baking the tool's binary into the devcontainer Dockerfile. Workflow YAML files do **not** need to change.


### PR DESCRIPTION
## Summary

- AI-authored commits on PR branches were blocking PR Tests behind a manual "Approve and run" gate (see PR #1018, where the gofmt follow-up commit sat queued for ~8 hours).
- Root cause: the AI CLI commits as `claude[bot] <claude[bot]@users.noreply.github.com>`. That email maps to the `claude[bot]` GitHub App, which isn't a repo collaborator — so GitHub's "require approval for first-time contributors" setting fires on every subsequent SHA.
- Fix: switch the AI-CLI commit email in `configure-ai.sh` to a `.invalid` address (RFC 6761 guarantees `.invalid` never maps to a GitHub account, so GitHub falls back to the pusher for contributor status). Tool branding is preserved in the author name so `git log --author=claude\[bot\]` still works.
- Also bumps the workflow-level `git config` in `ai-code-review.yml` from `claude[bot]` to `github-actions[bot]` (always trusted) as defense-in-depth for any future direct-from-workflow commits.

## Test plan

- [ ] Next AI-driven fix commit shows author `claude[bot] <claude-bot@ci.invalid>`.
- [ ] PR Tests runs immediately after that commit without requiring manual approval.
- [ ] `git log --author="claude\[bot\]"` still matches AI commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)