### PR TITLE
Fix #1036: Turn off Eight Sleep Pod when master wakes up

### DIFF
--- a/docs/flows/SLEEP_HYGIENE.md
+++ b/docs/flows/SLEEP_HYGIENE.md
@@ -282,6 +282,8 @@ flowchart TD
 | `isWakeSequenceActive` | bool | Wake sequence lights are protected |
 | `musicPlaybackType` | string | Set to "sleep" at bedtime, "wakeup" after lights up |
 
+On wake (when `isMasterAsleep` transitions false), the plugin also calls `climate.turn_off` on both Eight Sleep Pod climate entities (`climate.nick_s_eight_sleep_side_climate` and `climate.caroline_s_eight_sleep_side_climate`). This is a fire-and-forget side-effect — errors are logged but do not affect the wake sequence.
+
 ## Related Documentation
 
 - [DAY_PHASE_MODES.md](./DAY_PHASE_MODES.md) - Day phase and schedule configuration

--- a/docs/human/VISUAL_ARCHITECTURE.md
+++ b/docs/human/VISUAL_ARCHITECTURE.md
@@ -1038,6 +1038,7 @@ graph LR
     SleepHygiene --> WakeActive
     SleepHygiene --> SleepPrep
     SleepPrep --> Lighting
+    SleepHygiene -.->|Controls| EightSleep
     SleepHygiene -.->|Triggers| Music
     SleepHygiene -.->|Triggers| Lighting
 

--- a/homeautomation-go/internal/plugins/sleephygiene/manager.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager.go
@@ -274,6 +274,19 @@ func (m *Manager) handleMasterAsleepChange(key string, oldValue, newValue interf
 					m.logger.Error("Failed to clear isSleepPrepActive", zap.Error(err))
 				}
 			}
+
+			// Turn off Eight Sleep Pod - no need to heat/cool when nobody is in bed
+			m.logger.Info("Turning off Eight Sleep Pod climate for both sides")
+			for _, entity := range []string{
+				"climate.nick_s_eight_sleep_side_climate",
+				"climate.caroline_s_eight_sleep_side_climate",
+			} {
+				if err := m.haClient.CallService(m.ctx, "climate", "turn_off", map[string]interface{}{
+					"entity_id": entity,
+				}); err != nil {
+					m.logger.Error("Failed to turn off Eight Sleep climate", zap.String("entity", entity), zap.Error(err))
+				}
+			}
 		}
 
 		// Check if wake sequence was active

--- a/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
@@ -2220,3 +2220,81 @@ func TestCancelWake_ClearsMusicPlaybackTypeWhenAlreadySleep(t *testing.T) {
 		t.Errorf("Expected musicPlaybackType to be '' (cleared), got %s", musicType)
 	}
 }
+
+func TestHandleMasterAsleepChange_TurnsOffEightSleepOnWake(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2024, 1, 15, 7, 30, 0, 0, time.UTC)
+	manager, mockHA, stateManager, _ := setupTest(t, now)
+
+	stateManager.SetBool("isMasterAsleep", true)
+	snapshot := mockHA.ServiceCallCount()
+
+	manager.handleMasterAsleepChange("isMasterAsleep", true, false)
+
+	calls := mockHA.GetServiceCallsSince(snapshot)
+
+	// Find climate turn_off calls
+	var climateCalls []ha.ServiceCall
+	for _, c := range calls {
+		if c.Domain == "climate" && c.Service == "turn_off" {
+			climateCalls = append(climateCalls, c)
+		}
+	}
+
+	if len(climateCalls) != 2 {
+		t.Fatalf("Expected 2 climate.turn_off calls, got %d", len(climateCalls))
+	}
+
+	entities := map[string]bool{}
+	for _, c := range climateCalls {
+		if id, ok := c.Data["entity_id"].(string); ok {
+			entities[id] = true
+		}
+	}
+	if !entities["climate.nick_s_eight_sleep_side_climate"] {
+		t.Error("Expected climate.turn_off for nick_s_eight_sleep_side_climate")
+	}
+	if !entities["climate.caroline_s_eight_sleep_side_climate"] {
+		t.Error("Expected climate.turn_off for caroline_s_eight_sleep_side_climate")
+	}
+}
+
+func TestHandleMasterAsleepChange_NoEightSleepTurnOffInReadOnly(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2024, 1, 15, 7, 30, 0, 0, time.UTC)
+	env := testutil.NewEnv(t)
+	configLoader := config.NewLoader("../../../configs", env.Logger)
+	timeProvider := plugin.FixedTimeProvider{FixedTime: now}
+	manager := NewManager(context.Background(), env.MockHA, env.StateMgr, configLoader, env.Logger, true, timeProvider, nil)
+
+	env.StateMgr.SetBool("isMasterAsleep", true)
+	snapshot := env.MockHA.ServiceCallCount()
+
+	manager.handleMasterAsleepChange("isMasterAsleep", true, false)
+
+	calls := env.MockHA.GetServiceCallsSince(snapshot)
+	for _, c := range calls {
+		if c.Domain == "climate" {
+			t.Errorf("Unexpected climate service call in read-only mode: %s.%s", c.Domain, c.Service)
+		}
+	}
+}
+
+func TestHandleMasterAsleepChange_NoEightSleepTurnOffWhenFallingAsleep(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2024, 1, 15, 22, 0, 0, 0, time.UTC)
+	manager, mockHA, stateManager, _ := setupTest(t, now)
+
+	stateManager.SetBool("isMasterAsleep", false)
+	snapshot := mockHA.ServiceCallCount()
+
+	// isMasterAsleep becomes true (person going to sleep) — no climate turn_off expected
+	manager.handleMasterAsleepChange("isMasterAsleep", false, true)
+
+	calls := mockHA.GetServiceCallsSince(snapshot)
+	for _, c := range calls {
+		if c.Domain == "climate" {
+			t.Errorf("Unexpected climate service call when going to sleep: %s.%s", c.Domain, c.Service)
+		}
+	}
+}


### PR DESCRIPTION
Resolves #1036

## Summary
- In `sleephygiene/manager.go`, added `climate.turn_off` calls for both Eight Sleep side climate entities (`climate.nick_s_eight_sleep_side_climate` and `climate.caroline_s_eight_sleep_side_climate`) inside the `!newAsleep` branch of `handleMasterAsleepChange`, guarded by `!m.readOnly`
- The turn-off runs before the wake sequence check so it fires regardless of whether a wake sequence was active (handles the natural-wake case too)
- Added three unit tests: normal wake turns off both sides, read-only mode makes no climate calls, going-to-sleep direction makes no climate calls

## Test Plan
- `make test-no-cache` passes: all tests green, sleephygiene coverage 68.4%
- `TestHandleMasterAsleepChange_TurnsOffEightSleepOnWake` verifies both entities receive `climate.turn_off`
- `TestHandleMasterAsleepChange_NoEightSleepTurnOffInReadOnly` verifies read-only mode skips the calls
- `TestHandleMasterAsleepChange_NoEightSleepTurnOffWhenFallingAsleep` verifies no calls when `isMasterAsleep` becomes `true`

🤖 Generated by the AI assistant