### PR TITLE
fix(ci): preserve partial log on agent timeout/crash

### DIFF
--- a/.github/actions/run-ci-agent/action.yml
+++ b/.github/actions/run-ci-agent/action.yml
@@ -142,6 +142,16 @@ runs:
         # Mount the pre-script into a known path inside the container; the
         # wrapper below sources it so any vars it exports are visible to
         # envsubst.
+        #
+        # Capture the docker exit code instead of letting `set -e` abort
+        # this step — on a non-zero exit (timeout's 124, SIGKILL's 137,
+        # an agent crash) we still need to copy the staged log to the
+        # caller-requested path so upload-artifact has something to grab.
+        # Without this, the partial conversation log `tee` flushed inside
+        # the container is stranded at $STAGED_OUTPUT_FILE and the artifact
+        # upload finds nothing — exactly the diagnostic blackout the
+        # 90-min inner timeout was meant to prevent.
+        DOCKER_EXIT=0
         docker run --rm \
           --network host \
           --workdir /workspace \
@@ -167,7 +177,7 @@ runs:
             # OOM SIGKILL (exit 137), which leaves no diagnostic.
             timeout 90m bash .devcontainer/run-ai.sh "$PROMPT" 2>&1 \
               | tee "$CI_AGENT_OUTPUT_FILE"
-          '
+          ' || DOCKER_EXIT=$?
 
         # Copy the staged output back to the caller-requested path so
         # their upload-artifact step reads it from the same path they
@@ -179,6 +189,8 @@ runs:
           cp "$STAGED_OUTPUT_FILE" "$CI_AGENT_OUTPUT_FILE"
         fi
         rm -rf "$OUTPUT_STAGING_DIR"
+
+        exit "$DOCKER_EXIT"
 
     - name: Clean up staged files
       if: always()

--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -176,7 +176,7 @@ jobs:
         with:
           image: ${{ env.CI_IMAGE }}
           prompt_file: .github/ci/prompts/resolve-issue.md
-          output_file: ${{ github.workspace }}/resolve-issue-conversation.jsonl
+          output_file: ${{ runner.temp }}/resolve-issue-conversation.jsonl
           env: |
             AI_API_KEY=${{ vars.AI_API_KEY }}
             GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
@@ -198,5 +198,5 @@ jobs:
         if: always()
         with:
           name: resolve-issue-conversation-log
-          path: ${{ github.workspace }}/resolve-issue-conversation.jsonl
+          path: ${{ runner.temp }}/resolve-issue-conversation.jsonl
           retention-days: 7


### PR DESCRIPTION
## Summary
Code review on #1059 caught a bug in that PR's stated goal: the `timeout 90m` wrap was supposed to let `tee` flush a partial log before the host kills the container, but the outer `set -euo pipefail` aborts the step on docker's non-zero exit *before* the staged log gets copied to the caller's `output_file` path. The artifact upload step (`if: always()`) then finds nothing.

Net effect of #1059 alone: same diagnostic blackout as before, just at exit 124/137 instead of nowhere.

## Fix
- Capture the docker exit code with `|| DOCKER_EXIT=$?` so the cp/cleanup always runs.
- Re-exit with the captured code at the end so step status still reflects agent success/failure.
- Bonus: move the workflow's `output_file` from `${{ github.workspace }}/...` to `${{ runner.temp }}/...`, restoring the pre-refactor placement so the log doesn't sit in the checkout tree (also flagged in the same review under \"Worth Considering\").

## Test plan
- [ ] After merge, re-fire issue #1054 by unlabeling `ai-started`.
- [ ] On the success path, `resolve-issue-conversation-log` artifact should still upload as it does today.
- [ ] On a synthetic 90-min timeout (or any agent crash), the artifact should now contain the partial JSONL stream up to the kill point — exit code in the workflow log should be 124 (timeout) or the agent's own non-zero exit, not the silent 137 we hit on run [25289252722](https://github.com/NickBorgers/home-automation/actions/runs/25289252722).

Credit to the Code Review reviewer on #1059 for catching this — the partial-log goal was the whole point of the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)