### PR TITLE
refactor(notify): collapse to 2-tier urgency, notifier owns asleep-suppression

### DIFF
--- a/configs/notification_config.yaml
+++ b/configs/notification_config.yaml
@@ -4,14 +4,20 @@
 # security doorbell/vehicle/intruder alerts, energy/charging notifications,
 # infrastructure alerts, water-flow alerts, presence announcements).
 #
+# Each Announce call carries an UrgencyLevel:
+#   - UrgencyDeferable (default): suppressed entirely while master is asleep.
+#     Persistent-state plugins (vacuum, water-flow) own their own retry
+#     cadence and re-announce after wake; transient events (presence
+#     arrival) accept being missed.
+#   - UrgencyUrgent: always plays, even while asleep. Use for events that
+#     must wake the household (security, broken-pipe water flow, EV-charger
+#     safety, infrastructure crashes).
+#
 # Before each announcement the notifier:
 #   1. Snapshots each target speaker's current volume.
-#   2. Sets volume to awake_volume_percent (or asleep_volume_percent for
-#      routine announcements while master is asleep).
+#   2. Sets volume to awake_volume_percent.
 #   3. Calls tts.speak.
 #   4. After restore_delay_seconds, restores each speaker's prior volume.
-#
-# Urgent announcements (security alerts) ignore the asleep volume reduction.
 notification:
   # Default speaker list when a plugin does not override. Union of all
   # per-plugin lists in use today, so removing a plugin's hardcoded list
@@ -24,14 +30,10 @@ notification:
     - media_player.dining_room
     - media_player.kids_bathroom
 
-  # Volume (0-100) used when the master is awake, or for any urgent
-  # announcement regardless of sleep state.
+  # Volume (0-100) used for every announcement that plays. Announcements while
+  # master is asleep either play at this volume (UrgencyUrgent) or are dropped
+  # entirely (UrgencyDeferable) — there is no quieter mid-tier.
   awake_volume_percent: 20
-
-  # Volume (0-100) used for routine announcements while master is asleep.
-  # Vacuum already suppresses entirely while asleep; this only affects
-  # announcements that don't suppress (e.g. presence).
-  asleep_volume_percent: 30
 
   # TTS engine. tts.google_translate_en_com is the default in Home Assistant.
   tts_entity_id: tts.google_translate_en_com

--- a/configs/vacuum_config.yaml
+++ b/configs/vacuum_config.yaml
@@ -12,12 +12,10 @@ vacuum:
 
   announcement:
     # Re-announce an unresolved error this often, in Go duration syntax.
+    # Vacuum errors use UrgencyDeferable: the shared notifier suppresses
+    # delivery while input_boolean.master_asleep is on, but this repeat timer
+    # keeps ticking so the next attempt after wake makes it through.
     repeat_interval: "2h"
-
-    # When true, suppress TTS while input_boolean.master_asleep is on. The
-    # repeat timer keeps running; the next announcement fires at the next
-    # repeat_interval tick after master wakes.
-    suppress_while_master_asleep: true
 
     # Sentence prefix; the error description is appended after a colon.
     message_prefix: "Robot vacuum needs attention"

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -490,12 +490,12 @@ Each plugin corresponds to a Node-RED flow and implements domain-specific automa
 
 **Responsibilities:**
 - Monitor the robot vacuum's error sensor and announce actionable errors via TTS
-- Suppress announcements while master is asleep (configurable)
+- Suppress announcements while master is asleep
 - Re-announce unresolved errors on a configurable interval (default 2 hours) until cleared
 
 **Key Automations:**
 - **Error Announcement**: On error sensor transition from "No error" to a real error → TTS to common-area speakers
-- **Quiet Hours**: When `isMasterAsleep=true` (and `suppress_while_master_asleep` is set) → record error in shadow state but do not speak
+- **Quiet Hours**: When `isMasterAsleep=true` → notifier returns `ErrSuppressedAsleep`; vacuum records in shadow state and preserves repeat cadence
 - **Repeat Cadence**: Background ticker re-announces unresolved errors every `repeat_interval`
 - **Initial State**: On plugin start → if sensor already reports an error, announce immediately
 

--- a/docs/reference/PLUGIN_SYSTEM.md
+++ b/docs/reference/PLUGIN_SYSTEM.md
@@ -937,7 +937,7 @@ make pre-push
 Plugins that need to make spoken (TTS) announcements **must** use the shared `notify.Notifier` from `internal/notify` instead of calling `tts.speak` directly through the HA client. The notifier:
 
 1. **Snapshots** each target speaker's current volume.
-2. **Overrides** to a configured announcement volume (sleep-aware: louder when awake, quieter when asleep, unless the announcement is urgent).
+2. **Overrides** to `awake_volume_percent`. Deferable announcements are dropped entirely while master is asleep; Urgent announcements always play.
 3. **Speaks** the message via Home Assistant.
 4. **Restores** the prior speaker volume after a delay.
 
@@ -965,7 +965,7 @@ func createPlugin(ctx *plugin.Context) (plugin.Plugin, error) {
 ```go
 import "homeautomation/internal/notify"
 
-// Routine announcement (e.g. presence, vacuum, infrastructure alerts)
+// Deferable announcement (dropped while master is asleep; e.g. presence, vacuum errors)
 m.notifier.Announce(m.ctx, "Robot vacuum needs attention: dustbin missing",
     notify.WithSpeakers([]string{"media_player.kitchen", "media_player.front_room"}),
 )
@@ -981,7 +981,7 @@ m.notifier.Announce(m.ctx, "Person detected outside",
 
 ### Urgency levels
 
-- **`UrgencyRoutine`** (default) — uses `asleep_volume_percent` while `isMasterAsleep` is true. Use for: vacuum errors, presence announcements, infrastructure/septic alerts, water-flow alerts, EV-charger battery levels.
+- **`UrgencyDeferable`** (default) — dropped entirely while master is asleep; returns `ErrSuppressedAsleep`. Use for: vacuum errors, presence announcements, EV-charger battery levels.
 - **`UrgencyUrgent`** — always uses `awake_volume_percent` regardless of sleep state. Use for: doorbell, vehicle arrival, intruder detection, EV-charger safety alerts, anything else that **must** be heard.
 
 ### Read-only mode
@@ -1002,7 +1002,7 @@ assert.Equal(t, "Doorbell ringing", calls[0].Message)
 assert.Equal(t, notify.UrgencyUrgent, calls[0].Urgency)
 ```
 
-Configuration lives at `configs/notification_config.yaml` — see that file for the full set of tunables (default speakers, awake/asleep volumes, restore delay, TTS engine).
+Configuration lives at `configs/notification_config.yaml` — see that file for the full set of tunables (default speakers, awake volume, restore delay, TTS engine).
 
 ---
 

--- a/homeautomation-go/cmd/app/run.go
+++ b/homeautomation-go/cmd/app/run.go
@@ -359,7 +359,6 @@ func Run() {
 	pluginCtx.Notifier = notifier
 	logger.Info("Notifier initialized",
 		zap.Int("awake_volume_percent", notifyCfg.AwakeVolumePercent),
-		zap.Int("asleep_volume_percent", notifyCfg.AsleepVolumePercent),
 		zap.Int("default_speaker_count", len(notifyCfg.DefaultSpeakers)))
 
 	// Create all registered plugins using the plugin registry

--- a/homeautomation-go/internal/notify/config.go
+++ b/homeautomation-go/internal/notify/config.go
@@ -13,13 +13,11 @@ type Config struct {
 	// DefaultSpeakers are used when a caller does not pass WithSpeakers.
 	DefaultSpeakers []string `yaml:"default_speakers"`
 
-	// AwakeVolumePercent is the speaker volume (0-100) used while master is awake.
+	// AwakeVolumePercent is the speaker volume (0-100) used for every
+	// announcement that plays. Announcements while master is asleep either
+	// play at this volume (UrgencyUrgent) or are dropped entirely
+	// (UrgencyDeferable) — there is no quieter mid-tier.
 	AwakeVolumePercent int `yaml:"awake_volume_percent"`
-
-	// AsleepVolumePercent is the speaker volume (0-100) used for routine
-	// announcements while master is asleep. Urgent announcements ignore this
-	// and use AwakeVolumePercent.
-	AsleepVolumePercent int `yaml:"asleep_volume_percent"`
 
 	// TTSDomain / TTSService identify the Home Assistant service to call.
 	// Defaults to tts.speak.
@@ -49,7 +47,6 @@ type fileShape struct {
 
 const (
 	defaultAwakeVolumePercent  = 60
-	defaultAsleepVolumePercent = 30
 	defaultTTSDomain           = "tts"
 	defaultTTSService          = "speak"
 	defaultTTSEntityID         = "tts.google_translate_en_com"
@@ -101,9 +98,6 @@ func (c *Config) applyDefaults() {
 	if c.AwakeVolumePercent == 0 {
 		c.AwakeVolumePercent = defaultAwakeVolumePercent
 	}
-	if c.AsleepVolumePercent == 0 {
-		c.AsleepVolumePercent = defaultAsleepVolumePercent
-	}
 	if c.TTSDomain == "" {
 		c.TTSDomain = defaultTTSDomain
 	}
@@ -122,9 +116,6 @@ func (c *Config) applyDefaults() {
 func (c *Config) validate() error {
 	if c.AwakeVolumePercent < 0 || c.AwakeVolumePercent > 100 {
 		return fmt.Errorf("awake_volume_percent must be 0-100, got %d", c.AwakeVolumePercent)
-	}
-	if c.AsleepVolumePercent < 0 || c.AsleepVolumePercent > 100 {
-		return fmt.Errorf("asleep_volume_percent must be 0-100, got %d", c.AsleepVolumePercent)
 	}
 	if c.RestoreDelaySeconds < 0 {
 		return fmt.Errorf("restore_delay_seconds must be non-negative, got %d", c.RestoreDelaySeconds)

--- a/homeautomation-go/internal/notify/mock.go
+++ b/homeautomation-go/internal/notify/mock.go
@@ -23,7 +23,7 @@ type MockCall struct {
 
 // Announce implements Notifier.
 func (m *MockNotifier) Announce(_ context.Context, message string, opts ...AnnounceOption) error {
-	o := announceOpts{urgency: UrgencyRoutine}
+	o := announceOpts{urgency: UrgencyDeferable}
 	for _, opt := range opts {
 		opt(&o)
 	}

--- a/homeautomation-go/internal/notify/notify.go
+++ b/homeautomation-go/internal/notify/notify.go
@@ -6,11 +6,12 @@
 // Notifier interface rather than calling tts.speak directly. This guarantees
 // announcements remain audible regardless of the speakers' current state
 // (ducked music, paused playback, low background volume) and centralises
-// behavior such as sleep-aware volume reduction.
+// the asleep-aware suppression policy.
 package notify
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -26,19 +27,32 @@ type Notifier interface {
 	Announce(ctx context.Context, message string, opts ...AnnounceOption) error
 }
 
-// UrgencyLevel controls volume behavior when the master is asleep.
+// ErrSuppressedAsleep is returned by Announce when a UrgencyDeferable
+// announcement is dropped because the master is asleep. Callers that want to
+// track suppressed events (e.g. for shadow-state observability) should
+// errors.Is against this sentinel; callers that don't can ignore it.
+var ErrSuppressedAsleep = errors.New("notify: announcement suppressed (master asleep)")
+
+// UrgencyLevel controls how the notifier handles an announcement when the
+// master is asleep. Volume is always cfg.AwakeVolumePercent; urgency only
+// changes whether the announcement plays at all.
 type UrgencyLevel int
 
 const (
-	// UrgencyRoutine uses the asleep volume when isMasterAsleep is true.
-	UrgencyRoutine UrgencyLevel = iota
+	// UrgencyDeferable: drop entirely while master is asleep. Notifier returns
+	// ErrSuppressedAsleep. Persistent-state plugins (vacuum errors, etc.) own
+	// their own retry cadence and will re-announce after wake; transient
+	// events (presence arrival) accept being missed since they are stale by
+	// morning anyway.
+	UrgencyDeferable UrgencyLevel = iota
 
-	// UrgencyUrgent uses the awake volume even when asleep. Use for security
-	// alerts (doorbell, vehicle arrival, intruder detection) that must be heard.
+	// UrgencyUrgent: always play, even when asleep. Use for events that must
+	// wake the household (security alerts, doorbell, broken-pipe water flow,
+	// EV-charger safety conditions, infrastructure crashes).
 	UrgencyUrgent
 )
 
-// MasterAsleepStateVar is the state variable consulted for sleep-aware volume.
+// MasterAsleepStateVar is the state variable consulted for the suppress check.
 const MasterAsleepStateVar = "isMasterAsleep"
 
 type announceOpts struct {
@@ -56,7 +70,7 @@ func WithSpeakers(speakers []string) AnnounceOption {
 	}
 }
 
-// WithUrgency sets the announcement urgency. Default is UrgencyRoutine.
+// WithUrgency sets the announcement urgency. Default is UrgencyDeferable.
 func WithUrgency(level UrgencyLevel) AnnounceOption {
 	return func(o *announceOpts) { o.urgency = level }
 }
@@ -72,8 +86,9 @@ type Manager struct {
 	wg sync.WaitGroup
 }
 
-// NewManager constructs a Notifier. stateManager may be nil in tests; sleep-aware
-// volume falls back to AwakeVolumePercent in that case.
+// NewManager constructs a Notifier. stateManager may be nil in tests; the
+// asleep-suppression check then defaults to "awake" so announcements are not
+// silently dropped during tests that don't model sleep state.
 func NewManager(haClient ha.HAClient, stateManager *state.Manager, cfg Config, logger *zap.Logger, readOnly bool) *Manager {
 	cfg.applyDefaults()
 	return &Manager{
@@ -99,7 +114,7 @@ func (m *Manager) WaitForRestores() { m.wg.Wait() }
 func (m *Manager) Announce(ctx context.Context, message string, opts ...AnnounceOption) error {
 	o := announceOpts{
 		speakers: m.cfg.DefaultSpeakers,
-		urgency:  UrgencyRoutine,
+		urgency:  UrgencyDeferable,
 	}
 	for _, opt := range opts {
 		opt(&o)
@@ -111,7 +126,14 @@ func (m *Manager) Announce(ctx context.Context, message string, opts ...Announce
 		return fmt.Errorf("notify.Announce: empty message")
 	}
 
-	targetVolume := m.targetVolumePercent(o.urgency)
+	if o.urgency == UrgencyDeferable && m.isMasterAsleep() {
+		m.logger.Info("Announcement suppressed (master asleep)",
+			zap.String("message", message),
+			zap.Strings("speakers", o.speakers))
+		return ErrSuppressedAsleep
+	}
+
+	targetVolume := m.cfg.AwakeVolumePercent
 
 	if m.readOnly {
 		m.logger.Info("READ-ONLY: would announce TTS",
@@ -153,20 +175,14 @@ func (m *Manager) Announce(ctx context.Context, message string, opts ...Announce
 	return nil
 }
 
-func (m *Manager) targetVolumePercent(urgency UrgencyLevel) int {
-	if urgency == UrgencyRoutine && m.isMasterAsleep() {
-		return m.cfg.AsleepVolumePercent
-	}
-	return m.cfg.AwakeVolumePercent
-}
-
 func (m *Manager) isMasterAsleep() bool {
 	if m.stateManager == nil {
 		return false
 	}
 	v, err := m.stateManager.GetBool(MasterAsleepStateVar)
 	if err != nil {
-		// Conservative: treat as awake so announcements stay loud.
+		// Conservative: treat as awake so announcements still play. A missed
+		// urgent announcement is worse than one that played at the wrong time.
 		return false
 	}
 	return v

--- a/homeautomation-go/internal/notify/notify_test.go
+++ b/homeautomation-go/internal/notify/notify_test.go
@@ -163,7 +163,7 @@ func TestAnnounce_TTSFailureRestoresImmediately(t *testing.T) {
 	}
 }
 
-func TestAnnounce_SleepAwareVolumeRoutine(t *testing.T) {
+func TestAnnounce_DeferableWhileAsleep_SuppressesWithSentinel(t *testing.T) {
 	mockHA := ha.NewMockClient()
 	mockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{"volume_level": 0.40})
 
@@ -171,32 +171,54 @@ func TestAnnounce_SleepAwareVolumeRoutine(t *testing.T) {
 	if err := stateMgr.SetBool("isMasterAsleep", true); err != nil {
 		t.Fatalf("SetBool failed: %v", err)
 	}
-	// Clear the service calls SetBool may have made (e.g. input_boolean.turn_on)
-	// so we only observe Announce's calls below.
+	// Clear service calls from the SetBool (e.g. input_boolean.turn_on) so
+	// only the Announce's calls (or absence thereof) are observed.
 	mockHA.ClearServiceCalls()
 
 	m := newTestManager(t, mockHA, stateMgr, false, true)
 
-	if err := m.Announce(context.Background(), "Hi", WithSpeakers([]string{"media_player.kitchen"})); err != nil {
+	err := m.Announce(context.Background(), "Vacuum needs attention",
+		WithSpeakers([]string{"media_player.kitchen"}),
+		WithUrgency(UrgencyDeferable))
+	if !errors.Is(err, ErrSuppressedAsleep) {
+		t.Fatalf("expected ErrSuppressedAsleep, got %v", err)
+	}
+
+	if calls := mockHA.GetServiceCalls(); len(calls) != 0 {
+		t.Errorf("deferable+asleep should make zero HA calls, got %d: %+v", len(calls), calls)
+	}
+}
+
+func TestAnnounce_DeferableWhileAwake_PlaysAtAwakeVolume(t *testing.T) {
+	mockHA := ha.NewMockClient()
+	mockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{"volume_level": 0.40})
+
+	stateMgr := state.NewManager(mockHA, zaptest.NewLogger(t), false)
+	if err := stateMgr.SetBool("isMasterAsleep", false); err != nil {
+		t.Fatalf("SetBool failed: %v", err)
+	}
+	mockHA.ClearServiceCalls()
+
+	m := newTestManager(t, mockHA, stateMgr, false, true)
+
+	if err := m.Announce(context.Background(), "Hi",
+		WithSpeakers([]string{"media_player.kitchen"}),
+		WithUrgency(UrgencyDeferable)); err != nil {
 		t.Fatalf("Announce returned error: %v", err)
 	}
 	m.WaitForRestores()
 
-	// First call is the volume override - should use AsleepVolumePercent (30%)
 	calls := mockHA.GetServiceCalls()
 	if len(calls) < 1 {
 		t.Fatalf("expected at least one call")
 	}
 	override := calls[0]
-	if override.Domain != "media_player" || override.Service != "volume_set" {
-		t.Fatalf("expected first call to be volume_set, got %s.%s", override.Domain, override.Service)
-	}
-	if v, _ := override.Data["volume_level"].(float64); v != 0.30 {
-		t.Errorf("routine announcement while asleep: expected volume 0.30, got %v", v)
+	if v, _ := override.Data["volume_level"].(float64); v != 0.60 {
+		t.Errorf("deferable+awake: expected volume 0.60, got %v", v)
 	}
 }
 
-func TestAnnounce_SleepAwareVolumeUrgent(t *testing.T) {
+func TestAnnounce_UrgentWhileAsleep_PlaysAtAwakeVolume(t *testing.T) {
 	mockHA := ha.NewMockClient()
 	mockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{"volume_level": 0.40})
 
@@ -204,21 +226,24 @@ func TestAnnounce_SleepAwareVolumeUrgent(t *testing.T) {
 	if err := stateMgr.SetBool("isMasterAsleep", true); err != nil {
 		t.Fatalf("SetBool failed: %v", err)
 	}
-	// Clear the service calls SetBool may have made (e.g. input_boolean.turn_on)
-	// so we only observe Announce's calls below.
 	mockHA.ClearServiceCalls()
 
 	m := newTestManager(t, mockHA, stateMgr, false, true)
 
-	if err := m.Announce(context.Background(), "Person at door", WithSpeakers([]string{"media_player.kitchen"}), WithUrgency(UrgencyUrgent)); err != nil {
+	if err := m.Announce(context.Background(), "Person at door",
+		WithSpeakers([]string{"media_player.kitchen"}),
+		WithUrgency(UrgencyUrgent)); err != nil {
 		t.Fatalf("Announce returned error: %v", err)
 	}
 	m.WaitForRestores()
 
 	calls := mockHA.GetServiceCalls()
+	if len(calls) < 1 {
+		t.Fatalf("expected at least one call")
+	}
 	override := calls[0]
 	if v, _ := override.Data["volume_level"].(float64); v != 0.60 {
-		t.Errorf("urgent announcement while asleep: expected volume 0.60 (awake), got %v", v)
+		t.Errorf("urgent+asleep: expected volume 0.60, got %v", v)
 	}
 }
 
@@ -333,9 +358,6 @@ func TestLoadConfig_AppliesDefaults(t *testing.T) {
 	if cfg.AwakeVolumePercent != defaultAwakeVolumePercent {
 		t.Errorf("AwakeVolumePercent: expected %d, got %d", defaultAwakeVolumePercent, cfg.AwakeVolumePercent)
 	}
-	if cfg.AsleepVolumePercent != defaultAsleepVolumePercent {
-		t.Errorf("AsleepVolumePercent: expected %d, got %d", defaultAsleepVolumePercent, cfg.AsleepVolumePercent)
-	}
 	if cfg.TTSDomain != defaultTTSDomain {
 		t.Errorf("TTSDomain: expected %s, got %s", defaultTTSDomain, cfg.TTSDomain)
 	}
@@ -358,7 +380,7 @@ func TestConfigValidate_RejectsInvalidVolume(t *testing.T) {
 	}
 
 	cfg = DefaultConfig()
-	cfg.AsleepVolumePercent = -1
+	cfg.AwakeVolumePercent = -1
 	if err := cfg.validate(); err == nil {
 		t.Error("expected validate to reject negative volume")
 	}

--- a/homeautomation-go/internal/plugins/infrastructure/manager.go
+++ b/homeautomation-go/internal/plugins/infrastructure/manager.go
@@ -426,7 +426,10 @@ func (m *Manager) sendTTSAnnouncement(message string) {
 		"media_player.kids_bathroom",
 	}
 
-	if err := m.notifier.Announce(m.ctx, message, notify.WithSpeakers(speakers)); err != nil {
+	if err := m.notifier.Announce(m.ctx, message,
+		notify.WithSpeakers(speakers),
+		notify.WithUrgency(notify.UrgencyUrgent),
+	); err != nil {
 		m.logger.Error("Failed to send infrastructure announcement", zap.Error(err), zap.String("message", message))
 		return
 	}

--- a/homeautomation-go/internal/plugins/statetracking/manager.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager.go
@@ -798,7 +798,10 @@ func (m *Manager) announceArrivalDirect(person, message string, mediaPlayers []s
 		zap.String("message", message),
 		zap.Strings("media_players", mediaPlayers))
 
-	if err := m.notifier.Announce(m.ctx, message, notify.WithSpeakers(mediaPlayers)); err != nil {
+	if err := m.notifier.Announce(m.ctx, message,
+		notify.WithSpeakers(mediaPlayers),
+		notify.WithUrgency(notify.UrgencyDeferable),
+	); err != nil && !errors.Is(err, notify.ErrSuppressedAsleep) {
 		m.logger.Error("Failed to announce arrival",
 			zap.String("person", person),
 			zap.Error(err))

--- a/homeautomation-go/internal/plugins/vacuum/config.go
+++ b/homeautomation-go/internal/plugins/vacuum/config.go
@@ -29,9 +29,8 @@ type AnnouncementConfig struct {
 	// RepeatInterval is parsed from a Go duration string (e.g. "2h").
 	RepeatIntervalRaw string `yaml:"repeat_interval"`
 
-	SuppressWhileMasterAsleep bool     `yaml:"suppress_while_master_asleep"`
-	MessagePrefix             string   `yaml:"message_prefix"`
-	Speakers                  []string `yaml:"speakers"`
+	MessagePrefix string   `yaml:"message_prefix"`
+	Speakers      []string `yaml:"speakers"`
 
 	// RepeatInterval holds the parsed duration. Populated by LoadConfig.
 	RepeatInterval time.Duration `yaml:"-"`

--- a/homeautomation-go/internal/plugins/vacuum/manager.go
+++ b/homeautomation-go/internal/plugins/vacuum/manager.go
@@ -9,6 +9,7 @@ package vacuum
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -28,9 +29,6 @@ import (
 // (now - lastAnnouncedAt) >= config.Announcement.RepeatInterval, so this can
 // be small without spamming.
 const defaultRepeatCheckInterval = 1 * time.Minute
-
-// MasterAsleepStateVar is the state-manager key for the master-asleep flag.
-const MasterAsleepStateVar = "isMasterAsleep"
 
 // Manager handles vacuum error announcements.
 type Manager struct {
@@ -198,37 +196,37 @@ func (m *Manager) handleErrorChange(entityID string, oldState, newState *ha.Stat
 	m.maybeAnnounce(value)
 }
 
-// maybeAnnounce sends a TTS announcement for errorDesc, respecting read-only
-// mode and the suppress-while-asleep policy. Updates lastAnnouncedAt regardless
-// of whether the announcement was actually spoken (so the repeat cadence
-// applies uniformly to suppressed and spoken events).
+// maybeAnnounce sends a TTS announcement for errorDesc as a Deferable
+// announcement. The notifier suppresses delivery while master is asleep and
+// returns notify.ErrSuppressedAsleep; we update lastAnnouncedAt regardless so
+// the 2h repeat cadence applies uniformly to suppressed and spoken events.
 func (m *Manager) maybeAnnounce(errorDesc string) {
 	now := m.timeProvider.Now()
 	message := fmt.Sprintf("%s: %s", m.cfg.Vacuum.Announcement.MessagePrefix, errorDesc)
 
-	if m.cfg.Vacuum.Announcement.SuppressWhileMasterAsleep && m.isMasterAsleep() {
+	err := m.notifier.Announce(m.ctx, message,
+		notify.WithSpeakers(m.cfg.Vacuum.Announcement.Speakers),
+		notify.WithUrgency(notify.UrgencyDeferable))
+	switch {
+	case errors.Is(err, notify.ErrSuppressedAsleep):
 		m.logger.Info("Vacuum error TTS suppressed (master asleep)",
 			zap.String("error", errorDesc))
 		m.shadowTracker.RecordSuppressedWhileAsleep(now)
 		m.mu.Lock()
 		m.lastAnnouncedAt = now
 		m.mu.Unlock()
-		return
-	}
-
-	if err := m.notifier.Announce(m.ctx, message, notify.WithSpeakers(m.cfg.Vacuum.Announcement.Speakers)); err != nil {
+	case err != nil:
 		m.logger.Error("Failed to send vacuum announcement",
 			zap.String("message", message),
 			zap.Error(err))
 		// Still record the attempt so the repeat timer doesn't immediately retry.
 		m.recordAnnounced(now, message)
-		return
+	default:
+		m.logger.Info("Vacuum announcement sent",
+			zap.String("message", message),
+			zap.Strings("speakers", m.cfg.Vacuum.Announcement.Speakers))
+		m.recordAnnounced(now, message)
 	}
-
-	m.logger.Info("Vacuum announcement sent",
-		zap.String("message", message),
-		zap.Strings("speakers", m.cfg.Vacuum.Announcement.Speakers))
-	m.recordAnnounced(now, message)
 }
 
 func (m *Manager) recordAnnounced(at time.Time, message string) {
@@ -236,20 +234,6 @@ func (m *Manager) recordAnnounced(at time.Time, message string) {
 	m.lastAnnouncedAt = at
 	m.mu.Unlock()
 	m.shadowTracker.RecordAnnouncement(message, at)
-}
-
-func (m *Manager) isMasterAsleep() bool {
-	if m.stateManager == nil {
-		return false
-	}
-	v, err := m.stateManager.GetBool(MasterAsleepStateVar)
-	if err != nil {
-		// Conservative: if we can't determine sleep state, do NOT suppress.
-		// An audible announcement is preferable to silently swallowing an alert.
-		m.logger.Debug("Could not read isMasterAsleep, assuming awake", zap.Error(err))
-		return false
-	}
-	return v
 }
 
 // runRepeatLoop periodically re-evaluates whether to re-announce a stale error.

--- a/homeautomation-go/internal/plugins/vacuum/manager_test.go
+++ b/homeautomation-go/internal/plugins/vacuum/manager_test.go
@@ -24,7 +24,6 @@ func newTestConfig() *Config {
 	cfg.Vacuum.NoErrorValue = "No error"
 	cfg.Vacuum.Announcement.MessagePrefix = "Robot vacuum needs attention"
 	cfg.Vacuum.Announcement.RepeatInterval = 2 * time.Hour
-	cfg.Vacuum.Announcement.SuppressWhileMasterAsleep = true
 	cfg.Vacuum.Announcement.Speakers = []string{
 		"media_player.kitchen",
 		"media_player.sitting_room",
@@ -90,7 +89,7 @@ func TestVacuum_TransitionToError_Announces(t *testing.T) {
 			"media_player.kids_bathroom",
 		},
 		calls[0].Speakers)
-	assert.Equal(t, notify.UrgencyRoutine, calls[0].Urgency)
+	assert.Equal(t, notify.UrgencyDeferable, calls[0].Urgency)
 
 	st := mgr.GetShadowState()
 	assert.Equal(t, "Mop Dock Clean Water Tank empty", st.Outputs.CurrentError)
@@ -126,17 +125,24 @@ func TestVacuum_DifferentError_Announces(t *testing.T) {
 	assert.Contains(t, calls[1].Message, "Mop Dock Clean Water Tank empty")
 }
 
-func TestVacuum_SuppressedWhileMasterAsleep(t *testing.T) {
+func TestVacuum_NotifierSuppressedAsleep_RecordsAndPreservesCadence(t *testing.T) {
 	t.Parallel()
-	mgr, mockHA, stateMgr, mockNotifier := newTestManager(t, false, time.Now())
+	// Asleep-suppression now lives in the shared notifier, not vacuum. Vacuum
+	// passes UrgencyDeferable; the notifier returns ErrSuppressedAsleep when
+	// master is asleep. Vacuum reacts by incrementing the suppress counter and
+	// updating lastAnnouncedAt so the 2h repeat cadence still applies.
+	mgr, mockHA, _, mockNotifier := newTestManager(t, false, time.Now())
+	mockNotifier.Err = notify.ErrSuppressedAsleep
 	mockHA.SimulateStateChange(testErrorSensor, "No error")
-	require.NoError(t, stateMgr.SetBool("isMasterAsleep", true))
 	require.NoError(t, mgr.Start())
 	defer mgr.Stop()
 
 	setSensor(t, mockHA, "Mop Dock Clean Water Tank empty")
 
-	assert.Empty(t, mockNotifier.Calls(), "must not announce while master is asleep")
+	calls := mockNotifier.Calls()
+	require.Len(t, calls, 1, "vacuum still calls notifier; suppression is the notifier's decision")
+	assert.Equal(t, notify.UrgencyDeferable, calls[0].Urgency,
+		"vacuum errors must be Deferable so the notifier suppresses them while asleep")
 
 	st := mgr.GetShadowState()
 	assert.Equal(t, "Mop Dock Clean Water Tank empty", st.Outputs.CurrentError,

--- a/homeautomation-go/internal/plugins/waterflow/manager.go
+++ b/homeautomation-go/internal/plugins/waterflow/manager.go
@@ -463,7 +463,10 @@ func (m *Manager) sendTTSAnnouncement(message string) {
 		"media_player.kids_bathroom",
 	}
 
-	if err := m.notifier.Announce(m.ctx, message, notify.WithSpeakers(speakers)); err != nil {
+	if err := m.notifier.Announce(m.ctx, message,
+		notify.WithSpeakers(speakers),
+		notify.WithUrgency(notify.UrgencyUrgent),
+	); err != nil {
 		m.logger.Error("Failed to send waterflow announcement", zap.Error(err), zap.String("message", message))
 		return
 	}

--- a/homeautomation-go/test/integration/scenario_vacuum_error_test.go
+++ b/homeautomation-go/test/integration/scenario_vacuum_error_test.go
@@ -57,7 +57,6 @@ func setupVacuumTest(t *testing.T, fixedTime time.Time) (*vacuumEnv, func()) {
 	cfg.Vacuum.NoErrorValue = "No error"
 	cfg.Vacuum.Announcement.MessagePrefix = "Robot vacuum needs attention"
 	cfg.Vacuum.Announcement.RepeatInterval = 2 * time.Hour
-	cfg.Vacuum.Announcement.SuppressWhileMasterAsleep = true
 	cfg.Vacuum.Announcement.Speakers = []string{
 		"media_player.kitchen",
 		"media_player.sitting_room",

--- a/homeautomation-go/test/integration/scenario_vacuum_error_test.go
+++ b/homeautomation-go/test/integration/scenario_vacuum_error_test.go
@@ -27,7 +27,7 @@ import (
 //
 // INVARIANTS:
 //   - "No error" must NEVER trigger a TTS call.
-//   - When master is asleep and suppress_while_master_asleep is true, the
+//   - When master is asleep (vacuum uses UrgencyDeferable), the
 //     error must be tracked but NOT spoken.
 //   - The same error string re-emitted by HA must NOT cause an immediate
 //     duplicate announcement (the repeat timer governs cadence).


### PR DESCRIPTION
## Summary

Replace the muddled 3-way TTS urgency model (Routine / Urgent / vacuum-local-suppress) with **2 tiers** in the shared notifier and move asleep-suppression out of the vacuum plugin into `notify`.

| Urgency | Asleep behavior | Use case |
|---|---|---|
| `UrgencyDeferable` (default) | suppress entirely; notifier returns `ErrSuppressedAsleep` | vacuum errors, presence arrivals |
| `UrgencyUrgent` | plays at `awake_volume_percent` regardless of sleep state | security, doorbell, broken-pipe alert, EV-charger safety, infra crashes |

## Why drop the middle "quieter while asleep" tier

Bedroom Sonos is always playing rain sounds while we sleep, so any TTS interrupt wakes the household regardless of volume — 30% TTS over rain is still TTS over rain. The mid-tier was fake protection. Every notification is binary: wakes you or doesn't. Pick a side per call.

## Why persistent-vs-transient justifies "drop and forget"

- **Persistent-state plugins** (vacuum errors, water-flow alerts, infra alerts): the underlying sensor stays in alarm. Plugin re-evaluates on its own cadence and re-fires the announcement until the state clears. After wake, the next tick makes it through. No buffering needed in `notify`.
- **Transient events** (presence "Nick is home", doorbell): fire once. If asleep → drop. By morning the event is stale; queueing a "Nick arrived 6h ago" announcement at wake-time would just be noise.

## Changes

**`internal/notify/`**
- New const `UrgencyDeferable` (replaces `UrgencyRoutine`); `UrgencyUrgent` unchanged.
- New sentinel `ErrSuppressedAsleep`.
- `Announce()` short-circuits before any HA service calls if `Deferable + isMasterAsleep`. No volume snapshot, no goroutine.
- Drop `AsleepVolumePercent` config field, default const, validation, init log field. Single volume tier = `awake_volume_percent`.

**`internal/plugins/vacuum/`**
- Drop `SuppressWhileMasterAsleep` config field.
- Drop plugin-local `MasterAsleepStateVar` const + `isMasterAsleep()` method.
- Pass `WithUrgency(UrgencyDeferable)` to notifier.
- React to `errors.Is(err, notify.ErrSuppressedAsleep)` by incrementing existing shadow `SuppressedWhileAsleepCount` and updating `lastAnnouncedAt` (preserves the 2h repeat-cadence invariant).

**Per-plugin urgency reclassification** (every `Announce` now passes `WithUrgency` explicitly so future readers can grep urgency directly):

| Plugin | Old | New |
|---|---|---|
| vacuum | Routine + plugin suppress | **Deferable** |
| statetracking arrivals | Routine | **Deferable** |
| waterflow "broken pipe" | Routine | **Urgent** |
| infrastructure | Routine | **Urgent** |
| evcharger | Urgent | Urgent |
| security | Urgent | Urgent |

**Configs**
- `configs/notification_config.yaml`: drop `asleep_volume_percent`, update header comment to describe the 2-tier model.
- `configs/vacuum_config.yaml`: drop `suppress_while_master_asleep` flag and its comment block.

## Test plan

- [x] `make pre-commit` clean
- [x] `make unit-tests` passes (overall coverage 74.6%)
- [x] `make integration-tests` passes (vacuum scenario test still validates suppression — now via real notifier returning `ErrSuppressedAsleep` instead of vacuum-local check)
- [x] `make pre-push` passes
- [ ] After deploy, Gravwell shows `Notifier initialized awake_volume_percent=20` (no `asleep_volume_percent` field)
- [ ] During next sleep cycle: `tag=home-automation grep "Announcement suppressed (master asleep)"` is logged by `logger=notify` (not `logger=vacuum` like today)
- [ ] Vacuum re-announces after wake on the next 2h tick

## Out of scope

- No buffering / wake-time replay of dropped Deferable announcements (transient events are stale; persistent state re-fires).
- No mute/unmute handling. Bedroom Sonos always plays rain sounds → mute isn't a reliable DND signal anyway, and we don't need to override it for Urgent.
- No rename of `awake_volume_percent` → `volume_percent` (defer; would touch every config + migration consideration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)