### PR TITLE
fix: chmod CI output dirs for Docker UID mismatch

### DIFF
--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -191,6 +191,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p /tmp/resolve-output
+          chmod 777 /tmp/resolve-output
 
           docker run --rm \
             --network host \

--- a/.github/workflows/ai-diagnose-workflow-failure.yml
+++ b/.github/workflows/ai-diagnose-workflow-failure.yml
@@ -135,6 +135,7 @@ jobs:
           set -euo pipefail
 
           mkdir -p /tmp/diagnose-output
+          chmod 777 /tmp/diagnose-output
 
           # Run the agent inside the CI image. The prompt lives in the repo
           # at .github/ci/prompts/diagnose-workflow-failure.md and uses shell

--- a/.github/workflows/ha-deprecation-check.yml
+++ b/.github/workflows/ha-deprecation-check.yml
@@ -77,6 +77,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p /tmp/deprecation-output
+          chmod 777 /tmp/deprecation-output
 
           # The HA_VERSION_LINE paragraph swaps based on whether a specific
           # HA version was passed as an input. Computing it here (rather than


### PR DESCRIPTION
## Summary

Fixes the CI failure in [run #24967700107](https://github.com/NickBorgers/home-automation/actions/runs/24967700107/job/73109165772).

The AI workflow steps create `/tmp/*-output` directories on the **host**, then bind-mount them into Docker containers. The container process runs as a different UID than the host user that created the directory, so `tee` fails with `Permission denied` when trying to write the conversation log:

```
tee: /tmp/resolve-output/resolve-issue-conversation.jsonl: Permission denied
```

Under `set -euo pipefail`, this propagates as exit code 1 and fails the entire workflow step — even though the actual AI work completed successfully (PR #1027 was created).

**Fix:** `chmod 777` each output directory immediately after `mkdir -p`, so any UID inside the container can write to it. Applied to all three affected workflows:

- `ai-assistant.yml` — the one that failed
- `ai-diagnose-workflow-failure.yml` — same bind-mount pattern
- `ha-deprecation-check.yml` — same bind-mount pattern

## Test plan

- [ ] Re-run the `ai-assistant.yml` workflow on a new issue and confirm the step exits 0
- [ ] Verify the conversation log artifact is uploaded successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)