### PR TITLE
Fix #1049: update speakerGroup shadow state after async joins complete

### DIFF
--- a/homeautomation-go/internal/plugins/music/fadein.go
+++ b/homeautomation-go/internal/plugins/music/fadein.go
@@ -417,10 +417,14 @@ func (m *Manager) joinSpeakerWithRetry(p ParticipantWithVolume, leadSpeakerName 
 		m.logger.Warn("Speaker unavailable (async), skipping",
 			zap.String("speaker", p.PlayerName),
 			zap.Error(joinErr))
+		m.updateSpeakerGroupStatus(p.PlayerName, false, joinErr.Error())
 		return fmt.Errorf("speaker %s failed to join: %w", p.PlayerName, joinErr)
 	}
 
-	// Speaker joined successfully - check if it should be unmuted and start fade-in
+	// Speaker joined successfully - update shadow state and check if it should be unmuted
+	m.updateSpeakerGroupStatus(p.PlayerName, true, "")
+
+	// Check if it should be unmuted and start fade-in
 	if m.shouldUnmuteSpeaker(p) {
 		m.logger.Info("Speaker joined (async), starting fade-in",
 			zap.String("speaker", p.PlayerName),

--- a/homeautomation-go/internal/plugins/music/manager_shadow_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_shadow_test.go
@@ -357,3 +357,47 @@ func TestMusicShadowState_CaptureInputs_IncludesMuteConditionVariables(t *testin
 		}
 	}
 }
+
+// TestUpdateSpeakerGroupStatus verifies that async join results update the SpeakerGroup
+// shadow state entry for the correct speaker (regression test for issue #1049).
+func TestUpdateSpeakerGroupStatus(t *testing.T) {
+	t.Parallel()
+
+	stateManager := state.NewManager(nil, zap.NewNop(), true)
+	mockConfig := &MusicConfig{Music: make(map[string]MusicMode)}
+	manager := NewManager(context.Background(), nil, stateManager, mockConfig, zap.NewNop(), true, nil, nil)
+
+	// Seed SpeakerGroup with the initial "pending async join" state that
+	// executePlayback writes before launching the async goroutine.
+	initialSpeakers := []shadowstate.SpeakerState{
+		{PlayerName: "Front Room", IsLeader: true, Active: true},
+		{PlayerName: "Kitchen", Active: false, FailureReason: "pending async join"},
+		{PlayerName: "Bedroom", Active: false, FailureReason: "pending async join"},
+	}
+	manager.updateShadowOutputs("evening", nil, initialSpeakers, nil)
+
+	// Simulate Kitchen joining successfully.
+	manager.updateSpeakerGroupStatus("Kitchen", true, "")
+
+	// Simulate Bedroom failing.
+	manager.updateSpeakerGroupStatus("Bedroom", false, "connection timeout")
+
+	shadow := manager.GetShadowState()
+
+	for _, s := range shadow.Outputs.SpeakerGroup {
+		switch s.PlayerName {
+		case "Front Room":
+			if !s.Active || s.FailureReason != "" {
+				t.Errorf("Front Room: want active=true reason='', got active=%v reason=%q", s.Active, s.FailureReason)
+			}
+		case "Kitchen":
+			if !s.Active || s.FailureReason != "" {
+				t.Errorf("Kitchen: want active=true reason='', got active=%v reason=%q", s.Active, s.FailureReason)
+			}
+		case "Bedroom":
+			if s.Active || s.FailureReason != "connection timeout" {
+				t.Errorf("Bedroom: want active=false reason='connection timeout', got active=%v reason=%q", s.Active, s.FailureReason)
+			}
+		}
+	}
+}

--- a/homeautomation-go/internal/plugins/music/shadow.go
+++ b/homeautomation-go/internal/plugins/music/shadow.go
@@ -357,6 +357,13 @@ func (m *Manager) updateSpeakerGroupStatus(playerName string, active bool, failu
 			return
 		}
 	}
+	// playerName not found: a new playback session likely replaced the SpeakerGroup slice
+	// before this async goroutine finished. Log so stale goroutines are observable.
+	m.logger.Warn("updateSpeakerGroupStatus: speaker not found in SpeakerGroup (stale goroutine?)",
+		zap.String("speaker", playerName),
+		zap.Bool("active", active),
+		zap.String("failureReason", failureReason),
+	)
 }
 
 // recordPlaybackShadowState records shadow state after playback orchestration.

--- a/homeautomation-go/internal/plugins/music/shadow.go
+++ b/homeautomation-go/internal/plugins/music/shadow.go
@@ -118,7 +118,10 @@ func (m *Manager) updateShadowOutputs(mode string, playlist *shadowstate.Playlis
 					BaseVolume:    p.BaseVolume,
 					DefaultVolume: p.DefaultVolume,
 					IsLeader:      p.PlayerName == zone.LeadSpeaker,
-					Active:        true,
+					// Active=true here means "configured member of this active zone",
+					// not "successfully joined the Sonos group". For actual join status
+					// see SpeakerGroup which is updated by async join goroutines.
+					Active: true,
 				})
 			}
 			zoneShadowStates = append(zoneShadowStates, shadowstate.ZoneShadowState{
@@ -338,6 +341,22 @@ func (m *Manager) clearFadeInProgress(entityID string) {
 	}
 
 	m.shadowState.Metadata.LastUpdated = m.timeProvider.Now()
+}
+
+// updateSpeakerGroupStatus updates a single speaker's join status in the SpeakerGroup
+// shadow state. Called from async join goroutines after each speaker joins or fails.
+func (m *Manager) updateSpeakerGroupStatus(playerName string, active bool, failureReason string) {
+	m.shadowMu.Lock()
+	defer m.shadowMu.Unlock()
+
+	for i := range m.shadowState.Outputs.SpeakerGroup {
+		if m.shadowState.Outputs.SpeakerGroup[i].PlayerName == playerName {
+			m.shadowState.Outputs.SpeakerGroup[i].Active = active
+			m.shadowState.Outputs.SpeakerGroup[i].FailureReason = failureReason
+			m.shadowState.Metadata.LastUpdated = m.timeProvider.Now()
+			return
+		}
+	}
 }
 
 // recordPlaybackShadowState records shadow state after playback orchestration.


### PR DESCRIPTION
Resolves #1049

## Summary

- Added `updateSpeakerGroupStatus(playerName, active, failureReason)` in `shadow.go` — locks `shadowMu` and updates the matching `SpeakerGroup` entry for the named speaker.
- Called from `joinSpeakerWithRetry` in `fadein.go` on **both** success (`active=true, reason=""`) and final failure (`active=false, reason=<error>`), so the shadow state reflects the real async join outcome instead of staying frozen at `"pending async join"`.
- Added a code comment on the `activeZones` hardcoded `Active: true` to document it means *configured zone membership*, not *actual Sonos join status*. `speakerGroup` is the authoritative source for join status.

## Test Plan

- `TestUpdateSpeakerGroupStatus` (new) seeds `SpeakerGroup` with two followers at `"pending async join"`, simulates one success and one failure via `updateSpeakerGroupStatus`, then asserts the expected `Active`/`FailureReason` values.
- All existing unit and integration tests pass (`go test -race ./...`).

🤖 Generated by the AI assistant