### PR TITLE
Fix #1074: serialize HA handlers per entity

### DIFF
--- a/docs/reference/CONCURRENCY_LESSONS.md
+++ b/docs/reference/CONCURRENCY_LESSONS.md
@@ -216,6 +216,8 @@ func (c *Client) handleEvent(msg *Message) {
 - **Before Fix**: Frequent 10-second timeout errors in energy manager
 - **After Fix**: No timeouts, all HA updates succeed immediately
 
+**Note**: The actual implementation no longer uses bare `go entry.handler(...)`. Successive events for the same entity are now routed through a per-entity channel queue so handlers run FIFO (see Lesson 20). The principle — handlers must not block `receiveMessages` — still applies; the queue worker dispatches handlers into goroutines, keeping `receiveMessages` unblocked.
+
 ---
 
 ## Lesson 6: Always Test with Race Detector
@@ -905,6 +907,7 @@ Go's runtime only detects deadlocks when **all** goroutines are blocked. If even
 17. **Serialize calls to congestion-sensitive device networks** - Parallel UPnP calls to Sonos triggers timeout storms; sequence them instead
 18. **Use `waitForServiceCallQuiescenceSince` for absence assertions** - `waitForProcessing` only covers the HA handler fence; fire-and-forget goroutines require quiescence polling
 19. **Fence between GIVEN and WHEN phases** - always call `waitForProcessing` or `waitForBoolState` after GIVEN-phase `SetState` calls; only `input_boolean.*` entities have `MockHAServer` defaults and can be omitted when their default matches the test's starting value
+20. **Serialize per-entity event handlers via channel queues** - prevents out-of-order execution while preserving cross-entity parallelism
 
 ---
 
@@ -1081,7 +1084,7 @@ func handleShutdown() {
 - State manager: `internal/state/manager.go`
 - Mock server: `test/integration/mock_ha_server.go`
 
-**Last Updated**: 2026-04-30
+**Last Updated**: 2026-05-05
 **Test Status**: All 11/11 integration tests passing with `-race` flag
 
 ---
@@ -1402,7 +1405,84 @@ server.SetState("switch.sync_box_power", "on", map[string]interface{}{})
 
 ---
 
+## Lesson 20: Serialize Per-Entity Event Handlers via Channel Queues to Prevent Out-of-Order Execution
+
+**Pattern**: Route state-change events for each entity through a dedicated buffered channel, processed by a single goroutine, so handlers for the same entity run FIFO while handlers for different entities run in parallel.
+
+**Why**: Without this, concurrent goroutines dispatched for successive events on the same entity can execute out of order. If event N+1 arrives while N's handler is still running, a new goroutine starts immediately and may finish before N, producing incorrect state.
+
+**Race Scenario (Before Fix)**:
+```
+Entity "sensor.test": event "first" fires  → spawns G1 (slow)
+Entity "sensor.test": event "second" fires → spawns G2 (fast)
+G2 finishes: handler sees "second"
+G1 finishes: handler sees "first"   ← stale — flaky tests and incorrect state
+```
+
+**Correct Approach**: One buffered channel per entity; a single goroutine drains each queue. Successive events for the same entity are processed FIFO. Events for different entities still run in parallel (separate queues). All handlers for a single event run concurrently, but the queue worker waits for all to finish (`eventWg.Wait()`) before dequeuing the next event.
+
+```go
+// One channel per entity, drained by a single goroutine
+func (c *Client) getEntityEventQueue(entityID string) chan entityEventJob {
+    c.entityDispatchMu.Lock()
+    defer c.entityDispatchMu.Unlock()
+
+    if queue, ok := c.entityEventQueues[entityID]; ok {
+        return queue
+    }
+
+    queue := make(chan entityEventJob, entityEventQueueSize)
+    c.entityEventQueues[entityID] = queue
+    go c.processEntityEventQueue(queue)
+    return queue
+}
+
+func (c *Client) processEntityEventQueue(queue <-chan entityEventJob) {
+    for job := range queue {
+        var wg sync.WaitGroup
+        for _, entry := range job.entries {
+            wg.Add(1)
+            go func(h StateChangeHandler) {
+                defer wg.Done()
+                h(job.entityID, job.oldState, job.newState)
+            }(entry.handler)
+        }
+        wg.Wait() // wait for all handlers on this event before processing the next
+    }
+}
+```
+
+**Lifecycle — Close Channels on Disconnect**: The drain goroutines exit when the channel is closed. Always close all entity queue channels during shutdown:
+
+```go
+// In Disconnect(), after clearSubscribers():
+c.entityDispatchMu.Lock()
+for _, ch := range c.entityEventQueues {
+    close(ch)
+}
+c.entityEventQueues = make(map[string]chan entityEventJob)
+c.entityDispatchMu.Unlock()
+```
+
+**Known Tradeoff**: The channel send in `handleEvent` is synchronous. If 256 events pile up for one entity while a handler is waiting for a HA response, `receiveMessages` stalls (head-of-line blocking), potentially deadlocking. The buffer size of 256 makes this theoretical for home automation event rates, but the original per-goroutine approach was deadlock-free. Document this tradeoff in a code comment.
+
+**New lock in ordering**: `entityDispatchMu` (position 6, between `subsMu` and `nextSubIDMu`) protects the `entityEventQueues` map.
+
+**Where Applied**: `internal/ha/client.go` — `getEntityEventQueue`, `processEntityEventQueue`, `handleEvent`, `Disconnect`
+
+**Test That Validates This**: `TestClient_HandleEventSerializesHandlersPerEntity`
+
+**References**: PR #1076 (Issue #1074)
+
+---
+
 ## Change Log
+
+### 2026-05-05
+- **Added Lesson 20**: Serialize Per-Entity Event Handlers via Channel Queues to Prevent Out-of-Order Execution
+  - Documents the per-entity buffered channel pattern that prevents handlers for the same entity from running out of order
+  - Covers lifecycle (close channels on Disconnect), lock ordering (entityDispatchMu at position 6), and the known head-of-line blocking tradeoff
+  - Applied to `internal/ha/client.go` — PR #1076
 
 ### 2026-04-30
 - **Added Lesson 19**: Fence Between GIVEN and WHEN Phases to Prevent Handler Goroutine Races

--- a/homeautomation-go/internal/ha/client.go
+++ b/homeautomation-go/internal/ha/client.go
@@ -514,6 +514,15 @@ func (c *Client) Disconnect() error {
 	}
 
 	c.clearSubscribers()
+
+	// Close entity queue channels so processEntityEventQueue goroutines exit.
+	c.entityDispatchMu.Lock()
+	for _, ch := range c.entityEventQueues {
+		close(ch)
+	}
+	c.entityEventQueues = make(map[string]chan entityEventJob)
+	c.entityDispatchMu.Unlock()
+
 	c.logger.Info("Disconnected from Home Assistant")
 	return nil
 }
@@ -668,10 +677,6 @@ func (c *Client) WaitForHandlers() {
 func (c *Client) getEntityEventQueue(entityID string) chan entityEventJob {
 	c.entityDispatchMu.Lock()
 	defer c.entityDispatchMu.Unlock()
-
-	if c.entityEventQueues == nil {
-		c.entityEventQueues = make(map[string]chan entityEventJob)
-	}
 
 	queue, ok := c.entityEventQueues[entityID]
 	if ok {
@@ -924,6 +929,11 @@ func (c *Client) handleEvent(msg *Message) {
 	}
 
 	queue := c.getEntityEventQueue(eventData.EntityID)
+	// Known tradeoff: this send blocks receiveMessages if the 256-slot queue is full
+	// (head-of-line blocking). A handler stuck waiting for a HA response while 256
+	// same-entity events pile up would deadlock. This is not a realistic scenario for
+	// home automation event rates, but the original goroutine-per-event approach was
+	// deadlock-free. See Lesson 20 in CONCURRENCY_LESSONS.md.
 	queue <- entityEventJob{
 		entityID: eventData.EntityID,
 		oldState: eventData.OldState,

--- a/homeautomation-go/internal/ha/client.go
+++ b/homeautomation-go/internal/ha/client.go
@@ -68,6 +68,11 @@ const (
 
 	// minResultsForHealth is the minimum number of results needed before declaring unhealthy
 	minResultsForHealth = 3
+
+	// entityEventQueueSize is the per-entity state_changed event buffer.
+	// A full queue backpressures receiveMessages for that entity instead of
+	// allowing later events to overtake earlier ones.
+	entityEventQueueSize = 256
 )
 
 // HAClient defines the interface for Home Assistant WebSocket client
@@ -202,6 +207,13 @@ type subscriberEntry struct {
 	handler StateChangeHandler
 }
 
+type entityEventJob struct {
+	entityID string
+	oldState *State
+	newState *State
+	entries  []subscriberEntry
+}
+
 // Client implements HAClient interface
 //
 // Lock ordering (to prevent deadlocks, always acquire in this order):
@@ -210,8 +222,9 @@ type subscriberEntry struct {
 //  3. writeMu - websocket writes (also protects msgID to ensure ordered sends)
 //  4. pendingMu - pending response channels
 //  5. subsMu - subscribers
-//  6. nextSubIDMu - subscription ID counter
-//  7. healthMu - health tracking (acquired last, never held while acquiring others)
+//  6. entityDispatchMu - per-entity event queues
+//  7. nextSubIDMu - subscription ID counter
+//  8. healthMu - health tracking (acquired last, never held while acquiring others)
 //
 // Note: msgIDMu has been eliminated; msgID is now protected by writeMu to ensure
 // message IDs are allocated and sent atomically, preventing out-of-order sends.
@@ -232,18 +245,20 @@ type Client struct {
 	writeTimeoutCount  int       // Number of write timeouts detected
 	connectedAt        time.Time // When the current connection was established
 
-	msgID       int // Protected by writeMu (not separate mutex) to ensure atomic ID+send
-	pending     map[int]chan Message
-	pendingMu   sync.Mutex
-	subscribers map[string][]subscriberEntry
-	subsMu      sync.RWMutex
-	nextSubID   int
-	nextSubIDMu sync.Mutex
-	ctx         context.Context
-	cancel      context.CancelFunc
-	ctxMu       sync.RWMutex // Protects ctx and cancel
-	reconnect   bool
-	writeMu     sync.Mutex // Protects websocket writes AND msgID counter
+	msgID             int // Protected by writeMu (not separate mutex) to ensure atomic ID+send
+	pending           map[int]chan Message
+	pendingMu         sync.Mutex
+	subscribers       map[string][]subscriberEntry
+	subsMu            sync.RWMutex
+	entityDispatchMu  sync.Mutex
+	entityEventQueues map[string]chan entityEventJob
+	nextSubID         int
+	nextSubIDMu       sync.Mutex
+	ctx               context.Context
+	cancel            context.CancelFunc
+	ctxMu             sync.RWMutex // Protects ctx and cancel
+	reconnect         bool
+	writeMu           sync.Mutex // Protects websocket writes AND msgID counter
 
 	// Ping goroutine lifecycle management
 	pingCancel context.CancelFunc // Cancels the ping goroutine; protected by connMu
@@ -304,16 +319,17 @@ func (c *Client) resetContext() {
 func NewClient(url, token string, logger *zap.Logger) *Client {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Client{
-		url:            url,
-		token:          token,
-		logger:         logger,
-		pending:        make(map[int]chan Message),
-		subscribers:    make(map[string][]subscriberEntry),
-		ctx:            ctx,
-		cancel:         cancel,
-		reconnect:      true,
-		recentResults:  make([]bool, healthWindowSize),
-		eventProcessed: make(chan struct{}, 256),
+		url:               url,
+		token:             token,
+		logger:            logger,
+		pending:           make(map[int]chan Message),
+		subscribers:       make(map[string][]subscriberEntry),
+		entityEventQueues: make(map[string]chan entityEventJob),
+		ctx:               ctx,
+		cancel:            cancel,
+		reconnect:         true,
+		recentResults:     make([]bool, healthWindowSize),
+		eventProcessed:    make(chan struct{}, 256),
 	}
 }
 
@@ -649,6 +665,54 @@ func (c *Client) WaitForHandlers() {
 	}
 }
 
+func (c *Client) getEntityEventQueue(entityID string) chan entityEventJob {
+	c.entityDispatchMu.Lock()
+	defer c.entityDispatchMu.Unlock()
+
+	if c.entityEventQueues == nil {
+		c.entityEventQueues = make(map[string]chan entityEventJob)
+	}
+
+	queue, ok := c.entityEventQueues[entityID]
+	if ok {
+		return queue
+	}
+
+	queue = make(chan entityEventJob, entityEventQueueSize)
+	c.entityEventQueues[entityID] = queue
+	go c.processEntityEventQueue(queue)
+	return queue
+}
+
+func (c *Client) processEntityEventQueue(queue <-chan entityEventJob) {
+	for job := range queue {
+		var eventWg sync.WaitGroup
+		for _, entry := range job.entries {
+			eventWg.Add(1)
+			go func(h StateChangeHandler) {
+				defer c.handlerCount.Add(-1)
+				defer eventWg.Done()
+				h(job.entityID, job.oldState, job.newState)
+			}(entry.handler)
+		}
+
+		eventWg.Wait()
+		c.signalEventProcessed()
+	}
+}
+
+func (c *Client) signalEventProcessed() {
+	c.processedEvents.Add(1)
+	if c.eventProcessed == nil {
+		return
+	}
+
+	select {
+	case c.eventProcessed <- struct{}{}:
+	default:
+	}
+}
+
 // nextMsgID returns the next message ID.
 // IMPORTANT: Caller must hold writeMu to ensure atomic ID allocation + send.
 func (c *Client) nextMsgID() int {
@@ -847,32 +911,25 @@ func (c *Client) handleEvent(msg *Message) {
 	entries := append([]subscriberEntry(nil), c.subscribers[eventData.EntityID]...)
 	c.subsMu.RUnlock()
 
-	// Call handlers in separate goroutines to avoid blocking receiveMessages
-	// This prevents deadlocks when handlers try to send messages back to HA
+	// Queue handlers by entity so successive events for the same entity are
+	// processed FIFO while still allowing different entities to run in parallel.
+	// The queue worker invokes handlers asynchronously so receiveMessages can
+	// continue reading responses for handlers that call back into HA.
 	if len(entries) == 0 {
 		return
 	}
 
-	var eventWg sync.WaitGroup
-	for _, entry := range entries {
+	for range entries {
 		c.handlerCount.Add(1)
-		eventWg.Add(1)
-		go func(h StateChangeHandler) {
-			defer c.handlerCount.Add(-1)
-			defer eventWg.Done()
-			h(eventData.EntityID, eventData.OldState, eventData.NewState)
-		}(entry.handler)
 	}
 
-	// Signal event completion after all handlers finish (non-blocking)
-	go func() {
-		eventWg.Wait()
-		c.processedEvents.Add(1)
-		select {
-		case c.eventProcessed <- struct{}{}:
-		default:
-		}
-	}()
+	queue := c.getEntityEventQueue(eventData.EntityID)
+	queue <- entityEventJob{
+		entityID: eventData.EntityID,
+		oldState: eventData.OldState,
+		newState: eventData.NewState,
+		entries:  entries,
+	}
 }
 
 // handleDisconnect handles connection loss

--- a/homeautomation-go/internal/ha/client_test.go
+++ b/homeautomation-go/internal/ha/client_test.go
@@ -539,6 +539,88 @@ func TestClient_HandleEventBackpressuresHandlers(t *testing.T) {
 	}
 }
 
+func TestClient_HandleEventSerializesHandlersPerEntity(t *testing.T) {
+	t.Parallel()
+	client := &Client{
+		logger:         zap.NewNop(),
+		subscribers:    make(map[string][]subscriberEntry),
+		eventProcessed: make(chan struct{}, 8),
+	}
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondStarted := make(chan struct{})
+
+	var mu sync.Mutex
+	sequence := make([]string, 0, 2)
+
+	client.subscribers["sensor.test"] = []subscriberEntry{
+		{
+			subID: 1,
+			handler: func(entityID string, oldState, newState *State) {
+				switch newState.State {
+				case "first":
+					close(firstStarted)
+					<-releaseFirst
+				case "second":
+					close(secondStarted)
+				}
+
+				mu.Lock()
+				sequence = append(sequence, newState.State)
+				mu.Unlock()
+			},
+		},
+	}
+
+	sendEvent := func(value string) {
+		eventPayload := StateChangedEvent{
+			EntityID: "sensor.test",
+			NewState: &State{
+				EntityID: "sensor.test",
+				State:    value,
+			},
+		}
+		data, err := json.Marshal(eventPayload)
+		require.NoError(t, err)
+
+		client.handleEvent(&Message{
+			Type: "event",
+			Event: &Event{
+				EventType: "state_changed",
+				Data:      data,
+			},
+		})
+	}
+
+	sendEvent("first")
+	select {
+	case <-firstStarted:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("first handler did not start")
+	}
+
+	sendEvent("second")
+	select {
+	case <-secondStarted:
+		t.Fatal("second handler started before first handler completed")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(releaseFirst)
+	select {
+	case <-secondStarted:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("second handler did not start after first handler completed")
+	}
+
+	client.WaitForHandlers()
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"first", "second"}, sequence)
+}
+
 // TestClient_ConcurrentCallService verifies that concurrent CallService calls
 // result in messages with monotonically increasing IDs being sent in order.
 func TestClient_ConcurrentCallService(t *testing.T) {

--- a/homeautomation-go/internal/ha/client_test.go
+++ b/homeautomation-go/internal/ha/client_test.go
@@ -491,9 +491,18 @@ func TestClient_DisconnectClearsSubscribers(t *testing.T) {
 func TestClient_HandleEventBackpressuresHandlers(t *testing.T) {
 	t.Parallel()
 	client := &Client{
-		logger:      zap.NewNop(),
-		subscribers: make(map[string][]subscriberEntry),
+		logger:            zap.NewNop(),
+		subscribers:       make(map[string][]subscriberEntry),
+		entityEventQueues: make(map[string]chan entityEventJob),
 	}
+	t.Cleanup(func() {
+		client.entityDispatchMu.Lock()
+		for _, ch := range client.entityEventQueues {
+			close(ch)
+		}
+		client.entityEventQueues = make(map[string]chan entityEventJob)
+		client.entityDispatchMu.Unlock()
+	})
 
 	var calls int32
 	done := make(chan struct{})
@@ -542,10 +551,19 @@ func TestClient_HandleEventBackpressuresHandlers(t *testing.T) {
 func TestClient_HandleEventSerializesHandlersPerEntity(t *testing.T) {
 	t.Parallel()
 	client := &Client{
-		logger:         zap.NewNop(),
-		subscribers:    make(map[string][]subscriberEntry),
-		eventProcessed: make(chan struct{}, 8),
+		logger:            zap.NewNop(),
+		subscribers:       make(map[string][]subscriberEntry),
+		eventProcessed:    make(chan struct{}, 8),
+		entityEventQueues: make(map[string]chan entityEventJob),
 	}
+	t.Cleanup(func() {
+		client.entityDispatchMu.Lock()
+		for _, ch := range client.entityEventQueues {
+			close(ch)
+		}
+		client.entityEventQueues = make(map[string]chan entityEventJob)
+		client.entityDispatchMu.Unlock()
+	})
 
 	firstStarted := make(chan struct{})
 	releaseFirst := make(chan struct{})


### PR DESCRIPTION
Resolves #1074

## Summary
- Added per-entity FIFO dispatch queues for Home Assistant state_changed handlers so later events for the same entity cannot overtake earlier events.
- Kept handlers asynchronous and parallel across different entities.
- Added a regression test that blocks the first handler and verifies the second same-entity event does not start early.

## Test Plan
- make unit-tests
- make integration-tests
- cd homeautomation-go && go test -race -count=50 -run ThresholdBoundaries ./test/integration
- make pre-commit

🤖 Generated by the AI assistant