### PR TITLE
fix(ci): route ai-assistant through composite action and add inner timeout

### DIFF
--- a/.github/actions/run-ci-agent/action.yml
+++ b/.github/actions/run-ci-agent/action.yml
@@ -160,7 +160,12 @@ runs:
               source /tmp/ci-agent-pre-script.sh
             fi
             PROMPT=$(envsubst < "$CI_AGENT_PROMPT_FILE")
-            bash .devcontainer/run-ai.sh "$PROMPT" 2>&1 \
+            # Inner timeout sits below the typical 120-min workflow job
+            # timeout so SIGTERM fires first, letting `tee` flush a partial
+            # conversation log before the runner host kills the container.
+            # `timeout` exits 124 on TERM hit — distinguishable from a host
+            # OOM SIGKILL (exit 137), which leaves no diagnostic.
+            timeout 90m bash .devcontainer/run-ai.sh "$PROMPT" 2>&1 \
               | tee "$CI_AGENT_OUTPUT_FILE"
           '
 

--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -171,60 +171,32 @@ jobs:
           echo "Waiting 5 minutes for issue to be refined before ingesting..."
           sleep 300
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull CI image
-        run: docker pull "${CI_IMAGE}"
-
       - name: Resolve issue with AI assistant
-        env:
-          AI_API_KEY: ${{ vars.AI_API_KEY }}
-          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_TITLE: ${{ github.event.issue.title }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          OUTPUT_DIR="${{ runner.temp }}/resolve-output"
-          mkdir -p "$OUTPUT_DIR"
-
-          docker run --rm \
-            --network host \
-            --workdir /workspace \
-            -v "${{ github.workspace }}:/workspace" \
-            -v "$OUTPUT_DIR:/tmp/resolve-output" \
-            -e AI_API_KEY \
-            -e GH_TOKEN \
-            -e ISSUE_NUMBER \
-            -e ISSUE_TITLE \
-            -e REPO \
-            "${CI_IMAGE}" \
-            -lc '
-              set -euo pipefail
-              source .devcontainer/configure-ai.sh
-
-              # Fetch issue body and comments via API; export into env for
-              # envsubst expansion against the prompt template.
-              ISSUE_BODY=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq ".body")
-              ISSUE_COMMENTS=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
-                --jq ".[] | \"---\n**\(.user.login)** commented at \(.created_at):\n\(.body)\n\"" 2>/dev/null \
-                | head -c 50000 || echo "")
-              export ISSUE_BODY ISSUE_COMMENTS
-
-              PROMPT=$(envsubst < .github/ci/prompts/resolve-issue.md)
-              bash .devcontainer/run-ai.sh "$PROMPT" 2>&1 \
-                | tee /tmp/resolve-output/resolve-issue-conversation.jsonl
-            '
+        uses: ./.github/actions/run-ci-agent
+        with:
+          image: ${{ env.CI_IMAGE }}
+          prompt_file: .github/ci/prompts/resolve-issue.md
+          output_file: ${{ github.workspace }}/resolve-issue-conversation.jsonl
+          env: |
+            AI_API_KEY=${{ vars.AI_API_KEY }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
+            ISSUE_NUMBER=${{ github.event.issue.number }}
+            ISSUE_TITLE=${{ github.event.issue.title }}
+            REPO=${{ github.repository }}
+          # Fetch issue body and comments inside the container (gh is on PATH
+          # there with GH_TOKEN already injected via --env-file). The exported
+          # vars are picked up by envsubst when it expands the prompt template.
+          pre_script: |
+            ISSUE_BODY=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '.body')
+            ISSUE_COMMENTS=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+              --jq '.[] | "---\n**\(.user.login)** commented at \(.created_at):\n\(.body)\n"' 2>/dev/null \
+              | head -c 50000 || echo "")
+            export ISSUE_BODY ISSUE_COMMENTS
 
       - name: Upload issue resolution conversation log
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: resolve-issue-conversation-log
-          path: ${{ runner.temp }}/resolve-output/resolve-issue-conversation.jsonl
+          path: ${{ github.workspace }}/resolve-issue-conversation.jsonl
           retention-days: 7


### PR DESCRIPTION
## Summary
- Re-uses the existing `./.github/actions/run-ci-agent` composite action for the issue-resolution job, fixing the bind-mount permission bug that was discarding conversation logs (`tee: /tmp/resolve-output/...: Permission denied`).
- Wraps the in-container `bash run-ai.sh "$PROMPT"` call with `timeout 90m` so a runaway agent gets SIGTERM (exit 124) below the 120-min job timeout. `tee` flushes a partial log instead of dying silently as exit 137 — fixes the diagnostic blackout we hit on run [25289252722](https://github.com/NickBorgers/home-automation/actions/runs/25289252722).

## Why
On the dockergeneric self-hosted runner, the runner user (UID 1001) and the CI image's `ci` user (UID 1000) don't match. The inline `docker run` was bind-mounting an `OUTPUT_DIR` created via plain `mkdir -p`, so `tee` from inside the container hit `Permission denied`. The composite action already solves this by staging the output dir under `$RUNNER_TEMP/ci-agent-output/<unique>/` with `chmod 777` (and ensures host-visibility for the dockergeneric daemon). `home-automation-plus-security` already routes through the same action; this PR brings home-automation in line.

`hide-my-list` does the same thing (its `review-claude-run` action pre-creates the output dir with `chmod 777` and wraps the inner claude call with `timeout 30m`). This PR adopts that combined pattern.

## Changes
- `.github/workflows/ai-assistant.yml` — replaces the inline `docker run` + GHCR login + image pull + `OUTPUT_DIR` setup with a single `uses: ./.github/actions/run-ci-agent` step. Issue body/comments fetch moves to the composite action's `pre_script:` input. Net: -50 / +27 lines.
- `.github/actions/run-ci-agent/action.yml` — wraps the inner `bash run-ai.sh` call with `timeout 90m`.

## Test plan
- [ ] After merge, re-fire issue #1054 by removing its `ai-started` label (the workflow's `unlabeled` retry path).
- [ ] Confirm the workflow logs no longer contain `tee: ...: Permission denied`.
- [ ] Confirm the `resolve-issue-conversation-log` artifact uploads with non-zero size on both the success and timeout paths.
- [ ] If a future run hits the 90-min wall, the exit code should be 124 with a partial log present, not exit 137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)