### PR TITLE
fix: pass codex version via --release flag

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -85,7 +85,7 @@ RUN cd ~/.claude/plugins/cache/playwright-skill/playwright-skill/*/skills/playwr
 # Install Codex CLI (baked into image to avoid runtime downloads during CI runs)
 RUN curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused \
     "https://github.com/openai/codex/releases/download/rust-v${CODEX_CLI_VERSION}/install.sh" \
-    | sh -s -- "${CODEX_CLI_VERSION}"
+    | sh -s -- --release "${CODEX_CLI_VERSION}"
 
 # Switch back to root so onCreateCommand can create users dynamically.
 # The devcontainer's remoteUser setting ensures all commands run as the correct

--- a/.github/ci/Dockerfile
+++ b/.github/ci/Dockerfile
@@ -121,7 +121,7 @@ RUN cd ~/.claude/plugins/cache/playwright-skill/playwright-skill/*/skills/playwr
 # Install Codex CLI (pinned).
 RUN curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused \
         "https://github.com/openai/codex/releases/download/rust-v${CODEX_CLI_VERSION}/install.sh" \
-    | sh -s -- "${CODEX_CLI_VERSION}"
+    | sh -s -- --release "${CODEX_CLI_VERSION}"
 
 # Default entrypoint is bash — callers pass `-c '…'` (or `-lc '…'` if they
 # want a login shell; either works because /etc/profile.d/ci-path.sh


### PR DESCRIPTION
## Summary
- Codex `install.sh` upstream changed CLI contract: version is now `--release VERSION`, not positional
- Fresh devcontainer/CI builds fail with `Unknown argument: 0.125.0` (existing cached images mask the regression)
- Updates `.devcontainer/Dockerfile` and `.github/ci/Dockerfile`

## Test plan
- [ ] `devcontainer build --workspace-folder .` succeeds
- [ ] CI image build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)