### PR TITLE
Fix #1040: Audible TTS announcements via shared notifier

### DIFF
--- a/configs/notification_config.yaml
+++ b/configs/notification_config.yaml
@@ -1,0 +1,47 @@
+# Verbal (TTS) announcement configuration.
+#
+# Used by all plugins that produce verbal announcements (vacuum errors,
+# security doorbell/vehicle/intruder alerts, energy/charging notifications,
+# infrastructure alerts, water-flow alerts, presence announcements).
+#
+# Before each announcement the notifier:
+#   1. Snapshots each target speaker's current volume.
+#   2. Sets volume to awake_volume_percent (or asleep_volume_percent for
+#      routine announcements while master is asleep).
+#   3. Calls tts.speak.
+#   4. After restore_delay_seconds, restores each speaker's prior volume.
+#
+# Urgent announcements (security alerts) ignore the asleep volume reduction.
+notification:
+  # Default speaker list when a plugin does not override. Union of all
+  # per-plugin lists in use today, so removing a plugin's hardcoded list
+  # does not silence any room.
+  default_speakers:
+    - media_player.kitchen
+    - media_player.front_room
+    - media_player.sitting_room
+    - media_player.bedroom
+    - media_player.dining_room
+    - media_player.soundbar
+    - media_player.kids_bathroom
+
+  # Volume (0-100) used when the master is awake, or for any urgent
+  # announcement regardless of sleep state.
+  awake_volume_percent: 60
+
+  # Volume (0-100) used for routine announcements while master is asleep.
+  # Vacuum already suppresses entirely while asleep; this only affects
+  # announcements that don't suppress (e.g. presence).
+  asleep_volume_percent: 30
+
+  # TTS engine. tts.google_translate_en_com is the default in Home Assistant.
+  tts_entity_id: tts.google_translate_en_com
+
+  # When true, snapshot speaker volume before the announcement and restore
+  # after. Set to false only for diagnostics.
+  snapshot_restore: true
+
+  # How long to wait after the tts.speak call returns before restoring
+  # speaker volumes. Sized to cover typical announcement playback duration
+  # (3-7 seconds for short alerts).
+  restore_delay_seconds: 8

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -655,6 +655,10 @@ homeautomation-go/
 │   │   ├── manager.go               # ✅ State manager implementation
 │   │   ├── manager_test.go          # ✅ Unit tests
 │   │   └── variables.go             # ✅ 40 state variable definitions
+│   ├── notify/                      # ✅ Shared verbal (TTS) notifier
+│   │   ├── notify.go                # ✅ Notifier implementation (volume snapshot/restore)
+│   │   ├── config.go                # ✅ Config loader (notification_config.yaml)
+│   │   └── mock.go                  # ✅ MockNotifier for unit tests
 │   └── plugins/                     # ✅ Automation plugins (13 total)
 │       ├── statetracking/           # ✅ State Tracking plugin
 │       ├── dayphase/                # ✅ Day Phase plugin

--- a/docs/reference/PLUGIN_SYSTEM.md
+++ b/docs/reference/PLUGIN_SYSTEM.md
@@ -932,6 +932,80 @@ make pre-push
 
 ---
 
+## Verbal Notifications
+
+Plugins that need to make spoken (TTS) announcements **must** use the shared `notify.Notifier` from `internal/notify` instead of calling `tts.speak` directly through the HA client. The notifier:
+
+1. **Snapshots** each target speaker's current volume.
+2. **Overrides** to a configured announcement volume (sleep-aware: louder when awake, quieter when asleep, unless the announcement is urgent).
+3. **Speaks** the message via Home Assistant.
+4. **Restores** the prior speaker volume after a delay.
+
+This guarantees announcements remain audible regardless of the speakers' state (ducked music, paused playback, low background volume) without any per-plugin volume bookkeeping.
+
+### Accessing the notifier
+
+The notifier is available on `plugin.Context` as `ctx.Notifier`:
+
+```go
+func createPlugin(ctx *plugin.Context) (plugin.Plugin, error) {
+    notifier := ctx.Notifier
+    if notifier == nil {
+        // Fall back to a non-functional mock so the plugin can still
+        // load when the notifier is not wired (tests, partial bootstraps).
+        notifier = &notify.MockNotifier{}
+    }
+    manager := NewManager(..., notifier, ...)
+    return &pluginAdapter{manager: manager}, nil
+}
+```
+
+### Calling Announce
+
+```go
+import "homeautomation/internal/notify"
+
+// Routine announcement (e.g. presence, vacuum, infrastructure alerts)
+m.notifier.Announce(m.ctx, "Robot vacuum needs attention: dustbin missing",
+    notify.WithSpeakers([]string{"media_player.kitchen", "media_player.front_room"}),
+)
+
+// Urgent announcement (e.g. doorbell, intruder, EV-charger overheat)
+m.notifier.Announce(m.ctx, "Person detected outside",
+    notify.WithSpeakers(securitySpeakers),
+    notify.WithUrgency(notify.UrgencyUrgent),
+)
+```
+
+`WithSpeakers` is optional — if omitted, the notifier uses the `default_speakers` list from `configs/notification_config.yaml`.
+
+### Urgency levels
+
+- **`UrgencyRoutine`** (default) — uses `asleep_volume_percent` while `isMasterAsleep` is true. Use for: vacuum errors, presence announcements, infrastructure/septic alerts, water-flow alerts, EV-charger battery levels.
+- **`UrgencyUrgent`** — always uses `awake_volume_percent` regardless of sleep state. Use for: doorbell, vehicle arrival, intruder detection, EV-charger safety alerts, anything else that **must** be heard.
+
+### Read-only mode
+
+Plugins **should not** check `m.readOnly` before calling `Announce`. The notifier itself logs the intended announcement and skips the service call when the application is in read-only mode. This centralises read-only handling and avoids divergent per-plugin behavior.
+
+### Testing
+
+Use `notify.MockNotifier` to assert announcement behavior in unit tests without making any real service calls:
+
+```go
+mockNotifier := &notify.MockNotifier{}
+manager := NewManager(..., mockNotifier, ...)
+// trigger the code path that should announce
+calls := mockNotifier.Calls()
+require.Len(t, calls, 1)
+assert.Equal(t, "Doorbell ringing", calls[0].Message)
+assert.Equal(t, notify.UrgencyUrgent, calls[0].Urgency)
+```
+
+Configuration lives at `configs/notification_config.yaml` — see that file for the full set of tunables (default speakers, awake/asleep volumes, restore delay, TTS engine).
+
+---
+
 ## Best Practices
 
 ### 1. Always Respect Read-Only Mode

--- a/homeautomation-go/cmd/app/run.go
+++ b/homeautomation-go/cmd/app/run.go
@@ -17,6 +17,7 @@ import (
 	"homeautomation/internal/devserver"
 	"homeautomation/internal/ha"
 	"homeautomation/internal/logbuffer"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/ntfy"
 	"homeautomation/internal/plugins/energy"
 	"homeautomation/internal/plugins/reset"
@@ -343,6 +344,24 @@ func Run() {
 	pluginCtx.SoCoCliURL = socoCliURL
 	pluginCtx.ShutdownCtx = shutdownCtx
 
+	// Construct verbal-announcement notifier. Falls back to safe defaults if
+	// no notification_config.yaml is present so existing deployments keep working.
+	notifyCfgPath := filepath.Join(configDir, "notification_config.yaml")
+	notifyCfg, err := notify.LoadConfig(notifyCfgPath)
+	if err != nil {
+		logger.Warn("Failed to load notification config, using defaults",
+			zap.String("path", notifyCfgPath),
+			zap.Error(err))
+		defaultCfg := notify.DefaultConfig()
+		notifyCfg = &defaultCfg
+	}
+	notifier := notify.NewManager(client, stateManager, *notifyCfg, logger, readOnly)
+	pluginCtx.Notifier = notifier
+	logger.Info("Notifier initialized",
+		zap.Int("awake_volume_percent", notifyCfg.AwakeVolumePercent),
+		zap.Int("asleep_volume_percent", notifyCfg.AsleepVolumePercent),
+		zap.Int("default_speaker_count", len(notifyCfg.DefaultSpeakers)))
+
 	// Create all registered plugins using the plugin registry
 	plugins, err := plugin.CreateAll(pluginCtx)
 	if err != nil {
@@ -411,6 +430,9 @@ func Run() {
 	// waiting for their full retry budget (which could take several minutes).
 	cancelShutdown()
 	logger.Info("Cancelled shutdown context - service calls will exit quickly")
+
+	// Wait for any pending TTS volume restores so we don't leave speakers loud.
+	notifier.WaitForRestores()
 
 	// Stop dev server if running
 	if devServer != nil {

--- a/homeautomation-go/internal/notify/config.go
+++ b/homeautomation-go/internal/notify/config.go
@@ -1,0 +1,134 @@
+package notify
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config governs Notifier behavior.
+type Config struct {
+	// DefaultSpeakers are used when a caller does not pass WithSpeakers.
+	DefaultSpeakers []string `yaml:"default_speakers"`
+
+	// AwakeVolumePercent is the speaker volume (0-100) used while master is awake.
+	AwakeVolumePercent int `yaml:"awake_volume_percent"`
+
+	// AsleepVolumePercent is the speaker volume (0-100) used for routine
+	// announcements while master is asleep. Urgent announcements ignore this
+	// and use AwakeVolumePercent.
+	AsleepVolumePercent int `yaml:"asleep_volume_percent"`
+
+	// TTSDomain / TTSService identify the Home Assistant service to call.
+	// Defaults to tts.speak.
+	TTSDomain  string `yaml:"tts_domain"`
+	TTSService string `yaml:"tts_service"`
+
+	// TTSEntityID is the TTS engine to use (e.g. tts.google_translate_en_com).
+	TTSEntityID string `yaml:"tts_entity_id"`
+
+	// SnapshotRestore controls whether speaker volume is captured before the
+	// announcement and restored after RestoreDelay elapses. Set to false in
+	// the YAML to disable (e.g. for tests).
+	SnapshotRestore bool `yaml:"snapshot_restore"`
+
+	// RestoreDelaySeconds is how long to wait after the TTS service call
+	// returns before restoring speaker volumes. Sized to cover typical
+	// announcement playback duration.
+	RestoreDelaySeconds int `yaml:"restore_delay_seconds"`
+
+	// RestoreDelay is the parsed RestoreDelaySeconds. Populated by applyDefaults.
+	RestoreDelay time.Duration `yaml:"-"`
+}
+
+type fileShape struct {
+	Notification Config `yaml:"notification"`
+}
+
+const (
+	defaultAwakeVolumePercent  = 60
+	defaultAsleepVolumePercent = 30
+	defaultTTSDomain           = "tts"
+	defaultTTSService          = "speak"
+	defaultTTSEntityID         = "tts.google_translate_en_com"
+	defaultRestoreDelaySeconds = 8
+)
+
+// defaultSpeakers is the union of speaker lists currently used by plugins.
+// Used when no notification_config.yaml is present and no plugin override is given.
+var defaultSpeakers = []string{
+	"media_player.kitchen",
+	"media_player.front_room",
+	"media_player.sitting_room",
+	"media_player.bedroom",
+	"media_player.dining_room",
+	"media_player.soundbar",
+	"media_player.kids_bathroom",
+}
+
+// LoadConfig reads the notifier config from a YAML file. Missing fields fall
+// back to safe defaults so a partially-specified config still works.
+func LoadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read notification config: %w", err)
+	}
+	var f fileShape
+	if err := yaml.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("parse notification config: %w", err)
+	}
+	cfg := f.Notification
+	cfg.applyDefaults()
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// DefaultConfig returns a Config populated with safe defaults. Used when no
+// notification_config.yaml file is present.
+func DefaultConfig() Config {
+	c := Config{SnapshotRestore: true}
+	c.applyDefaults()
+	return c
+}
+
+func (c *Config) applyDefaults() {
+	if len(c.DefaultSpeakers) == 0 {
+		c.DefaultSpeakers = append([]string(nil), defaultSpeakers...)
+	}
+	if c.AwakeVolumePercent == 0 {
+		c.AwakeVolumePercent = defaultAwakeVolumePercent
+	}
+	if c.AsleepVolumePercent == 0 {
+		c.AsleepVolumePercent = defaultAsleepVolumePercent
+	}
+	if c.TTSDomain == "" {
+		c.TTSDomain = defaultTTSDomain
+	}
+	if c.TTSService == "" {
+		c.TTSService = defaultTTSService
+	}
+	if c.TTSEntityID == "" {
+		c.TTSEntityID = defaultTTSEntityID
+	}
+	if c.RestoreDelaySeconds == 0 {
+		c.RestoreDelaySeconds = defaultRestoreDelaySeconds
+	}
+	c.RestoreDelay = time.Duration(c.RestoreDelaySeconds) * time.Second
+}
+
+func (c *Config) validate() error {
+	if c.AwakeVolumePercent < 0 || c.AwakeVolumePercent > 100 {
+		return fmt.Errorf("awake_volume_percent must be 0-100, got %d", c.AwakeVolumePercent)
+	}
+	if c.AsleepVolumePercent < 0 || c.AsleepVolumePercent > 100 {
+		return fmt.Errorf("asleep_volume_percent must be 0-100, got %d", c.AsleepVolumePercent)
+	}
+	if c.RestoreDelaySeconds < 0 {
+		return fmt.Errorf("restore_delay_seconds must be non-negative, got %d", c.RestoreDelaySeconds)
+	}
+	return nil
+}

--- a/homeautomation-go/internal/notify/mock.go
+++ b/homeautomation-go/internal/notify/mock.go
@@ -1,0 +1,54 @@
+package notify
+
+import (
+	"context"
+	"sync"
+)
+
+// MockNotifier records Announce calls for tests. Safe for concurrent use.
+type MockNotifier struct {
+	mu    sync.Mutex
+	calls []MockCall
+
+	// Err, when non-nil, is returned from Announce.
+	Err error
+}
+
+// MockCall captures a single Announce invocation.
+type MockCall struct {
+	Message  string
+	Speakers []string
+	Urgency  UrgencyLevel
+}
+
+// Announce implements Notifier.
+func (m *MockNotifier) Announce(_ context.Context, message string, opts ...AnnounceOption) error {
+	o := announceOpts{urgency: UrgencyRoutine}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	m.mu.Lock()
+	m.calls = append(m.calls, MockCall{
+		Message:  message,
+		Speakers: append([]string(nil), o.speakers...),
+		Urgency:  o.urgency,
+	})
+	m.mu.Unlock()
+	return m.Err
+}
+
+// Calls returns a copy of the recorded calls.
+func (m *MockNotifier) Calls() []MockCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]MockCall, len(m.calls))
+	copy(out, m.calls)
+	return out
+}
+
+// Reset clears recorded calls.
+func (m *MockNotifier) Reset() {
+	m.mu.Lock()
+	m.calls = nil
+	m.mu.Unlock()
+}

--- a/homeautomation-go/internal/notify/notify.go
+++ b/homeautomation-go/internal/notify/notify.go
@@ -221,6 +221,11 @@ func (m *Manager) setVolumes(ctx context.Context, speakers []string, level float
 	}
 }
 
+// scheduleRestore waits RestoreDelay then restores priorVolumes. If two
+// announcements overlap within the delay window, the second snapshot captures
+// the announcement volume rather than the true prior level; the second restore
+// will then land at the first announcement's volume. This is acceptable given
+// that overlapping announcements are unlikely in practice.
 func (m *Manager) scheduleRestore(parentCtx context.Context, priorVolumes map[string]float64) {
 	m.wg.Add(1)
 	go func() {

--- a/homeautomation-go/internal/notify/notify.go
+++ b/homeautomation-go/internal/notify/notify.go
@@ -1,0 +1,253 @@
+// Package notify provides a shared TTS announcement helper that snapshots
+// speaker volume, overrides to a configured announcement volume, sends the
+// TTS via Home Assistant, and restores the prior volume after a delay.
+//
+// All plugins that need to make verbal announcements should depend on the
+// Notifier interface rather than calling tts.speak directly. This guarantees
+// announcements remain audible regardless of the speakers' current state
+// (ducked music, paused playback, low background volume) and centralises
+// behavior such as sleep-aware volume reduction.
+package notify
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"homeautomation/internal/ha"
+	"homeautomation/internal/state"
+
+	"go.uber.org/zap"
+)
+
+// Notifier sends verbal (TTS) announcements to speakers.
+type Notifier interface {
+	Announce(ctx context.Context, message string, opts ...AnnounceOption) error
+}
+
+// UrgencyLevel controls volume behavior when the master is asleep.
+type UrgencyLevel int
+
+const (
+	// UrgencyRoutine uses the asleep volume when isMasterAsleep is true.
+	UrgencyRoutine UrgencyLevel = iota
+
+	// UrgencyUrgent uses the awake volume even when asleep. Use for security
+	// alerts (doorbell, vehicle arrival, intruder detection) that must be heard.
+	UrgencyUrgent
+)
+
+// MasterAsleepStateVar is the state variable consulted for sleep-aware volume.
+const MasterAsleepStateVar = "isMasterAsleep"
+
+type announceOpts struct {
+	speakers []string
+	urgency  UrgencyLevel
+}
+
+// AnnounceOption customizes a single Announce call.
+type AnnounceOption func(*announceOpts)
+
+// WithSpeakers overrides the default speaker list for this announcement.
+func WithSpeakers(speakers []string) AnnounceOption {
+	return func(o *announceOpts) {
+		o.speakers = append([]string(nil), speakers...)
+	}
+}
+
+// WithUrgency sets the announcement urgency. Default is UrgencyRoutine.
+func WithUrgency(level UrgencyLevel) AnnounceOption {
+	return func(o *announceOpts) { o.urgency = level }
+}
+
+// Manager is the default Notifier implementation backed by Home Assistant.
+type Manager struct {
+	haClient     ha.HAClient
+	stateManager *state.Manager
+	cfg          Config
+	logger       *zap.Logger
+	readOnly     bool
+
+	wg sync.WaitGroup
+}
+
+// NewManager constructs a Notifier. stateManager may be nil in tests; sleep-aware
+// volume falls back to AwakeVolumePercent in that case.
+func NewManager(haClient ha.HAClient, stateManager *state.Manager, cfg Config, logger *zap.Logger, readOnly bool) *Manager {
+	cfg.applyDefaults()
+	return &Manager{
+		haClient:     haClient,
+		stateManager: stateManager,
+		cfg:          cfg,
+		logger:       logger.Named("notify"),
+		readOnly:     readOnly,
+	}
+}
+
+// WaitForRestores blocks until all pending volume restores complete. Use during
+// graceful shutdown to avoid leaving speakers at the announcement volume.
+func (m *Manager) WaitForRestores() { m.wg.Wait() }
+
+// Announce speaks message on the configured speakers. The TTS service call is
+// synchronous; the volume restore is scheduled asynchronously after
+// cfg.RestoreDelay so the caller does not block waiting for playback to end.
+//
+// Snapshot and restore failures are logged but do not fail the call - an
+// audible announcement at an unknown final volume is preferable to no
+// announcement.
+func (m *Manager) Announce(ctx context.Context, message string, opts ...AnnounceOption) error {
+	o := announceOpts{
+		speakers: m.cfg.DefaultSpeakers,
+		urgency:  UrgencyRoutine,
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	if len(o.speakers) == 0 {
+		return fmt.Errorf("notify.Announce: no speakers configured")
+	}
+	if message == "" {
+		return fmt.Errorf("notify.Announce: empty message")
+	}
+
+	targetVolume := m.targetVolumePercent(o.urgency)
+
+	if m.readOnly {
+		m.logger.Info("READ-ONLY: would announce TTS",
+			zap.String("message", message),
+			zap.Strings("speakers", o.speakers),
+			zap.Int("target_volume_percent", targetVolume),
+			zap.Int("urgency", int(o.urgency)))
+		return nil
+	}
+
+	var priorVolumes map[string]float64
+	if m.cfg.SnapshotRestore {
+		priorVolumes = m.snapshotVolumes(o.speakers)
+		m.setVolumes(ctx, o.speakers, float64(targetVolume)/100.0)
+	}
+
+	if err := m.haClient.CallService(ctx, m.cfg.TTSDomain, m.cfg.TTSService, map[string]interface{}{
+		"entity_id":              m.cfg.TTSEntityID,
+		"media_player_entity_id": o.speakers,
+		"message":                message,
+		"cache":                  true,
+	}); err != nil {
+		// On TTS failure, restore immediately so we don't leave speakers loud.
+		if m.cfg.SnapshotRestore && len(priorVolumes) > 0 {
+			m.restoreVolumesNow(ctx, priorVolumes)
+		}
+		return fmt.Errorf("tts.%s call failed: %w", m.cfg.TTSService, err)
+	}
+
+	m.logger.Info("Announcement sent",
+		zap.String("message", message),
+		zap.Strings("speakers", o.speakers),
+		zap.Int("target_volume_percent", targetVolume),
+		zap.Int("urgency", int(o.urgency)))
+
+	if m.cfg.SnapshotRestore && len(priorVolumes) > 0 {
+		m.scheduleRestore(ctx, priorVolumes)
+	}
+	return nil
+}
+
+func (m *Manager) targetVolumePercent(urgency UrgencyLevel) int {
+	if urgency == UrgencyRoutine && m.isMasterAsleep() {
+		return m.cfg.AsleepVolumePercent
+	}
+	return m.cfg.AwakeVolumePercent
+}
+
+func (m *Manager) isMasterAsleep() bool {
+	if m.stateManager == nil {
+		return false
+	}
+	v, err := m.stateManager.GetBool(MasterAsleepStateVar)
+	if err != nil {
+		// Conservative: treat as awake so announcements stay loud.
+		return false
+	}
+	return v
+}
+
+// snapshotVolumes reads the current volume_level for each speaker. Failures
+// are logged and the speaker is omitted from the returned map (so it is not
+// restored later).
+func (m *Manager) snapshotVolumes(speakers []string) map[string]float64 {
+	out := make(map[string]float64, len(speakers))
+	for _, entityID := range speakers {
+		st, err := m.haClient.GetState(entityID)
+		if err != nil {
+			m.logger.Warn("Failed to snapshot speaker volume; will not restore",
+				zap.String("entity_id", entityID),
+				zap.Error(err))
+			continue
+		}
+		raw, ok := st.Attributes["volume_level"]
+		if !ok {
+			m.logger.Debug("Speaker has no volume_level attribute; will not restore",
+				zap.String("entity_id", entityID))
+			continue
+		}
+		v, ok := raw.(float64)
+		if !ok {
+			m.logger.Debug("Speaker volume_level is not float; will not restore",
+				zap.String("entity_id", entityID),
+				zap.Any("value", raw))
+			continue
+		}
+		out[entityID] = v
+	}
+	return out
+}
+
+func (m *Manager) setVolumes(ctx context.Context, speakers []string, level float64) {
+	// One service call per speaker. Calling media_player.volume_set with a
+	// list entity_id is supported but failures are harder to diagnose; per-
+	// speaker calls give clear error attribution.
+	for _, entityID := range speakers {
+		err := m.haClient.CallService(ctx, "media_player", "volume_set", map[string]interface{}{
+			"entity_id":    entityID,
+			"volume_level": level,
+		})
+		if err != nil {
+			m.logger.Warn("Failed to set speaker volume for announcement",
+				zap.String("entity_id", entityID),
+				zap.Float64("volume_level", level),
+				zap.Error(err))
+		}
+	}
+}
+
+func (m *Manager) scheduleRestore(parentCtx context.Context, priorVolumes map[string]float64) {
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		select {
+		case <-time.After(m.cfg.RestoreDelay):
+		case <-parentCtx.Done():
+			// Parent cancelled (likely shutdown). Restore now anyway.
+		}
+		// Use a fresh context for the restore - parent may already be done.
+		restoreCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		m.restoreVolumesNow(restoreCtx, priorVolumes)
+	}()
+}
+
+func (m *Manager) restoreVolumesNow(ctx context.Context, priorVolumes map[string]float64) {
+	for entityID, level := range priorVolumes {
+		err := m.haClient.CallService(ctx, "media_player", "volume_set", map[string]interface{}{
+			"entity_id":    entityID,
+			"volume_level": level,
+		})
+		if err != nil {
+			m.logger.Warn("Failed to restore speaker volume after announcement",
+				zap.String("entity_id", entityID),
+				zap.Float64("volume_level", level),
+				zap.Error(err))
+		}
+	}
+}

--- a/homeautomation-go/internal/notify/notify_test.go
+++ b/homeautomation-go/internal/notify/notify_test.go
@@ -1,0 +1,365 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"homeautomation/internal/ha"
+	"homeautomation/internal/state"
+
+	"go.uber.org/zap/zaptest"
+)
+
+func newTestManager(t *testing.T, mockHA *ha.MockClient, stateMgr *state.Manager, readOnly bool, snapshotRestore bool) *Manager {
+	t.Helper()
+	cfg := DefaultConfig()
+	cfg.SnapshotRestore = snapshotRestore
+	// short restore delay so async restore tests don't take 8s
+	cfg.RestoreDelaySeconds = 1
+	cfg.RestoreDelay = 50 * time.Millisecond
+	return NewManager(mockHA, stateMgr, cfg, zaptest.NewLogger(t), readOnly)
+}
+
+func TestAnnounce_SnapshotOverrideSpeakRestore(t *testing.T) {
+	mockHA := ha.NewMockClient()
+	mockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{"volume_level": 0.25})
+	mockHA.SetState("media_player.front_room", "playing", map[string]interface{}{"volume_level": 0.40})
+
+	m := newTestManager(t, mockHA, nil, false, true)
+
+	err := m.Announce(context.Background(), "Test announcement", WithSpeakers([]string{
+		"media_player.kitchen",
+		"media_player.front_room",
+	}))
+	if err != nil {
+		t.Fatalf("Announce returned error: %v", err)
+	}
+
+	// Wait for async restore
+	m.WaitForRestores()
+
+	calls := mockHA.GetServiceCalls()
+
+	// Expect: 2 volume_set (override) + 1 tts.speak + 2 volume_set (restore) = 5
+	if len(calls) < 5 {
+		t.Fatalf("expected at least 5 service calls, got %d: %+v", len(calls), calls)
+	}
+
+	// First two calls: override volume to 0.6 (default awake)
+	for i := 0; i < 2; i++ {
+		c := calls[i]
+		if c.Domain != "media_player" || c.Service != "volume_set" {
+			t.Errorf("call %d: expected media_player.volume_set, got %s.%s", i, c.Domain, c.Service)
+		}
+		if v, _ := c.Data["volume_level"].(float64); v != 0.60 {
+			t.Errorf("call %d: expected volume_level 0.60, got %v", i, c.Data["volume_level"])
+		}
+	}
+
+	// Third call: tts.speak
+	tts := calls[2]
+	if tts.Domain != "tts" || tts.Service != "speak" {
+		t.Errorf("call 2: expected tts.speak, got %s.%s", tts.Domain, tts.Service)
+	}
+	if msg, _ := tts.Data["message"].(string); msg != "Test announcement" {
+		t.Errorf("expected message 'Test announcement', got %v", tts.Data["message"])
+	}
+
+	// Last two calls: restore prior volumes
+	restoreCalls := calls[3:]
+	restoredVolumes := map[string]float64{}
+	for _, c := range restoreCalls {
+		if c.Domain != "media_player" || c.Service != "volume_set" {
+			t.Errorf("expected restore call media_player.volume_set, got %s.%s", c.Domain, c.Service)
+			continue
+		}
+		entityID, _ := c.Data["entity_id"].(string)
+		level, _ := c.Data["volume_level"].(float64)
+		restoredVolumes[entityID] = level
+	}
+	if got := restoredVolumes["media_player.kitchen"]; got != 0.25 {
+		t.Errorf("kitchen restore: expected 0.25, got %v", got)
+	}
+	if got := restoredVolumes["media_player.front_room"]; got != 0.40 {
+		t.Errorf("front_room restore: expected 0.40, got %v", got)
+	}
+}
+
+func TestAnnounce_ReadOnlyDoesNothing(t *testing.T) {
+	mockHA := ha.NewMockClient()
+	mockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{"volume_level": 0.25})
+
+	m := newTestManager(t, mockHA, nil, true, true)
+
+	if err := m.Announce(context.Background(), "Hi", WithSpeakers([]string{"media_player.kitchen"})); err != nil {
+		t.Fatalf("Announce returned error: %v", err)
+	}
+	m.WaitForRestores()
+
+	if calls := mockHA.GetServiceCalls(); len(calls) != 0 {
+		t.Errorf("read-only mode should not make service calls, got %d", len(calls))
+	}
+}
+
+func TestAnnounce_EmptyMessageReturnsError(t *testing.T) {
+	mockHA := ha.NewMockClient()
+	m := newTestManager(t, mockHA, nil, false, true)
+
+	if err := m.Announce(context.Background(), "", WithSpeakers([]string{"media_player.kitchen"})); err == nil {
+		t.Error("expected error for empty message")
+	}
+}
+
+func TestAnnounce_NoSpeakersReturnsError(t *testing.T) {
+	mockHA := ha.NewMockClient()
+	m := newTestManager(t, mockHA, nil, false, true)
+	// Override default speakers to empty
+	m.cfg.DefaultSpeakers = nil
+
+	if err := m.Announce(context.Background(), "Hi"); err == nil {
+		t.Error("expected error when no speakers configured")
+	}
+}
+
+func TestAnnounce_TTSFailureRestoresImmediately(t *testing.T) {
+	mockHA := ha.NewMockClient()
+	mockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{"volume_level": 0.30})
+	mockHA.SetServiceError("tts", "speak", errors.New("tts unavailable"))
+
+	m := newTestManager(t, mockHA, nil, false, true)
+
+	err := m.Announce(context.Background(), "Hi", WithSpeakers([]string{"media_player.kitchen"}))
+	if err == nil {
+		t.Fatal("expected error from failed TTS")
+	}
+
+	// Errored services don't get recorded by the mock, so we expect:
+	//   1. override volume_set (recorded)
+	//   2. tts.speak (errored - not recorded)
+	//   3. restore volume_set (recorded)
+	calls := mockHA.GetServiceCalls()
+	if len(calls) != 2 {
+		t.Fatalf("expected exactly 2 recorded calls (override + restore), got %d: %+v", len(calls), calls)
+	}
+
+	// Override set to 0.60 (default awake), restore set back to 0.30
+	if v, _ := calls[0].Data["volume_level"].(float64); v != 0.60 {
+		t.Errorf("expected override to 0.60, got %v", v)
+	}
+	if v, _ := calls[1].Data["volume_level"].(float64); v != 0.30 {
+		t.Errorf("expected restore to 0.30, got %v", v)
+	}
+
+	// No goroutine restore should be pending
+	doneCh := make(chan struct{})
+	go func() { m.WaitForRestores(); close(doneCh) }()
+	select {
+	case <-doneCh:
+	case <-time.After(time.Second):
+		t.Error("WaitForRestores did not return promptly after TTS failure")
+	}
+}
+
+func TestAnnounce_SleepAwareVolumeRoutine(t *testing.T) {
+	mockHA := ha.NewMockClient()
+	mockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{"volume_level": 0.40})
+
+	stateMgr := state.NewManager(mockHA, zaptest.NewLogger(t), false)
+	if err := stateMgr.SetBool("isMasterAsleep", true); err != nil {
+		t.Fatalf("SetBool failed: %v", err)
+	}
+	// Clear the service calls SetBool may have made (e.g. input_boolean.turn_on)
+	// so we only observe Announce's calls below.
+	mockHA.ClearServiceCalls()
+
+	m := newTestManager(t, mockHA, stateMgr, false, true)
+
+	if err := m.Announce(context.Background(), "Hi", WithSpeakers([]string{"media_player.kitchen"})); err != nil {
+		t.Fatalf("Announce returned error: %v", err)
+	}
+	m.WaitForRestores()
+
+	// First call is the volume override - should use AsleepVolumePercent (30%)
+	calls := mockHA.GetServiceCalls()
+	if len(calls) < 1 {
+		t.Fatalf("expected at least one call")
+	}
+	override := calls[0]
+	if override.Domain != "media_player" || override.Service != "volume_set" {
+		t.Fatalf("expected first call to be volume_set, got %s.%s", override.Domain, override.Service)
+	}
+	if v, _ := override.Data["volume_level"].(float64); v != 0.30 {
+		t.Errorf("routine announcement while asleep: expected volume 0.30, got %v", v)
+	}
+}
+
+func TestAnnounce_SleepAwareVolumeUrgent(t *testing.T) {
+	mockHA := ha.NewMockClient()
+	mockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{"volume_level": 0.40})
+
+	stateMgr := state.NewManager(mockHA, zaptest.NewLogger(t), false)
+	if err := stateMgr.SetBool("isMasterAsleep", true); err != nil {
+		t.Fatalf("SetBool failed: %v", err)
+	}
+	// Clear the service calls SetBool may have made (e.g. input_boolean.turn_on)
+	// so we only observe Announce's calls below.
+	mockHA.ClearServiceCalls()
+
+	m := newTestManager(t, mockHA, stateMgr, false, true)
+
+	if err := m.Announce(context.Background(), "Person at door", WithSpeakers([]string{"media_player.kitchen"}), WithUrgency(UrgencyUrgent)); err != nil {
+		t.Fatalf("Announce returned error: %v", err)
+	}
+	m.WaitForRestores()
+
+	calls := mockHA.GetServiceCalls()
+	override := calls[0]
+	if v, _ := override.Data["volume_level"].(float64); v != 0.60 {
+		t.Errorf("urgent announcement while asleep: expected volume 0.60 (awake), got %v", v)
+	}
+}
+
+func TestAnnounce_SnapshotRestoreDisabled(t *testing.T) {
+	mockHA := ha.NewMockClient()
+	mockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{"volume_level": 0.25})
+
+	m := newTestManager(t, mockHA, nil, false, false)
+
+	if err := m.Announce(context.Background(), "Hi", WithSpeakers([]string{"media_player.kitchen"})); err != nil {
+		t.Fatalf("Announce returned error: %v", err)
+	}
+	m.WaitForRestores()
+
+	// Only the tts.speak call should happen - no volume snapshot or restore.
+	calls := mockHA.GetServiceCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 call (tts.speak), got %d: %+v", len(calls), calls)
+	}
+	if calls[0].Domain != "tts" || calls[0].Service != "speak" {
+		t.Errorf("expected tts.speak, got %s.%s", calls[0].Domain, calls[0].Service)
+	}
+}
+
+func TestAnnounce_MissingSpeakerStateOmittedFromRestore(t *testing.T) {
+	mockHA := ha.NewMockClient()
+	mockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{"volume_level": 0.25})
+	// Note: media_player.bedroom intentionally not set.
+
+	m := newTestManager(t, mockHA, nil, false, true)
+
+	if err := m.Announce(context.Background(), "Hi", WithSpeakers([]string{
+		"media_player.kitchen",
+		"media_player.bedroom",
+	})); err != nil {
+		t.Fatalf("Announce returned error: %v", err)
+	}
+	m.WaitForRestores()
+
+	calls := mockHA.GetServiceCalls()
+
+	// Count restore calls (volume_set) that happen after the tts.speak call
+	ttsIdx := -1
+	for i, c := range calls {
+		if c.Domain == "tts" && c.Service == "speak" {
+			ttsIdx = i
+			break
+		}
+	}
+	if ttsIdx == -1 {
+		t.Fatalf("tts.speak call not found")
+	}
+
+	// Restore calls only for entities with snapshotted state.
+	restoreCount := 0
+	for _, c := range calls[ttsIdx+1:] {
+		if c.Domain == "media_player" && c.Service == "volume_set" {
+			restoreCount++
+		}
+	}
+	if restoreCount != 1 {
+		t.Errorf("expected exactly 1 restore call (kitchen only), got %d", restoreCount)
+	}
+}
+
+func TestMockNotifier_RecordsCalls(t *testing.T) {
+	mock := &MockNotifier{}
+
+	if err := mock.Announce(context.Background(), "first", WithSpeakers([]string{"media_player.kitchen"})); err != nil {
+		t.Fatalf("Announce returned error: %v", err)
+	}
+	if err := mock.Announce(context.Background(), "second", WithUrgency(UrgencyUrgent)); err != nil {
+		t.Fatalf("Announce returned error: %v", err)
+	}
+
+	calls := mock.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", len(calls))
+	}
+	if calls[0].Message != "first" || calls[0].Speakers[0] != "media_player.kitchen" {
+		t.Errorf("call 0 unexpected: %+v", calls[0])
+	}
+	if calls[1].Message != "second" || calls[1].Urgency != UrgencyUrgent {
+		t.Errorf("call 1 unexpected: %+v", calls[1])
+	}
+
+	mock.Reset()
+	if calls := mock.Calls(); len(calls) != 0 {
+		t.Errorf("Reset did not clear calls: %d remaining", len(calls))
+	}
+}
+
+func TestMockNotifier_ConcurrentSafe(t *testing.T) {
+	mock := &MockNotifier{}
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = mock.Announce(context.Background(), "concurrent")
+		}()
+	}
+	wg.Wait()
+	if len(mock.Calls()) != 10 {
+		t.Errorf("expected 10 calls from concurrent goroutines, got %d", len(mock.Calls()))
+	}
+}
+
+func TestLoadConfig_AppliesDefaults(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.AwakeVolumePercent != defaultAwakeVolumePercent {
+		t.Errorf("AwakeVolumePercent: expected %d, got %d", defaultAwakeVolumePercent, cfg.AwakeVolumePercent)
+	}
+	if cfg.AsleepVolumePercent != defaultAsleepVolumePercent {
+		t.Errorf("AsleepVolumePercent: expected %d, got %d", defaultAsleepVolumePercent, cfg.AsleepVolumePercent)
+	}
+	if cfg.TTSDomain != defaultTTSDomain {
+		t.Errorf("TTSDomain: expected %s, got %s", defaultTTSDomain, cfg.TTSDomain)
+	}
+	if cfg.TTSEntityID != defaultTTSEntityID {
+		t.Errorf("TTSEntityID: expected %s, got %s", defaultTTSEntityID, cfg.TTSEntityID)
+	}
+	if !cfg.SnapshotRestore {
+		t.Error("SnapshotRestore should default to true")
+	}
+	if len(cfg.DefaultSpeakers) == 0 {
+		t.Error("DefaultSpeakers should not be empty")
+	}
+}
+
+func TestConfigValidate_RejectsInvalidVolume(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.AwakeVolumePercent = 150
+	if err := cfg.validate(); err == nil {
+		t.Error("expected validate to reject volume > 100")
+	}
+
+	cfg = DefaultConfig()
+	cfg.AsleepVolumePercent = -1
+	if err := cfg.validate(); err == nil {
+		t.Error("expected validate to reject negative volume")
+	}
+}

--- a/homeautomation-go/internal/plugins/evcharger/manager.go
+++ b/homeautomation-go/internal/plugins/evcharger/manager.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"homeautomation/internal/ha"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/ntfy"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
@@ -44,6 +45,7 @@ type Manager struct {
 	logger       *zap.Logger
 	readOnly     bool
 	ntfyClient   ntfy.Notifier
+	notifier     notify.Notifier
 
 	// Shadow state tracking
 	shadowTracker *shadowstate.EVChargerTracker
@@ -55,7 +57,7 @@ type Manager struct {
 }
 
 // NewManager creates a new EV charger safety manager
-func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.Manager, logger *zap.Logger, readOnly bool, registry *shadowstate.SubscriptionRegistry, ntfyClient ntfy.Notifier) *Manager {
+func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.Manager, logger *zap.Logger, readOnly bool, registry *shadowstate.SubscriptionRegistry, ntfyClient ntfy.Notifier, notifier notify.Notifier) *Manager {
 	shadowTracker := shadowstate.NewEVChargerTracker()
 
 	return &Manager{
@@ -65,6 +67,7 @@ func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.M
 		logger:        logger.Named("evcharger"),
 		readOnly:      readOnly,
 		ntfyClient:    ntfyClient,
+		notifier:      notifier,
 		shadowTracker: shadowTracker,
 		subHelper:     shadowstate.NewSubscriptionHelper(haClient, stateManager, registry, shadowTracker, "evcharger", logger.Named("evcharger")),
 	}
@@ -321,13 +324,8 @@ func (m *Manager) sendAlertNotifications(conditionType, sensor string) {
 	m.sendTTSAnnouncement(fmt.Sprintf("Warning: EV charger %s detected. The charger has been automatically turned off.", conditionType))
 }
 
-// sendTTSAnnouncement sends a TTS message to Sonos speakers
+// sendTTSAnnouncement sends an urgent verbal safety announcement.
 func (m *Manager) sendTTSAnnouncement(message string) {
-	if m.readOnly {
-		m.logger.Info("READ-ONLY: Would send TTS announcement", zap.String("message", message))
-		return
-	}
-
 	speakers := []string{
 		"media_player.bedroom",
 		"media_player.kitchen",
@@ -335,15 +333,13 @@ func (m *Manager) sendTTSAnnouncement(message string) {
 		"media_player.soundbar",
 	}
 
-	if err := m.haClient.CallService(m.ctx, "tts", "speak", map[string]interface{}{
-		"entity_id":              "tts.google_translate_en_com",
-		"media_player_entity_id": speakers,
-		"message":                message,
-		"cache":                  true,
-	}); err != nil {
-		m.logger.Error("Failed to send TTS announcement", zap.Error(err))
-	} else {
-		m.logger.Info("TTS announcement sent", zap.String("message", message))
-		m.shadowTracker.RecordTTSAnnouncement()
+	if err := m.notifier.Announce(m.ctx, message,
+		notify.WithSpeakers(speakers),
+		notify.WithUrgency(notify.UrgencyUrgent),
+	); err != nil {
+		m.logger.Error("Failed to send EV charger announcement", zap.Error(err))
+		return
 	}
+	m.logger.Info("EV charger announcement sent", zap.String("message", message))
+	m.shadowTracker.RecordTTSAnnouncement()
 }

--- a/homeautomation-go/internal/plugins/evcharger/manager_test.go
+++ b/homeautomation-go/internal/plugins/evcharger/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"homeautomation/internal/ha"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/ntfy"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
@@ -21,7 +22,7 @@ func createTestManager(mockHA *ha.MockClient, mockNtfy *ntfy.MockClient) *Manage
 	logger := zap.NewNop()
 	stateMgr := state.NewManager(mockHA, logger, false)
 	registry := shadowstate.NewSubscriptionRegistry()
-	return NewManager(context.Background(), mockHA, stateMgr, logger, false, registry, mockNtfy)
+	return NewManager(context.Background(), mockHA, stateMgr, logger, false, registry, mockNtfy, &notify.MockNotifier{})
 }
 
 // Helper to create a test manager in read-only mode
@@ -29,7 +30,7 @@ func createTestManagerReadOnly(mockHA *ha.MockClient, mockNtfy *ntfy.MockClient)
 	logger := zap.NewNop()
 	stateMgr := state.NewManager(mockHA, logger, false)
 	registry := shadowstate.NewSubscriptionRegistry()
-	return NewManager(context.Background(), mockHA, stateMgr, logger, true, registry, mockNtfy)
+	return NewManager(context.Background(), mockHA, stateMgr, logger, true, registry, mockNtfy, &notify.MockNotifier{})
 }
 
 func TestManager_OverheatDetection(t *testing.T) {
@@ -537,7 +538,7 @@ func TestManager_NotificationWithoutNtfyClient(t *testing.T) {
 	registry := shadowstate.NewSubscriptionRegistry()
 
 	// Create manager with nil ntfy client
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, registry, nil)
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, registry, nil, &notify.MockNotifier{})
 
 	require.NoError(t, manager.Start())
 	defer manager.Stop()

--- a/homeautomation-go/internal/plugins/evcharger/register.go
+++ b/homeautomation-go/internal/plugins/evcharger/register.go
@@ -3,6 +3,7 @@ package evcharger
 import (
 	"fmt"
 
+	"homeautomation/internal/notify"
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
 	"homeautomation/pkg/shadowstate"
@@ -32,7 +33,12 @@ func createPlugin(ctx *plugin.Context) (plugin.Plugin, error) {
 		return nil, fmt.Errorf("evcharger plugin requires internal state.Manager")
 	}
 
-	manager := NewManager(ctx.ShutdownCtx, haClient, stateManager, ctx.Logger, ctx.ReadOnly, ctx.Registry, ctx.NtfyClient)
+	notifier := ctx.Notifier
+	if notifier == nil {
+		notifier = &notify.MockNotifier{}
+	}
+
+	manager := NewManager(ctx.ShutdownCtx, haClient, stateManager, ctx.Logger, ctx.ReadOnly, ctx.Registry, ctx.NtfyClient, notifier)
 	return &pluginAdapter{manager: manager}, nil
 }
 

--- a/homeautomation-go/internal/plugins/infrastructure/manager.go
+++ b/homeautomation-go/internal/plugins/infrastructure/manager.go
@@ -10,6 +10,7 @@ import (
 
 	"homeautomation/internal/clock"
 	"homeautomation/internal/ha"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/ntfy"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
@@ -62,6 +63,7 @@ type Manager struct {
 	readOnly     bool
 	clock        clock.Clock
 	ntfyClient   ntfy.Notifier
+	notifier     notify.Notifier
 
 	// Shadow state tracking
 	shadowTracker *shadowstate.InfrastructureTracker
@@ -88,7 +90,7 @@ type Manager struct {
 }
 
 // NewManager creates a new infrastructure manager
-func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.Manager, logger *zap.Logger, readOnly bool, registry *shadowstate.SubscriptionRegistry, ntfyClient ntfy.Notifier) *Manager {
+func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.Manager, logger *zap.Logger, readOnly bool, registry *shadowstate.SubscriptionRegistry, ntfyClient ntfy.Notifier, notifier notify.Notifier) *Manager {
 	shadowTracker := shadowstate.NewInfrastructureTracker()
 
 	return &Manager{
@@ -99,14 +101,15 @@ func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.M
 		readOnly:      readOnly,
 		clock:         clock.NewRealClock(),
 		ntfyClient:    ntfyClient,
+		notifier:      notifier,
 		shadowTracker: shadowTracker,
 		subHelper:     shadowstate.NewSubscriptionHelper(haClient, stateManager, registry, shadowTracker, "infrastructure", logger.Named("infrastructure")),
 	}
 }
 
 // NewManagerWithClock creates a new infrastructure manager with a custom clock (for testing)
-func NewManagerWithClock(ctx context.Context, haClient ha.HAClient, stateManager *state.Manager, logger *zap.Logger, readOnly bool, registry *shadowstate.SubscriptionRegistry, ntfyClient ntfy.Notifier, c clock.Clock) *Manager {
-	m := NewManager(ctx, haClient, stateManager, logger, readOnly, registry, ntfyClient)
+func NewManagerWithClock(ctx context.Context, haClient ha.HAClient, stateManager *state.Manager, logger *zap.Logger, readOnly bool, registry *shadowstate.SubscriptionRegistry, ntfyClient ntfy.Notifier, notifier notify.Notifier, c clock.Clock) *Manager {
+	m := NewManager(ctx, haClient, stateManager, logger, readOnly, registry, ntfyClient, notifier)
 	m.clock = c
 	return m
 }
@@ -414,13 +417,8 @@ func (m *Manager) sendRecoveryNotification() {
 	}
 }
 
-// sendTTSAnnouncement sends a TTS message to Sonos speakers
+// sendTTSAnnouncement sends a verbal infrastructure alert via the shared notifier.
 func (m *Manager) sendTTSAnnouncement(message string) {
-	if m.readOnly {
-		m.logger.Info("READ-ONLY: Would send TTS announcement", zap.String("message", message))
-		return
-	}
-
 	speakers := []string{
 		"media_player.bedroom",
 		"media_player.kitchen",
@@ -429,17 +427,12 @@ func (m *Manager) sendTTSAnnouncement(message string) {
 		"media_player.kids_bathroom",
 	}
 
-	if err := m.haClient.CallService(m.ctx, "tts", "speak", map[string]interface{}{
-		"entity_id":              "tts.google_translate_en_com",
-		"media_player_entity_id": speakers,
-		"message":                message,
-		"cache":                  true,
-	}); err != nil {
-		m.logger.Error("Failed to send TTS announcement", zap.Error(err), zap.String("message", message))
-	} else {
-		m.logger.Info("TTS announcement sent", zap.String("message", message))
-		m.shadowTracker.RecordTTSAnnouncement(message)
+	if err := m.notifier.Announce(m.ctx, message, notify.WithSpeakers(speakers)); err != nil {
+		m.logger.Error("Failed to send infrastructure announcement", zap.Error(err), zap.String("message", message))
+		return
 	}
+	m.logger.Info("Infrastructure announcement sent", zap.String("message", message))
+	m.shadowTracker.RecordTTSAnnouncement(message)
 }
 
 // handleThermostatChange processes changes to thermostat entities

--- a/homeautomation-go/internal/plugins/infrastructure/manager_test.go
+++ b/homeautomation-go/internal/plugins/infrastructure/manager_test.go
@@ -7,6 +7,7 @@ import (
 
 	"homeautomation/internal/clock"
 	"homeautomation/internal/ha"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/ntfy"
 	"homeautomation/internal/state"
 
@@ -32,7 +33,7 @@ func getLastNtfyNotification(mockNtfy *ntfy.MockClient) *ntfy.Message {
 func createTestManager(mockHA *ha.MockClient, mockNtfy *ntfy.MockClient, mockClock *clock.MockClock) *Manager {
 	logger := zap.NewNop()
 	stateMgr := state.NewManager(mockHA, logger, false)
-	return NewManagerWithClock(context.Background(), mockHA, stateMgr, logger, false, nil, mockNtfy, mockClock)
+	return NewManagerWithClock(context.Background(), mockHA, stateMgr, logger, false, nil, mockNtfy, &notify.MockNotifier{}, mockClock)
 }
 
 func TestInfrastructureManager_NormalOperation(t *testing.T) {
@@ -412,7 +413,7 @@ func TestInfrastructureManager_ReadOnlyMode(t *testing.T) {
 	stateMgr := state.NewManager(mockHA, logger, false)
 
 	// Create manager in read-only mode
-	manager := NewManagerWithClock(context.Background(), mockHA, stateMgr, logger, true, nil, mockNtfy, mockClock)
+	manager := NewManagerWithClock(context.Background(), mockHA, stateMgr, logger, true, nil, mockNtfy, &notify.MockNotifier{}, mockClock)
 
 	// Trigger failure
 	manager.SimulatePowerReading(30.0)
@@ -580,7 +581,7 @@ func TestInfrastructureManager_NtfyClientNil(t *testing.T) {
 	stateMgr := state.NewManager(mockHA, logger, false)
 
 	// Create manager without ntfy client
-	manager := NewManagerWithClock(context.Background(), mockHA, stateMgr, logger, false, nil, nil, mockClock)
+	manager := NewManagerWithClock(context.Background(), mockHA, stateMgr, logger, false, nil, nil, &notify.MockNotifier{}, mockClock)
 
 	// Trigger failure - should not panic
 	manager.SimulatePowerReading(30.0)

--- a/homeautomation-go/internal/plugins/infrastructure/register.go
+++ b/homeautomation-go/internal/plugins/infrastructure/register.go
@@ -3,6 +3,7 @@ package infrastructure
 import (
 	"fmt"
 
+	"homeautomation/internal/notify"
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
 	"homeautomation/pkg/shadowstate"
@@ -32,7 +33,12 @@ func createPlugin(ctx *plugin.Context) (plugin.Plugin, error) {
 		return nil, fmt.Errorf("infrastructure plugin requires internal state.Manager")
 	}
 
-	manager := NewManager(ctx.ShutdownCtx, haClient, stateManager, ctx.Logger, ctx.ReadOnly, ctx.Registry, ctx.NtfyClient)
+	notifier := ctx.Notifier
+	if notifier == nil {
+		notifier = &notify.MockNotifier{}
+	}
+
+	manager := NewManager(ctx.ShutdownCtx, haClient, stateManager, ctx.Logger, ctx.ReadOnly, ctx.Registry, ctx.NtfyClient, notifier)
 	return &pluginAdapter{manager: manager}, nil
 }
 

--- a/homeautomation-go/internal/plugins/security/manager.go
+++ b/homeautomation-go/internal/plugins/security/manager.go
@@ -8,6 +8,7 @@ import (
 
 	"homeautomation/internal/clock"
 	"homeautomation/internal/ha"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
 
@@ -42,6 +43,7 @@ type Manager struct {
 	ctx           context.Context
 	haClient      ha.HAClient
 	stateManager  *state.Manager
+	notifier      notify.Notifier
 	logger        *zap.Logger
 	readOnly      bool
 	clock         clock.Clock
@@ -62,13 +64,14 @@ type Manager struct {
 }
 
 // NewManager creates a new Security manager
-func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.Manager, logger *zap.Logger, readOnly bool, registry *shadowstate.SubscriptionRegistry) *Manager {
+func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.Manager, notifier notify.Notifier, logger *zap.Logger, readOnly bool, registry *shadowstate.SubscriptionRegistry) *Manager {
 	shadowTracker := shadowstate.NewSecurityTracker()
 
 	return &Manager{
 		ctx:           ctx,
 		haClient:      haClient,
 		stateManager:  stateManager,
+		notifier:      notifier,
 		logger:        logger.Named("security"),
 		readOnly:      readOnly,
 		clock:         clock.NewRealClock(),
@@ -414,13 +417,10 @@ func (m *Manager) handleVehicleArriving(entity string, oldState, newState *ha.St
 	}
 }
 
-// sendTTSNotification sends a TTS message to all Sonos speakers
+// sendTTSNotification sends an urgent verbal announcement via the shared
+// notifier. Urgent announcements ignore the asleep volume reduction so they
+// remain audible at night (doorbell, vehicle arrival, intruder alerts).
 func (m *Manager) sendTTSNotification(message string) {
-	if m.readOnly {
-		m.logger.Info("READ-ONLY: Would send TTS notification", zap.String("message", message))
-		return
-	}
-
 	speakers := []string{
 		"media_player.bedroom",
 		"media_player.kitchen",
@@ -429,16 +429,14 @@ func (m *Manager) sendTTSNotification(message string) {
 		"media_player.kids_bathroom",
 	}
 
-	if err := m.haClient.CallService(m.ctx, "tts", "speak", map[string]interface{}{
-		"entity_id":              "tts.google_translate_en_com",
-		"media_player_entity_id": speakers,
-		"message":                message,
-		"cache":                  true,
-	}); err != nil {
-		m.logger.Error("Failed to send TTS notification", zap.Error(err), zap.String("message", message))
-	} else {
-		m.logger.Info("TTS notification sent", zap.String("message", message))
+	if err := m.notifier.Announce(m.ctx, message,
+		notify.WithSpeakers(speakers),
+		notify.WithUrgency(notify.UrgencyUrgent),
+	); err != nil {
+		m.logger.Error("Failed to send security announcement", zap.Error(err), zap.String("message", message))
+		return
 	}
+	m.logger.Info("Security announcement sent", zap.String("message", message))
 }
 
 // addTriggerToInputs adds the trigger field to the current shadow state inputs

--- a/homeautomation-go/internal/plugins/security/manager_test.go
+++ b/homeautomation-go/internal/plugins/security/manager_test.go
@@ -7,6 +7,7 @@ import (
 
 	"homeautomation/internal/clock"
 	"homeautomation/internal/ha"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/state"
 
 	"go.uber.org/zap"
@@ -27,7 +28,7 @@ func TestSecurityManager_LockdownOnEveryoneAsleep(t *testing.T) {
 	stateManager.SyncFromHA()
 
 	// Create security manager (not read-only so it can call services)
-	securityManager := NewManager(context.Background(), mockHA, stateManager, logger, false, nil)
+	securityManager := NewManager(context.Background(), mockHA, stateManager, &notify.MockNotifier{}, logger, false, nil)
 
 	// Use MockClock so the 30-second delay is instant (MockClock.Sleep is a no-op)
 	mockClock := clock.NewMockClock(time.Now())
@@ -91,7 +92,7 @@ func TestSecurityManager_LockdownOnNoOneHome(t *testing.T) {
 	stateManager.SyncFromHA()
 
 	// Create security manager
-	securityManager := NewManager(context.Background(), mockHA, stateManager, logger, false, nil)
+	securityManager := NewManager(context.Background(), mockHA, stateManager, &notify.MockNotifier{}, logger, false, nil)
 
 	// Use MockClock so the 30-second delay is instant (MockClock.Sleep is a no-op)
 	mockClock := clock.NewMockClock(time.Now())
@@ -154,7 +155,7 @@ func TestSecurityManager_LockdownAutoReset(t *testing.T) {
 	stateManager.SyncFromHA()
 
 	// Create security manager
-	securityManager := NewManager(context.Background(), mockHA, stateManager, logger, false, nil)
+	securityManager := NewManager(context.Background(), mockHA, stateManager, &notify.MockNotifier{}, logger, false, nil)
 
 	// Use MockClock so the 5-second delay is instant (MockClock.Sleep is a no-op)
 	mockClock := clock.NewMockClock(time.Now())
@@ -207,7 +208,7 @@ func TestSecurityManager_GarageAutoOpen(t *testing.T) {
 	stateManager.SyncFromHA()
 
 	// Create security manager
-	securityManager := NewManager(context.Background(), mockHA, stateManager, logger, false, nil)
+	securityManager := NewManager(context.Background(), mockHA, stateManager, &notify.MockNotifier{}, logger, false, nil)
 	if err := securityManager.Start(); err != nil {
 		t.Fatalf("Failed to start security manager: %v", err)
 	}
@@ -257,7 +258,7 @@ func TestSecurityManager_GarageNotOpenedWhenOccupied(t *testing.T) {
 	stateManager.SyncFromHA()
 
 	// Create security manager
-	securityManager := NewManager(context.Background(), mockHA, stateManager, logger, false, nil)
+	securityManager := NewManager(context.Background(), mockHA, stateManager, &notify.MockNotifier{}, logger, false, nil)
 	if err := securityManager.Start(); err != nil {
 		t.Fatalf("Failed to start security manager: %v", err)
 	}
@@ -297,8 +298,9 @@ func TestSecurityManager_DoorbellNotification(t *testing.T) {
 	stateManager := state.NewManager(mockHA, logger, false)
 	stateManager.SyncFromHA()
 
-	// Create security manager
-	securityManager := NewManager(context.Background(), mockHA, stateManager, logger, false, nil)
+	// Create security manager with a captured notifier we can inspect.
+	mockNotifier := &notify.MockNotifier{}
+	securityManager := NewManager(context.Background(), mockHA, stateManager, mockNotifier, logger, false, nil)
 
 	// Use MockClock so the 2-second delay between light flashes is instant
 	mockClock := clock.NewMockClock(time.Now())
@@ -317,28 +319,28 @@ func TestSecurityManager_DoorbellNotification(t *testing.T) {
 	// Wait for async processing (goroutine runs instantly with MockClock.Sleep as no-op)
 	time.Sleep(100 * time.Millisecond)
 
-	// Verify TTS was sent
-	calls := mockHA.GetServiceCallsSince(snapshot)
+	// Verify TTS was sent via the notifier (urgent — doorbell must be loud at night).
 	ttsFound := false
-	lightsFlashed := 0
-
-	for _, call := range calls {
-		if call.Domain == "tts" && call.Service == "speak" {
-			if msg, ok := call.Data["message"].(string); ok && msg == "Doorbell ringing" {
-				ttsFound = true
-			}
+	for _, c := range mockNotifier.Calls() {
+		if c.Message == "Doorbell ringing" && c.Urgency == notify.UrgencyUrgent {
+			ttsFound = true
+			break
 		}
+	}
+	if !ttsFound {
+		t.Errorf("Expected urgent doorbell announcement via notifier, got calls: %+v", mockNotifier.Calls())
+	}
+
+	// Verify light flashes still go directly through HA service calls.
+	calls := mockHA.GetServiceCallsSince(snapshot)
+	lightsFlashed := 0
+	for _, call := range calls {
 		if call.Domain == "light" && call.Service == "turn_on" {
 			if flash, ok := call.Data["flash"].(string); ok && flash == "short" {
 				lightsFlashed++
 			}
 		}
 	}
-
-	if !ttsFound {
-		t.Errorf("Expected TTS notification for doorbell, but service was not called")
-	}
-
 	if lightsFlashed != 2 {
 		t.Errorf("Expected lights to flash 2 times, but flashed %d times", lightsFlashed)
 	}
@@ -358,7 +360,7 @@ func TestSecurityManager_DoorbellRateLimiting(t *testing.T) {
 	stateManager.SyncFromHA()
 
 	// Create security manager
-	securityManager := NewManager(context.Background(), mockHA, stateManager, logger, false, nil)
+	securityManager := NewManager(context.Background(), mockHA, stateManager, &notify.MockNotifier{}, logger, false, nil)
 	if err := securityManager.Start(); err != nil {
 		t.Fatalf("Failed to start security manager: %v", err)
 	}
@@ -398,8 +400,9 @@ func TestSecurityManager_VehicleArrivalWithExpecting(t *testing.T) {
 	stateManager := state.NewManager(mockHA, logger, false)
 	stateManager.SyncFromHA()
 
-	// Create security manager
-	securityManager := NewManager(context.Background(), mockHA, stateManager, logger, false, nil)
+	// Create security manager with a captured notifier we can inspect.
+	mockNotifier := &notify.MockNotifier{}
+	securityManager := NewManager(context.Background(), mockHA, stateManager, mockNotifier, logger, false, nil)
 	if err := securityManager.Start(); err != nil {
 		t.Fatalf("Failed to start security manager: %v", err)
 	}
@@ -413,28 +416,27 @@ func TestSecurityManager_VehicleArrivalWithExpecting(t *testing.T) {
 	// Wait for async processing
 	time.Sleep(100 * time.Millisecond)
 
-	// Verify TTS was sent
-	calls := mockHA.GetServiceCallsSince(snapshot)
+	// Verify TTS was sent via notifier (urgent).
 	ttsFound := false
-	expectingReset := false
-
-	for _, call := range calls {
-		if call.Domain == "tts" && call.Service == "speak" {
-			if msg, ok := call.Data["message"].(string); ok && msg == "They have arrived" {
-				ttsFound = true
-			}
+	for _, c := range mockNotifier.Calls() {
+		if c.Message == "They have arrived" && c.Urgency == notify.UrgencyUrgent {
+			ttsFound = true
+			break
 		}
+	}
+	if !ttsFound {
+		t.Errorf("Expected urgent vehicle arrival announcement via notifier, got calls: %+v", mockNotifier.Calls())
+	}
+
+	// Verify isExpectingSomeone reset still goes through HA.
+	expectingReset := false
+	for _, call := range mockHA.GetServiceCallsSince(snapshot) {
 		if call.Domain == "input_boolean" && call.Service == "turn_off" {
 			if entityID, ok := call.Data["entity_id"].(string); ok && entityID == "input_boolean.expecting_someone" {
 				expectingReset = true
 			}
 		}
 	}
-
-	if !ttsFound {
-		t.Errorf("Expected TTS notification for vehicle arrival, but service was not called")
-	}
-
 	if !expectingReset {
 		t.Errorf("Expected isExpectingSomeone to be reset, but service was not called")
 	}
@@ -455,7 +457,7 @@ func TestSecurityManager_VehicleArrivalWithoutExpecting(t *testing.T) {
 	stateManager.SyncFromHA()
 
 	// Create security manager
-	securityManager := NewManager(context.Background(), mockHA, stateManager, logger, false, nil)
+	securityManager := NewManager(context.Background(), mockHA, stateManager, &notify.MockNotifier{}, logger, false, nil)
 	if err := securityManager.Start(); err != nil {
 		t.Fatalf("Failed to start security manager: %v", err)
 	}
@@ -496,7 +498,7 @@ func TestSecurityManager_ReadOnlyMode(t *testing.T) {
 	stateManager.SyncFromHA()
 
 	// Create security manager in read-only mode (this is what we're testing)
-	securityManager := NewManager(context.Background(), mockHA, stateManager, logger, true, nil)
+	securityManager := NewManager(context.Background(), mockHA, stateManager, &notify.MockNotifier{}, logger, true, nil)
 	if err := securityManager.Start(); err != nil {
 		t.Fatalf("Failed to start security manager: %v", err)
 	}
@@ -533,7 +535,7 @@ func TestSecurityManager_InvalidTypeHandling(t *testing.T) {
 	stateManager.SyncFromHA()
 
 	// Create security manager
-	securityManager := NewManager(context.Background(), mockHA, stateManager, logger, false, nil)
+	securityManager := NewManager(context.Background(), mockHA, stateManager, &notify.MockNotifier{}, logger, false, nil)
 	if err := securityManager.Start(); err != nil {
 		t.Fatalf("Failed to start security manager: %v", err)
 	}
@@ -584,7 +586,7 @@ func TestSecurityManager_OwnerReturnHome_DidNotReturn(t *testing.T) {
 	stateManager.SyncFromHA()
 
 	// Create security manager
-	securityManager := NewManager(context.Background(), mockHA, stateManager, logger, false, nil)
+	securityManager := NewManager(context.Background(), mockHA, stateManager, &notify.MockNotifier{}, logger, false, nil)
 	if err := securityManager.Start(); err != nil {
 		t.Fatalf("Failed to start security manager: %v", err)
 	}
@@ -622,7 +624,7 @@ func TestSecurityManager_VehicleArrivalRateLimiting(t *testing.T) {
 	stateManager.SyncFromHA()
 
 	// Create security manager
-	securityManager := NewManager(context.Background(), mockHA, stateManager, logger, false, nil)
+	securityManager := NewManager(context.Background(), mockHA, stateManager, &notify.MockNotifier{}, logger, false, nil)
 	if err := securityManager.Start(); err != nil {
 		t.Fatalf("Failed to start security manager: %v", err)
 	}
@@ -666,7 +668,7 @@ func TestSecurityManager_ReadOnlyModeGarage(t *testing.T) {
 	stateManager.SyncFromHA()
 
 	// Create security manager in READ-ONLY mode
-	securityManager := NewManager(context.Background(), mockHA, stateManager, logger, true, nil)
+	securityManager := NewManager(context.Background(), mockHA, stateManager, &notify.MockNotifier{}, logger, true, nil)
 	if err := securityManager.Start(); err != nil {
 		t.Fatalf("Failed to start security manager: %v", err)
 	}
@@ -703,7 +705,7 @@ func TestSecurityManager_ReadOnlyModeLockdownReset(t *testing.T) {
 	stateManager.SyncFromHA()
 
 	// Create security manager in READ-ONLY mode
-	securityManager := NewManager(context.Background(), mockHA, stateManager, logger, true, nil)
+	securityManager := NewManager(context.Background(), mockHA, stateManager, &notify.MockNotifier{}, logger, true, nil)
 
 	// Use MockClock so the 5-second delay is instant (MockClock.Sleep is a no-op)
 	mockClock := clock.NewMockClock(time.Now())
@@ -745,7 +747,7 @@ func TestSecurityManager_ReadOnlyModeVehicleArrival(t *testing.T) {
 	stateManager.SyncFromHA()
 
 	// Create security manager in READ-ONLY mode
-	securityManager := NewManager(context.Background(), mockHA, stateManager, logger, true, nil)
+	securityManager := NewManager(context.Background(), mockHA, stateManager, &notify.MockNotifier{}, logger, true, nil)
 	if err := securityManager.Start(); err != nil {
 		t.Fatalf("Failed to start security manager: %v", err)
 	}

--- a/homeautomation-go/internal/plugins/security/register.go
+++ b/homeautomation-go/internal/plugins/security/register.go
@@ -3,6 +3,7 @@ package security
 import (
 	"fmt"
 
+	"homeautomation/internal/notify"
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
 	"homeautomation/pkg/shadowstate"
@@ -32,7 +33,12 @@ func createPlugin(ctx *plugin.Context) (plugin.Plugin, error) {
 		return nil, fmt.Errorf("security plugin requires internal state.Manager")
 	}
 
-	manager := NewManager(ctx.ShutdownCtx, haClient, stateManager, ctx.Logger, ctx.ReadOnly, ctx.Registry)
+	notifier := ctx.Notifier
+	if notifier == nil {
+		notifier = &notify.MockNotifier{}
+	}
+
+	manager := NewManager(ctx.ShutdownCtx, haClient, stateManager, notifier, ctx.Logger, ctx.ReadOnly, ctx.Registry)
 	return &pluginAdapter{manager: manager}, nil
 }
 

--- a/homeautomation-go/internal/plugins/statetracking/manager.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager.go
@@ -14,6 +14,7 @@ import (
 
 	"homeautomation/internal/clock"
 	"homeautomation/internal/ha"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
 
@@ -64,6 +65,7 @@ type Manager struct {
 	logger       *zap.Logger
 	readOnly     bool
 	helper       *state.DerivedStateHelper
+	notifier     notify.Notifier
 	clock        clock.Clock
 
 	// Timers for sleep/wake detection
@@ -92,7 +94,7 @@ type Manager struct {
 }
 
 // NewManager creates a new State Tracking manager
-func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.Manager, logger *zap.Logger, readOnly bool, registry *shadowstate.SubscriptionRegistry, socoCliURL string) *Manager {
+func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.Manager, logger *zap.Logger, readOnly bool, registry *shadowstate.SubscriptionRegistry, socoCliURL string, notifier notify.Notifier) *Manager {
 	shadowTracker := shadowstate.NewStateTrackingTracker()
 
 	return &Manager{
@@ -103,6 +105,7 @@ func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.M
 		readOnly:      readOnly,
 		clock:         clock.NewRealClock(),
 		socoCliURL:    socoCliURL,
+		notifier:      notifier,
 		shadowTracker: shadowTracker,
 		subHelper:     shadowstate.NewSubscriptionHelper(haClient, stateManager, registry, shadowTracker, "statetracking", logger.Named("statetracking")),
 	}
@@ -780,19 +783,9 @@ func (m *Manager) getGroupCoordinator(speakerEntityID string) string {
 	return ""
 }
 
-// announceArrivalDirect makes a TTS announcement (caller has already checked if someone is home)
+// announceArrivalDirect makes an arrival announcement via the shared notifier
+// (caller has already checked if someone is home).
 func (m *Manager) announceArrivalDirect(person, message string, mediaPlayers []string) {
-	// Skip TTS in read-only mode
-	if m.readOnly {
-		m.logger.Info("Would announce arrival (read-only mode)",
-			zap.String("person", person),
-			zap.String("message", message),
-			zap.Strings("media_players", mediaPlayers))
-		// Still record in shadow state even in read-only mode
-		m.shadowTracker.RecordArrivalAnnouncement(person, message)
-		return
-	}
-
 	// Check if any target speaker is in a Sonos group; if so, send TTS to the
 	// group coordinator only (sending to individual group members breaks playback).
 	if coordinator := m.getGroupCoordinator(mediaPlayers[0]); coordinator != "" {
@@ -802,26 +795,18 @@ func (m *Manager) announceArrivalDirect(person, message string, mediaPlayers []s
 		mediaPlayers = []string{coordinator}
 	}
 
-	// Make the TTS announcement
-	m.logger.Info("Announcing arrival via TTS",
+	m.logger.Info("Announcing arrival via notifier",
 		zap.String("person", person),
 		zap.String("message", message),
 		zap.Strings("media_players", mediaPlayers))
 
-	err := m.haClient.CallService(m.ctx, "tts", "speak", map[string]interface{}{
-		"entity_id":              "tts.google_translate_en_com",
-		"message":                message,
-		"cache":                  true,
-		"media_player_entity_id": mediaPlayers,
-	})
-
-	if err != nil {
-		m.logger.Error("Failed to announce arrival via TTS",
+	if err := m.notifier.Announce(m.ctx, message, notify.WithSpeakers(mediaPlayers)); err != nil {
+		m.logger.Error("Failed to announce arrival",
 			zap.String("person", person),
 			zap.Error(err))
 	}
 
-	// Record in shadow state
+	// Record in shadow state regardless (the notifier itself records read-only intent).
 	m.shadowTracker.RecordArrivalAnnouncement(person, message)
 }
 

--- a/homeautomation-go/internal/plugins/statetracking/manager_test.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager_test.go
@@ -10,6 +10,7 @@ import (
 
 	"homeautomation/internal/clock"
 	"homeautomation/internal/ha"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/state"
 
 	"go.uber.org/zap"
@@ -62,7 +63,7 @@ func TestStateTrackingManager_IsAnyOwnerHome(t *testing.T) {
 				t.Fatalf("Failed to set isCarolineHome: %v", err)
 			}
 
-			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 			if err := manager.Start(); err != nil {
 				t.Fatalf("Failed to start manager: %v", err)
 			}
@@ -149,7 +150,7 @@ func TestStateTrackingManager_IsAnyoneHome(t *testing.T) {
 				t.Fatalf("Failed to set isAssistantHere: %v", err)
 			}
 
-			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 			if err := manager.Start(); err != nil {
 				t.Fatalf("Failed to start manager: %v", err)
 			}
@@ -223,7 +224,7 @@ func TestStateTrackingManager_SleepDerivedStates(t *testing.T) {
 				t.Fatalf("Failed to set isGuestAsleep: %v", err)
 			}
 
-			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 			if err := manager.Start(); err != nil {
 				t.Fatalf("Failed to start manager: %v", err)
 			}
@@ -272,7 +273,7 @@ func TestStateTrackingManager_DynamicUpdates(t *testing.T) {
 		t.Fatalf("Failed to set isAssistantHere: %v", err)
 	}
 
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 	if err := manager.Start(); err != nil {
 		t.Fatalf("Failed to start manager: %v", err)
 	}
@@ -334,7 +335,7 @@ func TestStateTrackingManager_SleepDynamicUpdates(t *testing.T) {
 		t.Fatalf("Failed to set isGuestAsleep: %v", err)
 	}
 
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 	if err := manager.Start(); err != nil {
 		t.Fatalf("Failed to start manager: %v", err)
 	}
@@ -394,7 +395,7 @@ func TestStateTrackingManager_StopCleansUpSubscriptions(t *testing.T) {
 	if err := stateMgr.SetBool("isNickHome", false); err != nil {
 		t.Fatalf("Failed to set isNickHome: %v", err)
 	}
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 	if err := manager.Start(); err != nil {
 		t.Fatalf("Failed to start manager: %v", err)
 	}
@@ -435,7 +436,7 @@ func TestStateTrackingManager_GuestAsleepAutoSync_NoGuests(t *testing.T) {
 	if err := stateMgr.SetBool("isGuestAsleep", false); err != nil {
 		t.Fatalf("Failed to set isGuestAsleep: %v", err)
 	}
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 	if err := manager.Start(); err != nil {
 		t.Fatalf("Failed to start manager: %v", err)
 	}
@@ -484,7 +485,7 @@ func TestStateTrackingManager_GuestAsleepAutoSync_WithGuests(t *testing.T) {
 	if err := stateMgr.SetBool("isGuestAsleep", true); err != nil {
 		t.Fatalf("Failed to set isGuestAsleep: %v", err)
 	}
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 	if err := manager.Start(); err != nil {
 		t.Fatalf("Failed to start manager: %v", err)
 	}
@@ -529,7 +530,7 @@ func TestStateTrackingManager_GuestAsleepAutoSync_GuestsLeave(t *testing.T) {
 	if err := stateMgr.SetBool("isGuestAsleep", false); err != nil {
 		t.Fatalf("Failed to set isGuestAsleep: %v", err)
 	}
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 	if err := manager.Start(); err != nil {
 		t.Fatalf("Failed to start manager: %v", err)
 	}
@@ -577,7 +578,7 @@ func TestStateTrackingManager_GuestAsleepAutoSync_InitialSync(t *testing.T) {
 		t.Fatalf("Failed to set isGuestAsleep: %v", err)
 	}
 	// Start manager - should auto-sync immediately
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 	if err := manager.Start(); err != nil {
 		t.Fatalf("Failed to start manager: %v", err)
 	}
@@ -609,7 +610,7 @@ func TestStateTrackingManager_Reset(t *testing.T) {
 	if err := stateMgr.SetBool("isCarolineHome", false); err != nil {
 		t.Fatalf("Failed to set isCarolineHome: %v", err)
 	}
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 	if err := manager.Start(); err != nil {
 		t.Fatalf("Failed to start manager: %v", err)
 	}
@@ -705,14 +706,12 @@ func TestStateTrackingManager_ArrivalAnnouncements(t *testing.T) {
 
 			tt.setupState(stateMgr)
 
-			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+			mockNotifier := &notify.MockNotifier{}
+			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", mockNotifier)
 			if err := manager.Start(); err != nil {
 				t.Fatalf("Failed to start manager: %v", err)
 			}
 			defer manager.Stop()
-
-			// Snapshot service call count before action
-			snapshot := mockHA.ServiceCallCount()
 
 			// Simulate arrival (off -> on)
 			mockHA.SetState(tt.entityID, "off", nil)
@@ -721,54 +720,29 @@ func TestStateTrackingManager_ArrivalAnnouncements(t *testing.T) {
 			// Give the async handler a moment to process
 			time.Sleep(50 * time.Millisecond)
 
-			// Verify TTS service was called
-			calls := mockHA.GetServiceCallsSince(snapshot)
+			calls := mockNotifier.Calls()
 			if len(calls) == 0 {
-				t.Fatal("Expected TTS service call, but no service calls were made")
+				t.Fatal("Expected announcement via notifier, but no calls were made")
 			}
 
-			// Find the TTS call
-			var ttsCall *ha.ServiceCall
-			for i := range calls {
-				if calls[i].Domain == "tts" && calls[i].Service == "speak" {
-					ttsCall = &calls[i]
-					break
-				}
+			ann := calls[0]
+			if ann.Message != tt.expectedMessage {
+				t.Errorf("Expected message='%s', got %q", tt.expectedMessage, ann.Message)
 			}
 
-			if ttsCall == nil {
-				t.Fatal("Expected TTS speak service call, but none was found")
-			}
-
-			// Verify TTS call parameters
-			if entityID, ok := ttsCall.Data["entity_id"].(string); !ok || entityID != "tts.google_translate_en_com" {
-				t.Errorf("Expected entity_id=tts.google_translate_en_com, got %v", ttsCall.Data["entity_id"])
-			}
-			if message, ok := ttsCall.Data["message"].(string); !ok || message != tt.expectedMessage {
-				t.Errorf("Expected message='%s', got %v", tt.expectedMessage, ttsCall.Data["message"])
-			}
-			if cache, ok := ttsCall.Data["cache"].(bool); !ok || cache != true {
-				t.Errorf("Expected cache=true, got %v", ttsCall.Data["cache"])
-			}
-
-			// Verify media players
-			mediaPlayers, ok := ttsCall.Data["media_player_entity_id"].([]string)
-			if !ok {
-				t.Fatalf("Expected media_player_entity_id to be []string, got %T", ttsCall.Data["media_player_entity_id"])
-			}
-			if len(mediaPlayers) != len(tt.expectedPlayers) {
-				t.Errorf("Expected %d media players, got %d", len(tt.expectedPlayers), len(mediaPlayers))
+			if len(ann.Speakers) != len(tt.expectedPlayers) {
+				t.Errorf("Expected %d media players, got %d", len(tt.expectedPlayers), len(ann.Speakers))
 			}
 			for _, expected := range tt.expectedPlayers {
 				found := false
-				for _, actual := range mediaPlayers {
+				for _, actual := range ann.Speakers {
 					if actual == expected {
 						found = true
 						break
 					}
 				}
 				if !found {
-					t.Errorf("Expected media player %s not found in TTS call", expected)
+					t.Errorf("Expected media player %s not found in announcement", expected)
 				}
 			}
 		})
@@ -797,19 +771,10 @@ func TestStateTrackingManager_NoAnnouncement(t *testing.T) {
 				mc.SetState("input_boolean.nick_home", "on", nil)
 			},
 		},
-		{
-			name:     "No announcement in read-only mode",
-			readOnly: true,
-			setupState: func(sm *state.Manager) {
-				sm.SetBool("isCarolineHome", true)
-				sm.SetBool("isNickHome", false)
-			},
-			simulate: func(mc *ha.MockClient) {
-				// Simulate Nick arriving home
-				mc.SetState("input_boolean.nick_home", "off", nil)
-				mc.SetState("input_boolean.nick_home", "on", nil)
-			},
-		},
+		// Note: read-only behavior is now owned by the notifier package, not
+		// statetracking. The plugin always invokes the notifier; the notifier
+		// itself decides whether to actually call Home Assistant. See
+		// internal/notify/notify_test.go for read-only coverage.
 		{
 			name:     "No announcement on state change from unknown",
 			readOnly: false,
@@ -832,26 +797,20 @@ func TestStateTrackingManager_NoAnnouncement(t *testing.T) {
 
 			tt.setupState(stateMgr)
 
-			manager := NewManager(context.Background(), mockHA, stateMgr, logger, tt.readOnly, nil, "")
+			mockNotifier := &notify.MockNotifier{}
+			manager := NewManager(context.Background(), mockHA, stateMgr, logger, tt.readOnly, nil, "", mockNotifier)
 			if err := manager.Start(); err != nil {
 				t.Fatalf("Failed to start manager: %v", err)
 			}
 			defer manager.Stop()
-
-			// Snapshot service call count before action
-			snapshot := mockHA.ServiceCallCount()
 
 			tt.simulate(mockHA)
 
 			// Give the async handler a moment to process
 			time.Sleep(50 * time.Millisecond)
 
-			// Verify NO TTS service was called
-			calls := mockHA.GetServiceCallsSince(snapshot)
-			for _, call := range calls {
-				if call.Domain == "tts" && call.Service == "speak" {
-					t.Error("Expected no TTS announcement, but TTS service was called")
-				}
+			if calls := mockNotifier.Calls(); len(calls) > 0 {
+				t.Errorf("Expected no announcement, but got %d call(s): %+v", len(calls), calls)
 			}
 		})
 	}
@@ -882,7 +841,7 @@ func TestStateTrackingManager_ShadowState_DerivedStatesUpdated(t *testing.T) {
 	}
 
 	// Create and start manager
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 	if err := manager.Start(); err != nil {
 		t.Fatalf("Failed to start manager: %v", err)
 	}
@@ -926,7 +885,7 @@ func TestStateTrackingManager_ShadowState_DerivedStatesUpdateOnChange(t *testing
 	}
 
 	// Create and start manager
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 	if err := manager.Start(); err != nil {
 		t.Fatalf("Failed to start manager: %v", err)
 	}
@@ -1017,7 +976,7 @@ func TestStateTrackingManager_NearHomeDetection(t *testing.T) {
 				t.Fatalf("Failed to set didOwnerJustReturnHome: %v", err)
 			}
 
-			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 			if err := manager.Start(); err != nil {
 				t.Fatalf("Failed to start manager: %v", err)
 			}
@@ -1108,7 +1067,7 @@ func TestStateTrackingManager_NearHomeDepartureCooldown(t *testing.T) {
 				t.Fatalf("Failed to set didOwnerJustReturnHome: %v", err)
 			}
 
-			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 			manager.SetClock(mockClock)
 			if err := manager.Start(); err != nil {
 				t.Fatalf("Failed to start manager: %v", err)
@@ -1237,7 +1196,8 @@ func TestStateTrackingManager_ArrivalDebounce(t *testing.T) {
 				t.Fatalf("Failed to set didOwnerJustReturnHome: %v", err)
 			}
 
-			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+			mockNotifier := &notify.MockNotifier{}
+			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", mockNotifier)
 			manager.SetClock(mockClock)
 			if err := manager.Start(); err != nil {
 				t.Fatalf("Failed to start manager: %v", err)
@@ -1254,8 +1214,8 @@ func TestStateTrackingManager_ArrivalDebounce(t *testing.T) {
 			// Advance time by the configured duration
 			mockClock.AdvanceAndProcess(tt.timeSinceDepart)
 
-			// Snapshot service call count before re-arrival
-			snapshot := mockHA.ServiceCallCount()
+			// Snapshot announcement count before re-arrival
+			beforeReArrival := len(mockNotifier.Calls())
 
 			// Simulate re-arrival (off -> on)
 			mockHA.SetState(tt.homeEntityID, "off", nil)
@@ -1264,15 +1224,7 @@ func TestStateTrackingManager_ArrivalDebounce(t *testing.T) {
 			// Give the async handler a moment to process
 			time.Sleep(50 * time.Millisecond)
 
-			// Verify TTS
-			calls := mockHA.GetServiceCallsSince(snapshot)
-			var ttsCalled bool
-			for _, call := range calls {
-				if call.Domain == "tts" && call.Service == "speak" {
-					ttsCalled = true
-					break
-				}
-			}
+			ttsCalled := len(mockNotifier.Calls()) > beforeReArrival
 			if ttsCalled != tt.expectTTS {
 				t.Errorf("Expected TTS called=%v, got %v (timeSinceDepart=%v)",
 					tt.expectTTS, ttsCalled, tt.timeSinceDepart)
@@ -1311,14 +1263,12 @@ func TestStateTrackingManager_ArrivalDebounce_FirstArrivalNotSuppressed(t *testi
 		t.Fatalf("Failed to set didOwnerJustReturnHome: %v", err)
 	}
 
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+	mockNotifier := &notify.MockNotifier{}
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", mockNotifier)
 	if err := manager.Start(); err != nil {
 		t.Fatalf("Failed to start manager: %v", err)
 	}
 	defer manager.Stop()
-
-	// Snapshot before arrival
-	snapshot := mockHA.ServiceCallCount()
 
 	// Nick arrives for the first time (no prior departure)
 	mockHA.SetState("input_boolean.nick_home", "off", nil)
@@ -1327,16 +1277,8 @@ func TestStateTrackingManager_ArrivalDebounce_FirstArrivalNotSuppressed(t *testi
 	time.Sleep(50 * time.Millisecond)
 
 	// Should NOT be suppressed — first arrival
-	calls := mockHA.GetServiceCallsSince(snapshot)
-	var ttsCalled bool
-	for _, call := range calls {
-		if call.Domain == "tts" && call.Service == "speak" {
-			ttsCalled = true
-			break
-		}
-	}
-	if !ttsCalled {
-		t.Error("Expected TTS announcement for first arrival (no prior departure), but none was made")
+	if len(mockNotifier.Calls()) == 0 {
+		t.Error("Expected announcement for first arrival (no prior departure), but none was made")
 	}
 
 	didOwnerReturn, _ := stateMgr.GetBool("didOwnerJustReturnHome")
@@ -1446,7 +1388,7 @@ func TestGetGroupCoordinator(t *testing.T) {
 			logger := zap.NewNop()
 			mockHA := ha.NewMockClient()
 			stateMgr := state.NewManager(mockHA, logger, false)
-			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, serverURL)
+			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, serverURL, &notify.MockNotifier{})
 
 			got := manager.getGroupCoordinator(tt.speakerEntity)
 			if got != tt.wantCoord {
@@ -1460,7 +1402,7 @@ func TestGetGroupCoordinator_NoSocoURL(t *testing.T) {
 	logger := zap.NewNop()
 	mockHA := ha.NewMockClient()
 	stateMgr := state.NewManager(mockHA, logger, false)
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 
 	got := manager.getGroupCoordinator("media_player.kitchen")
 	if got != "" {
@@ -1481,7 +1423,8 @@ func TestAnnounceArrivalDirect_UsesGroupCoordinator(t *testing.T) {
 	logger := zap.NewNop()
 	mockHA := ha.NewMockClient()
 	stateMgr := state.NewManager(mockHA, logger, false)
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, server.URL)
+	mockNotifier := &notify.MockNotifier{}
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, server.URL, mockNotifier)
 
 	manager.announceArrivalDirect("Nick", "Nick is home", []string{
 		"media_player.kitchen",
@@ -1489,27 +1432,12 @@ func TestAnnounceArrivalDirect_UsesGroupCoordinator(t *testing.T) {
 		"media_player.soundbar",
 	})
 
-	// Verify TTS was called with just the group coordinator
-	calls := mockHA.GetServiceCalls()
-	var ttsCall *ha.ServiceCall
-	for i := range calls {
-		if calls[i].Domain == "tts" && calls[i].Service == "speak" {
-			ttsCall = &calls[i]
-			break
-		}
+	calls := mockNotifier.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("Expected exactly 1 announcement, got %d", len(calls))
 	}
-
-	if ttsCall == nil {
-		t.Fatal("Expected TTS service call")
-	}
-
-	mediaPlayers, ok := ttsCall.Data["media_player_entity_id"].([]string)
-	if !ok {
-		t.Fatalf("Expected media_player_entity_id to be []string, got %T", ttsCall.Data["media_player_entity_id"])
-	}
-
-	if len(mediaPlayers) != 1 || mediaPlayers[0] != "media_player.front_room" {
-		t.Errorf("Expected TTS to target [media_player.front_room], got %v", mediaPlayers)
+	if len(calls[0].Speakers) != 1 || calls[0].Speakers[0] != "media_player.front_room" {
+		t.Errorf("Expected announcement to target [media_player.front_room], got %v", calls[0].Speakers)
 	}
 }
 
@@ -1517,8 +1445,9 @@ func TestAnnounceArrivalDirect_FallsBackWhenSocoDown(t *testing.T) {
 	logger := zap.NewNop()
 	mockHA := ha.NewMockClient()
 	stateMgr := state.NewManager(mockHA, logger, false)
+	mockNotifier := &notify.MockNotifier{}
 	// Use unreachable URL to simulate SoCo being down
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "http://127.0.0.1:1")
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "http://127.0.0.1:1", mockNotifier)
 
 	defaultSpeakers := []string{
 		"media_player.kitchen",
@@ -1526,25 +1455,11 @@ func TestAnnounceArrivalDirect_FallsBackWhenSocoDown(t *testing.T) {
 	}
 	manager.announceArrivalDirect("Nick", "Nick is home", defaultSpeakers)
 
-	calls := mockHA.GetServiceCalls()
-	var ttsCall *ha.ServiceCall
-	for i := range calls {
-		if calls[i].Domain == "tts" && calls[i].Service == "speak" {
-			ttsCall = &calls[i]
-			break
-		}
+	calls := mockNotifier.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("Expected exactly 1 announcement even when SoCo is down, got %d", len(calls))
 	}
-
-	if ttsCall == nil {
-		t.Fatal("Expected TTS service call even when SoCo is down")
-	}
-
-	mediaPlayers, ok := ttsCall.Data["media_player_entity_id"].([]string)
-	if !ok {
-		t.Fatalf("Expected media_player_entity_id to be []string, got %T", ttsCall.Data["media_player_entity_id"])
-	}
-
-	if len(mediaPlayers) != 2 {
-		t.Errorf("Expected fallback to default speakers (2), got %v", mediaPlayers)
+	if len(calls[0].Speakers) != 2 {
+		t.Errorf("Expected fallback to default speakers (2), got %v", calls[0].Speakers)
 	}
 }

--- a/homeautomation-go/internal/plugins/statetracking/register.go
+++ b/homeautomation-go/internal/plugins/statetracking/register.go
@@ -3,6 +3,7 @@ package statetracking
 import (
 	"fmt"
 
+	"homeautomation/internal/notify"
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
 	"homeautomation/pkg/shadowstate"
@@ -32,7 +33,12 @@ func createPlugin(ctx *plugin.Context) (plugin.Plugin, error) {
 		return nil, fmt.Errorf("statetracking plugin requires internal state.Manager")
 	}
 
-	manager := NewManager(ctx.ShutdownCtx, haClient, stateManager, ctx.Logger, ctx.ReadOnly, ctx.Registry, ctx.SoCoCliURL)
+	notifier := ctx.Notifier
+	if notifier == nil {
+		notifier = &notify.MockNotifier{}
+	}
+
+	manager := NewManager(ctx.ShutdownCtx, haClient, stateManager, ctx.Logger, ctx.ReadOnly, ctx.Registry, ctx.SoCoCliURL, notifier)
 	return &pluginAdapter{manager: manager}, nil
 }
 

--- a/homeautomation-go/internal/plugins/statetracking/sleep_detection_test.go
+++ b/homeautomation-go/internal/plugins/statetracking/sleep_detection_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"homeautomation/internal/ha"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/state"
 
 	"go.uber.org/zap"
@@ -28,7 +29,7 @@ func TestSleepDetection_HandlersInitialized(t *testing.T) {
 	}
 
 	// Create and start manager
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 	if err := manager.Start(); err != nil {
 		t.Fatalf("Failed to start manager: %v", err)
 	}
@@ -54,7 +55,7 @@ func TestSleepDetection_LightsTimerControl(t *testing.T) {
 		t.Fatalf("Failed to set isMasterAsleep: %v", err)
 	}
 
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 	if err := manager.Start(); err != nil {
 		t.Fatalf("Failed to start manager: %v", err)
 	}
@@ -93,7 +94,7 @@ func TestWakeDetection_DoorTimerControl(t *testing.T) {
 		t.Fatalf("Failed to set isMasterAsleep: %v", err)
 	}
 
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 	if err := manager.Start(); err != nil {
 		t.Fatalf("Failed to start manager: %v", err)
 	}
@@ -183,7 +184,7 @@ func TestDetectMasterAsleep_Conditions(t *testing.T) {
 				mockHA.SetState("light.primary_suite", tt.primarySuiteState, nil)
 			}
 
-			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 			if err := manager.Start(); err != nil {
 				t.Fatalf("Failed to start manager: %v", err)
 			}
@@ -215,7 +216,7 @@ func TestDetectMasterAwake_SetsAwake(t *testing.T) {
 	}
 	mockHA.SetState("input_boolean.primary_bedroom_door_open", "on", nil)
 
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 	if err := manager.Start(); err != nil {
 		t.Fatalf("Failed to start manager: %v", err)
 	}
@@ -245,7 +246,7 @@ func TestDetectMasterAwake_AbortsIfDoorClosed(t *testing.T) {
 	}
 	mockHA.SetState("input_boolean.primary_bedroom_door_open", "off", nil)
 
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "")
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &notify.MockNotifier{})
 	if err := manager.Start(); err != nil {
 		t.Fatalf("Failed to start manager: %v", err)
 	}

--- a/homeautomation-go/internal/plugins/vacuum/manager.go
+++ b/homeautomation-go/internal/plugins/vacuum/manager.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"homeautomation/internal/ha"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
 	"homeautomation/pkg/plugin"
@@ -31,19 +32,12 @@ const defaultRepeatCheckInterval = 1 * time.Minute
 // MasterAsleepStateVar is the state-manager key for the master-asleep flag.
 const MasterAsleepStateVar = "isMasterAsleep"
 
-// TTSDomain/TTSService are the HA service for spoken announcements.
-const (
-	TTSDomain     = "tts"
-	TTSService    = "speak"
-	TTSEntityID   = "tts.google_translate_en_com"
-	TTSCacheParam = true
-)
-
 // Manager handles vacuum error announcements.
 type Manager struct {
 	ctx          context.Context
 	haClient     ha.HAClient
 	stateManager *state.Manager
+	notifier     notify.Notifier
 	logger       *zap.Logger
 	readOnly     bool
 	timeProvider plugin.TimeProvider
@@ -74,6 +68,7 @@ func NewManager(
 	ctx context.Context,
 	haClient ha.HAClient,
 	stateManager *state.Manager,
+	notifier notify.Notifier,
 	cfg *Config,
 	logger *zap.Logger,
 	readOnly bool,
@@ -88,6 +83,7 @@ func NewManager(
 		ctx:                 ctx,
 		haClient:            haClient,
 		stateManager:        stateManager,
+		notifier:            notifier,
 		logger:              logger.Named("vacuum"),
 		readOnly:            readOnly,
 		timeProvider:        timeProvider,
@@ -210,14 +206,6 @@ func (m *Manager) maybeAnnounce(errorDesc string) {
 	now := m.timeProvider.Now()
 	message := fmt.Sprintf("%s: %s", m.cfg.Vacuum.Announcement.MessagePrefix, errorDesc)
 
-	if m.readOnly {
-		m.logger.Info("READ-ONLY: Would send TTS announcement",
-			zap.String("message", message),
-			zap.Strings("speakers", m.cfg.Vacuum.Announcement.Speakers))
-		m.recordAnnounced(now, message)
-		return
-	}
-
 	if m.cfg.Vacuum.Announcement.SuppressWhileMasterAsleep && m.isMasterAsleep() {
 		m.logger.Info("Vacuum error TTS suppressed (master asleep)",
 			zap.String("error", errorDesc))
@@ -228,13 +216,8 @@ func (m *Manager) maybeAnnounce(errorDesc string) {
 		return
 	}
 
-	if err := m.haClient.CallService(m.ctx, TTSDomain, TTSService, map[string]interface{}{
-		"entity_id":              TTSEntityID,
-		"media_player_entity_id": m.cfg.Vacuum.Announcement.Speakers,
-		"message":                message,
-		"cache":                  TTSCacheParam,
-	}); err != nil {
-		m.logger.Error("Failed to send vacuum TTS announcement",
+	if err := m.notifier.Announce(m.ctx, message, notify.WithSpeakers(m.cfg.Vacuum.Announcement.Speakers)); err != nil {
+		m.logger.Error("Failed to send vacuum announcement",
 			zap.String("message", message),
 			zap.Error(err))
 		// Still record the attempt so the repeat timer doesn't immediately retry.
@@ -242,7 +225,7 @@ func (m *Manager) maybeAnnounce(errorDesc string) {
 		return
 	}
 
-	m.logger.Info("Vacuum TTS announcement sent",
+	m.logger.Info("Vacuum announcement sent",
 		zap.String("message", message),
 		zap.Strings("speakers", m.cfg.Vacuum.Announcement.Speakers))
 	m.recordAnnounced(now, message)

--- a/homeautomation-go/internal/plugins/vacuum/manager_test.go
+++ b/homeautomation-go/internal/plugins/vacuum/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"homeautomation/internal/ha"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
 	"homeautomation/pkg/plugin"
@@ -34,31 +35,20 @@ func newTestConfig() *Config {
 	return cfg
 }
 
-func newTestManager(t *testing.T, readOnly bool, fixedTime time.Time) (*Manager, *ha.MockClient, *state.Manager) {
+func newTestManager(t *testing.T, readOnly bool, fixedTime time.Time) (*Manager, *ha.MockClient, *state.Manager, *notify.MockNotifier) {
 	t.Helper()
 	logger := zap.NewNop()
 	mockHA := ha.NewMockClient()
 	stateMgr := state.NewManager(mockHA, logger, false)
 	registry := shadowstate.NewSubscriptionRegistry()
 	tp := plugin.FixedTimeProvider{FixedTime: fixedTime}
+	mockNotifier := &notify.MockNotifier{}
 
-	mgr := NewManager(context.Background(), mockHA, stateMgr, newTestConfig(), logger, readOnly, tp, registry)
+	mgr := NewManager(context.Background(), mockHA, stateMgr, mockNotifier, newTestConfig(), logger, readOnly, tp, registry)
 	// Disable the background goroutine to keep tests fully synchronous;
 	// tests drive repeats via TickRepeatForTest.
 	mgr.SetRepeatCheckIntervalForTest(time.Hour)
-	return mgr, mockHA, stateMgr
-}
-
-func ttsCalls(t *testing.T, m *ha.MockClient) []ha.ServiceCall {
-	t.Helper()
-	calls := m.GetServiceCalls()
-	out := make([]ha.ServiceCall, 0, len(calls))
-	for _, c := range calls {
-		if c.Domain == "tts" && c.Service == "speak" {
-			out = append(out, c)
-		}
-	}
-	return out
+	return mgr, mockHA, stateMgr, mockNotifier
 }
 
 func setSensor(t *testing.T, mockHA *ha.MockClient, value string) {
@@ -68,32 +58,31 @@ func setSensor(t *testing.T, mockHA *ha.MockClient, value string) {
 
 func TestVacuum_NoErrorAtStartup_NoAnnouncement(t *testing.T) {
 	t.Parallel()
-	mgr, mockHA, _ := newTestManager(t, false, time.Now())
+	mgr, mockHA, _, mockNotifier := newTestManager(t, false, time.Now())
 
 	// Pre-seed the sensor in its healthy state before Start.
 	mockHA.SimulateStateChange(testErrorSensor, "No error")
 	require.NoError(t, mgr.Start())
 	defer mgr.Stop()
 
-	assert.Empty(t, ttsCalls(t, mockHA), "no TTS call expected when sensor starts at No error")
+	assert.Empty(t, mockNotifier.Calls(), "no announcement expected when sensor starts at No error")
 	assert.Empty(t, mgr.GetShadowState().Outputs.CurrentError)
 }
 
 func TestVacuum_TransitionToError_Announces(t *testing.T) {
 	t.Parallel()
-	mgr, mockHA, _ := newTestManager(t, false, time.Now())
+	mgr, mockHA, _, mockNotifier := newTestManager(t, false, time.Now())
 	mockHA.SimulateStateChange(testErrorSensor, "No error")
 	require.NoError(t, mgr.Start())
 	defer mgr.Stop()
 
 	setSensor(t, mockHA, "Mop Dock Clean Water Tank empty")
 
-	calls := ttsCalls(t, mockHA)
-	require.Len(t, calls, 1, "expected one TTS announcement")
-	assert.Equal(t, "tts.google_translate_en_com", calls[0].Data["entity_id"])
+	calls := mockNotifier.Calls()
+	require.Len(t, calls, 1, "expected one announcement")
 	assert.Equal(t,
 		"Robot vacuum needs attention: Mop Dock Clean Water Tank empty",
-		calls[0].Data["message"])
+		calls[0].Message)
 	assert.Equal(t,
 		[]string{
 			"media_player.kitchen",
@@ -102,8 +91,8 @@ func TestVacuum_TransitionToError_Announces(t *testing.T) {
 			"media_player.soundbar",
 			"media_player.kids_bathroom",
 		},
-		calls[0].Data["media_player_entity_id"])
-	assert.Equal(t, true, calls[0].Data["cache"])
+		calls[0].Speakers)
+	assert.Equal(t, notify.UrgencyRoutine, calls[0].Urgency)
 
 	st := mgr.GetShadowState()
 	assert.Equal(t, "Mop Dock Clean Water Tank empty", st.Outputs.CurrentError)
@@ -112,21 +101,21 @@ func TestVacuum_TransitionToError_Announces(t *testing.T) {
 
 func TestVacuum_SameErrorReemitted_NoExtraAnnouncement(t *testing.T) {
 	t.Parallel()
-	mgr, mockHA, _ := newTestManager(t, false, time.Now())
+	mgr, mockHA, _, mockNotifier := newTestManager(t, false, time.Now())
 	mockHA.SimulateStateChange(testErrorSensor, "No error")
 	require.NoError(t, mgr.Start())
 	defer mgr.Stop()
 
 	setSensor(t, mockHA, "Dustbin missing")
-	require.Len(t, ttsCalls(t, mockHA), 1)
+	require.Len(t, mockNotifier.Calls(), 1)
 
 	setSensor(t, mockHA, "Dustbin missing")
-	assert.Len(t, ttsCalls(t, mockHA), 1, "same error string must not re-announce")
+	assert.Len(t, mockNotifier.Calls(), 1, "same error string must not re-announce")
 }
 
 func TestVacuum_DifferentError_Announces(t *testing.T) {
 	t.Parallel()
-	mgr, mockHA, _ := newTestManager(t, false, time.Now())
+	mgr, mockHA, _, mockNotifier := newTestManager(t, false, time.Now())
 	mockHA.SimulateStateChange(testErrorSensor, "No error")
 	require.NoError(t, mgr.Start())
 	defer mgr.Stop()
@@ -134,14 +123,14 @@ func TestVacuum_DifferentError_Announces(t *testing.T) {
 	setSensor(t, mockHA, "Dustbin missing")
 	setSensor(t, mockHA, "Mop Dock Clean Water Tank empty")
 
-	calls := ttsCalls(t, mockHA)
+	calls := mockNotifier.Calls()
 	require.Len(t, calls, 2)
-	assert.Contains(t, calls[1].Data["message"], "Mop Dock Clean Water Tank empty")
+	assert.Contains(t, calls[1].Message, "Mop Dock Clean Water Tank empty")
 }
 
 func TestVacuum_SuppressedWhileMasterAsleep(t *testing.T) {
 	t.Parallel()
-	mgr, mockHA, stateMgr := newTestManager(t, false, time.Now())
+	mgr, mockHA, stateMgr, mockNotifier := newTestManager(t, false, time.Now())
 	mockHA.SimulateStateChange(testErrorSensor, "No error")
 	require.NoError(t, stateMgr.SetBool("isMasterAsleep", true))
 	require.NoError(t, mgr.Start())
@@ -149,7 +138,7 @@ func TestVacuum_SuppressedWhileMasterAsleep(t *testing.T) {
 
 	setSensor(t, mockHA, "Mop Dock Clean Water Tank empty")
 
-	assert.Empty(t, ttsCalls(t, mockHA), "TTS must not fire while master is asleep")
+	assert.Empty(t, mockNotifier.Calls(), "must not announce while master is asleep")
 
 	st := mgr.GetShadowState()
 	assert.Equal(t, "Mop Dock Clean Water Tank empty", st.Outputs.CurrentError,
@@ -160,35 +149,35 @@ func TestVacuum_SuppressedWhileMasterAsleep(t *testing.T) {
 func TestVacuum_RepeatAfterInterval(t *testing.T) {
 	t.Parallel()
 	t0 := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
-	mgr, mockHA, _ := newTestManager(t, false, t0)
+	mgr, mockHA, _, mockNotifier := newTestManager(t, false, t0)
 	mockHA.SimulateStateChange(testErrorSensor, "No error")
 	require.NoError(t, mgr.Start())
 	defer mgr.Stop()
 
 	setSensor(t, mockHA, "Dustbin missing")
-	require.Len(t, ttsCalls(t, mockHA), 1)
+	require.Len(t, mockNotifier.Calls(), 1)
 
 	// Tick before the repeat interval expires — no extra announcement.
 	mgr.timeProvider = plugin.FixedTimeProvider{FixedTime: t0.Add(1 * time.Hour)}
 	mgr.TickRepeatForTest()
-	assert.Len(t, ttsCalls(t, mockHA), 1)
+	assert.Len(t, mockNotifier.Calls(), 1)
 
 	// Tick after the 2h repeat interval — re-announces.
 	mgr.timeProvider = plugin.FixedTimeProvider{FixedTime: t0.Add(2*time.Hour + time.Second)}
 	mgr.TickRepeatForTest()
-	assert.Len(t, ttsCalls(t, mockHA), 2, "expected re-announcement after repeat interval")
+	assert.Len(t, mockNotifier.Calls(), 2, "expected re-announcement after repeat interval")
 }
 
 func TestVacuum_ErrorClears_StopsRepeating(t *testing.T) {
 	t.Parallel()
 	t0 := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
-	mgr, mockHA, _ := newTestManager(t, false, t0)
+	mgr, mockHA, _, mockNotifier := newTestManager(t, false, t0)
 	mockHA.SimulateStateChange(testErrorSensor, "No error")
 	require.NoError(t, mgr.Start())
 	defer mgr.Stop()
 
 	setSensor(t, mockHA, "Dustbin missing")
-	require.Len(t, ttsCalls(t, mockHA), 1)
+	require.Len(t, mockNotifier.Calls(), 1)
 
 	// Error clears.
 	setSensor(t, mockHA, "No error")
@@ -197,36 +186,39 @@ func TestVacuum_ErrorClears_StopsRepeating(t *testing.T) {
 	// Tick after a long time — must NOT re-announce, since the error is gone.
 	mgr.timeProvider = plugin.FixedTimeProvider{FixedTime: t0.Add(10 * time.Hour)}
 	mgr.TickRepeatForTest()
-	assert.Len(t, ttsCalls(t, mockHA), 1, "no re-announcement once error has cleared")
+	assert.Len(t, mockNotifier.Calls(), 1, "no re-announcement once error has cleared")
 }
 
-func TestVacuum_ReadOnly_SkipsTTSCall(t *testing.T) {
+func TestVacuum_ReadOnly_StillRecordsAndCallsNotifier(t *testing.T) {
 	t.Parallel()
-	mgr, mockHA, _ := newTestManager(t, true, time.Now())
+	// Vacuum no longer special-cases readOnly for TTS — that responsibility
+	// moved to the notifier. The plugin still records to shadow state and
+	// invokes the notifier; the notifier itself decides whether to actually
+	// call Home Assistant.
+	mgr, mockHA, _, mockNotifier := newTestManager(t, true, time.Now())
 	mockHA.SimulateStateChange(testErrorSensor, "No error")
 	require.NoError(t, mgr.Start())
 	defer mgr.Stop()
 
 	setSensor(t, mockHA, "Mop Dock Clean Water Tank empty")
 
-	assert.Empty(t, ttsCalls(t, mockHA), "READ_ONLY mode must not call HA tts.speak")
+	assert.Len(t, mockNotifier.Calls(), 1, "vacuum delegates to notifier in all modes")
 	st := mgr.GetShadowState()
 	assert.Equal(t, "Mop Dock Clean Water Tank empty", st.Outputs.CurrentError)
-	assert.Equal(t, 1, st.Outputs.AnnouncementsSinceErrorBegan,
-		"shadow state still records what would have been announced")
+	assert.Equal(t, 1, st.Outputs.AnnouncementsSinceErrorBegan)
 }
 
 func TestVacuum_InitialErrorActiveAtStartup_Announces(t *testing.T) {
 	t.Parallel()
-	mgr, mockHA, _ := newTestManager(t, false, time.Now())
+	mgr, mockHA, _, mockNotifier := newTestManager(t, false, time.Now())
 	// Sensor is already reporting an error before the plugin starts.
 	mockHA.SimulateStateChange(testErrorSensor, "Mop Dock Clean Water Tank empty")
 	require.NoError(t, mgr.Start())
 	defer mgr.Stop()
 
-	calls := ttsCalls(t, mockHA)
+	calls := mockNotifier.Calls()
 	require.Len(t, calls, 1, "an active error at startup should be announced once")
-	assert.Contains(t, calls[0].Data["message"], "Mop Dock Clean Water Tank empty")
+	assert.Contains(t, calls[0].Message, "Mop Dock Clean Water Tank empty")
 }
 
 func TestVacuum_LoadConfigDefaults(t *testing.T) {

--- a/homeautomation-go/internal/plugins/vacuum/register.go
+++ b/homeautomation-go/internal/plugins/vacuum/register.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"homeautomation/internal/notify"
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
 	"homeautomation/pkg/shadowstate"
@@ -36,7 +37,14 @@ func createPlugin(ctx *plugin.Context) (plugin.Plugin, error) {
 		return nil, fmt.Errorf("failed to load vacuum config: %w", err)
 	}
 
-	manager := NewManager(ctx.ShutdownCtx, haClient, stateManager, cfg, ctx.Logger, ctx.ReadOnly, ctx.TimeProvider, ctx.Registry)
+	notifier := ctx.Notifier
+	if notifier == nil {
+		// Fall back to a non-functional mock so the plugin can still load
+		// when the notifier is not wired (tests, partial bootstraps).
+		notifier = &notify.MockNotifier{}
+	}
+
+	manager := NewManager(ctx.ShutdownCtx, haClient, stateManager, notifier, cfg, ctx.Logger, ctx.ReadOnly, ctx.TimeProvider, ctx.Registry)
 	return &pluginAdapter{manager: manager}, nil
 }
 

--- a/homeautomation-go/internal/plugins/waterflow/manager.go
+++ b/homeautomation-go/internal/plugins/waterflow/manager.go
@@ -10,6 +10,7 @@ import (
 
 	"homeautomation/internal/clock"
 	"homeautomation/internal/ha"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/ntfy"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
@@ -57,6 +58,7 @@ type Manager struct {
 	readOnly     bool
 	clock        clock.Clock
 	ntfyClient   ntfy.Notifier
+	notifier     notify.Notifier
 
 	// Shadow state tracking
 	shadowTracker *shadowstate.WaterFlowTracker
@@ -80,7 +82,7 @@ type Manager struct {
 }
 
 // NewManager creates a new water flow manager
-func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.Manager, logger *zap.Logger, readOnly bool, registry *shadowstate.SubscriptionRegistry, ntfyClient ntfy.Notifier) *Manager {
+func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.Manager, logger *zap.Logger, readOnly bool, registry *shadowstate.SubscriptionRegistry, ntfyClient ntfy.Notifier, notifier notify.Notifier) *Manager {
 	shadowTracker := shadowstate.NewWaterFlowTracker()
 
 	return &Manager{
@@ -91,14 +93,15 @@ func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.M
 		readOnly:      readOnly,
 		clock:         clock.NewRealClock(),
 		ntfyClient:    ntfyClient,
+		notifier:      notifier,
 		shadowTracker: shadowTracker,
 		subHelper:     shadowstate.NewSubscriptionHelper(haClient, stateManager, registry, shadowTracker, "waterflow", logger.Named("waterflow")),
 	}
 }
 
 // NewManagerWithClock creates a new water flow manager with a custom clock (for testing)
-func NewManagerWithClock(ctx context.Context, haClient ha.HAClient, stateManager *state.Manager, logger *zap.Logger, readOnly bool, registry *shadowstate.SubscriptionRegistry, ntfyClient ntfy.Notifier, c clock.Clock) *Manager {
-	m := NewManager(ctx, haClient, stateManager, logger, readOnly, registry, ntfyClient)
+func NewManagerWithClock(ctx context.Context, haClient ha.HAClient, stateManager *state.Manager, logger *zap.Logger, readOnly bool, registry *shadowstate.SubscriptionRegistry, ntfyClient ntfy.Notifier, notifier notify.Notifier, c clock.Clock) *Manager {
+	m := NewManager(ctx, haClient, stateManager, logger, readOnly, registry, ntfyClient, notifier)
 	m.clock = c
 	return m
 }
@@ -451,13 +454,8 @@ func (m *Manager) sendRecoveryNotification() {
 	}
 }
 
-// sendTTSAnnouncement sends a TTS message to Sonos speakers
+// sendTTSAnnouncement sends a verbal water-flow alert via the shared notifier.
 func (m *Manager) sendTTSAnnouncement(message string) {
-	if m.readOnly {
-		m.logger.Info("READ-ONLY: Would send TTS announcement", zap.String("message", message))
-		return
-	}
-
 	speakers := []string{
 		"media_player.bedroom",
 		"media_player.kitchen",
@@ -466,17 +464,12 @@ func (m *Manager) sendTTSAnnouncement(message string) {
 		"media_player.kids_bathroom",
 	}
 
-	if err := m.haClient.CallService(m.ctx, "tts", "speak", map[string]interface{}{
-		"entity_id":              "tts.google_translate_en_com",
-		"media_player_entity_id": speakers,
-		"message":                message,
-		"cache":                  true,
-	}); err != nil {
-		m.logger.Error("Failed to send TTS announcement", zap.Error(err), zap.String("message", message))
-	} else {
-		m.logger.Info("TTS announcement sent", zap.String("message", message))
-		m.shadowTracker.RecordTTSAnnouncement()
+	if err := m.notifier.Announce(m.ctx, message, notify.WithSpeakers(speakers)); err != nil {
+		m.logger.Error("Failed to send waterflow announcement", zap.Error(err), zap.String("message", message))
+		return
 	}
+	m.logger.Info("Waterflow announcement sent", zap.String("message", message))
+	m.shadowTracker.RecordTTSAnnouncement()
 }
 
 // ============================================================================

--- a/homeautomation-go/internal/plugins/waterflow/manager_test.go
+++ b/homeautomation-go/internal/plugins/waterflow/manager_test.go
@@ -7,6 +7,7 @@ import (
 
 	"homeautomation/internal/clock"
 	"homeautomation/internal/ha"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/ntfy"
 	"homeautomation/internal/state"
 
@@ -32,7 +33,7 @@ func getLastNtfyNotification(mockNtfy *ntfy.MockClient) *ntfy.Message {
 func createTestManager(mockHA *ha.MockClient, mockNtfy *ntfy.MockClient, mockClock *clock.MockClock) *Manager {
 	logger := zap.NewNop()
 	stateMgr := state.NewManager(mockHA, logger, false)
-	return NewManagerWithClock(context.Background(), mockHA, stateMgr, logger, false, nil, mockNtfy, mockClock)
+	return NewManagerWithClock(context.Background(), mockHA, stateMgr, logger, false, nil, mockNtfy, &notify.MockNotifier{}, mockClock)
 }
 
 func TestWaterFlowManager_NormalFlow(t *testing.T) {
@@ -423,7 +424,7 @@ func TestWaterFlowManager_ReadOnlyMode(t *testing.T) {
 	stateMgr := state.NewManager(mockHA, logger, false)
 
 	// Create manager in read-only mode
-	manager := NewManagerWithClock(context.Background(), mockHA, stateMgr, logger, true, nil, mockNtfy, mockClock)
+	manager := NewManagerWithClock(context.Background(), mockHA, stateMgr, logger, true, nil, mockNtfy, &notify.MockNotifier{}, mockClock)
 
 	// Trigger urgent alert
 	manager.SimulateFlowReading(0.5)
@@ -584,7 +585,7 @@ func TestWaterFlowManager_NtfyClientNil(t *testing.T) {
 	stateMgr := state.NewManager(mockHA, logger, false)
 
 	// Create manager without ntfy client
-	manager := NewManagerWithClock(context.Background(), mockHA, stateMgr, logger, false, nil, nil, mockClock)
+	manager := NewManagerWithClock(context.Background(), mockHA, stateMgr, logger, false, nil, nil, &notify.MockNotifier{}, mockClock)
 
 	// Trigger urgent alert - should not panic
 	manager.SimulateFlowReading(0.5)

--- a/homeautomation-go/internal/plugins/waterflow/register.go
+++ b/homeautomation-go/internal/plugins/waterflow/register.go
@@ -3,6 +3,7 @@ package waterflow
 import (
 	"fmt"
 
+	"homeautomation/internal/notify"
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
 	"homeautomation/pkg/shadowstate"
@@ -32,7 +33,12 @@ func createPlugin(ctx *plugin.Context) (plugin.Plugin, error) {
 		return nil, fmt.Errorf("waterflow plugin requires internal state.Manager")
 	}
 
-	manager := NewManager(ctx.ShutdownCtx, haClient, stateManager, ctx.Logger, ctx.ReadOnly, ctx.Registry, ctx.NtfyClient)
+	notifier := ctx.Notifier
+	if notifier == nil {
+		notifier = &notify.MockNotifier{}
+	}
+
+	manager := NewManager(ctx.ShutdownCtx, haClient, stateManager, ctx.Logger, ctx.ReadOnly, ctx.Registry, ctx.NtfyClient, notifier)
 	return &pluginAdapter{manager: manager}, nil
 }
 

--- a/homeautomation-go/pkg/plugin/context.go
+++ b/homeautomation-go/pkg/plugin/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"homeautomation/internal/notify"
 	"homeautomation/internal/ntfy"
 	"homeautomation/internal/shadowstate"
 	pkgha "homeautomation/pkg/ha"
@@ -64,6 +65,12 @@ type Context struct {
 	// May be nil if NTFY_TOPIC_URL is not configured.
 	// Plugins should check for nil before sending notifications.
 	NtfyClient ntfy.Notifier
+
+	// Notifier sends verbal (TTS) announcements to speakers, snapshotting and
+	// restoring speaker volume around each call so announcements remain
+	// audible regardless of the speakers' current state. Plugins should use
+	// this instead of calling tts.speak directly.
+	Notifier notify.Notifier
 
 	// SoCoCliURL is the base URL for the SoCo-CLI HTTP API (Tidal playback).
 	// May be empty if SoCo-CLI is not available.

--- a/homeautomation-go/pkg/testutil/harness.go
+++ b/homeautomation-go/pkg/testutil/harness.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"homeautomation/internal/ha"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/plugins/statetracking"
 	"homeautomation/internal/state"
 	"homeautomation/internal/testlogger"
@@ -82,7 +83,7 @@ func NewTestEnv(addr, token string) (*TestEnv, error) {
 // dependency for other plugins that need computed state variables like
 // isAnyoneHome, isEveryoneAsleep, etc.
 func (e *TestEnv) StartStateTracking() error {
-	e.stateTracking = statetracking.NewManager(context.Background(), e.internalClient, e.internalStateManager, e.Logger, false, nil, "")
+	e.stateTracking = statetracking.NewManager(context.Background(), e.internalClient, e.internalStateManager, e.Logger, false, nil, "", &notify.MockNotifier{})
 	return e.stateTracking.Start()
 }
 

--- a/homeautomation-go/test/integration/scenario_concurrent_triggers_test.go
+++ b/homeautomation-go/test/integration/scenario_concurrent_triggers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"homeautomation/internal/notify"
 	"homeautomation/internal/plugins/lighting"
 	"homeautomation/internal/plugins/music"
 	"homeautomation/internal/plugins/statetracking"
@@ -56,7 +57,7 @@ func setupConcurrentTest(t *testing.T) (*concurrentEnv, func()) {
 		server:        server,
 		stateManager:  manager,
 		logger:        logger,
-		stateTracking: statetracking.NewManager(context.Background(), client, manager, logger, false, nil, ""),
+		stateTracking: statetracking.NewManager(context.Background(), client, manager, logger, false, nil, "", &notify.MockNotifier{}),
 		lighting:      lighting.NewManager(context.Background(), client, manager, lightingConfig, logger, false, nil),
 		music:         music.NewManager(context.Background(), client, manager, musicConfig, logger, false, nil, nil),
 	}

--- a/homeautomation-go/test/integration/scenario_energy_sleep_test.go
+++ b/homeautomation-go/test/integration/scenario_energy_sleep_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"homeautomation/internal/config"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/plugins/energy"
 	"homeautomation/internal/plugins/sleephygiene"
 	"homeautomation/internal/plugins/statetracking"
@@ -81,7 +82,7 @@ func setupEnergySleepTest(t *testing.T, fixedTime time.Time) (*energySleepEnv, f
 		server:        server,
 		manager:       manager,
 		logger:        logger,
-		stateTracking: statetracking.NewManager(context.Background(), client, manager, logger, false, nil, ""),
+		stateTracking: statetracking.NewManager(context.Background(), client, manager, logger, false, nil, "", &notify.MockNotifier{}),
 		energy:        energy.NewManager(context.Background(), client, manager, energyConfig, logger, false, time.UTC, nil),
 		sleepHygiene:  sleephygiene.NewManager(context.Background(), client, manager, configLoader, logger, false, timeProvider, nil),
 	}

--- a/homeautomation-go/test/integration/scenario_multi_plugin_test.go
+++ b/homeautomation-go/test/integration/scenario_multi_plugin_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"homeautomation/internal/ha"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/plugins/energy"
 	"homeautomation/internal/plugins/lighting"
 	"homeautomation/internal/plugins/statetracking"
@@ -52,7 +53,7 @@ func setupMultiPluginTest(t *testing.T) (*pluginTestEnv, func()) {
 		client:        client,
 		manager:       manager,
 		logger:        logger,
-		stateTracking: statetracking.NewManager(context.Background(), client, manager, logger, false, nil, ""),
+		stateTracking: statetracking.NewManager(context.Background(), client, manager, logger, false, nil, "", &notify.MockNotifier{}),
 		lighting:      lighting.NewManager(context.Background(), client, manager, lightingConfig, logger, false, nil),
 		tv:            tv.NewManager(context.Background(), client, manager, logger, false, nil),
 		energy:        energy.NewManager(context.Background(), client, manager, energyConfig, logger, false, nil, nil),

--- a/homeautomation-go/test/integration/scenario_music_lighting_test.go
+++ b/homeautomation-go/test/integration/scenario_music_lighting_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"homeautomation/internal/notify"
 	"homeautomation/internal/plugins/lighting"
 	"homeautomation/internal/plugins/music"
 	"homeautomation/internal/plugins/statetracking"
@@ -57,7 +58,7 @@ func setupMusicLightingTest(t *testing.T) (*musicLightingEnv, func()) {
 		server:        server,
 		stateManager:  manager,
 		logger:        logger,
-		stateTracking: statetracking.NewManager(context.Background(), client, manager, logger, false, nil, ""),
+		stateTracking: statetracking.NewManager(context.Background(), client, manager, logger, false, nil, "", &notify.MockNotifier{}),
 		lighting:      lighting.NewManager(context.Background(), client, manager, lightingConfig, logger, false, nil),
 		music:         music.NewManager(context.Background(), client, manager, musicConfig, logger, false, nil, nil),
 	}

--- a/homeautomation-go/test/integration/scenario_nighttime_safety_test.go
+++ b/homeautomation-go/test/integration/scenario_nighttime_safety_test.go
@@ -7,6 +7,7 @@ import (
 
 	"homeautomation/internal/config"
 	"homeautomation/internal/ha"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/plugins/lighting"
 	"homeautomation/internal/plugins/music"
 	"homeautomation/internal/plugins/sleephygiene"
@@ -67,7 +68,7 @@ func setupNighttimeSafetyTest(t *testing.T) (*nighttimeSafetyTestEnv, func()) {
 		client:        client,
 		stateManager:  stateManager,
 		logger:        logger,
-		stateTracking: statetracking.NewManager(context.Background(), client, stateManager, logger, false, nil, ""),
+		stateTracking: statetracking.NewManager(context.Background(), client, stateManager, logger, false, nil, "", &notify.MockNotifier{}),
 		lighting:      lighting.NewManager(context.Background(), client, stateManager, lightingConfig, logger, false, nil),
 		music:         music.NewManager(context.Background(), client, stateManager, musicConfig, logger, false, nil, nil),
 		sleepHygiene:  sleephygiene.NewManager(context.Background(), client, stateManager, configLoader, logger, false, nil, nil),

--- a/homeautomation-go/test/integration/scenario_security_test.go
+++ b/homeautomation-go/test/integration/scenario_security_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"homeautomation/internal/clock"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/plugins/security"
 	"homeautomation/internal/plugins/statetracking"
 	"homeautomation/internal/state"
@@ -23,11 +24,11 @@ func setupSecurityScenarioTest(t *testing.T) (*MockHAServer, *statetracking.Mana
 	logger := testlogger.New()
 
 	// Create and start State Tracking plugin (must start before Security)
-	stateTracking := statetracking.NewManager(context.Background(), client, stateManager, logger, false, nil, "")
+	stateTracking := statetracking.NewManager(context.Background(), client, stateManager, logger, false, nil, "", &notify.MockNotifier{})
 	require.NoError(t, stateTracking.Start(), "State Tracking manager should start successfully")
 
 	// Create and start Security plugin
-	securityManager := security.NewManager(context.Background(), client, stateManager, logger, false, nil)
+	securityManager := security.NewManager(context.Background(), client, stateManager, &notify.MockNotifier{}, logger, false, nil)
 	require.NoError(t, securityManager.Start(), "Security manager should start successfully")
 
 	cleanup := func() {
@@ -50,12 +51,12 @@ func setupSecurityScenarioTestWithMockClock(t *testing.T) (*MockHAServer, *state
 	mockClock := clock.NewMockClock(time.Now())
 
 	// Create and start State Tracking plugin with mock clock
-	stateTracking := statetracking.NewManager(context.Background(), client, stateManager, logger, false, nil, "")
+	stateTracking := statetracking.NewManager(context.Background(), client, stateManager, logger, false, nil, "", &notify.MockNotifier{})
 	stateTracking.SetClock(mockClock)
 	require.NoError(t, stateTracking.Start(), "State Tracking manager should start successfully")
 
 	// Create and start Security plugin with mock clock
-	securityManager := security.NewManager(context.Background(), client, stateManager, logger, false, nil)
+	securityManager := security.NewManager(context.Background(), client, stateManager, &notify.MockNotifier{}, logger, false, nil)
 	securityManager.SetClock(mockClock)
 	require.NoError(t, securityManager.Start(), "Security manager should start successfully")
 

--- a/homeautomation-go/test/integration/scenario_sleepprep_transition_test.go
+++ b/homeautomation-go/test/integration/scenario_sleepprep_transition_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"homeautomation/internal/config"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/plugins/music"
 	"homeautomation/internal/plugins/sleephygiene"
 	"homeautomation/internal/plugins/statetracking"
@@ -61,7 +62,7 @@ func setupSleepPrepTransitionTest(t *testing.T) (*sleepPrepTransitionEnv, func()
 		server:        server,
 		stateManager:  stateManager,
 		logger:        logger,
-		stateTracking: statetracking.NewManager(context.Background(), client, stateManager, logger, false, nil, ""),
+		stateTracking: statetracking.NewManager(context.Background(), client, stateManager, logger, false, nil, "", &notify.MockNotifier{}),
 		music:         music.NewManager(context.Background(), client, stateManager, musicConfig, logger, false, nil, nil),
 		sleepHygiene:  sleephygiene.NewManager(context.Background(), client, stateManager, configLoader, logger, false, nil, nil),
 	}

--- a/homeautomation-go/test/integration/scenario_tv_music_test.go
+++ b/homeautomation-go/test/integration/scenario_tv_music_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"homeautomation/internal/notify"
 	"homeautomation/internal/plugins/music"
 	"homeautomation/internal/plugins/statetracking"
 	"homeautomation/internal/plugins/tv"
@@ -53,7 +54,7 @@ func setupTVMusicTest(t *testing.T) (*tvMusicEnv, func()) {
 		server:        server,
 		stateManager:  manager,
 		logger:        logger,
-		stateTracking: statetracking.NewManager(context.Background(), client, manager, logger, false, nil, ""),
+		stateTracking: statetracking.NewManager(context.Background(), client, manager, logger, false, nil, "", &notify.MockNotifier{}),
 		tv:            tv.NewManager(context.Background(), client, manager, logger, false, nil),
 		music:         music.NewManager(context.Background(), client, manager, musicConfig, logger, false, nil, nil),
 	}

--- a/homeautomation-go/test/integration/scenario_vacuum_error_test.go
+++ b/homeautomation-go/test/integration/scenario_vacuum_error_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"homeautomation/internal/notify"
 	"homeautomation/internal/plugins/vacuum"
 	"homeautomation/internal/state"
 	"homeautomation/internal/testlogger"
@@ -66,7 +67,15 @@ func setupVacuumTest(t *testing.T, fixedTime time.Time) (*vacuumEnv, func()) {
 	}
 
 	tp := plugin.FixedTimeProvider{FixedTime: fixedTime}
-	mgr := vacuum.NewManager(context.Background(), client, manager, cfg, logger, false, tp, nil)
+	// Use a real notifier with snapshot/restore disabled so its tts.speak
+	// service call still flows through the mock HA server (where the test
+	// asserts it). Snapshot is disabled because mock speakers have no
+	// volume_level attribute and the per-speaker volume_set noise would
+	// confuse assertions.
+	notifyCfg := notify.DefaultConfig()
+	notifyCfg.SnapshotRestore = false
+	notifier := notify.NewManager(client, manager, notifyCfg, logger, false)
+	mgr := vacuum.NewManager(context.Background(), client, manager, notifier, cfg, logger, false, tp, nil)
 	mgr.SetRepeatCheckIntervalForTest(time.Hour) // park the background ticker; tests drive ticks explicitly
 	require.NoError(t, mgr.Start(), "vacuum plugin should start")
 

--- a/homeautomation-go/test/integration/scenario_wake_music_fade_test.go
+++ b/homeautomation-go/test/integration/scenario_wake_music_fade_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"homeautomation/internal/config"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/plugins/music"
 	"homeautomation/internal/plugins/sleephygiene"
 	"homeautomation/internal/plugins/statetracking"
@@ -65,7 +66,7 @@ func setupWakeMusicFadeTest(t *testing.T) (*wakeMusicFadeEnv, func()) {
 		server:        server,
 		logger:        logger,
 		stateManager:  stateManager,
-		stateTracking: statetracking.NewManager(context.Background(), client, stateManager, logger, false, nil, ""),
+		stateTracking: statetracking.NewManager(context.Background(), client, stateManager, logger, false, nil, "", &notify.MockNotifier{}),
 		music:         music.NewManager(context.Background(), client, stateManager, musicConfig, logger, false, nil, nil),
 		sleepHygiene:  sleephygiene.NewManager(context.Background(), client, stateManager, configLoader, logger, false, nil, nil),
 	}

--- a/homeautomation-go/test/integration/scenario_wakeup_zone_resolution_test.go
+++ b/homeautomation-go/test/integration/scenario_wakeup_zone_resolution_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"homeautomation/internal/config"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/plugins/music"
 	"homeautomation/internal/plugins/sleephygiene"
 	"homeautomation/internal/plugins/statetracking"
@@ -64,7 +65,7 @@ func setupWakeupZoneResolutionTest(t *testing.T) (*wakeupZoneEnv, func()) {
 		server:        server,
 		stateManager:  stateManager,
 		logger:        logger,
-		stateTracking: statetracking.NewManager(context.Background(), client, stateManager, logger, false, nil, ""),
+		stateTracking: statetracking.NewManager(context.Background(), client, stateManager, logger, false, nil, "", &notify.MockNotifier{}),
 		music:         music.NewManager(context.Background(), client, stateManager, musicConfig, logger, false, nil, nil),
 		sleepHygiene:  sleephygiene.NewManager(context.Background(), client, stateManager, configLoader, logger, false, nil, nil),
 	}


### PR DESCRIPTION
## Summary

Closes #1040. Verbal/TTS announcements were unreliably audible because every plugin called `tts.speak` with no volume control — the speakers played at whatever volume they were last set to. If music had been ducked or a speaker was paused at low volume, the announcement was inaudible. Concrete trigger: a vacuum announcement at startup ("Mop Dock Clean Water Tank empty") that was too quiet to understand.

This PR introduces a shared `internal/notify` package and migrates all 6 public plugins to use it. The same pattern applies to the private `security-private` plugin's "person detected outside" announcements once that downstream repo adopts the helper.

### What the notifier does

For every announcement:
1. **Snapshots** each target speaker's current `volume_level`.
2. **Overrides** to a configured announcement volume — sleep-aware (louder when awake, quieter when asleep) unless the announcement is urgent.
3. **Speaks** via `tts.speak`.
4. **Restores** prior volume after a delay (default 8s).

Urgency:
- `UrgencyRoutine` (default) — drops to `asleep_volume_percent` while `isMasterAsleep`. Used by vacuum, presence announcements, infrastructure/septic alerts, water-flow alerts.
- `UrgencyUrgent` — always uses `awake_volume_percent`. Used by security (doorbell, vehicle arrival) and EV-charger safety alerts. Same urgency level the private `security-private` plugin should use for "person detected outside".

### Config

New `configs/notification_config.yaml`:

```yaml
notification:
  default_speakers: [...]   # union of current per-plugin lists
  awake_volume_percent: 60
  asleep_volume_percent: 30
  tts_entity_id: tts.google_translate_en_com
  snapshot_restore: true
  restore_delay_seconds: 8
```

### Files

**New:**
- `internal/notify/{notify,config,mock,notify_test}.go`
- `configs/notification_config.yaml`

**Migrated:** vacuum, security, evcharger, infrastructure, waterflow, statetracking — each plugin's manager.go, register.go, and tests now route TTS through the notifier. Read-only mode is now owned by the notifier rather than each plugin individually.

**Wired:** `pkg/plugin/Context` exposes the notifier; `cmd/app/run.go` constructs it from `notification_config.yaml` and waits for pending volume restores at shutdown.

**Documented:** new "Verbal Notifications" section in `docs/reference/PLUGIN_SYSTEM.md`.

## Test plan
- [x] `make unit-tests` (74.9% coverage)
- [x] `make integration-tests`
- [x] `make pre-push`
- [ ] After deploy: trigger a vacuum announcement and confirm audibly louder than current behavior
- [ ] After deploy: set `input_boolean.master_asleep=on`, fire a routine announcement, confirm it is quieter
- [ ] After deploy: confirm music resumes at its prior volume after announcement (snapshot/restore working)
- [ ] After deploy: trigger doorbell while asleep, confirm urgent volume (loud) overrides sleep dimming
- [ ] Verify in Gravwell logs that announcements record snapshot/override/restore volumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)