### PR TITLE
Fix #1081: wait for HA receiver before closing queues

### DIFF
--- a/docs/reference/CONCURRENCY_LESSONS.md
+++ b/docs/reference/CONCURRENCY_LESSONS.md
@@ -1447,7 +1447,7 @@ c.entityDispatchMu.Unlock()
 
 **Why the non-blocking send**: Holding `entityDispatchMu` across a blocking channel send would deadlock: a full queue means a queued handler is running, and that handler may call back into HA, requiring `receiveMessages` to deliver a response — which cannot happen if `receiveMessages` is blocked on the send. The `select`/`default` drops the event and logs it instead of deadlocking. The 256-slot buffer makes drops extremely unlikely at home automation event rates.
 
-**Lifecycle — Close Channels on Disconnect**: The drain goroutines exit when the channel is closed. Always close all entity queue channels during shutdown:
+**Lifecycle — Close Channels on Disconnect**: The drain goroutines exit when the channel is closed. Always close all entity queue channels during shutdown. **Important**: before closing, wait for `receiveMessages` to exit via `<-receiveDone` so `handleEvent` can no longer send to these channels — see full sequence in `Disconnect()`.
 
 ```go
 // In Disconnect(), after clearSubscribers():
@@ -1470,6 +1470,12 @@ c.entityDispatchMu.Unlock()
 ---
 
 ## Change Log
+
+### 2026-05-05 (PR #1082)
+- **Fix race in Lesson 20 teardown**: `Disconnect()` previously closed per-entity queue channels while `receiveMessages` / `handleEvent` could still be sending to them — a use-after-close channel panic. Fix adds two primitives:
+  - `lifecycleMu sync.Mutex` (lock ordering position **1**, outermost) serializes concurrent `Connect()` / `Disconnect()` calls
+  - `receiveDone chan struct{}` closed by `receiveMessages` via `defer close(done)`; `Disconnect()` blocks on `<-receiveDone` before closing entity queues, ensuring the producer is gone first
+- **Updated Lesson 20**: corrected `entityDispatchMu` lock ordering position from 6 → **7** (shifted by the new `lifecycleMu` at position 1); added note that the channel-close loop must be preceded by the `receiveDone` drain step
 
 ### 2026-05-05
 - **Restored Lesson 20**: Serialize Per-Entity Event Handlers via Channel Queues

--- a/homeautomation-go/internal/ha/client.go
+++ b/homeautomation-go/internal/ha/client.go
@@ -496,6 +496,9 @@ func (c *Client) Disconnect() error {
 	c.connMu.Lock()
 
 	if !c.connected {
+		// Safe to skip <-receiveDone: receiveMessages only runs while connected, and
+		// handleDisconnect (the only path that exits receiveMessages) sets connected=false
+		// under connMu before returning, so this branch cannot race with handleEvent.
 		c.connMu.Unlock()
 		return nil
 	}

--- a/homeautomation-go/internal/ha/client.go
+++ b/homeautomation-go/internal/ha/client.go
@@ -217,14 +217,15 @@ type entityEventJob struct {
 // Client implements HAClient interface
 //
 // Lock ordering (to prevent deadlocks, always acquire in this order):
-//  1. connMu - connection state and metrics
-//  2. ctxMu - context for cancellation
-//  3. writeMu - websocket writes (also protects msgID to ensure ordered sends)
-//  4. pendingMu - pending response channels
-//  5. subsMu - subscribers
-//  6. entityDispatchMu - per-entity event queues
-//  7. nextSubIDMu - subscription ID counter
-//  8. healthMu - health tracking (acquired last, never held while acquiring others)
+//  1. lifecycleMu - connect/disconnect lifecycle
+//  2. connMu - connection state and metrics
+//  3. ctxMu - context for cancellation
+//  4. writeMu - websocket writes (also protects msgID to ensure ordered sends)
+//  5. pendingMu - pending response channels
+//  6. subsMu - subscribers
+//  7. entityDispatchMu - per-entity event queues
+//  8. nextSubIDMu - subscription ID counter
+//  9. healthMu - health tracking (acquired last, never held while acquiring others)
 //
 // Note: msgIDMu has been eliminated; msgID is now protected by writeMu to ensure
 // message IDs are allocated and sent atomically, preventing out-of-order sends.
@@ -238,6 +239,8 @@ type Client struct {
 	conn      *managedConn // Thread-safe connection wrapper
 	connected bool
 	connMu    sync.RWMutex // Protects connected, conn, reconnect, and connection metrics
+	// Serializes Connect and Disconnect while allowing receiveMessages to take connMu during teardown.
+	lifecycleMu sync.Mutex
 
 	// Connection metrics (protected by connMu)
 	disconnectCount    int       // Total number of disconnections
@@ -261,7 +264,8 @@ type Client struct {
 	writeMu           sync.Mutex // Protects websocket writes AND msgID counter
 
 	// Ping goroutine lifecycle management
-	pingCancel context.CancelFunc // Cancels the ping goroutine; protected by connMu
+	pingCancel  context.CancelFunc // Cancels the ping goroutine; protected by connMu
+	receiveDone chan struct{}      // Closed when the current receiveMessages goroutine exits; protected by connMu
 
 	// Reconnect callback (called after successful reconnection)
 	onReconnect   func()
@@ -335,6 +339,9 @@ func NewClient(url, token string, logger *zap.Logger) *Client {
 
 // Connect establishes WebSocket connection and authenticates
 func (c *Client) Connect() error {
+	c.lifecycleMu.Lock()
+	defer c.lifecycleMu.Unlock()
+
 	c.connMu.Lock()
 
 	if c.connected {
@@ -466,7 +473,9 @@ func (c *Client) Connect() error {
 	go c.sendPings(pingCtx, conn)
 
 	// Start background message receiver
-	go c.receiveMessages()
+	receiveDone := make(chan struct{})
+	c.receiveDone = receiveDone
+	go c.receiveMessages(receiveDone)
 
 	// Release lock before calling subscribeToStateChanges to avoid deadlock
 	c.connMu.Unlock()
@@ -481,10 +490,13 @@ func (c *Client) Connect() error {
 
 // Disconnect closes the WebSocket connection
 func (c *Client) Disconnect() error {
+	c.lifecycleMu.Lock()
+	defer c.lifecycleMu.Unlock()
+
 	c.connMu.Lock()
-	defer c.connMu.Unlock()
 
 	if !c.connected {
+		c.connMu.Unlock()
 		return nil
 	}
 
@@ -511,6 +523,16 @@ func (c *Client) Disconnect() error {
 
 		c.conn.Close()
 		c.conn = nil
+	}
+
+	receiveDone := c.receiveDone
+	c.receiveDone = nil
+	c.connMu.Unlock()
+
+	// Wait for receiveMessages to stop before closing entity queues. Otherwise
+	// handleEvent can still be sending to a per-entity queue while teardown closes it.
+	if receiveDone != nil {
+		<-receiveDone
 	}
 
 	c.clearSubscribers()
@@ -819,7 +841,9 @@ func (c *Client) sendMessage(msg interface{}) (*Message, error) {
 
 // receiveMessages handles incoming messages in the background.
 // Called from Connect() after connection is established, so conn is guaranteed non-nil.
-func (c *Client) receiveMessages() {
+func (c *Client) receiveMessages(done chan struct{}) {
+	defer close(done)
+
 	// Capture context reference - replaced on reconnect, so we capture once at start.
 	// When cancelled (by Disconnect or resetContext), we exit gracefully.
 	c.ctxMu.RLock()

--- a/homeautomation-go/internal/ha/client_test.go
+++ b/homeautomation-go/internal/ha/client_test.go
@@ -488,6 +488,49 @@ func TestClient_DisconnectClearsSubscribers(t *testing.T) {
 	assert.Empty(t, client.subscribers)
 }
 
+func TestClient_DisconnectWaitsForReceiverBeforeClosingEntityQueues(t *testing.T) {
+	t.Parallel()
+	logger := zap.NewNop()
+	client := NewClient("ws://example", "token", logger)
+	receiveDone := make(chan struct{})
+	queue := make(chan entityEventJob, 1)
+
+	client.connMu.Lock()
+	client.connected = true
+	client.receiveDone = receiveDone
+	client.connMu.Unlock()
+
+	client.entityDispatchMu.Lock()
+	client.entityEventQueues["sensor.test"] = queue
+	client.entityDispatchMu.Unlock()
+
+	disconnected := make(chan error, 1)
+	go func() {
+		disconnected <- client.Disconnect()
+	}()
+
+	select {
+	case err := <-disconnected:
+		require.NoError(t, err)
+		t.Fatal("Disconnect returned before receiveMessages exited")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	queue <- entityEventJob{}
+
+	close(receiveDone)
+	select {
+	case err := <-disconnected:
+		require.NoError(t, err)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Disconnect did not return after receiveMessages exited")
+	}
+
+	<-queue
+	_, ok := <-queue
+	assert.False(t, ok, "entity queue should close after receiveMessages exits")
+}
+
 func TestClient_HandleEventBackpressuresHandlers(t *testing.T) {
 	t.Parallel()
 	client := &Client{

--- a/homeautomation-go/internal/ha/client_test.go
+++ b/homeautomation-go/internal/ha/client_test.go
@@ -511,7 +511,7 @@ func TestClient_DisconnectWaitsForReceiverBeforeClosingEntityQueues(t *testing.T
 
 	select {
 	case err := <-disconnected:
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		t.Fatal("Disconnect returned before receiveMessages exited")
 	case <-time.After(20 * time.Millisecond):
 	}


### PR DESCRIPTION
Resolves #1081

## Summary
- Track the current Home Assistant receiver goroutine with a per-connection done channel.
- Serialize Connect/Disconnect lifecycle and wait for receiveMessages to exit before closing per-entity dispatch queues.
- Add a unit test covering the shutdown ordering invariant.

## Test Plan
- make unit-tests
- make pre-commit

🤖 Generated by the AI assistant