### PR TITLE
fix: use runner.temp for CI output dirs instead of /tmp

### DIFF
--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -190,14 +190,14 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          mkdir -p /tmp/resolve-output
-          chmod 777 /tmp/resolve-output
+          OUTPUT_DIR="${{ runner.temp }}/resolve-output"
+          mkdir -p "$OUTPUT_DIR"
 
           docker run --rm \
             --network host \
             --workdir /workspace \
             -v "${{ github.workspace }}:/workspace" \
-            -v /tmp/resolve-output:/tmp/resolve-output \
+            -v "$OUTPUT_DIR:/tmp/resolve-output" \
             -e AI_API_KEY \
             -e GH_TOKEN \
             -e ISSUE_NUMBER \
@@ -226,5 +226,5 @@ jobs:
         if: always()
         with:
           name: resolve-issue-conversation-log
-          path: /tmp/resolve-output/resolve-issue-conversation.jsonl
+          path: ${{ runner.temp }}/resolve-output/resolve-issue-conversation.jsonl
           retention-days: 7

--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -191,6 +191,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p /tmp/resolve-output
+          chmod 777 /tmp/resolve-output
 
           docker run --rm \
             --network host \

--- a/.github/workflows/ai-diagnose-workflow-failure.yml
+++ b/.github/workflows/ai-diagnose-workflow-failure.yml
@@ -133,9 +133,8 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-
-          mkdir -p /tmp/diagnose-output
-          chmod 777 /tmp/diagnose-output
+          OUTPUT_DIR="${{ runner.temp }}/diagnose-output"
+          mkdir -p "$OUTPUT_DIR"
 
           # Run the agent inside the CI image. The prompt lives in the repo
           # at .github/ci/prompts/diagnose-workflow-failure.md and uses shell
@@ -146,7 +145,7 @@ jobs:
             --network host \
             --workdir /workspace \
             -v "${{ github.workspace }}:/workspace" \
-            -v /tmp/diagnose-output:/tmp/diagnose-output \
+            -v "$OUTPUT_DIR:/tmp/diagnose-output" \
             -e AI_API_KEY \
             -e GH_TOKEN \
             -e WORKFLOW_NAME \
@@ -173,5 +172,5 @@ jobs:
         if: always()
         with:
           name: workflow-diagnosis-output
-          path: /tmp/diagnose-output/diagnose-output.jsonl
+          path: ${{ runner.temp }}/diagnose-output/diagnose-output.jsonl
           retention-days: 7

--- a/.github/workflows/ai-diagnose-workflow-failure.yml
+++ b/.github/workflows/ai-diagnose-workflow-failure.yml
@@ -135,6 +135,7 @@ jobs:
           set -euo pipefail
 
           mkdir -p /tmp/diagnose-output
+          chmod 777 /tmp/diagnose-output
 
           # Run the agent inside the CI image. The prompt lives in the repo
           # at .github/ci/prompts/diagnose-workflow-failure.md and uses shell

--- a/.github/workflows/ha-deprecation-check.yml
+++ b/.github/workflows/ha-deprecation-check.yml
@@ -76,8 +76,8 @@ jobs:
           HA_VERSION: ${{ inputs.ha_version || '' }}
         run: |
           set -euo pipefail
-          mkdir -p /tmp/deprecation-output
-          chmod 777 /tmp/deprecation-output
+          OUTPUT_DIR="${{ runner.temp }}/deprecation-output"
+          mkdir -p "$OUTPUT_DIR"
 
           # The HA_VERSION_LINE paragraph swaps based on whether a specific
           # HA version was passed as an input. Computing it here (rather than
@@ -94,7 +94,7 @@ jobs:
             --network host \
             --workdir /workspace \
             -v "${{ github.workspace }}:/workspace" \
-            -v /tmp/deprecation-output:/tmp/deprecation-output \
+            -v "$OUTPUT_DIR:/tmp/deprecation-output" \
             -e AI_API_KEY \
             -e GH_TOKEN \
             -e REPO \
@@ -115,13 +115,13 @@ jobs:
         if: always()
         with:
           name: deprecation-check-output
-          path: /tmp/deprecation-output/deprecation-check-output.jsonl
+          path: ${{ runner.temp }}/deprecation-output/deprecation-check-output.jsonl
           retention-days: 30  # Intentionally longer than 7-day default since this runs monthly
 
       - name: Validate deprecation check result
         if: always()
         run: |
-          OUTPUT_FILE="/tmp/deprecation-output/deprecation-check-output.jsonl"
+          OUTPUT_FILE="${{ runner.temp }}/deprecation-output/deprecation-check-output.jsonl"
           if [ ! -f "$OUTPUT_FILE" ]; then
             echo "::error::Deprecation check output file not found"
             exit 1

--- a/.github/workflows/ha-deprecation-check.yml
+++ b/.github/workflows/ha-deprecation-check.yml
@@ -77,6 +77,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p /tmp/deprecation-output
+          chmod 777 /tmp/deprecation-output
 
           # The HA_VERSION_LINE paragraph swaps based on whether a specific
           # HA version was passed as an input. Computing it here (rather than


### PR DESCRIPTION
## Summary

Fixes the CI failure in [run #24967700107](https://github.com/NickBorgers/home-automation/actions/runs/24967700107/job/73109165772).

The AI workflow steps create output directories on the **host**, then bind-mount them into Docker containers. This had two problems:

1. **UID mismatch** (the immediate failure): The container process runs as a different UID than the host runner user, so `tee` fails with `Permission denied`. Under `pipefail`, this kills the step with exit code 1 — even though the AI work completed successfully (PR #1027 was created).

2. **File accumulation**: Hardcoded `/tmp/*-output` paths persist across runs on the self-hosted runner, so output files pile up indefinitely.

**Fix:** Use `${{ runner.temp }}` for the host-side output directory. GitHub cleans this between runs (solving accumulation), and the runner user owns it (solving permissions). The container-side paths stay at `/tmp/*` unchanged — the bind mount maps `runner.temp/X` → `/tmp/X`.

Applied to all three affected workflows:
- `ai-assistant.yml`
- `ai-diagnose-workflow-failure.yml`
- `ha-deprecation-check.yml`

## Test plan

- [ ] Trigger `ai-assistant.yml` on a new issue — step exits 0, artifact uploads successfully
- [ ] Confirm no leftover `/tmp/*-output` dirs on the runner after the job completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)