### PR TITLE
feat(notify): replace HA TTS with Kokoro + media_player.play_media

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,6 +321,15 @@ HA_TOKEN=your_long_lived_access_token
 READ_ONLY=true
 ```
 
+**TTS env vars** (required in production for Kokoro TTS announcements):
+
+| Var | Default | Notes |
+|-----|---------|-------|
+| `TTS_ENDPOINT` | Kokoro URL on llms-mac-studio | OpenAI-compatible `/audio/speech` |
+| `TTS_VOICE` | `af_heart` | Kokoro voice name |
+| `TTS_SERVE_PORT` | `8085` | Port the local audio file server listens on |
+| `TTS_SERVE_URL` | **required** in non-dev | LAN base URL Sonos speakers can reach (e.g. `http://10.212.100.100:8085`) — Sonos cannot resolve Tailscale-served URLs |
+
 ## CI Runner (Self-Hosted GitHub Actions)
 
 Self-hosted GitHub Actions runner on `dockergeneric` for home-automation CI. Two containers share a network namespace: Tailscale sidecar (`ci-runner-ts`) and the runner itself (`ci-runner`).

--- a/configs/notification_config.yaml
+++ b/configs/notification_config.yaml
@@ -13,11 +13,15 @@
 #     must wake the household (security, broken-pipe water flow, EV-charger
 #     safety, infrastructure crashes).
 #
-# Before each announcement the notifier:
-#   1. Snapshots each target speaker's current volume.
-#   2. Sets volume to awake_volume_percent.
-#   3. Calls tts.speak.
-#   4. After restore_delay_seconds, restores each speaker's prior volume.
+# How an announcement is rendered:
+#   1. The text is synthesized to MP3 by a Kokoro TTS server (TTS_ENDPOINT).
+#   2. The MP3 is stored in a bounded in-memory cache and exposed at
+#      $TTS_SERVE_URL/audio/<id>.mp3 for Sonos to fetch over the LAN.
+#   3. Home Assistant's media_player.play_media is invoked with announce: true
+#      and extra.volume = awake_volume_percent. The Sonos integration
+#      snapshots the queue, current track, position, transport state, and
+#      volume, ducks/plays the announcement, and restores everything when
+#      playback ends — so resumption of the prior music is seamless.
 notification:
   # Default speaker list when a plugin does not override. Union of all
   # per-plugin lists in use today, so removing a plugin's hardcoded list
@@ -30,19 +34,7 @@ notification:
     - media_player.dining_room
     - media_player.kids_bathroom
 
-  # Volume (0-100) used for every announcement that plays. Announcements while
-  # master is asleep either play at this volume (UrgencyUrgent) or are dropped
-  # entirely (UrgencyDeferable) — there is no quieter mid-tier.
+  # Volume (0-100) the announcement is played at. Passed to
+  # media_player.play_media as extra.volume; HA restores the speaker's prior
+  # volume when the announcement ends.
   awake_volume_percent: 20
-
-  # TTS engine. tts.google_translate_en_com is the default in Home Assistant.
-  tts_entity_id: tts.google_translate_en_com
-
-  # When true, snapshot speaker volume before the announcement and restore
-  # after. Set to false only for diagnostics.
-  snapshot_restore: true
-
-  # How long to wait after the tts.speak call returns before restoring
-  # speaker volumes. Sized to cover typical announcement playback duration
-  # (3-7 seconds for short alerts).
-  restore_delay_seconds: 8

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -659,8 +659,13 @@ homeautomation-go/
 │   │   ├── alert.go                 # ✅ Alerter interface and Manager implementation
 │   │   ├── alert_test.go            # ✅ Unit tests
 │   │   └── mock.go                  # ✅ MockAlerter for unit tests
+│   ├── tts/                         # ✅ Kokoro TTS client, audio file server, synthesizer
+│   │   ├── client.go                # ✅ Kokoro HTTP client (OpenAI-compatible /audio/speech)
+│   │   ├── server.go                # ✅ Local audio file server (bounded in-memory cache)
+│   │   ├── synthesizer.go           # ✅ Service combining client + server
+│   │   └── mock.go                  # ✅ MockSynthesizer for unit tests
 │   ├── notify/                      # ✅ Shared verbal (TTS) notifier
-│   │   ├── notify.go                # ✅ Notifier implementation (volume snapshot/restore)
+│   │   ├── notify.go                # ✅ Notifier implementation (Kokoro TTS synthesis → media_player.play_media announce)
 │   │   ├── config.go                # ✅ Config loader (notification_config.yaml)
 │   │   └── mock.go                  # ✅ MockNotifier for unit tests
 │   └── plugins/                     # ✅ Automation plugins (13 total)

--- a/docs/reference/PLUGIN_SYSTEM.md
+++ b/docs/reference/PLUGIN_SYSTEM.md
@@ -934,14 +934,13 @@ make pre-push
 
 ## Verbal Notifications
 
-Plugins that need to make spoken (TTS) announcements **must** use the shared `notify.Notifier` from `pkg/notify` instead of calling `tts.speak` directly through the HA client. The notifier:
+Plugins that need to make spoken (TTS) announcements **must** use the shared `notify.Notifier` from `pkg/notify` instead of calling `media_player.play_media` directly through the HA client. The notifier:
 
-1. **Snapshots** each target speaker's current volume.
-2. **Overrides** to `awake_volume_percent`. Deferable announcements are dropped entirely while master is asleep; Urgent announcements always play.
-3. **Speaks** the message via Home Assistant.
-4. **Restores** the prior speaker volume after a delay.
+1. **Synthesizes** the text to MP3 via the Kokoro TTS server.
+2. **Serves** the MP3 from a local in-memory audio server reachable by Sonos over the LAN.
+3. **Plays** the announcement via `media_player.play_media` with `announce: true` and `extra.volume = awake_volume_percent/100`. The Sonos/HA integration handles snapshot, ducking, playback, and seamless queue restoration — no per-plugin volume bookkeeping required.
 
-This guarantees announcements remain audible regardless of the speakers' state (ducked music, paused playback, low background volume) without any per-plugin volume bookkeeping.
+Deferable announcements are dropped entirely while master is asleep; Urgent announcements always play.
 
 ### Accessing the notifier
 
@@ -1002,7 +1001,7 @@ assert.Equal(t, "Doorbell ringing", calls[0].Message)
 assert.Equal(t, notify.UrgencyUrgent, calls[0].Urgency)
 ```
 
-Configuration lives at `configs/notification_config.yaml` — see that file for the full set of tunables (default speakers, awake volume, restore delay, TTS engine).
+Configuration lives at `configs/notification_config.yaml` — see that file for the full set of tunables (default speakers, awake volume).
 
 ---
 

--- a/homeautomation-go/.env.example
+++ b/homeautomation-go/.env.example
@@ -29,3 +29,22 @@ READ_ONLY=false
 # Optional: SoCo-CLI HTTP API URL for Tidal playlist support
 # If not set, Tidal playlists in music_config.yaml will not work
 # SOCO_CLI_URL=http://127.0.0.1:8000
+
+# Required (production): Base URL Sonos speakers fetch synthesized announcements from.
+# This must be a LAN address reachable by the Sonos hardware on the local network
+# (Sonos cannot reach Tailscale-served URLs). Typically the LAN IP of the host
+# running this service plus the TTS_SERVE_PORT below.
+# Example: http://10.212.100.100:8085
+# TTS_SERVE_URL=http://10.212.100.100:8085
+
+# Optional: Port the local TTS audio file server listens on.
+# Default: 8085
+# TTS_SERVE_PORT=8085
+
+# Optional: Kokoro TTS endpoint (OpenAI-compatible /audio/speech)
+# Default: https://llms-mac-studio.featherback-mermaid.ts.net/v1/audio/speech
+# TTS_ENDPOINT=https://llms-mac-studio.featherback-mermaid.ts.net/v1/audio/speech
+
+# Optional: Kokoro voice id (e.g. af_heart, bf_emma, ...)
+# Default: af_heart
+# TTS_VOICE=af_heart

--- a/homeautomation-go/cmd/app/run.go
+++ b/homeautomation-go/cmd/app/run.go
@@ -24,6 +24,7 @@ import (
 	"homeautomation/internal/plugins/reset"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
+	"homeautomation/internal/tts"
 	"homeautomation/internal/version"
 	pkgha "homeautomation/pkg/ha"
 	"homeautomation/pkg/plugin"
@@ -198,6 +199,34 @@ func Run() {
 		logger.Info("SoCo-CLI URL configured for Tidal playback", zap.String("url", socoCliURL))
 	}
 
+	// TTS configuration: synthesize via Kokoro, serve MP3s on a LAN port that
+	// Sonos speakers can fetch from.
+	ttsEndpoint := os.Getenv("TTS_ENDPOINT")
+	if ttsEndpoint == "" {
+		ttsEndpoint = "https://llms-mac-studio.featherback-mermaid.ts.net/v1/audio/speech"
+	}
+	ttsVoice := os.Getenv("TTS_VOICE")
+	if ttsVoice == "" {
+		ttsVoice = "af_heart"
+	}
+	ttsServePort := 8085
+	if portStr := os.Getenv("TTS_SERVE_PORT"); portStr != "" {
+		if port, err := strconv.Atoi(portStr); err == nil {
+			ttsServePort = port
+		} else {
+			logger.Warn("Invalid TTS_SERVE_PORT value, using default",
+				zap.String("value", portStr), zap.Int("default", 8085))
+		}
+	}
+	ttsServeURL := os.Getenv("TTS_SERVE_URL")
+	if ttsServeURL == "" {
+		if devMode {
+			logger.Warn("TTS_SERVE_URL not set in DEV_MODE; announcements will fail (HA can't reach the audio server). Set it to a LAN URL Sonos speakers can fetch from.")
+		} else {
+			logger.Fatal("TTS_SERVE_URL must be set to the LAN base URL Sonos can reach (e.g. http://10.212.100.100:8085)")
+		}
+	}
+
 	logger.Info("Starting Home Automation Client",
 		zap.String("url", haURL),
 		zap.Bool("read_only", readOnly))
@@ -315,6 +344,27 @@ func Run() {
 	subscriptionRegistry := shadowstate.NewSubscriptionRegistry()
 	logger.Info("Subscription Registry created for automatic input tracking")
 
+	// Start TTS audio file server and build the synthesizer that notify uses.
+	// Constructed here (before the notifier) because notify.NewManager requires
+	// a Synthesizer; the HTTP API server below depends on the AlertNotifier
+	// (added in #1067) so it stays sequenced after the notifier.
+	ttsClient := tts.NewClient(ttsEndpoint, ttsVoice, logger)
+	ttsServer := tts.NewServer(fmt.Sprintf(":%d", ttsServePort), ttsServeURL, logger)
+	if err := ttsServer.Start(); err != nil {
+		logger.Fatal("Failed to start TTS audio file server", zap.Error(err))
+	}
+	defer func() {
+		if err := ttsServer.Stop(); err != nil {
+			logger.Error("Failed to stop TTS audio file server", zap.Error(err))
+		}
+	}()
+	ttsService := tts.NewService(ttsClient, ttsServer, logger)
+	logger.Info("TTS service initialized",
+		zap.String("endpoint", ttsEndpoint),
+		zap.String("voice", ttsVoice),
+		zap.Int("serve_port", ttsServePort),
+		zap.String("serve_url", ttsServeURL))
+
 	// Display current state
 	displayState(stateManager, logger)
 
@@ -346,7 +396,7 @@ func Run() {
 		defaultCfg := notify.DefaultConfig()
 		notifyCfg = &defaultCfg
 	}
-	notifier := notify.NewManager(client, stateManager, *notifyCfg, logger, readOnly)
+	notifier := notify.NewManager(client, stateManager, ttsService, *notifyCfg, logger, readOnly)
 	pluginCtx.Notifier = notifier
 	pluginCtx.AlertNotifier = alert.NewManager(ntfyClient, notifier, logger)
 	logger.Info("Notifier initialized",
@@ -431,9 +481,6 @@ func Run() {
 	// waiting for their full retry budget (which could take several minutes).
 	cancelShutdown()
 	logger.Info("Cancelled shutdown context - service calls will exit quickly")
-
-	// Wait for any pending TTS volume restores so we don't leave speakers loud.
-	notifier.WaitForRestores()
 
 	// Stop dev server if running
 	if devServer != nil {

--- a/homeautomation-go/internal/notify/config.go
+++ b/homeautomation-go/internal/notify/config.go
@@ -3,7 +3,6 @@ package notify
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -13,32 +12,13 @@ type Config struct {
 	// DefaultSpeakers are used when a caller does not pass WithSpeakers.
 	DefaultSpeakers []string `yaml:"default_speakers"`
 
-	// AwakeVolumePercent is the speaker volume (0-100) used for every
-	// announcement that plays. Announcements while master is asleep either
-	// play at this volume (UrgencyUrgent) or are dropped entirely
-	// (UrgencyDeferable) — there is no quieter mid-tier.
+	// AwakeVolumePercent is the speaker volume (0-100) the announcement is
+	// played at. It is passed to media_player.play_media as extra.volume so
+	// the Sonos integration can duck/play at this level and then restore the
+	// speaker's prior volume when the announcement ends. Announcements while
+	// master is asleep either play at this volume (UrgencyUrgent) or are
+	// dropped entirely (UrgencyDeferable) — there is no quieter mid-tier.
 	AwakeVolumePercent int `yaml:"awake_volume_percent"`
-
-	// TTSDomain / TTSService identify the Home Assistant service to call.
-	// Defaults to tts.speak.
-	TTSDomain  string `yaml:"tts_domain"`
-	TTSService string `yaml:"tts_service"`
-
-	// TTSEntityID is the TTS engine to use (e.g. tts.google_translate_en_com).
-	TTSEntityID string `yaml:"tts_entity_id"`
-
-	// SnapshotRestore controls whether speaker volume is captured before the
-	// announcement and restored after RestoreDelay elapses. Set to false in
-	// the YAML to disable (e.g. for tests).
-	SnapshotRestore bool `yaml:"snapshot_restore"`
-
-	// RestoreDelaySeconds is how long to wait after the TTS service call
-	// returns before restoring speaker volumes. Sized to cover typical
-	// announcement playback duration.
-	RestoreDelaySeconds int `yaml:"restore_delay_seconds"`
-
-	// RestoreDelay is the parsed RestoreDelaySeconds. Populated by applyDefaults.
-	RestoreDelay time.Duration `yaml:"-"`
 }
 
 type fileShape struct {
@@ -46,11 +26,7 @@ type fileShape struct {
 }
 
 const (
-	defaultAwakeVolumePercent  = 60
-	defaultTTSDomain           = "tts"
-	defaultTTSService          = "speak"
-	defaultTTSEntityID         = "tts.google_translate_en_com"
-	defaultRestoreDelaySeconds = 8
+	defaultAwakeVolumePercent = 60
 )
 
 // defaultSpeakers is the union of speaker lists currently used by plugins.
@@ -86,7 +62,7 @@ func LoadConfig(path string) (*Config, error) {
 // DefaultConfig returns a Config populated with safe defaults. Used when no
 // notification_config.yaml file is present.
 func DefaultConfig() Config {
-	c := Config{SnapshotRestore: true}
+	c := Config{}
 	c.applyDefaults()
 	return c
 }
@@ -98,27 +74,11 @@ func (c *Config) applyDefaults() {
 	if c.AwakeVolumePercent == 0 {
 		c.AwakeVolumePercent = defaultAwakeVolumePercent
 	}
-	if c.TTSDomain == "" {
-		c.TTSDomain = defaultTTSDomain
-	}
-	if c.TTSService == "" {
-		c.TTSService = defaultTTSService
-	}
-	if c.TTSEntityID == "" {
-		c.TTSEntityID = defaultTTSEntityID
-	}
-	if c.RestoreDelaySeconds == 0 {
-		c.RestoreDelaySeconds = defaultRestoreDelaySeconds
-	}
-	c.RestoreDelay = time.Duration(c.RestoreDelaySeconds) * time.Second
 }
 
 func (c *Config) validate() error {
 	if c.AwakeVolumePercent < 0 || c.AwakeVolumePercent > 100 {
 		return fmt.Errorf("awake_volume_percent must be 0-100, got %d", c.AwakeVolumePercent)
-	}
-	if c.RestoreDelaySeconds < 0 {
-		return fmt.Errorf("restore_delay_seconds must be non-negative, got %d", c.RestoreDelaySeconds)
 	}
 	return nil
 }

--- a/homeautomation-go/internal/notify/notify.go
+++ b/homeautomation-go/internal/notify/notify.go
@@ -1,23 +1,26 @@
-// Package notify provides a shared TTS announcement helper that snapshots
-// speaker volume, overrides to a configured announcement volume, sends the
-// TTS via Home Assistant, and restores the prior volume after a delay.
+// Package notify provides a shared verbal-announcement helper. Each
+// announcement is synthesized to MP3 by a Kokoro TTS server, served from a
+// local HTTP file server, and played on Sonos speakers via Home Assistant's
+// media_player.play_media with announce: true. The Sonos integration in HA
+// snapshots the queue, current track, position, transport state, and volume
+// before the announcement, ducks/plays the announcement at the configured
+// awake_volume_percent, and restores everything when playback ends — so
+// resumption of the prior music is seamless.
 //
 // All plugins that need to make verbal announcements should depend on the
-// Notifier interface rather than calling tts.speak directly. This guarantees
-// announcements remain audible regardless of the speakers' current state
-// (ducked music, paused playback, low background volume) and centralises
-// the asleep-aware suppression policy.
+// Notifier interface rather than constructing service calls directly. This
+// guarantees announcements remain audible regardless of the speakers' current
+// state and centralises the asleep-aware suppression policy.
 package notify
 
 import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
-	"time"
 
 	"homeautomation/internal/ha"
 	"homeautomation/internal/state"
+	"homeautomation/internal/tts"
 
 	"go.uber.org/zap"
 )
@@ -79,38 +82,31 @@ func WithUrgency(level UrgencyLevel) AnnounceOption {
 type Manager struct {
 	haClient     ha.HAClient
 	stateManager *state.Manager
+	synthesizer  tts.Synthesizer
 	cfg          Config
 	logger       *zap.Logger
 	readOnly     bool
-
-	wg sync.WaitGroup
 }
 
 // NewManager constructs a Notifier. stateManager may be nil in tests; the
 // asleep-suppression check then defaults to "awake" so announcements are not
 // silently dropped during tests that don't model sleep state.
-func NewManager(haClient ha.HAClient, stateManager *state.Manager, cfg Config, logger *zap.Logger, readOnly bool) *Manager {
+func NewManager(haClient ha.HAClient, stateManager *state.Manager, synthesizer tts.Synthesizer, cfg Config, logger *zap.Logger, readOnly bool) *Manager {
 	cfg.applyDefaults()
 	return &Manager{
 		haClient:     haClient,
 		stateManager: stateManager,
+		synthesizer:  synthesizer,
 		cfg:          cfg,
 		logger:       logger.Named("notify"),
 		readOnly:     readOnly,
 	}
 }
 
-// WaitForRestores blocks until all pending volume restores complete. Use during
-// graceful shutdown to avoid leaving speakers at the announcement volume.
-func (m *Manager) WaitForRestores() { m.wg.Wait() }
-
-// Announce speaks message on the configured speakers. The TTS service call is
-// synchronous; the volume restore is scheduled asynchronously after
-// cfg.RestoreDelay so the caller does not block waiting for playback to end.
-//
-// Snapshot and restore failures are logged but do not fail the call - an
-// audible announcement at an unknown final volume is preferable to no
-// announcement.
+// Announce speaks message on the configured speakers. Synthesis is performed
+// before the HA service call; HA's Sonos integration handles snapshot, ducking,
+// playback, and seamless restoration of the prior queue/track/volume via
+// announce: true.
 func (m *Manager) Announce(ctx context.Context, message string, opts ...AnnounceOption) error {
 	o := announceOpts{
 		speakers: m.cfg.DefaultSpeakers,
@@ -144,34 +140,29 @@ func (m *Manager) Announce(ctx context.Context, message string, opts ...Announce
 		return nil
 	}
 
-	var priorVolumes map[string]float64
-	if m.cfg.SnapshotRestore {
-		priorVolumes = m.snapshotVolumes(o.speakers)
-		m.setVolumes(ctx, o.speakers, float64(targetVolume)/100.0)
+	url, err := m.synthesizer.SynthesizeAndServe(ctx, message)
+	if err != nil {
+		return fmt.Errorf("synthesize announcement: %w", err)
 	}
 
-	if err := m.haClient.CallService(ctx, m.cfg.TTSDomain, m.cfg.TTSService, map[string]interface{}{
-		"entity_id":              m.cfg.TTSEntityID,
-		"media_player_entity_id": o.speakers,
-		"message":                message,
-		"cache":                  true,
+	if err := m.haClient.CallService(ctx, "media_player", "play_media", map[string]interface{}{
+		"entity_id":          o.speakers,
+		"media_content_id":   url,
+		"media_content_type": "music",
+		"announce":           true,
+		"extra": map[string]interface{}{
+			"volume": float64(targetVolume) / 100.0,
+		},
 	}); err != nil {
-		// On TTS failure, restore immediately so we don't leave speakers loud.
-		if m.cfg.SnapshotRestore && len(priorVolumes) > 0 {
-			m.restoreVolumesNow(ctx, priorVolumes)
-		}
-		return fmt.Errorf("tts.%s call failed: %w", m.cfg.TTSService, err)
+		return fmt.Errorf("media_player.play_media call failed: %w", err)
 	}
 
 	m.logger.Info("Announcement sent",
 		zap.String("message", message),
 		zap.Strings("speakers", o.speakers),
 		zap.Int("target_volume_percent", targetVolume),
-		zap.Int("urgency", int(o.urgency)))
-
-	if m.cfg.SnapshotRestore && len(priorVolumes) > 0 {
-		m.scheduleRestore(ctx, priorVolumes)
-	}
+		zap.Int("urgency", int(o.urgency)),
+		zap.String("audio_url", url))
 	return nil
 }
 
@@ -186,89 +177,4 @@ func (m *Manager) isMasterAsleep() bool {
 		return false
 	}
 	return v
-}
-
-// snapshotVolumes reads the current volume_level for each speaker. Failures
-// are logged and the speaker is omitted from the returned map (so it is not
-// restored later).
-func (m *Manager) snapshotVolumes(speakers []string) map[string]float64 {
-	out := make(map[string]float64, len(speakers))
-	for _, entityID := range speakers {
-		st, err := m.haClient.GetState(entityID)
-		if err != nil {
-			m.logger.Warn("Failed to snapshot speaker volume; will not restore",
-				zap.String("entity_id", entityID),
-				zap.Error(err))
-			continue
-		}
-		raw, ok := st.Attributes["volume_level"]
-		if !ok {
-			m.logger.Debug("Speaker has no volume_level attribute; will not restore",
-				zap.String("entity_id", entityID))
-			continue
-		}
-		v, ok := raw.(float64)
-		if !ok {
-			m.logger.Debug("Speaker volume_level is not float; will not restore",
-				zap.String("entity_id", entityID),
-				zap.Any("value", raw))
-			continue
-		}
-		out[entityID] = v
-	}
-	return out
-}
-
-func (m *Manager) setVolumes(ctx context.Context, speakers []string, level float64) {
-	// One service call per speaker. Calling media_player.volume_set with a
-	// list entity_id is supported but failures are harder to diagnose; per-
-	// speaker calls give clear error attribution.
-	for _, entityID := range speakers {
-		err := m.haClient.CallService(ctx, "media_player", "volume_set", map[string]interface{}{
-			"entity_id":    entityID,
-			"volume_level": level,
-		})
-		if err != nil {
-			m.logger.Warn("Failed to set speaker volume for announcement",
-				zap.String("entity_id", entityID),
-				zap.Float64("volume_level", level),
-				zap.Error(err))
-		}
-	}
-}
-
-// scheduleRestore waits RestoreDelay then restores priorVolumes. If two
-// announcements overlap within the delay window, the second snapshot captures
-// the announcement volume rather than the true prior level; the second restore
-// will then land at the first announcement's volume. This is acceptable given
-// that overlapping announcements are unlikely in practice.
-func (m *Manager) scheduleRestore(parentCtx context.Context, priorVolumes map[string]float64) {
-	m.wg.Add(1)
-	go func() {
-		defer m.wg.Done()
-		select {
-		case <-time.After(m.cfg.RestoreDelay):
-		case <-parentCtx.Done():
-			// Parent cancelled (likely shutdown). Restore now anyway.
-		}
-		// Use a fresh context for the restore - parent may already be done.
-		restoreCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		m.restoreVolumesNow(restoreCtx, priorVolumes)
-	}()
-}
-
-func (m *Manager) restoreVolumesNow(ctx context.Context, priorVolumes map[string]float64) {
-	for entityID, level := range priorVolumes {
-		err := m.haClient.CallService(ctx, "media_player", "volume_set", map[string]interface{}{
-			"entity_id":    entityID,
-			"volume_level": level,
-		})
-		if err != nil {
-			m.logger.Warn("Failed to restore speaker volume after announcement",
-				zap.String("entity_id", entityID),
-				zap.Float64("volume_level", level),
-				zap.Error(err))
-		}
-	}
 }

--- a/homeautomation-go/internal/notify/notify_test.go
+++ b/homeautomation-go/internal/notify/notify_test.go
@@ -3,9 +3,9 @@ package notify
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
-	"time"
 
 	"homeautomation/internal/ha"
 	"homeautomation/internal/state"
@@ -13,100 +13,132 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-func newTestManager(t *testing.T, mockHA *ha.MockClient, stateMgr *state.Manager, readOnly bool, snapshotRestore bool) *Manager {
-	t.Helper()
-	cfg := DefaultConfig()
-	cfg.SnapshotRestore = snapshotRestore
-	// short restore delay so async restore tests don't take 8s
-	cfg.RestoreDelaySeconds = 1
-	cfg.RestoreDelay = 50 * time.Millisecond
-	return NewManager(mockHA, stateMgr, cfg, zaptest.NewLogger(t), readOnly)
+// fakeSynth returns a canned URL (or err) and records what it was asked to say.
+type fakeSynth struct {
+	mu       sync.Mutex
+	url      string
+	err      error
+	messages []string
 }
 
-func TestAnnounce_SnapshotOverrideSpeakRestore(t *testing.T) {
+func (f *fakeSynth) SynthesizeAndServe(_ context.Context, text string) (string, error) {
+	f.mu.Lock()
+	f.messages = append(f.messages, text)
+	f.mu.Unlock()
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.url, nil
+}
+
+func (f *fakeSynth) Messages() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.messages))
+	copy(out, f.messages)
+	return out
+}
+
+func newTestManager(t *testing.T, mockHA *ha.MockClient, stateMgr *state.Manager, synth *fakeSynth, readOnly bool) *Manager {
+	t.Helper()
+	cfg := DefaultConfig()
+	if synth == nil {
+		synth = &fakeSynth{url: "http://test/audio/abc.mp3"}
+	}
+	return NewManager(mockHA, stateMgr, synth, cfg, zaptest.NewLogger(t), readOnly)
+}
+
+// equalStringSlices compares two []string when one of them comes back as
+// interface{} from the mock service-call data.
+func equalStringSlices(want []string, got interface{}) bool {
+	gs, ok := got.([]string)
+	if !ok {
+		return false
+	}
+	if len(gs) != len(want) {
+		return false
+	}
+	for i := range want {
+		if gs[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestAnnounce_PlaysViaMediaPlayerWithAnnounceFlag(t *testing.T) {
 	mockHA := ha.NewMockClient()
-	mockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{"volume_level": 0.25})
-	mockHA.SetState("media_player.front_room", "playing", map[string]interface{}{"volume_level": 0.40})
+	synth := &fakeSynth{url: "http://10.212.100.100:8085/audio/deadbeef.mp3"}
 
-	m := newTestManager(t, mockHA, nil, false, true)
+	speakers := []string{"media_player.kitchen", "media_player.front_room"}
+	m := newTestManager(t, mockHA, nil, synth, false)
 
-	err := m.Announce(context.Background(), "Test announcement", WithSpeakers([]string{
-		"media_player.kitchen",
-		"media_player.front_room",
-	}))
-	if err != nil {
-		t.Fatalf("Announce returned error: %v", err)
+	if err := m.Announce(context.Background(), "Test announcement", WithSpeakers(speakers)); err != nil {
+		t.Fatalf("Announce: %v", err)
 	}
 
-	// Wait for async restore
-	m.WaitForRestores()
+	// Synthesizer should have been asked to speak the message exactly once.
+	if msgs := synth.Messages(); len(msgs) != 1 || msgs[0] != "Test announcement" {
+		t.Errorf("synthesizer messages: want [Test announcement], got %v", msgs)
+	}
 
 	calls := mockHA.GetServiceCalls()
-
-	// Expect: 2 volume_set (override) + 1 tts.speak + 2 volume_set (restore) = 5
-	if len(calls) < 5 {
-		t.Fatalf("expected at least 5 service calls, got %d: %+v", len(calls), calls)
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 service call (media_player.play_media), got %d: %+v", len(calls), calls)
+	}
+	c := calls[0]
+	if c.Domain != "media_player" || c.Service != "play_media" {
+		t.Fatalf("call: want media_player.play_media, got %s.%s", c.Domain, c.Service)
+	}
+	if !equalStringSlices(speakers, c.Data["entity_id"]) {
+		t.Errorf("entity_id: want %v, got %v", speakers, c.Data["entity_id"])
+	}
+	if got, _ := c.Data["media_content_id"].(string); got != synth.url {
+		t.Errorf("media_content_id: want %s, got %v", synth.url, c.Data["media_content_id"])
+	}
+	if got, _ := c.Data["media_content_type"].(string); got != "music" {
+		t.Errorf("media_content_type: want music, got %v", c.Data["media_content_type"])
+	}
+	if got, _ := c.Data["announce"].(bool); !got {
+		t.Errorf("announce: want true, got %v", c.Data["announce"])
+	}
+	extra, ok := c.Data["extra"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("extra: want map, got %T (%v)", c.Data["extra"], c.Data["extra"])
+	}
+	wantVol := float64(defaultAwakeVolumePercent) / 100.0
+	if got, _ := extra["volume"].(float64); got != wantVol {
+		t.Errorf("extra.volume: want %v, got %v", wantVol, got)
 	}
 
-	// First two calls: override volume to 0.6 (default awake)
-	for i := 0; i < 2; i++ {
-		c := calls[i]
-		if c.Domain != "media_player" || c.Service != "volume_set" {
-			t.Errorf("call %d: expected media_player.volume_set, got %s.%s", i, c.Domain, c.Service)
+	// Asserts the snapshot/restore code is gone: nothing should fiddle with volume_set.
+	for _, c := range calls {
+		if c.Domain == "media_player" && c.Service == "volume_set" {
+			t.Errorf("unexpected volume_set call: %+v", c)
 		}
-		if v, _ := c.Data["volume_level"].(float64); v != 0.60 {
-			t.Errorf("call %d: expected volume_level 0.60, got %v", i, c.Data["volume_level"])
-		}
-	}
-
-	// Third call: tts.speak
-	tts := calls[2]
-	if tts.Domain != "tts" || tts.Service != "speak" {
-		t.Errorf("call 2: expected tts.speak, got %s.%s", tts.Domain, tts.Service)
-	}
-	if msg, _ := tts.Data["message"].(string); msg != "Test announcement" {
-		t.Errorf("expected message 'Test announcement', got %v", tts.Data["message"])
-	}
-
-	// Last two calls: restore prior volumes
-	restoreCalls := calls[3:]
-	restoredVolumes := map[string]float64{}
-	for _, c := range restoreCalls {
-		if c.Domain != "media_player" || c.Service != "volume_set" {
-			t.Errorf("expected restore call media_player.volume_set, got %s.%s", c.Domain, c.Service)
-			continue
-		}
-		entityID, _ := c.Data["entity_id"].(string)
-		level, _ := c.Data["volume_level"].(float64)
-		restoredVolumes[entityID] = level
-	}
-	if got := restoredVolumes["media_player.kitchen"]; got != 0.25 {
-		t.Errorf("kitchen restore: expected 0.25, got %v", got)
-	}
-	if got := restoredVolumes["media_player.front_room"]; got != 0.40 {
-		t.Errorf("front_room restore: expected 0.40, got %v", got)
 	}
 }
 
 func TestAnnounce_ReadOnlyDoesNothing(t *testing.T) {
 	mockHA := ha.NewMockClient()
-	mockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{"volume_level": 0.25})
+	synth := &fakeSynth{url: "http://test/audio/x.mp3"}
 
-	m := newTestManager(t, mockHA, nil, true, true)
+	m := newTestManager(t, mockHA, nil, synth, true)
 
 	if err := m.Announce(context.Background(), "Hi", WithSpeakers([]string{"media_player.kitchen"})); err != nil {
 		t.Fatalf("Announce returned error: %v", err)
 	}
-	m.WaitForRestores()
-
 	if calls := mockHA.GetServiceCalls(); len(calls) != 0 {
-		t.Errorf("read-only mode should not make service calls, got %d", len(calls))
+		t.Errorf("read-only should make zero HA calls, got %d", len(calls))
+	}
+	if msgs := synth.Messages(); len(msgs) != 0 {
+		t.Errorf("read-only should not call synthesizer, got %d messages", len(msgs))
 	}
 }
 
 func TestAnnounce_EmptyMessageReturnsError(t *testing.T) {
 	mockHA := ha.NewMockClient()
-	m := newTestManager(t, mockHA, nil, false, true)
+	m := newTestManager(t, mockHA, nil, nil, false)
 
 	if err := m.Announce(context.Background(), "", WithSpeakers([]string{"media_player.kitchen"})); err == nil {
 		t.Error("expected error for empty message")
@@ -115,8 +147,7 @@ func TestAnnounce_EmptyMessageReturnsError(t *testing.T) {
 
 func TestAnnounce_NoSpeakersReturnsError(t *testing.T) {
 	mockHA := ha.NewMockClient()
-	m := newTestManager(t, mockHA, nil, false, true)
-	// Override default speakers to empty
+	m := newTestManager(t, mockHA, nil, nil, false)
 	m.cfg.DefaultSpeakers = nil
 
 	if err := m.Announce(context.Background(), "Hi"); err == nil {
@@ -124,58 +155,44 @@ func TestAnnounce_NoSpeakersReturnsError(t *testing.T) {
 	}
 }
 
-func TestAnnounce_TTSFailureRestoresImmediately(t *testing.T) {
+func TestAnnounce_SynthesizerFailureSkipsHA(t *testing.T) {
 	mockHA := ha.NewMockClient()
-	mockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{"volume_level": 0.30})
-	mockHA.SetServiceError("tts", "speak", errors.New("tts unavailable"))
+	synth := &fakeSynth{err: errors.New("kokoro down")}
 
-	m := newTestManager(t, mockHA, nil, false, true)
+	m := newTestManager(t, mockHA, nil, synth, false)
 
 	err := m.Announce(context.Background(), "Hi", WithSpeakers([]string{"media_player.kitchen"}))
 	if err == nil {
-		t.Fatal("expected error from failed TTS")
+		t.Fatal("expected error from synthesizer failure")
 	}
+	if calls := mockHA.GetServiceCalls(); len(calls) != 0 {
+		t.Errorf("synthesis failure should not trigger HA calls, got %d: %+v", len(calls), calls)
+	}
+}
 
-	// Errored services don't get recorded by the mock, so we expect:
-	//   1. override volume_set (recorded)
-	//   2. tts.speak (errored - not recorded)
-	//   3. restore volume_set (recorded)
-	calls := mockHA.GetServiceCalls()
-	if len(calls) != 2 {
-		t.Fatalf("expected exactly 2 recorded calls (override + restore), got %d: %+v", len(calls), calls)
-	}
+func TestAnnounce_PlayMediaFailurePropagates(t *testing.T) {
+	mockHA := ha.NewMockClient()
+	mockHA.SetServiceError("media_player", "play_media", errors.New("HA down"))
+	synth := &fakeSynth{url: "http://test/audio/x.mp3"}
 
-	// Override set to 0.60 (default awake), restore set back to 0.30
-	if v, _ := calls[0].Data["volume_level"].(float64); v != 0.60 {
-		t.Errorf("expected override to 0.60, got %v", v)
-	}
-	if v, _ := calls[1].Data["volume_level"].(float64); v != 0.30 {
-		t.Errorf("expected restore to 0.30, got %v", v)
-	}
+	m := newTestManager(t, mockHA, nil, synth, false)
 
-	// No goroutine restore should be pending
-	doneCh := make(chan struct{})
-	go func() { m.WaitForRestores(); close(doneCh) }()
-	select {
-	case <-doneCh:
-	case <-time.After(time.Second):
-		t.Error("WaitForRestores did not return promptly after TTS failure")
+	err := m.Announce(context.Background(), "Hi", WithSpeakers([]string{"media_player.kitchen"}))
+	if err == nil {
+		t.Fatal("expected error from media_player.play_media failure")
 	}
 }
 
 func TestAnnounce_DeferableWhileAsleep_SuppressesWithSentinel(t *testing.T) {
 	mockHA := ha.NewMockClient()
-	mockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{"volume_level": 0.40})
-
 	stateMgr := state.NewManager(mockHA, zaptest.NewLogger(t), false)
 	if err := stateMgr.SetBool("isMasterAsleep", true); err != nil {
 		t.Fatalf("SetBool failed: %v", err)
 	}
-	// Clear service calls from the SetBool (e.g. input_boolean.turn_on) so
-	// only the Announce's calls (or absence thereof) are observed.
 	mockHA.ClearServiceCalls()
+	synth := &fakeSynth{url: "http://test/audio/x.mp3"}
 
-	m := newTestManager(t, mockHA, stateMgr, false, true)
+	m := newTestManager(t, mockHA, stateMgr, synth, false)
 
 	err := m.Announce(context.Background(), "Vacuum needs attention",
 		WithSpeakers([]string{"media_player.kitchen"}),
@@ -183,129 +200,65 @@ func TestAnnounce_DeferableWhileAsleep_SuppressesWithSentinel(t *testing.T) {
 	if !errors.Is(err, ErrSuppressedAsleep) {
 		t.Fatalf("expected ErrSuppressedAsleep, got %v", err)
 	}
-
 	if calls := mockHA.GetServiceCalls(); len(calls) != 0 {
 		t.Errorf("deferable+asleep should make zero HA calls, got %d: %+v", len(calls), calls)
+	}
+	if msgs := synth.Messages(); len(msgs) != 0 {
+		t.Errorf("suppressed announcement should not synthesize, got %d messages", len(msgs))
 	}
 }
 
 func TestAnnounce_DeferableWhileAwake_PlaysAtAwakeVolume(t *testing.T) {
 	mockHA := ha.NewMockClient()
-	mockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{"volume_level": 0.40})
-
 	stateMgr := state.NewManager(mockHA, zaptest.NewLogger(t), false)
 	if err := stateMgr.SetBool("isMasterAsleep", false); err != nil {
 		t.Fatalf("SetBool failed: %v", err)
 	}
 	mockHA.ClearServiceCalls()
 
-	m := newTestManager(t, mockHA, stateMgr, false, true)
+	m := newTestManager(t, mockHA, stateMgr, nil, false)
 
 	if err := m.Announce(context.Background(), "Hi",
 		WithSpeakers([]string{"media_player.kitchen"}),
 		WithUrgency(UrgencyDeferable)); err != nil {
 		t.Fatalf("Announce returned error: %v", err)
 	}
-	m.WaitForRestores()
 
 	calls := mockHA.GetServiceCalls()
-	if len(calls) < 1 {
-		t.Fatalf("expected at least one call")
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d: %+v", len(calls), calls)
 	}
-	override := calls[0]
-	if v, _ := override.Data["volume_level"].(float64); v != 0.60 {
-		t.Errorf("deferable+awake: expected volume 0.60, got %v", v)
+	extra, _ := calls[0].Data["extra"].(map[string]interface{})
+	want := float64(defaultAwakeVolumePercent) / 100.0
+	if got, _ := extra["volume"].(float64); got != want {
+		t.Errorf("deferable+awake: want extra.volume %v, got %v", want, got)
 	}
 }
 
 func TestAnnounce_UrgentWhileAsleep_PlaysAtAwakeVolume(t *testing.T) {
 	mockHA := ha.NewMockClient()
-	mockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{"volume_level": 0.40})
-
 	stateMgr := state.NewManager(mockHA, zaptest.NewLogger(t), false)
 	if err := stateMgr.SetBool("isMasterAsleep", true); err != nil {
 		t.Fatalf("SetBool failed: %v", err)
 	}
 	mockHA.ClearServiceCalls()
 
-	m := newTestManager(t, mockHA, stateMgr, false, true)
+	m := newTestManager(t, mockHA, stateMgr, nil, false)
 
 	if err := m.Announce(context.Background(), "Person at door",
 		WithSpeakers([]string{"media_player.kitchen"}),
 		WithUrgency(UrgencyUrgent)); err != nil {
 		t.Fatalf("Announce returned error: %v", err)
 	}
-	m.WaitForRestores()
 
-	calls := mockHA.GetServiceCalls()
-	if len(calls) < 1 {
-		t.Fatalf("expected at least one call")
-	}
-	override := calls[0]
-	if v, _ := override.Data["volume_level"].(float64); v != 0.60 {
-		t.Errorf("urgent+asleep: expected volume 0.60, got %v", v)
-	}
-}
-
-func TestAnnounce_SnapshotRestoreDisabled(t *testing.T) {
-	mockHA := ha.NewMockClient()
-	mockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{"volume_level": 0.25})
-
-	m := newTestManager(t, mockHA, nil, false, false)
-
-	if err := m.Announce(context.Background(), "Hi", WithSpeakers([]string{"media_player.kitchen"})); err != nil {
-		t.Fatalf("Announce returned error: %v", err)
-	}
-	m.WaitForRestores()
-
-	// Only the tts.speak call should happen - no volume snapshot or restore.
 	calls := mockHA.GetServiceCalls()
 	if len(calls) != 1 {
-		t.Fatalf("expected exactly 1 call (tts.speak), got %d: %+v", len(calls), calls)
+		t.Fatalf("expected 1 call, got %d: %+v", len(calls), calls)
 	}
-	if calls[0].Domain != "tts" || calls[0].Service != "speak" {
-		t.Errorf("expected tts.speak, got %s.%s", calls[0].Domain, calls[0].Service)
-	}
-}
-
-func TestAnnounce_MissingSpeakerStateOmittedFromRestore(t *testing.T) {
-	mockHA := ha.NewMockClient()
-	mockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{"volume_level": 0.25})
-	// Note: media_player.bedroom intentionally not set.
-
-	m := newTestManager(t, mockHA, nil, false, true)
-
-	if err := m.Announce(context.Background(), "Hi", WithSpeakers([]string{
-		"media_player.kitchen",
-		"media_player.bedroom",
-	})); err != nil {
-		t.Fatalf("Announce returned error: %v", err)
-	}
-	m.WaitForRestores()
-
-	calls := mockHA.GetServiceCalls()
-
-	// Count restore calls (volume_set) that happen after the tts.speak call
-	ttsIdx := -1
-	for i, c := range calls {
-		if c.Domain == "tts" && c.Service == "speak" {
-			ttsIdx = i
-			break
-		}
-	}
-	if ttsIdx == -1 {
-		t.Fatalf("tts.speak call not found")
-	}
-
-	// Restore calls only for entities with snapshotted state.
-	restoreCount := 0
-	for _, c := range calls[ttsIdx+1:] {
-		if c.Domain == "media_player" && c.Service == "volume_set" {
-			restoreCount++
-		}
-	}
-	if restoreCount != 1 {
-		t.Errorf("expected exactly 1 restore call (kitchen only), got %d", restoreCount)
+	extra, _ := calls[0].Data["extra"].(map[string]interface{})
+	want := float64(defaultAwakeVolumePercent) / 100.0
+	if got, _ := extra["volume"].(float64); got != want {
+		t.Errorf("urgent+asleep: want extra.volume %v, got %v", want, got)
 	}
 }
 
@@ -343,7 +296,7 @@ func TestMockNotifier_ConcurrentSafe(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_ = mock.Announce(context.Background(), "concurrent")
+			_ = mock.Announce(context.Background(), fmt.Sprintf("concurrent-%d", 0))
 		}()
 	}
 	wg.Wait()
@@ -357,15 +310,6 @@ func TestLoadConfig_AppliesDefaults(t *testing.T) {
 
 	if cfg.AwakeVolumePercent != defaultAwakeVolumePercent {
 		t.Errorf("AwakeVolumePercent: expected %d, got %d", defaultAwakeVolumePercent, cfg.AwakeVolumePercent)
-	}
-	if cfg.TTSDomain != defaultTTSDomain {
-		t.Errorf("TTSDomain: expected %s, got %s", defaultTTSDomain, cfg.TTSDomain)
-	}
-	if cfg.TTSEntityID != defaultTTSEntityID {
-		t.Errorf("TTSEntityID: expected %s, got %s", defaultTTSEntityID, cfg.TTSEntityID)
-	}
-	if !cfg.SnapshotRestore {
-		t.Error("SnapshotRestore should default to true")
 	}
 	if len(cfg.DefaultSpeakers) == 0 {
 		t.Error("DefaultSpeakers should not be empty")

--- a/homeautomation-go/internal/notify/notify_test.go
+++ b/homeautomation-go/internal/notify/notify_test.go
@@ -294,10 +294,10 @@ func TestMockNotifier_ConcurrentSafe(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
-		go func() {
+		go func(n int) {
 			defer wg.Done()
-			_ = mock.Announce(context.Background(), fmt.Sprintf("concurrent-%d", 0))
-		}()
+			_ = mock.Announce(context.Background(), fmt.Sprintf("concurrent-%d", n))
+		}(i)
 	}
 	wg.Wait()
 	if len(mock.Calls()) != 10 {

--- a/homeautomation-go/internal/tts/client.go
+++ b/homeautomation-go/internal/tts/client.go
@@ -1,0 +1,85 @@
+// Package tts provides text-to-speech synthesis (via a Kokoro server) and a
+// local HTTP file server that exposes the synthesized MP3s to LAN media
+// players (Sonos) so Home Assistant can tell them to play
+// http://<lan-ip>:<port>/audio/<id>.mp3.
+package tts
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// Client speaks to an OpenAI-compatible TTS server (we use Kokoro). Stateless;
+// safe for concurrent use.
+type Client struct {
+	endpoint string
+	voice    string
+	http     *http.Client
+	logger   *zap.Logger
+}
+
+// NewClient builds a Kokoro client. The 30s timeout covers paragraph-length
+// synthesis on a moderately loaded server; short phrases return in ~2s.
+func NewClient(endpoint, voice string, logger *zap.Logger) *Client {
+	return &Client{
+		endpoint: endpoint,
+		voice:    voice,
+		http:     &http.Client{Timeout: 30 * time.Second},
+		logger:   logger.Named("tts.client"),
+	}
+}
+
+type kokoroRequest struct {
+	Input          string `json:"input"`
+	Voice          string `json:"voice"`
+	Model          string `json:"model"`
+	ResponseFormat string `json:"response_format"`
+}
+
+// Synthesize returns the MP3 bytes spoken from text. Returns an error on
+// non-2xx response or empty body. No retry — Kokoro outages are rare and
+// announcement loss is acceptable.
+func (c *Client) Synthesize(ctx context.Context, text string) ([]byte, error) {
+	body, err := json.Marshal(kokoroRequest{
+		Input:          text,
+		Voice:          c.voice,
+		Model:          "kokoro",
+		ResponseFormat: "mp3",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal kokoro request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build kokoro request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("kokoro request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("kokoro returned %d: %s", resp.StatusCode, string(snippet))
+	}
+
+	mp3, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read kokoro response: %w", err)
+	}
+	if len(mp3) == 0 {
+		return nil, fmt.Errorf("kokoro returned empty body")
+	}
+	return mp3, nil
+}

--- a/homeautomation-go/internal/tts/client_test.go
+++ b/homeautomation-go/internal/tts/client_test.go
@@ -1,0 +1,126 @@
+package tts
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap/zaptest"
+)
+
+func TestClient_Synthesize_Success(t *testing.T) {
+	canned := []byte("\xFF\xFB\x90\x00fake-mp3-bytes")
+	var gotMethod, gotCT string
+	var gotBody kokoroRequest
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotCT = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "audio/mpeg")
+		_, _ = w.Write(canned)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "af_heart", zaptest.NewLogger(t))
+	mp3, err := c.Synthesize(context.Background(), "hello world")
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method: want POST, got %s", gotMethod)
+	}
+	if gotCT != "application/json" {
+		t.Errorf("content-type: want application/json, got %s", gotCT)
+	}
+	if gotBody.Input != "hello world" {
+		t.Errorf("input: want 'hello world', got %q", gotBody.Input)
+	}
+	if gotBody.Voice != "af_heart" {
+		t.Errorf("voice: want af_heart, got %q", gotBody.Voice)
+	}
+	if gotBody.Model != "kokoro" {
+		t.Errorf("model: want kokoro, got %q", gotBody.Model)
+	}
+	if gotBody.ResponseFormat != "mp3" {
+		t.Errorf("response_format: want mp3, got %q", gotBody.ResponseFormat)
+	}
+	if string(mp3) != string(canned) {
+		t.Errorf("body: want %d bytes round-tripped, got %d", len(canned), len(mp3))
+	}
+}
+
+func TestClient_Synthesize_VoiceConfigurable(t *testing.T) {
+	var gotVoice string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req kokoroRequest
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &req)
+		gotVoice = req.Voice
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "bf_emma", zaptest.NewLogger(t))
+	if _, err := c.Synthesize(context.Background(), "hi"); err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	if gotVoice != "bf_emma" {
+		t.Errorf("voice: want bf_emma, got %q", gotVoice)
+	}
+}
+
+func TestClient_Synthesize_Non2xxErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("kokoro down"))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "af_heart", zaptest.NewLogger(t))
+	_, err := c.Synthesize(context.Background(), "hi")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error should include status: %v", err)
+	}
+}
+
+func TestClient_Synthesize_EmptyBodyErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "audio/mpeg")
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "af_heart", zaptest.NewLogger(t))
+	_, err := c.Synthesize(context.Background(), "hi")
+	if err == nil {
+		t.Fatal("expected error on empty body")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error should mention empty body: %v", err)
+	}
+}
+
+func TestClient_Synthesize_ContextCancel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "af_heart", zaptest.NewLogger(t))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := c.Synthesize(ctx, "hi")
+	if err == nil {
+		t.Fatal("expected error on cancelled context")
+	}
+}

--- a/homeautomation-go/internal/tts/mock.go
+++ b/homeautomation-go/internal/tts/mock.go
@@ -1,0 +1,46 @@
+package tts
+
+import (
+	"context"
+	"sync"
+)
+
+// MockSynthesizer is a Synthesizer for tests. Returns URL (default
+// "http://test/audio/mock.mp3") and records every text it was asked to speak.
+// Safe for concurrent use.
+type MockSynthesizer struct {
+	mu       sync.Mutex
+	URL      string
+	Err      error
+	messages []string
+}
+
+// SynthesizeAndServe implements Synthesizer.
+func (m *MockSynthesizer) SynthesizeAndServe(_ context.Context, text string) (string, error) {
+	m.mu.Lock()
+	m.messages = append(m.messages, text)
+	m.mu.Unlock()
+	if m.Err != nil {
+		return "", m.Err
+	}
+	if m.URL != "" {
+		return m.URL, nil
+	}
+	return "http://test/audio/mock.mp3", nil
+}
+
+// Messages returns a copy of every text Synthesize was asked to speak.
+func (m *MockSynthesizer) Messages() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.messages))
+	copy(out, m.messages)
+	return out
+}
+
+// Reset clears recorded messages.
+func (m *MockSynthesizer) Reset() {
+	m.mu.Lock()
+	m.messages = nil
+	m.mu.Unlock()
+}

--- a/homeautomation-go/internal/tts/server.go
+++ b/homeautomation-go/internal/tts/server.go
@@ -1,0 +1,168 @@
+package tts
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+const (
+	defaultTTL = 5 * time.Minute
+	defaultCap = 32
+)
+
+// Server stores synthesized MP3s in memory and serves them at
+// /audio/{id}.mp3 over plain HTTP so LAN-only Sonos speakers can fetch them.
+type Server struct {
+	baseURL    string
+	addr       string
+	logger     *zap.Logger
+	httpServer *http.Server
+	ttl        time.Duration
+	cap        int
+
+	mu    sync.Mutex
+	items map[string]item
+	now   func() time.Time // injectable clock for tests
+}
+
+type item struct {
+	body      []byte
+	expiresAt time.Time
+}
+
+// NewServer constructs an audio file server. addr is the listen address
+// (e.g. ":8085"); baseURL is what we hand to Sonos (e.g.
+// "http://10.212.100.100:8085") — typically dockergeneric's LAN address.
+func NewServer(addr, baseURL string, logger *zap.Logger) *Server {
+	s := &Server{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		addr:    addr,
+		logger:  logger.Named("tts.server"),
+		ttl:     defaultTTL,
+		cap:     defaultCap,
+		items:   make(map[string]item),
+		now:     time.Now,
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/audio/", s.handleAudio)
+	s.httpServer = &http.Server{
+		Addr:         addr,
+		Handler:      mux,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+	return s
+}
+
+// Start launches the audio file server in a goroutine. Returns nil on
+// success; ListenAndServe errors are logged from the goroutine.
+func (s *Server) Start() error {
+	s.logger.Info("Starting TTS audio file server",
+		zap.String("addr", s.addr),
+		zap.String("base_url", s.baseURL))
+	go func() {
+		if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			s.logger.Error("TTS audio server error", zap.Error(err))
+		}
+	}()
+	return nil
+}
+
+// Stop gracefully shuts down the audio file server with a 5s deadline.
+func (s *Server) Stop() error {
+	s.logger.Info("Stopping TTS audio file server")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.httpServer.Shutdown(ctx); err != nil {
+		return fmt.Errorf("shutdown TTS audio server: %w", err)
+	}
+	return nil
+}
+
+// Store puts mp3 in the cache and returns the absolute URL Sonos should fetch.
+// Evicts expired entries and (if still over cap) the oldest entries.
+func (s *Server) Store(mp3 []byte) (string, error) {
+	id, err := newID()
+	if err != nil {
+		return "", err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+	for k, v := range s.items {
+		if !v.expiresAt.After(now) {
+			delete(s.items, k)
+		}
+	}
+	for len(s.items) >= s.cap {
+		var oldestKey string
+		var oldestAt time.Time
+		first := true
+		for k, v := range s.items {
+			if first || v.expiresAt.Before(oldestAt) {
+				oldestKey = k
+				oldestAt = v.expiresAt
+				first = false
+			}
+		}
+		delete(s.items, oldestKey)
+	}
+
+	s.items[id] = item{body: mp3, expiresAt: now.Add(s.ttl)}
+	return fmt.Sprintf("%s/audio/%s.mp3", s.baseURL, id), nil
+}
+
+func (s *Server) handleAudio(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/audio/"), ".mp3")
+	if id == "" || strings.ContainsAny(id, "/.") {
+		http.NotFound(w, r)
+		return
+	}
+
+	s.mu.Lock()
+	it, ok := s.items[id]
+	expired := ok && !it.expiresAt.After(s.now())
+	if expired {
+		delete(s.items, id)
+	}
+	s.mu.Unlock()
+
+	if !ok || expired {
+		s.logger.Debug("audio not found", zap.String("id", id))
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", "audio/mpeg")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(it.body)))
+	if r.Method == http.MethodHead {
+		return
+	}
+	if _, err := w.Write(it.body); err != nil {
+		s.logger.Debug("write audio response failed", zap.String("id", id), zap.Error(err))
+	}
+}
+
+func newID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("generate audio id: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
+}

--- a/homeautomation-go/internal/tts/server.go
+++ b/homeautomation-go/internal/tts/server.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -63,14 +64,20 @@ func NewServer(addr, baseURL string, logger *zap.Logger) *Server {
 	return s
 }
 
-// Start launches the audio file server in a goroutine. Returns nil on
-// success; ListenAndServe errors are logged from the goroutine.
+// Start binds the listen port and launches the audio file server in a
+// goroutine. Returns an error immediately if the port cannot be bound so the
+// caller can Fatal at startup rather than discovering the failure later when
+// Sonos tries to fetch an audio URL that never existed.
 func (s *Server) Start() error {
+	ln, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		return fmt.Errorf("TTS audio server listen %s: %w", s.addr, err)
+	}
 	s.logger.Info("Starting TTS audio file server",
 		zap.String("addr", s.addr),
 		zap.String("base_url", s.baseURL))
 	go func() {
-		if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := s.httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
 			s.logger.Error("TTS audio server error", zap.Error(err))
 		}
 	}()

--- a/homeautomation-go/internal/tts/server_test.go
+++ b/homeautomation-go/internal/tts/server_test.go
@@ -1,0 +1,151 @@
+package tts
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap/zaptest"
+)
+
+// newTestServer wraps httptest around the Server's mux so we don't need a
+// real listening port.
+func newTestServer(t *testing.T) (*Server, *httptest.Server) {
+	t.Helper()
+	s := NewServer(":0", "http://placeholder", zaptest.NewLogger(t))
+	ts := httptest.NewServer(http.HandlerFunc(s.handleAudio))
+	t.Cleanup(ts.Close)
+	s.baseURL = ts.URL // serve URLs through httptest
+	return s, ts
+}
+
+func TestServer_StoreAndServe(t *testing.T) {
+	s, _ := newTestServer(t)
+	body := []byte("\xFF\xFB\x90mp3-bytes")
+
+	url, err := s.Store(body)
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if !strings.HasPrefix(url, s.baseURL+"/audio/") || !strings.HasSuffix(url, ".mp3") {
+		t.Errorf("unexpected URL: %s", url)
+	}
+
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: want 200, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "audio/mpeg" {
+		t.Errorf("content-type: want audio/mpeg, got %s", got)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != "no-store" {
+		t.Errorf("cache-control: want no-store, got %s", got)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != string(body) {
+		t.Errorf("body mismatch: want %d bytes, got %d", len(body), len(got))
+	}
+}
+
+func TestServer_NotFound(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	resp, err := http.Get(ts.URL + "/audio/nonexistent.mp3")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("status: want 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestServer_PathTraversalRejected(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	for _, p := range []string{"/audio/../etc.mp3", "/audio/.mp3", "/audio/.mp3"} {
+		resp, err := http.Get(ts.URL + p)
+		if err != nil {
+			t.Fatalf("GET %s: %v", p, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != 404 {
+			t.Errorf("path %q: want 404, got %d", p, resp.StatusCode)
+		}
+	}
+}
+
+func TestServer_TTLExpiry(t *testing.T) {
+	s, _ := newTestServer(t)
+	now := time.Now()
+	s.now = func() time.Time { return now }
+	s.ttl = 100 * time.Millisecond
+
+	url, err := s.Store([]byte("abc"))
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	// Before expiry: served.
+	resp, _ := http.Get(url)
+	if resp.StatusCode != 200 {
+		t.Errorf("pre-expiry: want 200, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// Advance the injected clock past TTL.
+	s.now = func() time.Time { return now.Add(time.Second) }
+	resp, _ = http.Get(url)
+	if resp.StatusCode != 404 {
+		t.Errorf("post-expiry: want 404, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
+func TestServer_CapEvictsOldest(t *testing.T) {
+	s, _ := newTestServer(t)
+	// Pin clock so eviction is deterministic.
+	now := time.Now()
+	tick := 0
+	s.now = func() time.Time {
+		tick++
+		return now.Add(time.Duration(tick) * time.Millisecond)
+	}
+	s.cap = 3
+
+	urls := make([]string, 0, 5)
+	for i := 0; i < 5; i++ {
+		url, err := s.Store([]byte{byte(i)})
+		if err != nil {
+			t.Fatalf("Store: %v", err)
+		}
+		urls = append(urls, url)
+	}
+
+	// First two entries should have been evicted.
+	for i, url := range urls {
+		resp, _ := http.Get(url)
+		got := resp.StatusCode
+		resp.Body.Close()
+		if i < 2 {
+			if got != 404 {
+				t.Errorf("entry %d: want 404 (evicted), got %d", i, got)
+			}
+		} else {
+			if got != 200 {
+				t.Errorf("entry %d: want 200 (kept), got %d", i, got)
+			}
+		}
+	}
+
+	if len(s.items) != 3 {
+		t.Errorf("cap: want 3 items kept, got %d", len(s.items))
+	}
+}

--- a/homeautomation-go/internal/tts/server_test.go
+++ b/homeautomation-go/internal/tts/server_test.go
@@ -70,7 +70,7 @@ func TestServer_NotFound(t *testing.T) {
 func TestServer_PathTraversalRejected(t *testing.T) {
 	_, ts := newTestServer(t)
 
-	for _, p := range []string{"/audio/../etc.mp3", "/audio/.mp3", "/audio/.mp3"} {
+	for _, p := range []string{"/audio/../etc.mp3", "/audio/.mp3", "/audio/./etc.mp3"} {
 		resp, err := http.Get(ts.URL + p)
 		if err != nil {
 			t.Fatalf("GET %s: %v", p, err)

--- a/homeautomation-go/internal/tts/synthesizer.go
+++ b/homeautomation-go/internal/tts/synthesizer.go
@@ -1,0 +1,46 @@
+package tts
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+)
+
+// Synthesizer is the seam notify.Manager depends on. Tests inject a fake.
+type Synthesizer interface {
+	SynthesizeAndServe(ctx context.Context, text string) (string, error)
+}
+
+// Service combines a Kokoro client and a local audio file server.
+type Service struct {
+	client *Client
+	server *Server
+	logger *zap.Logger
+}
+
+// NewService wires a client and server into a Synthesizer.
+func NewService(client *Client, server *Server, logger *zap.Logger) *Service {
+	return &Service{
+		client: client,
+		server: server,
+		logger: logger.Named("tts.service"),
+	}
+}
+
+// SynthesizeAndServe synthesizes text to MP3 via Kokoro, stores the bytes
+// in the local audio server, and returns the URL Sonos should fetch.
+func (s *Service) SynthesizeAndServe(ctx context.Context, text string) (string, error) {
+	mp3, err := s.client.Synthesize(ctx, text)
+	if err != nil {
+		return "", fmt.Errorf("synthesize: %w", err)
+	}
+	url, err := s.server.Store(mp3)
+	if err != nil {
+		return "", fmt.Errorf("store mp3: %w", err)
+	}
+	s.logger.Debug("synthesized announcement",
+		zap.Int("bytes", len(mp3)),
+		zap.String("url", url))
+	return url, nil
+}

--- a/homeautomation-go/test/integration/scenario_vacuum_error_test.go
+++ b/homeautomation-go/test/integration/scenario_vacuum_error_test.go
@@ -10,6 +10,7 @@ import (
 	"homeautomation/internal/plugins/vacuum"
 	"homeautomation/internal/state"
 	"homeautomation/internal/testlogger"
+	"homeautomation/internal/tts"
 	"homeautomation/pkg/plugin"
 
 	"github.com/stretchr/testify/assert"
@@ -42,6 +43,7 @@ type vacuumEnv struct {
 	manager *state.Manager
 	logger  *zap.Logger
 	vacuum  *vacuum.Manager
+	synth   *tts.MockSynthesizer
 }
 
 func setupVacuumTest(t *testing.T, fixedTime time.Time) (*vacuumEnv, func()) {
@@ -66,20 +68,19 @@ func setupVacuumTest(t *testing.T, fixedTime time.Time) (*vacuumEnv, func()) {
 	}
 
 	tp := plugin.FixedTimeProvider{FixedTime: fixedTime}
-	// Use a real notifier with snapshot/restore disabled so its tts.speak
-	// service call still flows through the mock HA server (where the test
-	// asserts it). Snapshot is disabled because mock speakers have no
-	// volume_level attribute and the per-speaker volume_set noise would
-	// confuse assertions.
+	// Use a real notifier with a fake TTS synthesizer so the resulting
+	// media_player.play_media service call flows through the mock HA server
+	// (where the test asserts it). The synth records the spoken text so the
+	// test can verify the message content without parsing the HA call.
 	notifyCfg := notify.DefaultConfig()
-	notifyCfg.SnapshotRestore = false
-	notifier := notify.NewManager(client, manager, notifyCfg, logger, false)
+	synth := &tts.MockSynthesizer{URL: "http://test/audio/vacuum.mp3"}
+	notifier := notify.NewManager(client, manager, synth, notifyCfg, logger, false)
 	alerter := alert.NewManager(nil, notifier, logger)
 	mgr := vacuum.NewManager(context.Background(), client, manager, alerter, cfg, logger, false, tp, nil)
 	mgr.SetRepeatCheckIntervalForTest(time.Hour) // park the background ticker; tests drive ticks explicitly
 	require.NoError(t, mgr.Start(), "vacuum plugin should start")
 
-	env := &vacuumEnv{server: server, manager: manager, logger: logger, vacuum: mgr}
+	env := &vacuumEnv{server: server, manager: manager, logger: logger, vacuum: mgr, synth: synth}
 
 	cleanup := func() {
 		mgr.Stop()
@@ -89,7 +90,7 @@ func setupVacuumTest(t *testing.T, fixedTime time.Time) (*vacuumEnv, func()) {
 }
 
 func vacuumTTSCalls(server *MockHAServer) []ServiceCall {
-	return FilterServiceCalls(server.GetServiceCalls(), "tts", "speak")
+	return FilterServiceCalls(server.GetServiceCalls(), "media_player", "play_media")
 }
 
 // TestScenario_VacuumError_AnnouncesWhenErrorAppears verifies that a transition
@@ -109,14 +110,18 @@ func TestScenario_VacuumError_AnnouncesWhenErrorAppears(t *testing.T) {
 	t.Log("THEN: A TTS announcement is sent within stateWaitTimeout")
 	require.Eventually(t, func() bool {
 		return len(vacuumTTSCalls(env.server)) >= 1
-	}, stateWaitTimeout, statePollInterval, "expected at least one tts.speak call")
+	}, stateWaitTimeout, statePollInterval, "expected at least one media_player.play_media call")
 
 	calls := vacuumTTSCalls(env.server)
 	require.NotEmpty(t, calls)
-	msg, _ := calls[0].ServiceData["message"].(string)
-	assert.Contains(t, msg, "Mop Dock Clean Water Tank empty",
-		"announcement message must include the error description")
-	assert.Equal(t, "tts.google_translate_en_com", calls[0].ServiceData["entity_id"])
+	assert.Equal(t, "music", calls[0].ServiceData["media_content_type"])
+	assert.Equal(t, true, calls[0].ServiceData["announce"])
+	assert.Equal(t, "http://test/audio/vacuum.mp3", calls[0].ServiceData["media_content_id"])
+
+	msgs := env.synth.Messages()
+	require.NotEmpty(t, msgs, "synthesizer should have been called")
+	assert.Contains(t, msgs[0], "Mop Dock Clean Water Tank empty",
+		"synthesized text must include the error description")
 }
 
 // TestScenario_VacuumError_SuppressedWhileMasterAsleep verifies that an error
@@ -143,9 +148,9 @@ func TestScenario_VacuumError_SuppressedWhileMasterAsleep(t *testing.T) {
 	}, stateWaitTimeout, statePollInterval,
 		"shadow state should reflect the active error")
 
-	t.Log("...but no tts.speak service call is sent.")
+	t.Log("...but no media_player.play_media service call is sent.")
 	waitForServiceCallQuiescenceSince(t, env.server, snapshot, 200*time.Millisecond)
-	calls := FilterServiceCalls(env.server.GetServiceCallsSince(snapshot), "tts", "speak")
+	calls := FilterServiceCalls(env.server.GetServiceCallsSince(snapshot), "media_player", "play_media")
 	assert.Empty(t, calls, "TTS must not fire while master is asleep")
 
 	st := env.vacuum.GetShadowState()
@@ -179,6 +184,6 @@ func TestScenario_VacuumError_StopsRepeatingAfterClear(t *testing.T) {
 
 	t.Log("THEN: Subsequent repeat ticks must not produce a new announcement")
 	env.vacuum.TickRepeatForTest()
-	newCalls := FilterServiceCalls(env.server.GetServiceCallsSince(snapshot), "tts", "speak")
+	newCalls := FilterServiceCalls(env.server.GetServiceCallsSince(snapshot), "media_player", "play_media")
 	assert.Empty(t, newCalls, "no announcements should fire after the error has cleared")
 }


### PR DESCRIPTION
## Summary

- Replaces HA's `tts.speak` (robotic Google Translate voice) with local Kokoro TTS synthesis. The Go service POSTs text to the Kokoro endpoint, gets MP3 bytes, serves them on `:8085/audio/{id}.mp3` for Sonos to fetch over the LAN, and tells HA to play the URL via `media_player.play_media`.
- Uses HA's `announce: true` flag so the Sonos integration natively snapshots queue + current track + position + transport state + volume around the announcement and restores everything on completion — playback resumption is seamless. Manual volume snapshot/override/restore + `WaitForRestores` removed (would race HA's restore).
- All four affected plugins (security, waterflow, evcharger, statetracking) already went through `alert.Alerter` → `notify.Notifier`; the only `tts.speak` site lived in `notify.go` and is now the only `media_player.play_media` site. Plugin code unchanged.

## Files

- `internal/tts/` (new): Kokoro HTTP client, in-process audio file server with bounded TTL (5min) + cap (32 entries), `Synthesizer` interface + `Service` façade, and `MockSynthesizer` for tests.
- `internal/notify/`: `Manager` takes a `tts.Synthesizer`; `Announce` synthesizes → stores → calls `media_player.play_media` once with `announce: true` and `extra.volume = AwakeVolumePercent/100`. `Config` trimmed (removed `TTSDomain`/`TTSService`/`TTSEntityID`/`SnapshotRestore`/`RestoreDelaySeconds`).
- `cmd/app/run.go`: reads `TTS_ENDPOINT`/`TTS_VOICE`/`TTS_SERVE_PORT`/`TTS_SERVE_URL`, wires service.
- `configs/notification_config.yaml`, `.env.example`: docs + new env vars.

## New env vars

| Var | Default | Notes |
|-----|---------|-------|
| `TTS_ENDPOINT` | Kokoro URL on llms-mac-studio | OpenAI-compatible `/audio/speech` |
| `TTS_VOICE` | `af_heart` | |
| `TTS_SERVE_PORT` | `8085` | |
| `TTS_SERVE_URL` | **required** in non-dev | Must be a LAN URL Sonos can reach (e.g. `http://10.212.100.100:8085`) — Sonos cannot resolve Tailscale-served URLs. |

## Test plan

- [x] `make pre-commit` (gofmt, goimports, vet, staticcheck, build)
- [x] `make unit-tests` — coverage 74.5%, includes new `internal/tts` tests (client request shape, voice config, non-2xx, empty body, ctx cancel; server serve, 404, path-traversal, TTL with injected clock, cap eviction) and rewritten `notify_test.go` (single `media_player.play_media` call, no `volume_set`, synth-failure short-circuits HA, sleep suppression intact)
- [x] `make integration-tests` — all 11 tests pass; vacuum scenario rewired to `tts.MockSynthesizer` and asserts on `media_player.play_media`
- [ ] **Live deploy verification** (cannot run from devcontainer — Tailscale endpoint not reachable):
  - [ ] Set `TTS_SERVE_URL` to dockergeneric's LAN IP, deploy
  - [ ] Confirm `Home Automation starting` log + new `TTS service initialized` log
  - [ ] Trigger a `UrgencyUrgent` announcement on a Sonos speaker that's mid-playback at known volume — verify announcement plays at `awake_volume_percent`, then prior track resumes from same position at original volume
  - [ ] Repeat with a Sonos group (kitchen + front_room grouped) — group should remain intact, both speakers resume
  - [ ] Repeat with idle speaker — announcement plays, speaker returns to idle (no spurious music)

🤖 Generated with [Claude Code](https://claude.com/claude-code)