### PR TITLE
Fix #1026: Use explicit mute/on instead of mute toggle

### DIFF
--- a/homeautomation-go/internal/plugins/music/occupancy_scenario_test.go
+++ b/homeautomation-go/internal/plugins/music/occupancy_scenario_test.go
@@ -461,7 +461,7 @@ func TestScenario_MutedSpeaker_GetsTargetVolumeSetDuringPlayback(t *testing.T) {
 			if path == "/Study/volume/6" {
 				foundStudyVolumeSet = true
 			}
-			if path == "/Study/mute" {
+			if path == "/Study/mute/on" {
 				foundStudyMute = true
 			}
 		}
@@ -586,7 +586,7 @@ func TestScenario_TVPlaying_PreMutesFollowers_EvenIfJoinFails(t *testing.T) {
 			if path == "/Study/volume/6" {
 				foundStudyVolumeSet = true
 			}
-			if path == "/Study/mute" {
+			if path == "/Study/mute/on" {
 				foundStudyMute = true
 			}
 		}

--- a/homeautomation-go/internal/plugins/music/sococli.go
+++ b/homeautomation-go/internal/plugins/music/sococli.go
@@ -167,8 +167,8 @@ func (c *SoCoClient) Mute(speakerName string) error {
 		return nil
 	}
 
-	// GET /{speaker}/mute
-	endpoint := fmt.Sprintf("%s/%s/mute",
+	// GET /{speaker}/mute/on (explicit mute-on, not toggle)
+	endpoint := fmt.Sprintf("%s/%s/mute/on",
 		c.baseURL,
 		url.PathEscape(speakerName))
 

--- a/homeautomation-go/internal/plugins/music/sococli_test.go
+++ b/homeautomation-go/internal/plugins/music/sococli_test.go
@@ -339,7 +339,7 @@ func TestSoCoClient_MuteUnmute(t *testing.T) {
 		client := NewSoCoClient(server.URL, logger, false)
 		err := client.Mute("Kitchen")
 		require.NoError(t, err)
-		assert.Equal(t, "/Kitchen/mute", requestPath)
+		assert.Equal(t, "/Kitchen/mute/on", requestPath)
 	})
 
 	t.Run("unmute uses correct endpoint", func(t *testing.T) {

--- a/homeautomation-go/internal/plugins/music/speaker_commands_test.go
+++ b/homeautomation-go/internal/plugins/music/speaker_commands_test.go
@@ -225,7 +225,7 @@ func TestSpeakerSetMute_RoutesThroughSoCo(t *testing.T) {
 	// Test mute
 	err := manager.speakerSetMute("Kitchen", true)
 	require.NoError(t, err)
-	assert.Equal(t, "/Kitchen/mute", paths.Get(0))
+	assert.Equal(t, "/Kitchen/mute/on", paths.Get(0))
 
 	// Test unmute
 	err = manager.speakerSetMute("Kitchen", false)


### PR DESCRIPTION
Resolves #1026

## Summary
- Changed `SoCoClient.Mute()` in `sococli.go` to call `GET /{speaker}/mute/on` instead of `GET /{speaker}/mute`
- The toggle endpoint (`/mute`) would accidentally unmute a speaker that was already muted; `/mute/on` is idempotent
- Updated three test files to assert the correct `/mute/on` endpoint path

## Test Plan
- `make unit-tests` passes (all music plugin tests green, coverage 85.2%)
- Existing `TestSoCoClient_MuteUnmute` now verifies `/Kitchen/mute/on` is called
- `TestSpeakerSetMute` in `speaker_commands_test.go` now verifies `/Kitchen/mute/on`
- Two assertions in `occupancy_scenario_test.go` updated to expect `/Study/mute/on`

🤖 Generated by the AI assistant