### PR TITLE
Fix #1075: add integration test processing barriers

### DIFF
--- a/homeautomation-go/test/integration/scenario_computed_state_test.go
+++ b/homeautomation-go/test/integration/scenario_computed_state_test.go
@@ -191,6 +191,7 @@ func TestScenario_ComputedState_ReactsToIsAnyOwnerHomeChange(t *testing.T) {
 	// WHEN: Owner comes home (still awake)
 	t.Log("WHEN: Owner comes home")
 	server.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	waitForProcessing(t, manager)
 
 	// THEN: isAnyoneHomeAndAwake should become true
 	t.Log("THEN: isAnyoneHomeAndAwake should become true")
@@ -199,6 +200,7 @@ func TestScenario_ComputedState_ReactsToIsAnyOwnerHomeChange(t *testing.T) {
 	// WHEN: Owner leaves
 	t.Log("WHEN: Owner leaves")
 	server.SetState("input_boolean.any_owner_home", "off", map[string]interface{}{})
+	waitForProcessing(t, manager)
 
 	// THEN: isAnyoneHomeAndAwake should become false
 	t.Log("THEN: isAnyoneHomeAndAwake should become false")
@@ -217,6 +219,7 @@ func TestScenario_ComputedState_ReactsToIsAnyoneAsleepChange(t *testing.T) {
 	server.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
 	server.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
 	server.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
+	waitForProcessing(t, manager)
 
 	// Verify initial state
 	waitForBoolState(t, manager, "isAnyoneHomeAndAwake", true, "Initially should be true when owner is home and awake")
@@ -224,6 +227,7 @@ func TestScenario_ComputedState_ReactsToIsAnyoneAsleepChange(t *testing.T) {
 	// WHEN: Someone falls asleep
 	t.Log("WHEN: Someone falls asleep")
 	server.SetState("input_boolean.anyone_asleep", "on", map[string]interface{}{})
+	waitForProcessing(t, manager)
 
 	// THEN: isAnyoneHomeAndAwake should become false
 	t.Log("THEN: isAnyoneHomeAndAwake should become false")
@@ -232,6 +236,7 @@ func TestScenario_ComputedState_ReactsToIsAnyoneAsleepChange(t *testing.T) {
 	// WHEN: Everyone wakes up
 	t.Log("WHEN: Everyone wakes up")
 	server.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
+	waitForProcessing(t, manager)
 
 	// THEN: isAnyoneHomeAndAwake should become true again
 	t.Log("THEN: isAnyoneHomeAndAwake should become true again")
@@ -259,6 +264,7 @@ func TestScenario_ComputedState_SyncsToHomeAssistant(t *testing.T) {
 	// WHEN: Owner comes home (triggering computed state change)
 	t.Log("WHEN: Owner comes home")
 	server.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	waitForProcessing(t, manager)
 
 	// Wait for sync to HA
 	waitForServiceCallSince(t, server, snapshot, "input_boolean", "turn_on", "computed state should sync to HA")
@@ -299,6 +305,7 @@ func TestScenario_ComputedState_RapidChanges(t *testing.T) {
 	server.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
 	server.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
 	server.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
+	waitForProcessing(t, manager)
 	// Allow computed state to settle
 	waitForBoolState(t, manager, "isAnyoneHomeAndAwake", true, "computed state should settle to true")
 
@@ -348,6 +355,7 @@ func TestScenario_ComputedState_BothDependenciesChange(t *testing.T) {
 	// Ensure first change is processed before sending second
 	waitForProcessing(t, manager)
 	server.SetState("input_boolean.anyone_asleep", "on", map[string]interface{}{})
+	waitForProcessing(t, manager)
 
 	// THEN: Final state should be false (owner home but asleep)
 	t.Log("THEN: Should be false (owner home but asleep)")
@@ -359,6 +367,7 @@ func TestScenario_ComputedState_BothDependenciesChange(t *testing.T) {
 	// Ensure first change is processed before sending second
 	waitForProcessing(t, manager)
 	server.SetState("input_boolean.any_owner_home", "off", map[string]interface{}{})
+	waitForProcessing(t, manager)
 
 	// THEN: Final state should be false (no owner home)
 	t.Log("THEN: Should be false (no owner home)")
@@ -377,6 +386,7 @@ func TestScenario_ComputedState_AssistantArrivesWhileOwnerAsleep(t *testing.T) {
 	server.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
 	server.SetState("input_boolean.anyone_asleep", "on", map[string]interface{}{})
 	server.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
+	waitForProcessing(t, manager)
 
 	// Verify initial state: should be false (owner asleep)
 	waitForBoolState(t, manager, "isAnyoneHomeAndAwake", false, "Initially should be false when owner is home but asleep")
@@ -384,6 +394,7 @@ func TestScenario_ComputedState_AssistantArrivesWhileOwnerAsleep(t *testing.T) {
 	// WHEN: Assistant arrives while owner is still asleep
 	t.Log("WHEN: Assistant arrives while owner is still asleep")
 	server.SetState("input_boolean.assistant_here", "on", map[string]interface{}{})
+	waitForProcessing(t, manager)
 
 	// THEN: isAnyoneHomeAndAwake should become TRUE (Assistant is awake!)
 	t.Log("THEN: isAnyoneHomeAndAwake should become TRUE")
@@ -392,6 +403,7 @@ func TestScenario_ComputedState_AssistantArrivesWhileOwnerAsleep(t *testing.T) {
 	// WHEN: Assistant leaves
 	t.Log("WHEN: Assistant leaves")
 	server.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
+	waitForProcessing(t, manager)
 
 	// THEN: isAnyoneHomeAndAwake should become false again (owner still asleep)
 	t.Log("THEN: isAnyoneHomeAndAwake should become false again")

--- a/homeautomation-go/test/integration/scenario_concurrent_triggers_test.go
+++ b/homeautomation-go/test/integration/scenario_concurrent_triggers_test.go
@@ -207,8 +207,10 @@ func TestScenario_RapidPresenceChanges_StableState(t *testing.T) {
 		expectedHome := i%2 == 0
 		if i%2 == 0 {
 			env.server.SetState("input_boolean.caroline_home", "on", map[string]interface{}{})
+			waitForProcessing(t, env.stateManager)
 		} else {
 			env.server.SetState("input_boolean.caroline_home", "off", map[string]interface{}{})
+			waitForProcessing(t, env.stateManager)
 		}
 		waitForBoolState(t, env.stateManager, "isCarolineHome", expectedHome, "presence change %d should propagate", i)
 	}

--- a/homeautomation-go/test/integration/scenario_concurrent_triggers_test.go
+++ b/homeautomation-go/test/integration/scenario_concurrent_triggers_test.go
@@ -202,7 +202,11 @@ func TestScenario_RapidPresenceChanges_StableState(t *testing.T) {
 	// ========== WHEN ==========
 	t.Log("WHEN: Caroline's presence rapidly toggles (sensor flicker)")
 
-	// Simulate rapid presence changes
+	// Simulate rapid presence changes. waitForProcessing after each flip ensures
+	// each event fully propagates before the next is sent — this serializes the
+	// flips rather than truly firing them concurrently. The test validates that
+	// each individual change reaches a consistent state, not concurrency under load
+	// (see TestScenario_MultipleConcurrentChanges_HandlesCorrectly for that).
 	for i := 0; i < 5; i++ {
 		expectedHome := i%2 == 0
 		if i%2 == 0 {

--- a/homeautomation-go/test/integration/scenario_energy_sleep_test.go
+++ b/homeautomation-go/test/integration/scenario_energy_sleep_test.go
@@ -290,6 +290,7 @@ func TestScenario_EnergyTransitions_SleepStateUnaffected(t *testing.T) {
 	env.server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "90.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
+	waitForProcessing(t, env.manager)
 
 	// Wait for initial battery state to settle
 	waitForStringState(t, env.manager, "batteryEnergyLevel", "green", "Battery should start at green")

--- a/homeautomation-go/test/integration/scenario_energy_test.go
+++ b/homeautomation-go/test/integration/scenario_energy_test.go
@@ -84,6 +84,7 @@ func TestScenario_BatteryLevelChanges_UpdateEnergyLevels(t *testing.T) {
 	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "85.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
+	waitForProcessing(t, manager)
 
 	// Verify initial state is green
 	waitForStringState(t, manager, "batteryEnergyLevel", "green", "Battery level should be green at 85%")
@@ -93,6 +94,7 @@ func TestScenario_BatteryLevelChanges_UpdateEnergyLevels(t *testing.T) {
 	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "55.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
+	waitForProcessing(t, manager)
 
 	// THEN: Battery level should be yellow
 	t.Log("THEN: Battery level should be yellow")
@@ -103,6 +105,7 @@ func TestScenario_BatteryLevelChanges_UpdateEnergyLevels(t *testing.T) {
 	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "15.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
+	waitForProcessing(t, manager)
 
 	// THEN: Battery level should be black
 	t.Log("THEN: Battery level should be black")
@@ -121,9 +124,11 @@ func TestScenario_SolarProductionUpdates_CalculatesEnergyLevel(t *testing.T) {
 	server.SetState("sensor.energy_next_hour", "0.0", map[string]interface{}{
 		"unit_of_measurement": "kW",
 	})
+	waitForProcessing(t, manager)
 	server.SetState("sensor.energy_production_today_remaining", "0.0", map[string]interface{}{
 		"unit_of_measurement": "kWh",
 	})
+	waitForProcessing(t, manager)
 
 	// Verify initial state
 	waitForStringState(t, manager, "solarProductionEnergyLevel", "yellow", "Solar level should be yellow with no production (meets yellow threshold)")
@@ -133,9 +138,11 @@ func TestScenario_SolarProductionUpdates_CalculatesEnergyLevel(t *testing.T) {
 	server.SetState("sensor.energy_next_hour", "2.0", map[string]interface{}{
 		"unit_of_measurement": "kW",
 	})
+	waitForProcessing(t, manager)
 	server.SetState("sensor.energy_production_today_remaining", "15.0", map[string]interface{}{
 		"unit_of_measurement": "kWh",
 	})
+	waitForProcessing(t, manager)
 
 	// THEN: Solar level should be green (threshold: 0 kW, 10 kWh)
 	t.Log("THEN: Solar level should be green")
@@ -146,9 +153,11 @@ func TestScenario_SolarProductionUpdates_CalculatesEnergyLevel(t *testing.T) {
 	server.SetState("sensor.energy_next_hour", "1.0", map[string]interface{}{
 		"unit_of_measurement": "kW",
 	})
+	waitForProcessing(t, manager)
 	server.SetState("sensor.energy_production_today_remaining", "5.0", map[string]interface{}{
 		"unit_of_measurement": "kWh",
 	})
+	waitForProcessing(t, manager)
 
 	// THEN: Solar level should be yellow (threshold: 0 kW, 0 kWh)
 	t.Log("THEN: Solar level should be yellow")
@@ -203,6 +212,7 @@ func TestScenario_GridAvailability_RecalculatesFreeEnergy(t *testing.T) {
 	t.Log("WHEN: Grid goes offline")
 	err = manager.SetBool("isGridAvailable", false)
 	require.NoError(t, err)
+	waitForProcessing(t, manager)
 
 	// THEN: Free energy should be false (no grid = no free energy)
 	t.Log("THEN: Free energy should be false")
@@ -212,6 +222,7 @@ func TestScenario_GridAvailability_RecalculatesFreeEnergy(t *testing.T) {
 	t.Log("WHEN: Grid comes back online")
 	err = manager.SetBool("isGridAvailable", true)
 	require.NoError(t, err)
+	waitForProcessing(t, manager)
 
 	// THEN: Free energy should still be false (we're at noon, outside the window)
 	t.Log("THEN: Free energy should still be false (noon is outside 21:00-07:00)")
@@ -276,9 +287,11 @@ func TestScenario_OverallEnergyLevel_ReflectsWorstState(t *testing.T) {
 	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "85.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
+	waitForProcessing(t, manager)
 	server.SetState("sensor.energy_next_hour", "2.0", map[string]interface{}{
 		"unit_of_measurement": "kW",
 	})
+	waitForProcessing(t, manager)
 	server.SetState("sensor.energy_production_today_remaining", "15.0", map[string]interface{}{
 		"unit_of_measurement": "kWh",
 	})
@@ -292,6 +305,7 @@ func TestScenario_OverallEnergyLevel_ReflectsWorstState(t *testing.T) {
 	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "15.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
+	waitForProcessing(t, manager)
 
 	// THEN: Overall level should reflect the lower state
 	// According to the algorithm, solar can boost the battery-derived result by at most one level.
@@ -307,9 +321,11 @@ func TestScenario_OverallEnergyLevel_ReflectsWorstState(t *testing.T) {
 	server.SetState("sensor.energy_next_hour", "0.0", map[string]interface{}{
 		"unit_of_measurement": "kW",
 	})
+	waitForProcessing(t, manager)
 	server.SetState("sensor.energy_production_today_remaining", "0.0", map[string]interface{}{
 		"unit_of_measurement": "kWh",
 	})
+	waitForProcessing(t, manager)
 
 	// THEN: Solar should settle to yellow for this test config, and overall should stay red
 	t.Log("THEN: Overall level should stay low")
@@ -367,8 +383,10 @@ func TestScenario_FreeEnergyTimeWindow_OverridesEnergyLevel(t *testing.T) {
 	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "15.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
+	waitForProcessing(t, manager)
 	err = manager.SetBool("isGridAvailable", true)
 	require.NoError(t, err)
+	waitForProcessing(t, manager)
 
 	// Verify free energy is available (we're at 22:00, inside the 21:00-07:00 window)
 	waitForBoolState(t, manager, "isFreeEnergyAvailable", true, "Free energy should be available at 22:00 with grid online")
@@ -398,6 +416,7 @@ func TestScenario_ThresholdBoundaries_HandlesExactValues(t *testing.T) {
 	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "80.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
+	waitForProcessing(t, manager)
 
 	waitForStringState(t, manager, "batteryEnergyLevel", "green", "Battery level should be green at exactly 80%")
 
@@ -406,6 +425,7 @@ func TestScenario_ThresholdBoundaries_HandlesExactValues(t *testing.T) {
 	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "79.9", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
+	waitForProcessing(t, manager)
 
 	waitForStringState(t, manager, "batteryEnergyLevel", "yellow", "Battery level should be yellow at 79.9%")
 
@@ -414,6 +434,7 @@ func TestScenario_ThresholdBoundaries_HandlesExactValues(t *testing.T) {
 	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "50.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
+	waitForProcessing(t, manager)
 
 	waitForStringState(t, manager, "batteryEnergyLevel", "yellow", "Battery level should be yellow at exactly 50%")
 
@@ -422,6 +443,7 @@ func TestScenario_ThresholdBoundaries_HandlesExactValues(t *testing.T) {
 	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "49.9", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
+	waitForProcessing(t, manager)
 
 	waitForStringState(t, manager, "batteryEnergyLevel", "red", "Battery level should be red at 49.9%")
 
@@ -430,6 +452,7 @@ func TestScenario_ThresholdBoundaries_HandlesExactValues(t *testing.T) {
 	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "20.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
+	waitForProcessing(t, manager)
 
 	waitForStringState(t, manager, "batteryEnergyLevel", "red", "Battery level should be red at exactly 20%")
 
@@ -438,6 +461,7 @@ func TestScenario_ThresholdBoundaries_HandlesExactValues(t *testing.T) {
 	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "19.9", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
+	waitForProcessing(t, manager)
 
 	waitForStringState(t, manager, "batteryEnergyLevel", "black", "Battery level should be black at 19.9%")
 }
@@ -454,12 +478,15 @@ func TestScenario_MultipleConcurrentChanges_HandlesCorrectly(t *testing.T) {
 	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "85.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
+	waitForProcessing(t, manager)
 	server.SetState("sensor.energy_next_hour", "3.0", map[string]interface{}{
 		"unit_of_measurement": "kW",
 	})
+	waitForProcessing(t, manager)
 	server.SetState("sensor.energy_production_today_remaining", "20.0", map[string]interface{}{
 		"unit_of_measurement": "kWh",
 	})
+	waitForProcessing(t, manager)
 
 	// Wait for initial state to stabilize
 	waitForStringState(t, manager, "batteryEnergyLevel", "green", "Battery should be green at 85%")

--- a/homeautomation-go/test/integration/scenario_energy_test.go
+++ b/homeautomation-go/test/integration/scenario_energy_test.go
@@ -505,6 +505,10 @@ func TestScenario_MultipleConcurrentChanges_HandlesCorrectly(t *testing.T) {
 	// WHEN: Multiple rapid changes occur simultaneously
 	t.Log("WHEN: Multiple rapid changes occur simultaneously")
 
+	// Barriers are intentionally omitted here: these three SetState calls fire
+	// without draining in between, exercising the system under true concurrent
+	// load across different entities (battery, solar, grid). Assertions below use
+	// waitForStringState/waitForBoolState to tolerate non-deterministic ordering.
 	// Change battery
 	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "25.0", map[string]interface{}{
 		"unit_of_measurement": "%",

--- a/homeautomation-go/test/integration/scenario_lighting_test.go
+++ b/homeautomation-go/test/integration/scenario_lighting_test.go
@@ -83,6 +83,7 @@ func TestScenario_DayPhaseEvening_ActivatesCorrectScenes(t *testing.T) {
 	// WHEN: Day phase changes to evening
 	t.Log("WHEN: Day phase changes to evening")
 	server.SetState("input_text.day_phase", "evening", map[string]interface{}{})
+	waitForProcessing(t, stateManager)
 
 	// Wait for scene activation
 	waitForServiceCallSince(t, server, snapshot, "scene", "turn_on", "evening scenes should be activated")
@@ -418,6 +419,7 @@ func TestScenario_MultipleStateChanges_HandlesCorrectly(t *testing.T) {
 	waitForCondition(t, func() bool {
 		return server.ServiceCallCount() > callsBeforeEvening
 	}, "should process afternoon day phase change before next change")
+	waitForProcessing(t, stateManager)
 	server.SetState("input_text.day_phase", "evening", map[string]interface{}{})
 	callsBeforeTV := server.ServiceCallCount()
 	waitForCondition(t, func() bool {

--- a/homeautomation-go/test/integration/scenario_nighttime_safety_test.go
+++ b/homeautomation-go/test/integration/scenario_nighttime_safety_test.go
@@ -222,6 +222,7 @@ func TestScenario_SleepMusic_ContinuesWhenMasterAsleep(t *testing.T) {
 	require.NoError(t, env.stateManager.SetBool("isMasterAsleep", false))
 	require.NoError(t, env.stateManager.SetBool("isEveryoneAsleep", false))
 	require.NoError(t, env.stateManager.SetString("musicPlaybackType", ""))
+	waitForProcessing(t, env.stateManager)
 
 	env.server.SetState("media_player.bedroom", "idle", map[string]interface{}{})
 	env.server.SetState("media_player.kitchen", "idle", map[string]interface{}{})
@@ -295,6 +296,7 @@ func TestScenario_MorningMusic_BedroomMutedWhenMasterAsleep(t *testing.T) {
 	require.NoError(t, env.stateManager.SetBool("isMasterAsleep", true)) // CRITICAL: Still asleep!
 	require.NoError(t, env.stateManager.SetBool("isEveryoneAsleep", false))
 	require.NoError(t, env.stateManager.SetBool("isAnyoneAsleep", true))
+	waitForProcessing(t, env.stateManager)
 
 	// Set up mock speakers
 	env.server.SetState("media_player.bedroom", "idle", map[string]interface{}{
@@ -445,6 +447,7 @@ func TestScenario_WakeCancellation_RevertsToSleepMusicDuringNight(t *testing.T) 
 	require.NoError(t, env.stateManager.SetBool("isMasterAsleep", true))
 	require.NoError(t, env.stateManager.SetBool("isWakeSequenceActive", true))
 	require.NoError(t, env.stateManager.SetString("musicPlaybackType", "wakeup"))
+	waitForProcessing(t, env.stateManager)
 
 	// Bedroom lights are on during wake sequence
 	env.server.SetState("light.primary_suite", "on", map[string]interface{}{
@@ -529,6 +532,7 @@ func TestScenario_DayMusic_BedroomMutedWhenMasterAsleep(t *testing.T) {
 	require.NoError(t, env.stateManager.SetBool("isAnyoneHomeAndAwake", true)) // Someone awake
 	require.NoError(t, env.stateManager.SetBool("isMasterAsleep", true))       // But master napping!
 	require.NoError(t, env.stateManager.SetBool("isEveryoneAsleep", false))
+	waitForProcessing(t, env.stateManager)
 
 	env.server.SetState("media_player.bedroom", "idle", map[string]interface{}{
 		"volume_level": 0.1,

--- a/homeautomation-go/test/integration/scenario_owner_handoff_test.go
+++ b/homeautomation-go/test/integration/scenario_owner_handoff_test.go
@@ -111,6 +111,7 @@ func TestScenario_OwnerHandoff_LockdownSuppressedDuringGracePeriod(t *testing.T)
 
 	t.Log("AND: Nick's presence briefly flaps false (simulating 8-second sensor glitch)")
 	server.SetState("input_boolean.nick_home", "off", nil)
+	waitForProcessing(t, manager)
 	waitForBoolState(t, manager, "isNickHome", false, "isNickHome should be false during flap")
 	waitForServiceCallQuiescenceSince(t, server, snapshot, 200*time.Millisecond)
 

--- a/homeautomation-go/test/integration/scenario_security_test.go
+++ b/homeautomation-go/test/integration/scenario_security_test.go
@@ -182,6 +182,7 @@ func TestScenario_DidOwnerJustReturnHomeAutoReset(t *testing.T) {
 	t.Log("GIVEN: Nick arrives home")
 
 	server.SetState("input_boolean.nick_home", "off", nil)
+	waitForProcessing(t, manager)
 	waitForBoolState(t, manager, "isNickHome", false, "isNickHome should be false initially")
 
 	server.SetState("input_boolean.nick_home", "on", nil)
@@ -290,6 +291,7 @@ func TestScenario_OwnerLeavesAndReturns(t *testing.T) {
 	waitForBoolState(t, manager, "didOwnerJustReturnHome", true, "didOwnerJustReturnHome should be true after Nick arrives")
 
 	server.SetState("input_boolean.nick_home", "off", nil)
+	waitForProcessing(t, manager)
 
 	// Use polling helper instead of time.Sleep to wait for the departure to be processed
 	waitForBoolState(t, manager, "didOwnerJustReturnHome", false, "didOwnerJustReturnHome should be false when owner leaves")

--- a/homeautomation-go/test/integration/scenario_sexmode_test.go
+++ b/homeautomation-go/test/integration/scenario_sexmode_test.go
@@ -112,6 +112,7 @@ func TestScenario_SexModeActivation_ActivatesNightScene(t *testing.T) {
 	t.Log("WHEN: Sex mode is activated")
 
 	server.SetState("input_boolean.sex", "on", nil)
+	waitForProcessing(t, stateManager)
 
 	t.Log("THEN: Primary Suite night scene should be activated")
 
@@ -131,7 +132,7 @@ func TestScenario_SexModeActivation_ActivatesNightScene(t *testing.T) {
 // sets both Eight Sleep beds to the coldest setting (auto-detected from entity attributes)
 func TestScenario_SexModeActivation_SetsEightSleepToColdest(t *testing.T) {
 	t.Parallel()
-	server, _, _, cleanup := setupSexModeScenarioTest(t)
+	server, _, stateManager, cleanup := setupSexModeScenarioTest(t)
 	defer cleanup()
 
 	t.Log("GIVEN: Sex mode is off")
@@ -141,6 +142,7 @@ func TestScenario_SexModeActivation_SetsEightSleepToColdest(t *testing.T) {
 	t.Log("WHEN: Sex mode is activated")
 
 	server.SetState("input_boolean.sex", "on", nil)
+	waitForProcessing(t, stateManager)
 
 	t.Log("THEN: Both Eight Sleep sides should be set to coldest (auto-detected min_temp: 55)")
 
@@ -253,6 +255,7 @@ func TestScenario_SexModeDeactivation_RestoresMusicType(t *testing.T) {
 	t.Log("WHEN: Sex mode is deactivated")
 
 	server.SetState("input_boolean.sex", "off", nil)
+	waitForProcessing(t, stateManager)
 
 	t.Log("THEN: musicPlaybackType should be restored to 'working'")
 
@@ -272,6 +275,7 @@ func TestScenario_SexModeDeactivation_ActivatesDayPhaseScene(t *testing.T) {
 
 	require.NoError(t, stateManager.SetString("dayPhase", "sunset"))
 	require.NoError(t, stateManager.SetBool("isMasterAsleep", false))
+	waitForProcessing(t, stateManager)
 
 	// Activate sex mode
 	server.SetState("input_boolean.sex", "on", nil)
@@ -284,6 +288,7 @@ func TestScenario_SexModeDeactivation_ActivatesDayPhaseScene(t *testing.T) {
 		eightSleepCalls := FilterServiceCalls(allCalls, "climate", "set_temperature")
 		return len(eightSleepCalls) >= 2
 	}, stateWaitTimeout, statePollInterval, "Both Eight Sleep beds should be adjusted during activation")
+	waitForProcessing(t, stateManager)
 
 	snapshot := server.ServiceCallCount()
 
@@ -335,6 +340,7 @@ func TestScenario_SexModeDeactivation_TurnsOffLightsWhenAsleep(t *testing.T) {
 	t.Log("WHEN: Sex mode is deactivated")
 
 	server.SetState("input_boolean.sex", "off", nil)
+	waitForProcessing(t, stateManager)
 
 	t.Log("THEN: Primary Suite lights should be turned off (not scene activated)")
 
@@ -378,6 +384,7 @@ func TestScenario_SexModeDeactivation_DifferentDayPhases(t *testing.T) {
 
 			require.NoError(t, stateManager.SetString("dayPhase", phase))
 			require.NoError(t, stateManager.SetBool("isMasterAsleep", false))
+			waitForProcessing(t, stateManager)
 
 			// Activate sex mode
 			server.SetState("input_boolean.sex", "on", nil)
@@ -597,6 +604,7 @@ func TestScenario_SexModeActivationDeactivationCycle(t *testing.T) {
 		eightSleepCalls := FilterServiceCalls(sinceCalls, "climate", "set_temperature")
 		return len(eightSleepCalls) >= 2
 	}, stateWaitTimeout, statePollInterval, "Both Eight Sleep beds should be adjusted during activation")
+	waitForProcessing(t, stateManager)
 
 	activationCalls := len(server.GetServiceCallsSince(snapshot))
 	t.Logf("  Activation made %d service calls", activationCalls)
@@ -755,6 +763,7 @@ func TestScenario_SexModeDuringWakeSequence_CancelsWakeSequence(t *testing.T) {
 	require.NoError(t, stateManager.SetBool("isAnyoneAsleep", true))
 	require.NoError(t, stateManager.SetString("musicPlaybackType", "sleep"))
 	require.NoError(t, stateManager.SetString("dayPhase", "morning"))
+	waitForProcessing(t, stateManager)
 
 	// Set up bedroom speaker for the wake sequence
 	server.SetState("media_player.bedroom", "playing", map[string]interface{}{
@@ -807,6 +816,7 @@ func TestScenario_SexModeDuringWakeSequence_PreventsWakeMusicOverride(t *testing
 	require.NoError(t, stateManager.SetBool("isAnyoneAsleep", true))
 	require.NoError(t, stateManager.SetString("musicPlaybackType", "sleep"))
 	require.NoError(t, stateManager.SetString("dayPhase", "morning"))
+	waitForProcessing(t, stateManager)
 
 	server.SetState("media_player.bedroom", "playing", map[string]interface{}{
 		"volume_level": 0.30,

--- a/homeautomation-go/test/integration/scenario_sleephygiene_test.go
+++ b/homeautomation-go/test/integration/scenario_sleephygiene_test.go
@@ -1131,6 +1131,7 @@ func TestScenario_WakeSequence_ActivatesWakeMusic(t *testing.T) {
 	// Set on both server AND state manager since sleephygiene reads from state manager.
 	server.SetState("input_boolean.wake_sequence_active", "on", map[string]interface{}{})
 	require.NoError(t, stateManager.SetBool("isWakeSequenceActive", true))
+	waitForProcessing(t, stateManager)
 
 	// Start with sleep music playing (typical state before wake)
 	server.SetState("input_text.music_playback_type", "sleep", map[string]interface{}{})

--- a/homeautomation-go/test/integration/scenario_tv_lighting_test.go
+++ b/homeautomation-go/test/integration/scenario_tv_lighting_test.go
@@ -97,6 +97,7 @@ func TestScenario_SyncBoxRecovery_LightingPluginRestoresScene(t *testing.T) {
 	require.NoError(t, env.stateManager.SetBool("isAnyoneHomeAndAwake", true))
 	require.NoError(t, env.stateManager.SetBool("isEveryoneAsleep", false))
 	require.NoError(t, env.stateManager.SetString("dayPhase", "evening"))
+	waitForProcessing(t, env.stateManager)
 
 	// Set up required entities so the TV plugin can recalculate state on recovery.
 	// Without these, GetState returns an error and the recovery handler exits early

--- a/homeautomation-go/test/integration/scenario_tv_test.go
+++ b/homeautomation-go/test/integration/scenario_tv_test.go
@@ -60,6 +60,7 @@ func TestScenario_AppleTVPlaying(t *testing.T) {
 	server.SetState("media_player.big_beautiful_oled", "playing", map[string]interface{}{
 		"friendly_name": "Apple TV",
 	})
+	waitForProcessing(t, manager)
 
 	t.Log("THEN: Verify isAppleTVPlaying and isTVPlaying are both true")
 
@@ -84,6 +85,7 @@ func TestScenario_HDMIInputSwitch(t *testing.T) {
 	server.SetState("media_player.sony_xr_65a80k", "on", map[string]interface{}{})
 	server.SetState("switch.sync_box_power", "on", map[string]interface{}{})
 	server.SetState("select.sync_box_hdmi_input", "AppleTV", map[string]interface{}{})
+	waitForProcessing(t, manager)
 
 	// Wait for initial state
 	waitForBoolState(t, manager, "isTVPlaying", true, "isTVPlaying should initially be true when AppleTV is playing")
@@ -92,6 +94,7 @@ func TestScenario_HDMIInputSwitch(t *testing.T) {
 
 	// Switch HDMI input to Xbox
 	server.SetState("select.sync_box_hdmi_input", "Xbox", map[string]interface{}{})
+	waitForProcessing(t, manager)
 
 	t.Log("THEN: Verify isTVPlaying is still true (Xbox input assumes playing)")
 
@@ -102,6 +105,7 @@ func TestScenario_HDMIInputSwitch(t *testing.T) {
 
 	// Switch back to Apple TV
 	server.SetState("select.sync_box_hdmi_input", "AppleTV", map[string]interface{}{})
+	waitForProcessing(t, manager)
 
 	t.Log("THEN: Verify isTVPlaying remains true")
 
@@ -144,6 +148,7 @@ func TestScenario_TVRemoteKillSwitch(t *testing.T) {
 
 	// TV panel turns off - sync box stays on
 	server.SetState("media_player.sony_xr_65a80k", "off", map[string]interface{}{})
+	waitForProcessing(t, manager)
 
 	t.Log("THEN: isTVPlaying should be forced false (kill switch)")
 
@@ -167,24 +172,28 @@ func TestScenario_MultipleInputs(t *testing.T) {
 		"friendly_name": "Apple TV",
 	})
 	server.SetState("select.sync_box_hdmi_input", "AppleTV", map[string]interface{}{})
+	waitForProcessing(t, manager)
 	waitForBoolState(t, manager, "isTVon", true, "isTVon should be true when TV remote is on")
 
 	t.Log("WHEN: Switching between multiple HDMI inputs")
 
 	// Switch to Xbox
 	server.SetState("select.sync_box_hdmi_input", "Xbox", map[string]interface{}{})
+	waitForProcessing(t, manager)
 
 	// Verify isTVPlaying is true for Xbox
 	waitForBoolState(t, manager, "isTVPlaying", true, "isTVPlaying should be true for Xbox")
 
 	// Switch to Cable
 	server.SetState("select.sync_box_hdmi_input", "Cable", map[string]interface{}{})
+	waitForProcessing(t, manager)
 
 	// Verify isTVPlaying is true for Cable
 	waitForBoolState(t, manager, "isTVPlaying", true, "isTVPlaying should be true for Cable")
 
 	// Switch back to AppleTV (idle)
 	server.SetState("select.sync_box_hdmi_input", "AppleTV", map[string]interface{}{})
+	waitForProcessing(t, manager)
 
 	t.Log("THEN: Verify isTVPlaying is false (AppleTV is idle)")
 
@@ -255,6 +264,7 @@ func TestScenario_RapidInputSwitching(t *testing.T) {
 		"friendly_name": "Apple TV",
 	})
 	server.SetState("select.sync_box_hdmi_input", "AppleTV", map[string]interface{}{})
+	waitForProcessing(t, manager)
 	waitForBoolState(t, manager, "isTVPlaying", true, "isTVPlaying should be true when AppleTV is playing")
 
 	t.Log("WHEN: Rapidly switching HDMI inputs")
@@ -263,6 +273,7 @@ func TestScenario_RapidInputSwitching(t *testing.T) {
 	inputs := []string{"Xbox", "Cable", "AppleTV", "Xbox", "AppleTV", "Cable", "AppleTV"}
 	for _, input := range inputs {
 		server.SetState("select.sync_box_hdmi_input", input, map[string]interface{}{})
+		waitForProcessing(t, manager)
 	}
 
 	t.Log("THEN: Verify final state is consistent (AppleTV playing)")
@@ -286,6 +297,7 @@ func TestScenario_AppleTVPlaybackStateChanges(t *testing.T) {
 	server.SetState("media_player.big_beautiful_oled", "idle", map[string]interface{}{
 		"friendly_name": "Apple TV",
 	})
+	waitForProcessing(t, manager)
 	waitForBoolState(t, manager, "isTVon", true, "isTVon should be true when TV remote is on")
 
 	testCases := []struct {
@@ -306,6 +318,7 @@ func TestScenario_AppleTVPlaybackStateChanges(t *testing.T) {
 		server.SetState("media_player.big_beautiful_oled", tc.state, map[string]interface{}{
 			"friendly_name": "Apple TV",
 		})
+		waitForProcessing(t, manager)
 
 		t.Logf("THEN: Verify isAppleTVPlaying is %v and isTVPlaying is %v", tc.expectedPlaying, tc.expectedPlaying)
 

--- a/homeautomation-go/test/integration/scenario_user_stories_test.go
+++ b/homeautomation-go/test/integration/scenario_user_stories_test.go
@@ -93,6 +93,7 @@ func TestUserStory_WakeSequence_StateCoordination(t *testing.T) {
 	server.SetState("input_boolean.anyone_asleep", "on", nil)
 	server.SetState("input_boolean.master_asleep", "on", nil)
 	server.SetState("input_boolean.wake_sequence_active", "off", nil)
+	waitForProcessing(t, stateManager)
 
 	// Verify initial state
 	waitForBoolState(t, stateManager, "isWakeSequenceActive", false, "Wake sequence should NOT be active initially")
@@ -105,6 +106,7 @@ func TestUserStory_WakeSequence_StateCoordination(t *testing.T) {
 	// The fix from PR #564: isWakeSequenceActive is set IMMEDIATELY
 	// when handleBeginWake() fires, not 5 minutes later in handleWake()
 	server.SetState("input_boolean.wake_sequence_active", "on", nil)
+	waitForProcessing(t, stateManager)
 
 	// CRITICAL ASSERTION: isWakeSequenceActive must be true NOW
 	waitForBoolState(t, stateManager, "isWakeSequenceActive", true,
@@ -120,6 +122,7 @@ func TestUserStory_WakeSequence_StateCoordination(t *testing.T) {
 	// Before PR #564, this would cause sleep music to restart because
 	// isWakeSequenceActive was still false during this window
 	server.SetState("input_text.day_phase", "morning", nil)
+	waitForProcessing(t, stateManager)
 
 	// Verify state is as expected for morning zone to activate
 	waitForStringState(t, stateManager, "dayPhase", "morning", "dayPhase should become morning")
@@ -175,6 +178,7 @@ func TestUserStory_WakeSequence_CancelReturnsToSleep(t *testing.T) {
 	server.SetState("input_boolean.anyone_asleep", "on", nil)
 	server.SetState("input_boolean.master_asleep", "on", nil)
 	server.SetState("input_boolean.wake_sequence_active", "on", nil)
+	waitForProcessing(t, stateManager)
 
 	waitForBoolState(t, stateManager, "isWakeSequenceActive", true, "Wake sequence should be active")
 
@@ -184,6 +188,7 @@ func TestUserStory_WakeSequence_CancelReturnsToSleep(t *testing.T) {
 	t.Log("WHEN: User cancels wake sequence")
 
 	server.SetState("input_boolean.wake_sequence_active", "off", nil)
+	waitForProcessing(t, stateManager)
 
 	// =========================================================================
 	// THEN: Sleep zone can now match again
@@ -221,6 +226,7 @@ func TestUserStory_CompleteMorningRoutine_StateTransitions(t *testing.T) {
 	server.SetState("input_boolean.anyone_asleep", "on", nil)
 	server.SetState("input_boolean.master_asleep", "on", nil)
 	server.SetState("input_boolean.wake_sequence_active", "off", nil)
+	waitForProcessing(t, stateManager)
 
 	// Verify: Sleep zone should match
 	waitForStringState(t, stateManager, "dayPhase", "night", "dayPhase should be night")
@@ -235,6 +241,7 @@ func TestUserStory_CompleteMorningRoutine_StateTransitions(t *testing.T) {
 	t.Log("PHASE 2: Alarm fires (begin_wake)")
 
 	server.SetState("input_boolean.wake_sequence_active", "on", nil)
+	waitForProcessing(t, stateManager)
 	waitForBoolState(t, stateManager, "isWakeSequenceActive", true, "isWakeSequenceActive must be true immediately")
 	t.Log("  isWakeSequenceActive=true ✓")
 
@@ -244,6 +251,7 @@ func TestUserStory_CompleteMorningRoutine_StateTransitions(t *testing.T) {
 	t.Log("PHASE 3: Sunrise during fade-out")
 
 	server.SetState("input_text.day_phase", "morning", nil)
+	waitForProcessing(t, stateManager)
 	waitForStringState(t, stateManager, "dayPhase", "morning", "dayPhase should become morning")
 
 	isWakeActive, _ := stateManager.GetBool("isWakeSequenceActive")
@@ -258,6 +266,7 @@ func TestUserStory_CompleteMorningRoutine_StateTransitions(t *testing.T) {
 
 	server.SetState("input_boolean.master_asleep", "off", nil)
 	server.SetState("input_boolean.anyone_asleep", "off", nil)
+	waitForProcessing(t, stateManager)
 	waitForBoolState(t, stateManager, "isMasterAsleep", false, "isMasterAsleep should become false")
 	waitForBoolState(t, stateManager, "isAnyoneAsleep", false, "isAnyoneAsleep should become false")
 	t.Log("  Morning zone now matches via normal trigger: dayPhase=morning, isAnyoneAsleep=false ✓")
@@ -269,6 +278,7 @@ func TestUserStory_CompleteMorningRoutine_StateTransitions(t *testing.T) {
 
 	server.SetState("input_boolean.wake_sequence_active", "off", nil)
 	server.SetState("input_text.day_phase", "day", nil)
+	waitForProcessing(t, stateManager)
 	waitForStringState(t, stateManager, "dayPhase", "day", "dayPhase should become day")
 	waitForBoolState(t, stateManager, "isWakeSequenceActive", false, "isWakeSequenceActive should become false")
 	t.Log("  Day zone conditions: dayPhase=day, isAnyoneAsleep=false ✓")
@@ -310,6 +320,7 @@ func TestRegression_PR564_IsWakeSequenceActiveSetImmediately(t *testing.T) {
 	server.SetState("input_boolean.anyone_asleep", "on", nil)
 	server.SetState("input_boolean.master_asleep", "on", nil)
 	server.SetState("input_boolean.wake_sequence_active", "off", nil)
+	waitForProcessing(t, stateManager)
 	waitForBoolState(t, stateManager, "isWakeSequenceActive", false, "initial isWakeSequenceActive should be false")
 
 	// T+0: Eight Sleep alarm fires (begin_wake)
@@ -317,6 +328,7 @@ func TestRegression_PR564_IsWakeSequenceActiveSetImmediately(t *testing.T) {
 
 	// THE FIX: isWakeSequenceActive is set IMMEDIATELY in handleBeginWake
 	server.SetState("input_boolean.wake_sequence_active", "on", nil)
+	waitForProcessing(t, stateManager)
 
 	// CRITICAL: Must be true NOW, not after 5 minutes
 	waitForBoolState(t, stateManager, "isWakeSequenceActive", true,


### PR DESCRIPTION
Resolves #1075

## Summary
- Added `waitForProcessing` barriers between sequential same-entity `SetState` calls across integration scenarios.
- Added defensive barriers for audited multi-input computed-state cases, manager state writes followed by HA `SetState`, and rapid state-change loops covered by the issue.
- Re-ran the static scans for same-entity `SetState` and manager-write-to-`SetState` sequences; both are clean.

## Test Plan
- `make unit-tests` ✅
- `make integration-tests` ✅
- `make pre-commit` ✅
- `cd homeautomation-go && go test ./test/integration/... -race -count=10 -timeout=30m` ❌ exposed remaining package-level flakes under full parallel soak:
  - `TestScenario_ThresholdBoundaries_HandlesExactValues`
  - `TestHighFrequencyStateChanges`
  - `TestScenario_WakeCancellation_ClearsMusicPlaybackType`
  - `TestScenario_BatteryLevelChanges_UpdateEnergyLevels`
- Isolated ten-pass reruns for the failing soak cases passed:
  - `cd homeautomation-go && go test ./test/integration/... -race -count=10 -run 'TestScenario_BatteryLevelChanges_UpdateEnergyLevels|TestScenario_ThresholdBoundaries_HandlesExactValues' -timeout=5m` ✅
  - `cd homeautomation-go && go test ./test/integration/... -race -count=10 -run 'TestHighFrequencyStateChanges|TestScenario_WakeCancellation_ClearsMusicPlaybackType' -timeout=5m` ✅

🤖 Generated by the AI assistant