### PR TITLE
fix(notify): lower awake TTS volume to 35%

### DIFF
--- a/configs/notification_config.yaml
+++ b/configs/notification_config.yaml
@@ -27,7 +27,7 @@ notification:
 
   # Volume (0-100) used when the master is awake, or for any urgent
   # announcement regardless of sleep state.
-  awake_volume_percent: 60
+  awake_volume_percent: 35
 
   # Volume (0-100) used for routine announcements while master is asleep.
   # Vacuum already suppresses entirely while asleep; this only affects


### PR DESCRIPTION
## Summary

- 60% was uncomfortably loud, especially on the Soundbar when AppleTV is playing and `leave_muted_if: isTVPlaying=true` keeps the other Sonos speakers muted (so the Soundbar is the only audible target).
- Lower `awake_volume_percent` to 35% in `configs/notification_config.yaml`. Single-line config change.
- Leaves `asleep_volume_percent: 30` unchanged.

## Context

This morning's vacuum announcement ("Robot vacuum needs attention: Mop Dock Clean Water Tank empty", 13:23Z) confirmed that the new shared notifier from #1041 is live in production and overriding speakers to 60%. That's the intended mechanism, just too loud a target for our home.

Closed redundant PR #1042 (independent reimplementation of the same fix for #1040 — superseded by #1041).

## Test plan

- [x] Pre-commit hooks passed (gofmt, goimports, vet, staticcheck, build)
- [x] Pre-push hooks passed (unit + integration tests, coverage 74.6%)
- [ ] After merge + deploy, verify in Gravwell: `tag=home-automation grep "Notifier initialized"` shows `awake_volume_percent: 35`
- [ ] Next real TTS announcement is noticeably quieter on the Soundbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)