### PR TITLE
Fix #1043: Fix flaky TV scenario tests due to handler goroutine race

### DIFF
--- a/homeautomation-go/pkg/testutil/mock_ha_server.go
+++ b/homeautomation-go/pkg/testutil/mock_ha_server.go
@@ -319,6 +319,8 @@ func (s *MockHAServer) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			s.handleRegistryList(wrapper, msg)
 		case "config/device_registry/list":
 			s.handleRegistryList(wrapper, msg)
+		case "config_entries/reload":
+			s.handleConfigEntryReload(wrapper, msg)
 		}
 	}
 }
@@ -342,6 +344,27 @@ func (s *MockHAServer) handleRegistryList(wrapper *connWrapper, msg json.RawMess
 		Type:    "result",
 		Success: &success,
 		Result:  emptyList,
+	})
+	wrapper.writeMu.Unlock()
+}
+
+// handleConfigEntryReload handles config_entries/reload requests.
+// Returns immediate success so the TV plugin's reloadBraviaIntegration does not block
+// the 10-second sendMessage timeout during integration tests.
+func (s *MockHAServer) handleConfigEntryReload(wrapper *connWrapper, msg json.RawMessage) {
+	var req struct {
+		ID int `json:"id"`
+	}
+	if err := json.Unmarshal(msg, &req); err != nil {
+		return
+	}
+
+	success := true
+	wrapper.writeMu.Lock()
+	wrapper.conn.WriteJSON(Message{
+		ID:      req.ID,
+		Type:    "result",
+		Success: &success,
 	})
 	wrapper.writeMu.Unlock()
 }

--- a/homeautomation-go/test/integration/scenario_tv_test.go
+++ b/homeautomation-go/test/integration/scenario_tv_test.go
@@ -358,13 +358,15 @@ func TestScenario_TVOffSyncBoxOn(t *testing.T) {
 
 	t.Log("GIVEN: TV is off, sync box is off, HDMI input is on a non-AppleTV input")
 
-	// Set initial states - TV is off
+	// Set initial states - TV is off. Note: switch.sync_box_power is intentionally NOT set here
+	// because its default in MockHAServer is also "off", and setting it redundantly would spawn a
+	// handler goroutine that can race with the "on" event we send later.
 	server.SetState("media_player.sony_xr_65a80k", "off", map[string]interface{}{})
-	server.SetState("switch.sync_box_power", "off", map[string]interface{}{})
 	server.SetState("select.sync_box_hdmi_input", "HDMI 1", map[string]interface{}{})
 	server.SetState("media_player.big_beautiful_oled", "off", map[string]interface{}{
 		"friendly_name": "Apple TV",
 	})
+	waitForProcessing(t, manager)
 
 	// Wait for initial state
 	waitForBoolState(t, manager, "isTVon", false, "isTVon should be false when TV remote is off")
@@ -399,13 +401,15 @@ func TestScenario_SyncBoxPowerOnRecalculates(t *testing.T) {
 
 	t.Log("GIVEN: TV panel is on, sync box is off, HDMI input is AppleTV")
 
-	// Set initial states - TV panel on, sync box off
+	// Set initial states - TV panel on, sync box off. Note: switch.sync_box_power is intentionally
+	// NOT set here; its default in MockHAServer is already "off". Setting it redundantly would spawn
+	// a handler goroutine that can race with the "on" event sent later in the test.
 	server.SetState("media_player.sony_xr_65a80k", "on", map[string]interface{}{})
-	server.SetState("switch.sync_box_power", "off", map[string]interface{}{})
 	server.SetState("select.sync_box_hdmi_input", "AppleTV", map[string]interface{}{})
 	server.SetState("media_player.big_beautiful_oled", "idle", map[string]interface{}{
 		"friendly_name": "Apple TV",
 	})
+	waitForProcessing(t, manager)
 
 	// Wait for initial state
 	waitForBoolState(t, manager, "isTVon", false, "isTVon should be false when sync box is off")


### PR DESCRIPTION
## Summary

- **Root cause**: `TestScenario_TVOffSyncBoxOn` and `TestScenario_SyncBoxPowerOnRecalculates` both called `server.SetState("switch.sync_box_power", "off", ...)` during test setup. Since `isTVon` defaults to `false`, `waitForBoolState(isTVon, false)` returned immediately — before the async G_off handler goroutine finished. The subsequent `SetState("switch.sync_box_power", "on")` spawned G_on, and if the Go scheduler ran G_off *after* G_on, it reset `isTVon` back to `false`, causing a 10-second timeout.
- **Fix 1 (test)**: Removed the redundant `SetState("switch.sync_box_power", "off")` from both tests. The entity already defaults to `"off"` in `MockHAServer`, so no event is needed. Added `waitForProcessing()` after remaining setup calls so all initial handler goroutines drain before the test's WHEN phase begins.
- **Fix 2 (mock server)**: Added `config_entries/reload` handler to `MockHAServer`. Without it, `reloadBraviaIntegration` (triggered when sync box turns on with TV panel off) blocked for 10 seconds waiting for a WebSocket response that never came, inflating test duration and adding scheduling pressure that made the race more likely.

## Test plan

- [x] `TestScenario_TVOffSyncBoxOn` passes with `-count=5 -race` (5 consecutive runs, no failures)
- [x] `TestScenario_SyncBoxPowerOnRecalculates` passes with `-count=5 -race`
- [x] Full integration suite passes: `go test -race ./test/integration/...`
- [x] `go build -buildvcs=false ./...` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)