### PR TITLE
Fix #995: Add departure debounce for isAnyoneHome

### DIFF
--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -599,7 +599,7 @@ The system includes a **ComputedStateRegistry** for managing derived state varia
 | Variable | Formula | Dependencies |
 |----------|---------|--------------|
 | `isAnyOwnerHome` | `isNickHome OR isCarolineHome` | isNickHome, isCarolineHome |
-| `isAnyoneHome` | `isAnyOwnerHome OR isAssistantHere` | isAnyOwnerHome, isAssistantHere |
+| `isAnyoneHome` | `isAnyOwnerHome OR isAssistantHere` (departure debounced 5 min) | isAnyOwnerHome, isAssistantHere |
 | `isAnyoneAsleep` | `isMasterAsleep OR isGuestAsleep` | isMasterAsleep, isGuestAsleep |
 | `isEveryoneAsleep` | `isMasterAsleep AND isGuestAsleep` | isMasterAsleep, isGuestAsleep |
 | `isAnyoneHomeAndAwake` | `(isAnyOwnerHome && !isAnyoneAsleep) \|\| isAssistantHere \|\| wakeSequenceLatch` | isAnyOwnerHome, isAnyoneAsleep, isAssistantHere, isWakeSequenceActive |

--- a/docs/flows/STATE_TRACKING.md
+++ b/docs/flows/STATE_TRACKING.md
@@ -23,23 +23,31 @@ flowchart TD
         guest["isGuestAsleep"]
     end
 
-    subgraph Derived["Derived States"]
+    subgraph Presence["Presence Derived States"]
         anyOwner["isAnyOwnerHome<br/>= Nick OR Caroline"]
+        departureDebounce["Departure Debounce<br/>5 min (issue #995)"]
         anyone["isAnyoneHome<br/>= anyOwner OR Assistant"]
+    end
+
+    subgraph Sleep["Sleep Derived States"]
         anyAsleep["isAnyoneAsleep<br/>= Master OR Guest"]
         everyAsleep["isEveryoneAsleep<br/>= Master AND Guest"]
     end
 
     nick --> anyOwner
     caroline --> anyOwner
-    anyOwner --> anyone
-    assistant --> anyone
+    anyOwner -->|"arrival: immediate"| anyone
+    anyOwner -->|"departure"| departureDebounce
+    assistant -->|"arrival: immediate"| anyone
+    assistant -->|"departure"| departureDebounce
+    departureDebounce -->|"5 min elapsed,<br/>still departed"| anyone
     master --> anyAsleep
     guest --> anyAsleep
     master --> everyAsleep
     guest --> everyAsleep
 
     style anyOwner fill:#3498db,color:#fff
+    style departureDebounce fill:#e67e22,color:#fff
     style anyone fill:#27ae60,color:#fff
     style anyAsleep fill:#6c5ce7,color:#fff
     style everyAsleep fill:#1a1a2e,color:#fff
@@ -263,7 +271,7 @@ flowchart TD
 | Variable | Formula | Description |
 |----------|---------|-------------|
 | `isAnyOwnerHome` | Nick OR Caroline | Any owner present |
-| `isAnyoneHome` | anyOwner OR Assistant | Anyone present |
+| `isAnyoneHome` | anyOwner OR Assistant (departures debounced 5 min) | Anyone present |
 | `isAnyoneAsleep` | Master OR Guest | Someone asleep |
 | `isEveryoneAsleep` | Master AND Guest | Everyone asleep |
 | `didOwnerJustReturnHome` | (tracked) | Owner arrived recently |

--- a/homeautomation-go/internal/plugins/statetracking/manager.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager.go
@@ -130,6 +130,7 @@ func (m *Manager) Start() error {
 
 	// Create and start the derived state helper
 	m.helper = state.NewDerivedStateHelper(m.stateManager, m.logger)
+	m.helper.SetClock(m.clock)
 
 	// Wire up callback to update shadow state when derived states are computed
 	m.helper.SetUpdateCallback(func(anyOwnerHome, anyoneHome, anyoneAsleep, everyoneAsleep bool) {

--- a/homeautomation-go/internal/state/computed_registry.go
+++ b/homeautomation-go/internal/state/computed_registry.go
@@ -6,8 +6,14 @@ import (
 	"sync"
 	"time"
 
+	"homeautomation/internal/clock"
+
 	"go.uber.org/zap"
 )
+
+// AnyoneHomeDepartureDebounceDelay is how long isAnyoneHome must remain false
+// before the computed output emits the departure.
+const AnyoneHomeDepartureDebounceDelay = 5 * time.Minute
 
 // UpdateMode defines how a computed state is updated
 type UpdateMode int
@@ -78,6 +84,10 @@ type ComputedStateRegistry struct {
 	providers map[string]*providerState
 	mu        sync.RWMutex
 	started   bool
+
+	clock                    clock.Clock
+	anyoneHomeDepartureMu    sync.Mutex
+	anyoneHomeDepartureTimer clock.Timer
 }
 
 // NewComputedStateRegistry creates a new computed state registry
@@ -86,6 +96,7 @@ func NewComputedStateRegistry(manager *Manager, logger *zap.Logger) *ComputedSta
 		manager:   manager,
 		logger:    logger.Named("computed-registry"),
 		providers: make(map[string]*providerState),
+		clock:     clock.NewRealClock(),
 	}
 }
 
@@ -261,6 +272,9 @@ func (r *ComputedStateRegistry) computeAndSet(provider *ComputedStateProvider) e
 		if !ok {
 			return fmt.Errorf("expected bool for %s, got %T", provider.Name, newValue)
 		}
+		if provider.Name == "isAnyoneHome" {
+			return r.setAnyoneHomeWithDepartureDebounce(provider, boolVal)
+		}
 		if err := r.manager.SetBool(provider.Name, boolVal); err != nil {
 			return fmt.Errorf("failed to set bool: %w", err)
 		}
@@ -292,6 +306,97 @@ func (r *ComputedStateRegistry) computeAndSet(provider *ComputedStateProvider) e
 	return nil
 }
 
+func (r *ComputedStateRegistry) setAnyoneHomeWithDepartureDebounce(
+	provider *ComputedStateProvider,
+	newValue bool,
+) error {
+	if newValue {
+		r.cancelAnyoneHomeDepartureDebounce()
+		if err := r.manager.SetBool(provider.Name, true); err != nil {
+			return fmt.Errorf("failed to set bool: %w", err)
+		}
+		if provider.OnComputed != nil {
+			provider.OnComputed(true)
+		}
+		return nil
+	}
+
+	currentValue, err := r.manager.GetBool(provider.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get current bool: %w", err)
+	}
+	if !currentValue {
+		if err := r.manager.SetBool(provider.Name, false); err != nil {
+			return fmt.Errorf("failed to set bool: %w", err)
+		}
+		if provider.OnComputed != nil {
+			provider.OnComputed(false)
+		}
+		return nil
+	}
+
+	r.anyoneHomeDepartureMu.Lock()
+	if r.anyoneHomeDepartureTimer != nil {
+		r.anyoneHomeDepartureMu.Unlock()
+		return nil
+	}
+	r.anyoneHomeDepartureTimer = r.clock.AfterFunc(AnyoneHomeDepartureDebounceDelay, func() {
+		r.finishAnyoneHomeDepartureDebounce(provider)
+	})
+	r.anyoneHomeDepartureMu.Unlock()
+
+	r.logger.Info("Started isAnyoneHome departure debounce",
+		zap.Duration("delay", AnyoneHomeDepartureDebounceDelay))
+	return nil
+}
+
+func (r *ComputedStateRegistry) cancelAnyoneHomeDepartureDebounce() {
+	r.anyoneHomeDepartureMu.Lock()
+	defer r.anyoneHomeDepartureMu.Unlock()
+
+	if r.anyoneHomeDepartureTimer == nil {
+		return
+	}
+	r.anyoneHomeDepartureTimer.Stop()
+	r.anyoneHomeDepartureTimer = nil
+	r.logger.Info("Canceled isAnyoneHome departure debounce")
+}
+
+func (r *ComputedStateRegistry) finishAnyoneHomeDepartureDebounce(provider *ComputedStateProvider) {
+	r.anyoneHomeDepartureMu.Lock()
+	r.anyoneHomeDepartureTimer = nil
+	r.anyoneHomeDepartureMu.Unlock()
+
+	ctx := &ComputeContext{
+		manager: r.manager,
+		logger:  r.logger.Named(provider.Name),
+	}
+
+	value, err := provider.ComputeFunc(ctx)
+	if err != nil {
+		r.logger.Error("Failed to recompute after isAnyoneHome departure debounce",
+			zap.Error(err))
+		return
+	}
+	boolVal, ok := value.(bool)
+	if !ok {
+		r.logger.Error("Unexpected isAnyoneHome computed type",
+			zap.String("type", fmt.Sprintf("%T", value)))
+		return
+	}
+	if boolVal {
+		return
+	}
+	if err := r.manager.SetBool(provider.Name, false); err != nil {
+		r.logger.Error("Failed to emit debounced isAnyoneHome departure",
+			zap.Error(err))
+		return
+	}
+	if provider.OnComputed != nil {
+		provider.OnComputed(false)
+	}
+}
+
 // Stop stops all providers and cleans up subscriptions
 func (r *ComputedStateRegistry) Stop() {
 	r.mu.Lock()
@@ -309,6 +414,8 @@ func (r *ComputedStateRegistry) Stop() {
 
 // stopAllProviders stops all providers without locking
 func (r *ComputedStateRegistry) stopAllProviders() {
+	r.cancelAnyoneHomeDepartureDebounce()
+
 	// First, signal all periodic goroutines to stop
 	for _, ps := range r.providers {
 		if ps.stopChan != nil {

--- a/homeautomation-go/internal/state/computed_v2_test.go
+++ b/homeautomation-go/internal/state/computed_v2_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"homeautomation/internal/clock"
 	"homeautomation/internal/ha"
 	"homeautomation/internal/testlogger"
 
@@ -128,6 +129,98 @@ func TestSetupComputedStateV2_ReactsToDependencyChanges(t *testing.T) {
 
 	isAnyoneHomeAndAwake, _ := manager.GetBool("isAnyoneHomeAndAwake")
 	assert.True(t, isAnyoneHomeAndAwake, "isAnyoneHomeAndAwake should be true after Nick arrives")
+}
+
+func TestSetupComputedStateV2_DebouncesAnyoneHomeDeparture(t *testing.T) {
+	t.Parallel()
+	logger := testlogger.New()
+	mockClient := ha.NewMockClient()
+	mockClock := clock.NewMockClock(time.Date(2026, 4, 15, 4, 10, 3, 0, time.UTC))
+
+	mockClient.SetState("input_boolean.nick_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.caroline_home", "off", map[string]interface{}{})
+	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
+	mockClient.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.master_asleep", "off", map[string]interface{}{})
+	mockClient.SetState("input_boolean.guest_asleep", "off", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
+	mockClient.SetState("input_boolean.everyone_asleep", "off", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home_and_awake", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.wake_sequence_active", "off", map[string]interface{}{})
+	mockClient.Connect()
+
+	manager := NewManager(mockClient, logger, false)
+	require.NoError(t, manager.SyncFromHA())
+
+	registry := manager.GetComputedStateRegistry()
+	registry.clock = mockClock
+
+	require.NoError(t, manager.SetupComputedStateV2())
+	defer manager.StopComputedState()
+
+	value, err := manager.GetBool("isAnyoneHome")
+	require.NoError(t, err)
+	assert.True(t, value, "GIVEN: someone is home")
+
+	mockClient.SimulateStateChange("input_boolean.nick_home", "off")
+
+	value, err = manager.GetBool("isAnyoneHome")
+	require.NoError(t, err)
+	assert.True(t, value, "THEN: isAnyoneHome stays true during the departure debounce window")
+
+	mockClock.AdvanceAndProcess(AnyoneHomeDepartureDebounceDelay - time.Second)
+	value, err = manager.GetBool("isAnyoneHome")
+	require.NoError(t, err)
+	assert.True(t, value, "THEN: isAnyoneHome remains true before the full debounce delay elapses")
+
+	mockClock.AdvanceAndProcess(time.Second)
+	value, err = manager.GetBool("isAnyoneHome")
+	require.NoError(t, err)
+	assert.False(t, value, "THEN: isAnyoneHome emits false after the full debounce delay")
+}
+
+func TestSetupComputedStateV2_CancelsAnyoneHomeDepartureDebounceOnBounce(t *testing.T) {
+	t.Parallel()
+	logger := testlogger.New()
+	mockClient := ha.NewMockClient()
+	mockClock := clock.NewMockClock(time.Date(2026, 4, 15, 4, 10, 3, 0, time.UTC))
+
+	mockClient.SetState("input_boolean.nick_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.caroline_home", "off", map[string]interface{}{})
+	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
+	mockClient.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.master_asleep", "off", map[string]interface{}{})
+	mockClient.SetState("input_boolean.guest_asleep", "off", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
+	mockClient.SetState("input_boolean.everyone_asleep", "off", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home_and_awake", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.wake_sequence_active", "off", map[string]interface{}{})
+	mockClient.Connect()
+
+	manager := NewManager(mockClient, logger, false)
+	require.NoError(t, manager.SyncFromHA())
+
+	registry := manager.GetComputedStateRegistry()
+	registry.clock = mockClock
+
+	require.NoError(t, manager.SetupComputedStateV2())
+	defer manager.StopComputedState()
+
+	mockClient.SimulateStateChange("input_boolean.nick_home", "off")
+	mockClock.AdvanceAndProcess(85 * time.Second)
+
+	value, err := manager.GetBool("isAnyoneHome")
+	require.NoError(t, err)
+	assert.True(t, value, "THEN: a short departure does not emit isAnyoneHome=false")
+
+	mockClient.SimulateStateChange("input_boolean.nick_home", "on")
+	mockClock.AdvanceAndProcess(AnyoneHomeDepartureDebounceDelay)
+
+	value, err = manager.GetBool("isAnyoneHome")
+	require.NoError(t, err)
+	assert.True(t, value, "THEN: returning during the window cancels the pending false emission")
 }
 
 func TestSetupComputedStateV2_WakeSequenceLatch(t *testing.T) {

--- a/homeautomation-go/internal/state/helpers.go
+++ b/homeautomation-go/internal/state/helpers.go
@@ -1,6 +1,10 @@
 package state
 
 import (
+	"sync"
+
+	"homeautomation/internal/clock"
+
 	"go.uber.org/zap"
 )
 
@@ -13,10 +17,13 @@ type DerivedStatesCallback func(anyOwnerHome, anyoneHome, anyoneAsleep, everyone
 
 // DerivedStateHelper manages automatic computation of derived states
 type DerivedStateHelper struct {
-	manager  *Manager
-	logger   *zap.Logger
-	subs     []Subscription
-	onUpdate DerivedStatesCallback
+	manager                  *Manager
+	logger                   *zap.Logger
+	subs                     []Subscription
+	onUpdate                 DerivedStatesCallback
+	clock                    clock.Clock
+	anyoneHomeDepartureMu    sync.Mutex
+	anyoneHomeDepartureTimer clock.Timer
 }
 
 // NewDerivedStateHelper creates a new helper for managing derived states
@@ -25,7 +32,13 @@ func NewDerivedStateHelper(manager *Manager, logger *zap.Logger) *DerivedStateHe
 		manager: manager,
 		logger:  logger,
 		subs:    make([]Subscription, 0),
+		clock:   clock.NewRealClock(),
 	}
+}
+
+// SetClock sets the clock implementation for debounce timers.
+func (h *DerivedStateHelper) SetClock(c clock.Clock) {
+	h.clock = c
 }
 
 // SetUpdateCallback sets a callback that is invoked whenever derived states are computed.
@@ -75,6 +88,7 @@ func (h *DerivedStateHelper) Start() error {
 // Stop unsubscribes from all state changes
 func (h *DerivedStateHelper) Stop() {
 	h.logger.Info("Stopping derived state helper")
+	h.cancelAnyoneHomeDepartureDebounce()
 	for _, sub := range h.subs {
 		sub.Unsubscribe()
 	}
@@ -238,21 +252,82 @@ func (h *DerivedStateHelper) updateIsAnyoneHome() {
 
 	// Get current value to check if it changed
 	currentValue, _ := h.manager.GetBool("isAnyoneHome")
-	if currentValue == isAnyoneHome {
-		return // No change
+	if isAnyoneHome {
+		h.cancelAnyoneHomeDepartureDebounce()
+		if currentValue == isAnyoneHome {
+			return // No change
+		}
+		if err := h.manager.SetBool("isAnyoneHome", true); err != nil {
+			h.logger.Error("Failed to update isAnyoneHome", zap.Error(err))
+			return
+		}
+
+		h.logger.Info("Updated isAnyoneHome",
+			zap.Bool("isAnyOwnerHome", isAnyOwnerHome),
+			zap.Bool("isAssistantHere", isAssistantHere),
+			zap.Bool("isAnyoneHome", true))
+
+		// Notify callback with updated derived states
+		h.notifyCallback()
+		return
 	}
 
-	if err := h.manager.SetBool("isAnyoneHome", isAnyoneHome); err != nil {
+	if !currentValue {
+		return
+	}
+
+	h.anyoneHomeDepartureMu.Lock()
+	defer h.anyoneHomeDepartureMu.Unlock()
+
+	if h.anyoneHomeDepartureTimer != nil {
+		return
+	}
+	h.anyoneHomeDepartureTimer = h.clock.AfterFunc(AnyoneHomeDepartureDebounceDelay, func() {
+		h.finishAnyoneHomeDepartureDebounce()
+	})
+	h.logger.Info("Started isAnyoneHome departure debounce",
+		zap.Duration("delay", AnyoneHomeDepartureDebounceDelay))
+}
+
+func (h *DerivedStateHelper) cancelAnyoneHomeDepartureDebounce() {
+	h.anyoneHomeDepartureMu.Lock()
+	defer h.anyoneHomeDepartureMu.Unlock()
+
+	if h.anyoneHomeDepartureTimer == nil {
+		return
+	}
+	h.anyoneHomeDepartureTimer.Stop()
+	h.anyoneHomeDepartureTimer = nil
+	h.logger.Info("Canceled isAnyoneHome departure debounce")
+}
+
+func (h *DerivedStateHelper) finishAnyoneHomeDepartureDebounce() {
+	h.anyoneHomeDepartureMu.Lock()
+	h.anyoneHomeDepartureTimer = nil
+	h.anyoneHomeDepartureMu.Unlock()
+
+	isAnyOwnerHome, err1 := h.manager.GetBool("isAnyOwnerHome")
+	isAssistantHere, err2 := h.manager.GetBool("isAssistantHere")
+	if err1 != nil || err2 != nil {
+		h.logger.Error("Failed to get presence states after departure debounce",
+			zap.Error(err1),
+			zap.Error(err2))
+		return
+	}
+	if isAnyOwnerHome || isAssistantHere {
+		return
+	}
+
+	if err := h.manager.SetBool("isAnyoneHome", false); err != nil {
 		h.logger.Error("Failed to update isAnyoneHome", zap.Error(err))
 		return
 	}
 
-	h.logger.Info("Updated isAnyoneHome",
+	h.logger.Info("Updated isAnyoneHome after departure debounce",
 		zap.Bool("isAnyOwnerHome", isAnyOwnerHome),
 		zap.Bool("isAssistantHere", isAssistantHere),
-		zap.Bool("isAnyoneHome", isAnyoneHome))
+		zap.Bool("isAnyoneHome", false))
 
-	// Notify callback with updated derived states
 	h.notifyCallback()
 }
 

--- a/homeautomation-go/internal/state/helpers_test.go
+++ b/homeautomation-go/internal/state/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"homeautomation/internal/clock"
 	"homeautomation/internal/ha"
 	"homeautomation/internal/testlogger"
 
@@ -14,6 +15,7 @@ func TestDerivedStateHelper_IsAnyoneHome(t *testing.T) {
 	t.Parallel()
 	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
+	mockClock := clock.NewMockClock(time.Date(2026, 4, 15, 4, 10, 3, 0, time.UTC))
 	manager := NewManager(mockClient, logger, false)
 
 	// Initialize state
@@ -22,6 +24,7 @@ func TestDerivedStateHelper_IsAnyoneHome(t *testing.T) {
 	manager.SetBool("isAnyoneHome", false)
 
 	helper := NewDerivedStateHelper(manager, logger)
+	helper.SetClock(mockClock)
 	err := helper.Start()
 	assert.NoError(t, err)
 	defer helper.Stop()
@@ -57,6 +60,10 @@ func TestDerivedStateHelper_IsAnyoneHome(t *testing.T) {
 	manager.SetBool("isNickHome", false)
 	manager.SetBool("isCarolineHome", false)
 	time.Sleep(100 * time.Millisecond)
+	isAnyoneHome, _ = manager.GetBool("isAnyoneHome")
+	assert.True(t, isAnyoneHome, "isAnyoneHome should remain true during departure debounce")
+
+	mockClock.AdvanceAndProcess(AnyoneHomeDepartureDebounceDelay)
 	isAnyoneHome, _ = manager.GetBool("isAnyoneHome")
 	assert.False(t, isAnyoneHome, "isAnyoneHome should be false when both away")
 }

--- a/homeautomation-go/test/integration/scenario_multi_plugin_test.go
+++ b/homeautomation-go/test/integration/scenario_multi_plugin_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"homeautomation/internal/alert"
+	"homeautomation/internal/clock"
 	"homeautomation/internal/ha"
 	"homeautomation/internal/plugins/energy"
 	"homeautomation/internal/plugins/lighting"
@@ -30,6 +32,7 @@ type pluginTestEnv struct {
 	client        *ha.Client
 	manager       *state.Manager
 	logger        *zap.Logger
+	clock         *clock.MockClock
 	stateTracking *statetracking.Manager
 	lighting      *lighting.Manager
 	tv            *tv.Manager
@@ -42,6 +45,7 @@ func setupMultiPluginTest(t *testing.T) (*pluginTestEnv, func()) {
 	server, client, manager, baseCleanup := setupTest(t)
 
 	logger := testlogger.New()
+	mockClock := clock.NewMockClock(time.Date(2026, 4, 15, 4, 10, 3, 0, time.UTC))
 
 	// Load test configs
 	lightingConfig := loadTestLightingConfig(t)
@@ -53,11 +57,13 @@ func setupMultiPluginTest(t *testing.T) (*pluginTestEnv, func()) {
 		client:        client,
 		manager:       manager,
 		logger:        logger,
+		clock:         mockClock,
 		stateTracking: statetracking.NewManager(context.Background(), client, manager, logger, false, nil, "", &alert.MockAlerter{}),
 		lighting:      lighting.NewManager(context.Background(), client, manager, lightingConfig, logger, false, nil),
 		tv:            tv.NewManager(context.Background(), client, manager, logger, false, nil),
 		energy:        energy.NewManager(context.Background(), client, manager, energyConfig, logger, false, nil, nil),
 	}
+	env.stateTracking.SetClock(mockClock)
 
 	// Start all plugins (state tracking MUST start first as other plugins depend on derived states)
 	require.NoError(t, env.stateTracking.Start(), "Failed to start state tracking plugin")
@@ -242,7 +248,7 @@ func TestScenario_EveryoneLeaves_CoordinatedResponse(t *testing.T) {
 	env, cleanup := setupMultiPluginTest(t)
 	defer cleanup()
 
-	t.Log("========== TEST: Presence + Multiple Plugins Integration ==========")
+	t.Log("========== TEST: Departure debounce protects presence-dependent plugins ==========")
 
 	// ========== GIVEN ==========
 	t.Log("GIVEN: Nick and Caroline are both home, house is active")
@@ -267,11 +273,11 @@ func TestScenario_EveryoneLeaves_CoordinatedResponse(t *testing.T) {
 	env.server.SetState("input_boolean.caroline_home", "off", map[string]interface{}{})
 
 	// ========== THEN ==========
-	t.Log("THEN: Verify all presence-dependent plugins respond appropriately")
+	t.Log("THEN: isAnyoneHome stays true during the debounce window")
 
 	// ASSERTION 1: Presence states updated correctly
 	waitForBoolState(t, env.manager, "isCarolineHome", false, "isCarolineHome should become false")
-	waitForBoolState(t, env.manager, "isAnyoneHome", false, "isAnyoneHome should become false when everyone leaves")
+	waitForProcessing(t, env.manager)
 	isNickHome, err := env.manager.GetBool("isNickHome")
 	assert.NoError(t, err)
 	assert.False(t, isNickHome)
@@ -282,21 +288,20 @@ func TestScenario_EveryoneLeaves_CoordinatedResponse(t *testing.T) {
 
 	isAnyoneHome, err := env.manager.GetBool("isAnyoneHome")
 	assert.NoError(t, err)
-	assert.False(t, isAnyoneHome, "isAnyoneHome should be false when everyone leaves")
+	assert.True(t, isAnyoneHome, "isAnyoneHome should remain true until the departure debounce expires")
 
-	// ASSERTION 2: Lighting plugin should respond to absence
 	calls := env.server.GetServiceCallsSince(snapshot)
-	t.Logf("Total service calls after everyone left: %d", len(calls))
-
-	// The lighting plugin should reactivate scenes based on the new presence state
 	sceneActivations := filterServiceCalls(calls, "scene", "turn_on")
-	t.Logf("Scene activations in response to absence: %d", len(sceneActivations))
+	assert.Empty(t, sceneActivations,
+		"Presence-dependent plugins should not react to absence before the departure debounce expires")
 
-	// We expect lighting to respond when presence changes
-	assert.GreaterOrEqual(t, len(sceneActivations), 0,
-		"Lighting should respond to presence changes (may turn off or activate away scenes)")
+	t.Log("THEN: after the full debounce delay, isAnyoneHome emits false")
+	env.clock.AdvanceAndProcess(state.AnyoneHomeDepartureDebounceDelay)
+	waitForProcessing(t, env.manager)
 
-	t.Log("✓ Presence + Multiple Plugins integration test passed")
+	waitForBoolState(t, env.manager, "isAnyoneHome", false, "isAnyoneHome should become false after debounce")
+
+	t.Log("✓ Departure debounce integration test passed")
 }
 
 // ============================================================================

--- a/homeautomation-go/test/integration/scenario_owner_handoff_test.go
+++ b/homeautomation-go/test/integration/scenario_owner_handoff_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"homeautomation/internal/state"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -147,6 +149,11 @@ func TestScenario_OwnerHandoff_LockdownAllowedAfterGracePeriod(t *testing.T) {
 	t.Log("AND: Nick genuinely departs")
 	server.SetState("input_boolean.nick_home", "off", nil)
 	waitForBoolState(t, manager, "isNickHome", false, "isNickHome should be false after departure")
+	waitForProcessing(t, manager)
+
+	t.Log("AND: The departure debounce expires")
+	mockClock.AdvanceAndProcess(state.AnyoneHomeDepartureDebounceDelay)
+	waitForBoolState(t, manager, "isAnyoneHome", false, "isAnyoneHome should become false after departure debounce")
 
 	t.Log("THEN: Lockdown MUST be activated (grace period has expired)")
 	waitForServiceCallWithEntitySince(t, server, snapshot, "input_boolean", "turn_off", "input_boolean.lockdown",


### PR DESCRIPTION
Resolves #995

## Summary
- Added a 5-minute departure debounce before derived `isAnyoneHome` emits `false`
- Cancels the pending departure when presence returns during the debounce window
- Covered both the V2 computed registry and the current statetracking derived-state helper path

## Test Plan
- `make unit-tests`
- `make integration-tests`
- `make pre-commit`

🤖 Generated by the AI assistant