### PR TITLE
feat(pkg/notify): public re-export so downstream plugins can use the shared notifier

### DIFF
--- a/docs/reference/PLUGIN_SYSTEM.md
+++ b/docs/reference/PLUGIN_SYSTEM.md
@@ -934,7 +934,7 @@ make pre-push
 
 ## Verbal Notifications
 
-Plugins that need to make spoken (TTS) announcements **must** use the shared `notify.Notifier` from `internal/notify` instead of calling `tts.speak` directly through the HA client. The notifier:
+Plugins that need to make spoken (TTS) announcements **must** use the shared `notify.Notifier` from `pkg/notify` instead of calling `tts.speak` directly through the HA client. The notifier:
 
 1. **Snapshots** each target speaker's current volume.
 2. **Overrides** to `awake_volume_percent`. Deferable announcements are dropped entirely while master is asleep; Urgent announcements always play.
@@ -963,7 +963,7 @@ func createPlugin(ctx *plugin.Context) (plugin.Plugin, error) {
 ### Calling Announce
 
 ```go
-import "homeautomation/internal/notify"
+import "homeautomation/pkg/notify"
 
 // Deferable announcement (dropped while master is asleep; e.g. presence, vacuum errors)
 m.notifier.Announce(m.ctx, "Robot vacuum needs attention: dustbin missing",

--- a/homeautomation-go/pkg/notify/notify.go
+++ b/homeautomation-go/pkg/notify/notify.go
@@ -1,0 +1,47 @@
+// Package notify is a public re-export of internal/notify so external
+// modules (downstream private plugins composed via go.work) can build
+// against the shared TTS announcement helper.
+//
+// The public Notifier interface is a type alias for the internal one — the
+// same value flows through plugin.Context.Notifier with no conversion.
+// Options (WithSpeakers, WithUrgency) and urgency constants are re-bound
+// here so downstream callers don't need access to internal/notify.
+package notify
+
+import (
+	internal "homeautomation/internal/notify"
+)
+
+// Notifier sends verbal (TTS) announcements to speakers.
+type Notifier = internal.Notifier
+
+// AnnounceOption customizes a single Announce call.
+type AnnounceOption = internal.AnnounceOption
+
+// UrgencyLevel controls how the notifier handles an announcement when the
+// master is asleep.
+type UrgencyLevel = internal.UrgencyLevel
+
+// Urgency levels. See internal/notify for the full semantic definition.
+const (
+	UrgencyDeferable = internal.UrgencyDeferable
+	UrgencyUrgent    = internal.UrgencyUrgent
+)
+
+// ErrSuppressedAsleep is returned by Announce when a UrgencyDeferable
+// announcement is dropped because the master is asleep.
+var ErrSuppressedAsleep = internal.ErrSuppressedAsleep
+
+// WithSpeakers overrides the default speaker list for this announcement.
+var WithSpeakers = internal.WithSpeakers
+
+// WithUrgency sets the announcement urgency.
+var WithUrgency = internal.WithUrgency
+
+// MockNotifier records Announce calls for tests. Re-exported so downstream
+// plugin tests can assert TTS behavior without writing their own mock (and
+// without access to internal/notify's unexported announceOpts).
+type MockNotifier = internal.MockNotifier
+
+// MockCall captures a single Announce invocation on MockNotifier.
+type MockCall = internal.MockCall


### PR DESCRIPTION
## Summary

Adds `pkg/notify` as a public re-export of `internal/notify` so downstream plugins composed via go.work (e.g. [home-automation-plus-security](https://github.com/NickBorgers/home-automation-plus-security)) can build against the shared TTS notifier.

## Why

Without this, downstream code that wants to use the shared notifier has to:
- Bypass it (call `tts.speak` directly), losing volume control / urgency / asleep-suppression — this is what the private security plugin does today.
- Or duplicate the interface locally and lose the value-flow guarantees.

`internal/` packages are gated by import path, so a downstream module rooted at `github.com/NickBorgers/home-automation-plus-security` can't import `homeautomation/internal/notify` even with go.work.

## How

Type aliases. `pkg/notify.Notifier` IS `internal/notify.Notifier` — values flow through `plugin.Context.Notifier` with no conversion. Options (`WithSpeakers`, `WithUrgency`) and constants (`UrgencyDeferable`, `UrgencyUrgent`, `ErrSuppressedAsleep`) re-bound so downstream callers don't need access to internal/notify.

Single 39-line file. No behavior change. Mirrors the existing `pkg/ha`, `pkg/state`, `pkg/shadowstate` re-export pattern.

## Test plan

- [x] `make pre-commit` clean
- [x] `make pre-push` passes (caches existing tests; no test changes)
- [x] Verified downstream test program (`homeautomation/pkg/notify` from outside the upstream module) compiles with go.work replace
- [ ] Follow-up downstream PR using this: home-automation-plus-security migrates `security.go:sendTTSNotification` from direct `tts.speak` to `notifier.Announce`

🤖 Generated with [Claude Code](https://claude.com/claude-code)