### PR TITLE
chore(notify): double TTS announcement volume to 40

### DIFF
--- a/configs/notification_config.yaml
+++ b/configs/notification_config.yaml
@@ -37,4 +37,4 @@ notification:
   # Volume (0-100) the announcement is played at. Passed to
   # media_player.play_media as extra.volume; HA restores the speaker's prior
   # volume when the announcement ends.
-  awake_volume_percent: 20
+  awake_volume_percent: 40


### PR DESCRIPTION
## Summary

Bumps `awake_volume_percent` in `configs/notification_config.yaml` from `20` → `40`. Kokoro announcements via `media_player.play_media` (with `announce: true`, `extra.volume`) were noticeably too quiet on Sonos in production. HA still restores each speaker's prior volume after the announcement ends, so this only affects the announcement playback level.

## Test plan

- [x] `make pre-commit` (yamllint, gofmt, vet, staticcheck, build)
- [x] `make unit-tests` (cached — no Go changes)
- [x] `make integration-tests`
- [ ] After deploy, fire `POST /api/notify` with `urgency: urgent` and confirm announcement is comfortably audible without being startling, and that prior music resumes at original volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)