### PR TITLE
Fix #1038: Promote sleep/wake-detection log levels for observability

### DIFF
--- a/homeautomation-go/internal/plugins/statetracking/manager.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager.go
@@ -252,14 +252,14 @@ func (m *Manager) handlePrimarySuiteLightsChange(entityID string, oldState, newS
 
 	if lightsOff {
 		// Start 1-minute timer for sleep detection
-		m.logger.Debug("Primary suite lights turned off, starting 1-minute sleep detection timer")
+		m.logger.Info("Primary suite lights turned off, starting 1-minute sleep detection timer")
 		m.masterSleepTimer = m.clock.AfterFunc(SleepDetectionDelay, func() {
 			m.detectMasterAsleep()
 		})
 		// Update shadow state
 		m.shadowTracker.UpdateSleepDetectionTimer(true)
 	} else {
-		m.logger.Debug("Primary suite lights turned on, canceling sleep detection")
+		m.logger.Info("Primary suite lights turned on, canceling sleep detection")
 		// Update shadow state
 		m.shadowTracker.UpdateSleepDetectionTimer(false)
 	}
@@ -267,7 +267,7 @@ func (m *Manager) handlePrimarySuiteLightsChange(entityID string, oldState, newS
 
 // detectMasterAsleep runs after lights have been off for 1 minute
 func (m *Manager) detectMasterAsleep() {
-	m.logger.Debug("1-minute timer expired, checking if should mark master asleep")
+	m.logger.Info("1-minute timer expired, checking if should mark master asleep")
 
 	// Check if anyone is home
 	isAnyoneHome, err := m.stateManager.GetBool("isAnyoneHome")
@@ -277,7 +277,7 @@ func (m *Manager) detectMasterAsleep() {
 	}
 
 	if !isAnyoneHome {
-		m.logger.Debug("Nobody home, not marking master asleep")
+		m.logger.Info("Nobody home, not marking master asleep")
 		return
 	}
 
@@ -289,7 +289,7 @@ func (m *Manager) detectMasterAsleep() {
 	}
 
 	if isMasterAsleep {
-		m.logger.Debug("Master already marked asleep, nothing to do")
+		m.logger.Info("Master already marked asleep, nothing to do")
 		return
 	}
 
@@ -302,7 +302,7 @@ func (m *Manager) detectMasterAsleep() {
 		return
 	}
 	if lightState.State != "off" {
-		m.logger.Debug("Primary suite lights no longer off, aborting sleep detection",
+		m.logger.Warn("Primary suite lights no longer off, aborting sleep detection",
 			zap.String("light_state", lightState.State))
 		return
 	}
@@ -345,14 +345,14 @@ func (m *Manager) handlePrimaryBedroomDoorChange(entityID string, oldState, newS
 
 	if doorOpen {
 		// Start 20-second timer for wake detection
-		m.logger.Debug("Primary bedroom door opened, starting 20-second wake detection timer")
+		m.logger.Info("Primary bedroom door opened, starting 20-second wake detection timer")
 		m.masterWakeTimer = m.clock.AfterFunc(WakeDetectionDelay, func() {
 			m.detectMasterAwake()
 		})
 		// Update shadow state
 		m.shadowTracker.UpdateWakeDetectionTimer(true)
 	} else {
-		m.logger.Debug("Primary bedroom door closed, canceling wake detection")
+		m.logger.Info("Primary bedroom door closed, canceling wake detection")
 		// Update shadow state
 		m.shadowTracker.UpdateWakeDetectionTimer(false)
 	}
@@ -368,7 +368,7 @@ func (m *Manager) detectMasterAwake() {
 		return
 	}
 	if doorState.State != "on" {
-		m.logger.Debug("Primary bedroom door no longer open, aborting wake detection",
+		m.logger.Warn("Primary bedroom door no longer open, aborting wake detection",
 			zap.String("door_state", doorState.State))
 		return
 	}

--- a/homeautomation-go/internal/plugins/statetracking/manager.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager.go
@@ -360,6 +360,7 @@ func (m *Manager) handlePrimaryBedroomDoorChange(entityID string, oldState, newS
 
 // detectMasterAwake runs after door has been open for 20 seconds
 func (m *Manager) detectMasterAwake() {
+	m.logger.Info("20-second timer expired, checking if should mark master awake")
 	// Re-validate trigger condition: confirm the bedroom door is still open before marking awake.
 	// The door may have been closed again during the 20-second delay. (#1017)
 	doorState, err := m.haClient.GetState("input_boolean.primary_bedroom_door_open")


### PR DESCRIPTION
Resolves #1038

## Summary

- Promoted 6 sleep-detection log statements from `Debug` → `Info` (timer start, cancel, expiry, nobody-home abort, already-asleep no-op) and 1 to `Warn` (re-validation abort: lights no longer off — the suspected #1017 race)
- Applied matching treatment to wake-detection paths in `handlePrimaryBedroomDoorChange` / `detectMasterAwake` (timer start, cancel, and re-validation abort → Info/Warn)
- Pure logging change: no state, no logic, no new helpers

## Test Plan

- `make unit-tests` passes (74.8% coverage, all packages green)
- After deploying, a lights-off event at midnight should produce visible `info`-level Gravwell entries showing each branch taken through the sleep-detection state machine

🤖 Generated by the AI assistant