### PR TITLE
Fix #1057: Add septic tank alarm monitoring

### DIFF
--- a/docs/human/VISUAL_ARCHITECTURE.md
+++ b/docs/human/VISUAL_ARCHITECTURE.md
@@ -968,6 +968,7 @@ graph LR
         WaterFlowPlugin[Water Flow Plugin<br/>Order: 71]
         EVChargerPlugin[EV Charger Safety Plugin<br/>Order: 5]
         VacuumPlugin[Robot Vacuum Plugin<br/>Order: 60]
+        InfrastructurePlugin[Infrastructure Plugin]
         ResetCoord[Reset Coordinator<br/>Order: 90]
     end
 
@@ -980,6 +981,7 @@ graph LR
         WaterFlowSensor[sensor.droplet_flow_rate]
         EVChargerSensors[binary_sensor.leaf_charger_*<br/>sensor.leaf_charger_*<br/>switch.leaf_charger]
         VacuumErrorSensor[sensor.valetudo_*_error]
+        SepticAlarmSensor[event.septic_alarm_going_off]
     end
 
     NickHome --> StateTracking
@@ -1089,6 +1091,9 @@ graph LR
 
     VacuumErrorSensor --> VacuumPlugin
     MasterAsleep --> VacuumPlugin
+
+    SepticAlarmSensor --> InfrastructurePlugin
+    InfrastructurePlugin -.->|Notifications| Ntfy
 
     Reset --> ResetCoord
     ResetCoord -.->|Reset| StateTracking

--- a/homeautomation-go/internal/plugins/infrastructure/manager.go
+++ b/homeautomation-go/internal/plugins/infrastructure/manager.go
@@ -89,6 +89,7 @@ type Manager struct {
 
 	// Septic alarm tracking
 	septicAlarmActive     bool      // Whether the physical alarm is currently sounding
+	septicAlarmNotified   bool      // Whether we sent a notification for the current alarm burst
 	lastAlarmNotification time.Time // Last time we sent an alarm notification (for cooldown)
 
 	// Thermostat state tracking
@@ -475,9 +476,13 @@ func (m *Manager) handleSepticAlarmEvent(entityID string, oldState, newState *ha
 		}
 		m.septicAlarmActive = true
 		inCooldown := !m.lastAlarmNotification.IsZero() && m.clock.Since(m.lastAlarmNotification) < SepticAlarmCooldown
-		if !inCooldown {
+		var sinceLastNotification time.Duration
+		if inCooldown {
+			sinceLastNotification = m.clock.Since(m.lastAlarmNotification)
+		} else {
 			m.lastAlarmNotification = now
 		}
+		m.septicAlarmNotified = !inCooldown
 		m.shadowTracker.UpdateSepticAlarmActive(now)
 		m.mu.Unlock()
 
@@ -486,17 +491,19 @@ func (m *Manager) handleSepticAlarmEvent(entityID string, oldState, newState *ha
 			m.sendSepticAlarmNotification()
 		} else {
 			m.logger.Debug("Septic alarm notification suppressed (cooldown)",
-				zap.Duration("since_last", m.clock.Since(m.lastAlarmNotification)))
+				zap.Duration("since_last", sinceLastNotification))
 		}
 
 	case "KeyReleased":
 		m.mu.Lock()
 		wasActive := m.septicAlarmActive
+		wasNotified := m.septicAlarmNotified
 		m.septicAlarmActive = false
+		m.septicAlarmNotified = false
 		m.shadowTracker.UpdateSepticAlarmCleared(now)
 		m.mu.Unlock()
 
-		if wasActive {
+		if wasActive && wasNotified {
 			m.logger.Info("Septic alarm cleared")
 			m.sendSepticAlarmRecoveryNotification()
 		}

--- a/homeautomation-go/internal/plugins/infrastructure/manager.go
+++ b/homeautomation-go/internal/plugins/infrastructure/manager.go
@@ -23,6 +23,9 @@ const (
 	// SepticSensorEntity is the Home Assistant entity for the septic system power sensor
 	SepticSensorEntity = "sensor.span_left_most_of_house_aerobic_septic_system_power"
 
+	// SepticAlarmEntity is the Z-Wave event entity for the physical septic alarm buzzer
+	SepticAlarmEntity = "event.septic_alarm_going_off"
+
 	// AeratorMinPowerW is the minimum power expected from the aerator (below = failure)
 	AeratorMinPowerW = 50.0
 
@@ -43,6 +46,9 @@ const (
 
 	// RepeatAlertCooldown prevents repeat alert spam
 	RepeatAlertCooldown = 4 * time.Hour
+
+	// SepticAlarmCooldown is the minimum time between septic alarm notifications
+	SepticAlarmCooldown = 30 * time.Minute
 )
 
 // Thermostat entity constants
@@ -80,6 +86,10 @@ type Manager struct {
 	lastRecoveryNotification time.Time // Last time we sent a recovery notification
 	isAeratorFailure         bool      // Currently in aerator failure state
 	isPumpStuck              bool      // Currently in pump stuck state
+
+	// Septic alarm tracking
+	septicAlarmActive     bool      // Whether the physical alarm is currently sounding
+	lastAlarmNotification time.Time // Last time we sent an alarm notification (for cooldown)
 
 	// Thermostat state tracking
 	wellHVACAction string // Current hvac_action for well thermostat
@@ -126,6 +136,11 @@ func (m *Manager) Start() error {
 	// Subscribe to the septic power sensor
 	if err := m.subHelper.SubscribeToEntity(SepticSensorEntity, m.handlePowerChange); err != nil {
 		return fmt.Errorf("failed to subscribe to septic power sensor: %w", err)
+	}
+
+	// Subscribe to the septic alarm event entity
+	if err := m.subHelper.SubscribeToEntity(SepticAlarmEntity, m.handleSepticAlarmEvent); err != nil {
+		return fmt.Errorf("failed to subscribe to septic alarm entity: %w", err)
 	}
 
 	// Subscribe to thermostat entities
@@ -437,6 +452,115 @@ func (m *Manager) sendTTSAnnouncement(message string) {
 	m.shadowTracker.RecordTTSAnnouncement(message)
 }
 
+// handleSepticAlarmEvent processes Z-Wave key events from the physical septic alarm sensor
+func (m *Manager) handleSepticAlarmEvent(entityID string, oldState, newState *ha.State) {
+	if newState == nil {
+		return
+	}
+
+	eventType, ok := newState.Attributes["event_type"].(string)
+	if !ok {
+		return
+	}
+
+	now := m.clock.Now()
+
+	switch eventType {
+	case "KeyPressed", "KeyHeldDown":
+		m.mu.Lock()
+		if m.septicAlarmActive {
+			// Already tracking this alarm burst — skip duplicate events
+			m.mu.Unlock()
+			return
+		}
+		m.septicAlarmActive = true
+		inCooldown := !m.lastAlarmNotification.IsZero() && m.clock.Since(m.lastAlarmNotification) < SepticAlarmCooldown
+		if !inCooldown {
+			m.lastAlarmNotification = now
+		}
+		m.shadowTracker.UpdateSepticAlarmActive(now)
+		m.mu.Unlock()
+
+		m.logger.Info("Septic alarm activated", zap.String("event_type", eventType))
+		if !inCooldown {
+			m.sendSepticAlarmNotification()
+		} else {
+			m.logger.Debug("Septic alarm notification suppressed (cooldown)",
+				zap.Duration("since_last", m.clock.Since(m.lastAlarmNotification)))
+		}
+
+	case "KeyReleased":
+		m.mu.Lock()
+		wasActive := m.septicAlarmActive
+		m.septicAlarmActive = false
+		m.shadowTracker.UpdateSepticAlarmCleared(now)
+		m.mu.Unlock()
+
+		if wasActive {
+			m.logger.Info("Septic alarm cleared")
+			m.sendSepticAlarmRecoveryNotification()
+		}
+	}
+}
+
+// sendSepticAlarmNotification sends ntfy + deferable TTS when the septic alarm fires
+func (m *Manager) sendSepticAlarmNotification() {
+	const message = "The septic tank alarm is going off. The tank may be full."
+
+	m.shadowTracker.RecordNotification("septic_alarm", message, "default")
+	m.shadowTracker.IncrementAlarmNotificationCount()
+
+	if m.ntfyClient != nil {
+		if err := m.ntfyClient.Send(&ntfy.Message{
+			Title:    "Septic Alarm",
+			Body:     message,
+			Priority: ntfy.PriorityDefault,
+			Tags:     []string{"warning", "toilet"},
+		}); err != nil {
+			m.logger.Error("Failed to send septic alarm notification", zap.Error(err))
+		} else {
+			m.logger.Info("Septic alarm notification sent")
+		}
+	} else {
+		m.logger.Warn("ntfy client not configured, cannot send septic alarm notification")
+	}
+
+	speakers := []string{
+		"media_player.bedroom",
+		"media_player.kitchen",
+		"media_player.dining_room",
+		"media_player.kids_bathroom",
+	}
+	if err := m.notifier.Announce(m.ctx, message,
+		notify.WithSpeakers(speakers),
+		notify.WithUrgency(notify.UrgencyDeferable),
+	); err != nil && err != notify.ErrSuppressedAsleep {
+		m.logger.Error("Failed to send septic alarm announcement", zap.Error(err))
+	} else if err == nil {
+		m.shadowTracker.RecordTTSAnnouncement(message)
+	}
+}
+
+// sendSepticAlarmRecoveryNotification sends ntfy when the septic alarm stops
+func (m *Manager) sendSepticAlarmRecoveryNotification() {
+	const message = "Septic alarm has stopped."
+
+	m.shadowTracker.RecordNotification("septic_alarm_cleared", message, "default")
+
+	if m.ntfyClient != nil {
+		if err := m.ntfyClient.Send(&ntfy.Message{
+			Title:    "Septic Alarm Cleared",
+			Body:     message,
+			Priority: ntfy.PriorityDefault,
+			Tags:     []string{"white_check_mark"},
+		}); err != nil {
+			m.logger.Error("Failed to send septic alarm recovery notification", zap.Error(err))
+		} else {
+			m.logger.Info("Septic alarm recovery notification sent")
+		}
+	}
+}
+
 // handleThermostatChange processes changes to thermostat entities
 func (m *Manager) handleThermostatChange(entityID string, oldState, newState *ha.State) {
 	if newState == nil {
@@ -568,6 +692,23 @@ func (m *Manager) sendThermostatNotification(alertType, message string, currentT
 // ============================================================================
 // Test Helpers - exported for testing only
 // ============================================================================
+
+// SimulateSepticAlarmEvent simulates a septic alarm event for testing
+func (m *Manager) SimulateSepticAlarmEvent(eventType string) {
+	newState := &ha.State{
+		EntityID:   SepticAlarmEntity,
+		State:      m.clock.Now().Format(time.RFC3339),
+		Attributes: map[string]interface{}{"event_type": eventType},
+	}
+	m.handleSepticAlarmEvent(SepticAlarmEntity, nil, newState)
+}
+
+// IsSepticAlarmActive returns whether the septic alarm is currently active for testing
+func (m *Manager) IsSepticAlarmActive() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.septicAlarmActive
+}
 
 // SimulatePowerReading simulates a power sensor reading for testing
 func (m *Manager) SimulatePowerReading(powerW float64) {

--- a/homeautomation-go/internal/plugins/infrastructure/manager_test.go
+++ b/homeautomation-go/internal/plugins/infrastructure/manager_test.go
@@ -600,6 +600,208 @@ func TestInfrastructureManager_NtfyClientNil(t *testing.T) {
 }
 
 // ============================================================================
+// Septic Alarm Tests
+// ============================================================================
+
+func TestSepticAlarm_KeyPressedSendsNotification(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := createTestManager(mockHA, mockNtfy, mockClock)
+
+	// Alarm fires
+	manager.SimulateSepticAlarmEvent("KeyPressed")
+
+	if !manager.IsSepticAlarmActive() {
+		t.Error("Expected alarm to be active after KeyPressed")
+	}
+	if count := countNtfyNotifications(mockNtfy); count != 1 {
+		t.Errorf("Expected 1 notification on KeyPressed, got %d", count)
+	}
+	msg := getLastNtfyNotification(mockNtfy)
+	if msg.Title != "Septic Alarm" {
+		t.Errorf("Expected title 'Septic Alarm', got '%s'", msg.Title)
+	}
+
+	// Verify shadow state
+	shadow := manager.GetShadowState()
+	if !shadow.Outputs.SepticAlarmStatus.IsActive {
+		t.Error("Expected SepticAlarmStatus.IsActive to be true")
+	}
+	if shadow.Outputs.SepticAlarmStatus.NotificationCount != 1 {
+		t.Errorf("Expected NotificationCount 1, got %d", shadow.Outputs.SepticAlarmStatus.NotificationCount)
+	}
+}
+
+func TestSepticAlarm_KeyHeldDownDebounced(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := createTestManager(mockHA, mockNtfy, mockClock)
+
+	// First event activates alarm
+	manager.SimulateSepticAlarmEvent("KeyPressed")
+	// Hundreds of held-down events should not send additional notifications
+	for i := 0; i < 100; i++ {
+		manager.SimulateSepticAlarmEvent("KeyHeldDown")
+	}
+
+	if count := countNtfyNotifications(mockNtfy); count != 1 {
+		t.Errorf("Expected exactly 1 notification despite 101 events, got %d", count)
+	}
+}
+
+func TestSepticAlarm_KeyReleasedClearsAlarm(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := createTestManager(mockHA, mockNtfy, mockClock)
+
+	manager.SimulateSepticAlarmEvent("KeyPressed")
+	manager.SimulateSepticAlarmEvent("KeyReleased")
+
+	if manager.IsSepticAlarmActive() {
+		t.Error("Expected alarm to be inactive after KeyReleased")
+	}
+	// Should have alarm notification + recovery notification
+	if count := countNtfyNotifications(mockNtfy); count != 2 {
+		t.Errorf("Expected 2 notifications (alarm + recovery), got %d", count)
+	}
+	msg := getLastNtfyNotification(mockNtfy)
+	if msg.Title != "Septic Alarm Cleared" {
+		t.Errorf("Expected title 'Septic Alarm Cleared', got '%s'", msg.Title)
+	}
+
+	// Verify shadow state
+	shadow := manager.GetShadowState()
+	if shadow.Outputs.SepticAlarmStatus.IsActive {
+		t.Error("Expected SepticAlarmStatus.IsActive to be false after cleared")
+	}
+	if shadow.Outputs.SepticAlarmStatus.LastCleared.IsZero() {
+		t.Error("Expected LastCleared to be set")
+	}
+}
+
+func TestSepticAlarm_CooldownPreventsRepeatNotification(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	startTime := time.Now()
+	mockClock := clock.NewMockClock(startTime)
+
+	manager := createTestManager(mockHA, mockNtfy, mockClock)
+
+	// First alarm fires and clears
+	manager.SimulateSepticAlarmEvent("KeyPressed")
+	manager.SimulateSepticAlarmEvent("KeyReleased")
+	firstCount := countNtfyNotifications(mockNtfy)
+
+	// Second alarm fires within cooldown — should not send alarm notification
+	mockClock.Advance(5 * time.Minute)
+	manager.SimulateSepticAlarmEvent("KeyPressed")
+
+	if count := countNtfyNotifications(mockNtfy); count != firstCount {
+		t.Errorf("Expected %d notifications (cooldown active), got %d", firstCount, count)
+	}
+}
+
+func TestSepticAlarm_NotifiesAfterCooldownExpires(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	startTime := time.Now()
+	mockClock := clock.NewMockClock(startTime)
+
+	manager := createTestManager(mockHA, mockNtfy, mockClock)
+
+	// First alarm
+	manager.SimulateSepticAlarmEvent("KeyPressed")
+	manager.SimulateSepticAlarmEvent("KeyReleased")
+	afterFirstAlarm := countNtfyNotifications(mockNtfy)
+
+	// Wait past cooldown
+	mockClock.Advance(31 * time.Minute)
+
+	// Second alarm should notify again
+	manager.SimulateSepticAlarmEvent("KeyPressed")
+
+	if count := countNtfyNotifications(mockNtfy); count <= afterFirstAlarm {
+		t.Errorf("Expected new notification after cooldown expired, got same count %d", count)
+	}
+	msg := getLastNtfyNotification(mockNtfy)
+	if msg.Title != "Septic Alarm" {
+		t.Errorf("Expected title 'Septic Alarm', got '%s'", msg.Title)
+	}
+}
+
+func TestSepticAlarm_KeyReleasedWithoutActiveAlarmNoRecovery(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := createTestManager(mockHA, mockNtfy, mockClock)
+
+	// KeyReleased with no prior alarm should not send recovery notification
+	manager.SimulateSepticAlarmEvent("KeyReleased")
+
+	if count := countNtfyNotifications(mockNtfy); count != 0 {
+		t.Errorf("Expected 0 notifications for spurious KeyReleased, got %d", count)
+	}
+}
+
+func TestSepticAlarm_ShadowStateTracking(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	mockClock := clock.NewMockClock(time.Now())
+
+	manager := createTestManager(mockHA, mockNtfy, mockClock)
+
+	// Initial state
+	shadow := manager.GetShadowState()
+	if shadow.Outputs.SepticAlarmStatus.IsActive {
+		t.Error("Expected alarm initially inactive")
+	}
+	if shadow.Outputs.SepticAlarmStatus.NotificationCount != 0 {
+		t.Errorf("Expected NotificationCount 0 initially, got %d", shadow.Outputs.SepticAlarmStatus.NotificationCount)
+	}
+
+	// After alarm
+	manager.SimulateSepticAlarmEvent("KeyPressed")
+	shadow = manager.GetShadowState()
+	if !shadow.Outputs.SepticAlarmStatus.IsActive {
+		t.Error("Expected alarm active after KeyPressed")
+	}
+	if shadow.Outputs.SepticAlarmStatus.LastDetected.IsZero() {
+		t.Error("Expected LastDetected to be set after KeyPressed")
+	}
+
+	// After cleared
+	manager.SimulateSepticAlarmEvent("KeyReleased")
+	shadow = manager.GetShadowState()
+	if shadow.Outputs.SepticAlarmStatus.IsActive {
+		t.Error("Expected alarm inactive after KeyReleased")
+	}
+	if shadow.Outputs.SepticAlarmStatus.LastCleared.IsZero() {
+		t.Error("Expected LastCleared to be set after KeyReleased")
+	}
+}
+
+// ============================================================================
 // Thermostat Monitoring Tests
 // ============================================================================
 

--- a/homeautomation-go/internal/plugins/infrastructure/manager_test.go
+++ b/homeautomation-go/internal/plugins/infrastructure/manager_test.go
@@ -762,6 +762,32 @@ func TestSepticAlarm_KeyReleasedWithoutActiveAlarmNoRecovery(t *testing.T) {
 	}
 }
 
+func TestSepticAlarm_CooldownReleaseNoRecoveryNotification(t *testing.T) {
+	t.Parallel()
+
+	mockHA := ha.NewMockClient()
+	mockNtfy := ntfy.NewMockClient()
+	startTime := time.Now()
+	mockClock := clock.NewMockClock(startTime)
+
+	manager := createTestManager(mockHA, mockNtfy, mockClock)
+
+	// First alarm fires and clears (establishes cooldown)
+	manager.SimulateSepticAlarmEvent("KeyPressed")
+	manager.SimulateSepticAlarmEvent("KeyReleased")
+	afterFirstCycle := countNtfyNotifications(mockNtfy) // alarm + recovery = 2
+
+	// Second alarm fires within cooldown — notification suppressed
+	mockClock.Advance(5 * time.Minute)
+	manager.SimulateSepticAlarmEvent("KeyPressed")
+	// Alarm clears — should NOT send recovery because no alarm notification was sent
+	manager.SimulateSepticAlarmEvent("KeyReleased")
+
+	if count := countNtfyNotifications(mockNtfy); count != afterFirstCycle {
+		t.Errorf("Expected no new notifications when alarm was suppressed by cooldown, got %d extra", count-afterFirstCycle)
+	}
+}
+
 func TestSepticAlarm_ShadowStateTracking(t *testing.T) {
 	t.Parallel()
 

--- a/homeautomation-go/internal/shadowstate/tracker.go
+++ b/homeautomation-go/internal/shadowstate/tracker.go
@@ -1862,6 +1862,32 @@ func (it *InfrastructureTracker) UpdateBarnThermostat(state ThermostatState) {
 	it.State().Metadata.LastUpdated = time.Now()
 }
 
+// UpdateSepticAlarmActive marks the septic alarm as active with the detection time
+func (it *InfrastructureTracker) UpdateSepticAlarmActive(detected time.Time) {
+	it.Lock()
+	defer it.Unlock()
+	it.state.Outputs.SepticAlarmStatus.IsActive = true
+	it.state.Outputs.SepticAlarmStatus.LastDetected = detected
+	it.state.Metadata.LastUpdated = time.Now()
+}
+
+// UpdateSepticAlarmCleared marks the septic alarm as cleared
+func (it *InfrastructureTracker) UpdateSepticAlarmCleared(cleared time.Time) {
+	it.Lock()
+	defer it.Unlock()
+	it.state.Outputs.SepticAlarmStatus.IsActive = false
+	it.state.Outputs.SepticAlarmStatus.LastCleared = cleared
+	it.state.Metadata.LastUpdated = time.Now()
+}
+
+// IncrementAlarmNotificationCount increments the septic alarm notification counter
+func (it *InfrastructureTracker) IncrementAlarmNotificationCount() {
+	it.Lock()
+	defer it.Unlock()
+	it.state.Outputs.SepticAlarmStatus.NotificationCount++
+	it.state.Metadata.LastUpdated = time.Now()
+}
+
 // GetState returns the current shadow state (thread-safe copy)
 func (it *InfrastructureTracker) GetState() *InfrastructureShadowState {
 	it.RLock()
@@ -1875,6 +1901,7 @@ func (it *InfrastructureTracker) GetState() *InfrastructureShadowState {
 		},
 		Outputs: InfrastructureOutputs{
 			SepticSystemStatus: s.Outputs.SepticSystemStatus,
+			SepticAlarmStatus:  s.Outputs.SepticAlarmStatus,
 			ThermostatStatus:   s.Outputs.ThermostatStatus,
 			ActiveAlerts:       make([]InfrastructureAlert, len(s.Outputs.ActiveAlerts)),
 			LastUpdate:         s.Outputs.LastUpdate,

--- a/homeautomation-go/internal/shadowstate/types.go
+++ b/homeautomation-go/internal/shadowstate/types.go
@@ -923,11 +923,20 @@ type LowBatteryAlert struct {
 // InfrastructureOutputs tracks septic system state and alerts
 type InfrastructureOutputs struct {
 	SepticSystemStatus  SepticSystemStatus          `json:"septicSystemStatus"`
+	SepticAlarmStatus   SepticAlarmStatus           `json:"septicAlarmStatus"`
 	ThermostatStatus    ThermostatStatus            `json:"thermostatStatus"`
 	ActiveAlerts        []InfrastructureAlert       `json:"activeAlerts,omitempty"`
 	LastNotification    *InfrastructureNotification `json:"lastNotification,omitempty"`
 	LastTTSAnnouncement *InfrastructureTTS          `json:"lastTTSAnnouncement,omitempty"`
 	LastUpdate          time.Time                   `json:"lastUpdate"`
+}
+
+// SepticAlarmStatus tracks the physical septic alarm sensor state
+type SepticAlarmStatus struct {
+	IsActive          bool      `json:"isActive"`
+	LastDetected      time.Time `json:"lastDetected,omitempty"`
+	LastCleared       time.Time `json:"lastCleared,omitempty"`
+	NotificationCount int       `json:"notificationCount"`
 }
 
 // ThermostatStatus tracks the current state of monitored thermostats


### PR DESCRIPTION
Resolves #1057

## Summary

- Subscribes to `event.septic_alarm_going_off` (Z-Wave key event entity) in the infrastructure plugin
- On `KeyPressed` or `KeyHeldDown`: marks alarm active, sends ntfy notification + deferable TTS (suppressed when asleep)
- On `KeyReleased`: clears alarm state, sends ntfy recovery notification (no TTS)
- Rate-limited: one notification per activation, 30-minute cooldown between activations
- `KeyHeldDown` bursts (~5/sec) are debounced — only the first event per activation triggers notification
- Shadow state tracks `isActive`, `lastDetected`, `lastCleared`, `notificationCount` for observability at `/api/shadow/infrastructure`

## Test Plan

- `TestSepticAlarm_KeyPressedSendsNotification` — first KeyPressed sends ntfy with correct title
- `TestSepticAlarm_KeyHeldDownDebounced` — 101 events produce exactly 1 notification
- `TestSepticAlarm_KeyReleasedClearsAlarm` — KeyReleased clears state and sends recovery ntfy
- `TestSepticAlarm_CooldownPreventsRepeatNotification` — second alarm within 30 min is suppressed
- `TestSepticAlarm_NotifiesAfterCooldownExpires` — second alarm after 31 min does notify
- `TestSepticAlarm_KeyReleasedWithoutActiveAlarmNoRecovery` — spurious KeyReleased sends nothing
- `TestSepticAlarm_ShadowStateTracking` — shadow state fields updated correctly

All unit tests pass (74.6% coverage).

🤖 Generated by the AI assistant