### PR TITLE
Fix #1032: replace waitForProcessing with quiescence waits in flaky integration tests

### DIFF
--- a/homeautomation-go/test/integration/scenario_security_test.go
+++ b/homeautomation-go/test/integration/scenario_security_test.go
@@ -161,8 +161,9 @@ func TestScenario_OwnerReturnsHomeGarageOccupied(t *testing.T) {
 
 	t.Log("BUT: Garage door should NOT be opened (occupied)")
 
-	// Wait for all handlers to complete, then verify no garage open call was made
-	waitForProcessing(t, manager)
+	// Use quiescence to drain fire-and-forget goroutines before asserting no garage call.
+	// waitForProcessing only covers HA event handlers, not goroutines spawned by them.
+	waitForServiceCallQuiescenceSince(t, server, snapshot, 200*time.Millisecond)
 
 	garageOpenCall := FindServiceCallWithEntityID(server.GetServiceCallsSince(snapshot), "cover", "open_cover", "cover.garage_door_door")
 	assert.Nil(t, garageOpenCall, "Garage door should NOT open when garage is occupied")
@@ -338,7 +339,9 @@ func TestScenario_OnlyOwnersTriggersGarage(t *testing.T) {
 
 	t.Log("AND: Garage door should NOT be opened")
 
-	waitForProcessing(t, manager)
+	// Use quiescence to drain fire-and-forget goroutines before asserting no garage call.
+	// waitForProcessing only covers HA event handlers, not goroutines spawned by them.
+	waitForServiceCallQuiescenceSince(t, server, snapshot, 200*time.Millisecond)
 
 	garageOpenCall := FindServiceCallWithEntityID(server.GetServiceCallsSince(snapshot), "cover", "open_cover", "cover.garage_door_door")
 	assert.Nil(t, garageOpenCall, "Garage should not open for guest arrival")

--- a/homeautomation-go/test/integration/scenario_sexmode_test.go
+++ b/homeautomation-go/test/integration/scenario_sexmode_test.go
@@ -340,6 +340,10 @@ func TestScenario_SexModeDeactivation_TurnsOffLightsWhenAsleep(t *testing.T) {
 
 	// Wait for light turn off call
 	waitForServiceCallSince(t, server, snapshot, "light", "turn_off", "lights should be turned off")
+	// Quiescence ensures all concurrent goroutines have drained before we assert
+	// that no scene was activated. Quiescence (not Stabilize) because we expect
+	// no additional calls beyond light.turn_off.
+	waitForServiceCallQuiescenceSince(t, server, snapshot, 200*time.Millisecond)
 
 	// Should NOT activate a scene
 	calls := server.GetServiceCallsSince(snapshot)
@@ -449,8 +453,10 @@ func TestScenario_SexModeDuplicateActivation_Ignored(t *testing.T) {
 	// Manually trigger handleSexModeOn to simulate duplicate
 	// This tests the internal guard
 	sexModeManager.Reset() // Reset checks current state and won't re-activate
-	// Allow async Reset to complete
-	waitForProcessing(t, stateManager)
+	// Reset launches handlers asynchronously; wait for quiescence (no new calls for
+	// stabilizeWindow) rather than waitForProcessing, which only covers HA event
+	// handlers, not fire-and-forget goroutines spawned by them.
+	waitForServiceCallQuiescenceSince(t, server, snapshot, 200*time.Millisecond)
 
 	t.Log("THEN: No additional service calls should be made")
 
@@ -480,8 +486,9 @@ func TestScenario_SexModeDeactivationWithoutActivation_Ignored(t *testing.T) {
 	t.Log("WHEN: Sex mode is turned off (was already off)")
 
 	server.SetState("input_boolean.sex", "off", nil)
-	// Wait for state to be processed (expecting no change)
-	waitForProcessing(t, stateManager)
+	// SetState launches handlers asynchronously; use quiescence (not waitForProcessing)
+	// to ensure fire-and-forget goroutines have drained before asserting zero calls.
+	waitForServiceCallQuiescenceSince(t, server, snapshot, 200*time.Millisecond)
 
 	t.Log("THEN: No actions should be taken and music type should remain 'day'")
 


### PR DESCRIPTION
Resolves #1032

## Summary

- Replaced `waitForProcessing` (which only drains HA event-handler goroutines) with `waitForServiceCallQuiescenceSince` in 5 tests that assert **zero service calls** after an async trigger.
- `waitForProcessing` does not cover fire-and-forget goroutines spawned by those handlers (e.g., Eight Sleep `climate.set_temperature` calls in sex mode), so those late goroutines could land after the snapshot under CI load, causing spurious failures.
- `waitForServiceCallQuiescenceSince` polls the service-call count until stable for a 200 ms window, guaranteeing all fans-out have drained before the assertion.

**Tests fixed:**
| Test | File |
|------|------|
| `TestScenario_SexModeDuplicateActivation_Ignored` (the CI failure from PR #1030) | `scenario_sexmode_test.go` |
| `TestScenario_SexModeDeactivationWithoutActivation_Ignored` | `scenario_sexmode_test.go` |
| `TestScenario_SexModeDeactivation_TurnsOffLightsWhenAsleep` | `scenario_sexmode_test.go` |
| `TestScenario_OwnerReturnsHomeGarageOccupied` | `scenario_security_test.go` |
| `TestScenario_OnlyOwnersTriggersGarage` | `scenario_security_test.go` |

**Audited as not-bug-affected** (existence/finding assertions, not counting, or already use the correct helper):
- `scenario_sexmode_test.go` lines 110, 139, 188, 288, 333 (now fixed), 392, 539, 579 — the remaining unfixed ones use `assert.NotNil`/`FindServiceCallWithEntityID` (existence, not count), or are guarded by `assert.Eventually`.
- `scenario_security_test.go` lines 90, 127, 295, 326, 379, 418 — either existence-only assertions or already use `waitForServiceCallQuiescenceSince`.
- `scenario_computed_state_test.go:257` — safe (existence assertion, not counting).
- `scenario_sleepprep_lighting_test.go:86, 156` — safe (already use `waitForServiceCallsToStabilizeSince`).

## Test Plan

- All 11 integration tests pass: `go test -race -count=1 ./test/integration/...`
- Each fixed test can be stress-tested with `go test -race -count=20 -run '^TestName$' ./test/integration/...` to confirm no flakiness.

🤖 Generated by the AI assistant