### PR TITLE
Fix #1021: update README devcontainer section for nested-devcontainer credential path

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The devcontainer automatically:
 - Installs git hooks (pre-commit and pre-push validation)
 - Installs GitHub CLI, Claude Code CLI, and Playwright (with Chromium)
 - Configures VS Code extensions for Go and Mermaid
-- Imports your host GitHub CLI token and Claude Code credentials into the container so long as you are logged in locally before opening the devcontainer (you will see warnings during startup if host credentials are missing)
+- Imports your host GitHub CLI token and Claude Code credentials into the container so long as you are logged in locally before opening the devcontainer (you will see warnings during startup if host credentials are missing). When running inside another devcontainer (nested), credentials are used via the existing bind-mount rather than being copied; token refresh requires re-running `claude login` on the host if the token expires.
 
 ### Manual Setup (Without Devcontainer)
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ The devcontainer automatically:
 - Installs git hooks (pre-commit and pre-push validation)
 - Installs GitHub CLI, Claude Code CLI, and Playwright (with Chromium)
 - Configures VS Code extensions for Go and Mermaid
-- Imports your host GitHub CLI token and Claude Code credentials into the container so long as you are logged in locally before opening the devcontainer (you will see warnings during startup if host credentials are missing). When running inside another devcontainer (nested), credentials are used via the existing bind-mount rather than being copied; token refresh requires re-running `claude login` on the host if the token expires.
+- Imports your host GitHub CLI token and Claude Code credentials into the container so long as you are logged in locally before opening the devcontainer (you will see warnings during startup if host credentials are missing)
+- **Nested devcontainer:** Credentials are used via the existing bind-mount rather than copied; re-run `claude login` on the host to refresh an expired token.
 
 ### Manual Setup (Without Devcontainer)
 


### PR DESCRIPTION
Resolves #1021

## Summary
- Updated README.md line 71 to append a note about the nested-devcontainer credential path: when running inside another devcontainer, credentials are used via the existing bind-mount rather than being copied, and token refresh requires re-running `claude login` on the host if the token expires.

## Test Plan
- Documentation-only change; no code logic affected.
- Verified unit tests pass (`make unit-tests`).

🤖 Generated by the AI assistant