### PR TITLE
feat(ci): switch resolve-issue to codex; expose model as env var

### DIFF
--- a/.devcontainer/configure-ai.sh
+++ b/.devcontainer/configure-ai.sh
@@ -36,10 +36,15 @@ case "$AI_TOOL" in
     # `@users.noreply.github.com`.
     AI_GIT_NAME_DEFAULT="codex[bot]"
     AI_GIT_EMAIL_DEFAULT="codex-bot@ci.invalid"
-    # Codex reads its provider config from ~/.codex/config.toml.
+    # Codex reads its provider config from ~/.codex/config.toml. The model
+    # is settable per-workflow via the CODEX_MODEL env var (passed through
+    # the run-ci-agent composite action's env-file plumbing). Falling back
+    # to the default lets local devcontainer use work without a workflow
+    # context.
+    CODEX_MODEL="${CODEX_MODEL:-gpt-5.5}"
     mkdir -p "$HOME/.codex"
     cat > "$HOME/.codex/config.toml" <<EOF
-model = "gpt-5-codex"
+model = "${CODEX_MODEL}"
 model_provider = "litellm"
 
 [model_providers.litellm]

--- a/.devcontainer/configure-ai.sh
+++ b/.devcontainer/configure-ai.sh
@@ -39,7 +39,7 @@ case "$AI_TOOL" in
     # Codex reads its provider config from ~/.codex/config.toml. The model
     # is settable per-workflow via the CODEX_MODEL env var (passed through
     # the run-ci-agent composite action's env-file plumbing). Falling back
-    # to the default lets local devcontainer use work without a workflow
+    # to the default lets local devcontainer work without a workflow
     # context.
     CODEX_MODEL="${CODEX_MODEL:-gpt-5.5}"
     mkdir -p "$HOME/.codex"

--- a/.devcontainer/run-ai.sh
+++ b/.devcontainer/run-ai.sh
@@ -34,7 +34,7 @@ case "$AI_TOOL" in
     exec claude -p \
       --dangerously-skip-permissions \
       --permission-mode=bypassPermissions \
-      --model claude-sonnet-4-6 \
+      --model "${CLAUDE_MODEL:-claude-sonnet-4-6}" \
       "$PROMPT"
     ;;
   codex)

--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -183,6 +183,8 @@ jobs:
             ISSUE_NUMBER=${{ github.event.issue.number }}
             ISSUE_TITLE=${{ github.event.issue.title }}
             REPO=${{ github.repository }}
+            AI_TOOL=codex
+            CODEX_MODEL=gpt-5.5
           # Fetch issue body and comments inside the container (gh is on PATH
           # there with GH_TOKEN already injected via --env-file). The exported
           # vars are picked up by envsubst when it expands the prompt template.

--- a/docs/operations/AI_GHA_PIPELINES.md
+++ b/docs/operations/AI_GHA_PIPELINES.md
@@ -739,15 +739,16 @@ gh workflow run "AI Code Review" \
 
 ### Model Selection
 
-Most pipeline jobs invoke Claude Code CLI with `claude-sonnet-4-6` via the self-hosted LiteLLM Anthropic-compatible passthrough; the `resolve-issue` job uses Codex with `gpt-5.5`.
+Most pipelines invoke Claude Code CLI with `claude-sonnet-4-6` via the self-hosted LiteLLM Anthropic-compatible passthrough. The `resolve-issue` job in `ai-assistant.yml` is the exception — it runs the Codex CLI against `gpt-5.5` via the LiteLLM OpenAI-compatible passthrough.
 
-| Pipeline/Job | Model | Rationale |
-|-------------|-------|-----------|
-| `ai-assistant.yml` — interactive (`/autoresolve`) | `claude-sonnet-4-6` | Open-ended implementation and repo changes |
-| `ai-assistant.yml` — `resolve-issue` | `gpt-5.5` (Codex, via `CODEX_MODEL`) | Issue resolution |
-| `ai-code-review.yml` review and merge jobs | `claude-sonnet-4-6` | Consistent review quality across the pipeline |
-| `ai-diagnose-workflow-failure.yml` | `claude-sonnet-4-6` | Failure triage and classification |
-| `ha-deprecation-check.yml` | `claude-sonnet-4-6` | Release-note scanning and issue creation |
+The model for each path is overridable per-workflow via env vars passed into the run-ci-agent composite action: `CODEX_MODEL` (codex path) and `CLAUDE_MODEL` (claude path). Defaults live in `.devcontainer/configure-ai.sh` (codex) and `.devcontainer/run-ai.sh` (claude).
+
+| Pipeline/Job | Tool | Model | Rationale |
+|-------------|------|-------|-----------|
+| `ai-assistant.yml` resolve-issue | codex | `gpt-5.5` | Issue resolution; uses Codex per cross-repo alignment |
+| `ai-code-review.yml` review and merge jobs | claude | `claude-sonnet-4-6` | Consistent review quality across the pipeline |
+| `ai-diagnose-workflow-failure.yml` | claude | `claude-sonnet-4-6` | Failure triage and classification |
+| `ha-deprecation-check.yml` | claude | `claude-sonnet-4-6` | Release-note scanning and issue creation |
 
 The workflow display names are `AI Assistant`, `AI Code Review`, and `AI Diagnose Workflow Failure`, with filenames `ai-assistant.yml`, `ai-code-review.yml`, and `ai-diagnose-workflow-failure.yml`. Plumbing is tool-agnostic so the underlying CLI can be swapped without renaming anything.
 

--- a/docs/operations/AI_GHA_PIPELINES.md
+++ b/docs/operations/AI_GHA_PIPELINES.md
@@ -739,11 +739,12 @@ gh workflow run "AI Code Review" \
 
 ### Model Selection
 
-The pipelines currently invoke Claude Code CLI with `claude-sonnet-4-6` via the self-hosted LiteLLM Anthropic-compatible passthrough.
+Most pipeline jobs invoke Claude Code CLI with `claude-sonnet-4-6` via the self-hosted LiteLLM Anthropic-compatible passthrough; the `resolve-issue` job uses Codex with `gpt-5.5`.
 
 | Pipeline/Job | Model | Rationale |
 |-------------|-------|-----------|
-| `ai-assistant.yml` interactive and issue resolution | `claude-sonnet-4-6` | Open-ended implementation and repo changes |
+| `ai-assistant.yml` — interactive (`/autoresolve`) | `claude-sonnet-4-6` | Open-ended implementation and repo changes |
+| `ai-assistant.yml` — `resolve-issue` | `gpt-5.5` (Codex, via `CODEX_MODEL`) | Issue resolution |
 | `ai-code-review.yml` review and merge jobs | `claude-sonnet-4-6` | Consistent review quality across the pipeline |
 | `ai-diagnose-workflow-failure.yml` | `claude-sonnet-4-6` | Failure triage and classification |
 | `ha-deprecation-check.yml` | `claude-sonnet-4-6` | Release-note scanning and issue creation |
@@ -752,11 +753,23 @@ The workflow display names are `AI Assistant`, `AI Code Review`, and `AI Diagnos
 
 ### Swapping the Backing AI Tool
 
-The pipelines route every CLI invocation through `.devcontainer/run-ai.sh`, which reads `.devcontainer/ai-tool.env` to decide which tool to actually run. Swapping between supported tools is a one-file change:
+The pipelines route every CLI invocation through `.devcontainer/run-ai.sh`, which reads `.devcontainer/ai-tool.env` to decide which tool to actually run. There are two ways to swap the tool:
+
+**Global swap (all jobs):** A one-file change to `ai-tool.env`:
 
 1. Edit `.devcontainer/ai-tool.env` and change `AI_TOOL` to the desired value (currently `claude` or `codex`). The `AI_BASE_URL` for that tool is selected automatically by the `case` block in the same file.
 2. If the new tool needs a different API key, update the `ANTHROPIC_API_KEY` secret value in GitHub Actions settings — the secret name is kept for historical reasons, but the value can hold whatever key the new tool needs. (Workflow env blocks map it to a generic `AI_API_KEY` that `run-ai.sh` re-exports under the tool-specific env var name.)
 3. Rebuild the devcontainer image once so the next CI run picks up the new `ai-tool.env`.
+
+**Per-job override (individual jobs only):** Individual jobs can override the tool and model by injecting variables into the workflow's `env-file` block. For example, to run a specific job with Codex at a particular model version:
+
+```yaml
+env-file: |
+  AI_TOOL=codex
+  CODEX_MODEL=gpt-5.5
+```
+
+The equivalent override for Claude is `AI_TOOL=claude` with `CLAUDE_MODEL=claude-sonnet-4-6`. These env vars are picked up by `configure-ai.sh` (which writes the tool-specific on-disk config) and `run-ai.sh` (which selects the right CLI invocation). Per-job overrides take precedence over the global `ai-tool.env` defaults.
 
 What each script does on a swap:
 


### PR DESCRIPTION
## Summary
- Resolve-issue (`ai-assistant.yml`) now invokes codex instead of claude. Live observation on the previous run showed `AI pipeline configured: AI_TOOL=claude (bot identity: claude[bot])` — that was the default coming from `.devcontainer/ai-tool.env:13`.
- Codex model is now settable per-workflow via `CODEX_MODEL` env var (default `gpt-5.5`), mirroring hide-my-list's `CODEX_MODEL_DEFAULT` pattern in `configure-codex.sh:18`.
- Symmetric `CLAUDE_MODEL` env support added to `run-ai.sh` for the claude path (default unchanged: `claude-sonnet-4-6`).

## Why
Step 1 of a cross-repo alignment pass that:
1. Makes resolve-issue use codex on all 3 repos (only ha was wrong).
2. Exposes the model as a workflow-level env var so future bumps are a one-line workflow change.

`home-automation-plus-security` and `hide-my-list` already run codex for resolve-issue. Sibling PRs follow this one for the model-as-variable cleanup in those repos.

## Scope
**Only resolve-issue is affected.** The 3 other ha workflows that share `run-ai.sh` (ai-code-review, ai-diagnose-workflow-failure, ha-deprecation-check) keep their `AI_TOOL=claude` default from `ai-tool.env` — no change to those.

## Test plan
- [ ] After merge, re-fire issue #1054 (remove `ai-started` label).
- [ ] Workflow log should now contain `AI pipeline configured: AI_TOOL=codex (bot identity: codex[bot])` from `configure-ai.sh:73`.
- [ ] Resulting PR body should be authored by `codex[bot]`, not `claude[bot]`.
- [ ] `~/.codex/config.toml` inside the container should show `model = "gpt-5.5"`.
- [ ] Sanity-check: a subsequent `ai-code-review.yml` run on a non-resolve-issue PR should still log `AI_TOOL=claude` — confirming we only flipped the resolve-issue path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)