### PR TITLE
Fix #1083: send Sonos announce volume as percent

### DIFF
--- a/docs/reference/PLUGIN_SYSTEM.md
+++ b/docs/reference/PLUGIN_SYSTEM.md
@@ -938,7 +938,7 @@ Plugins that need to make spoken (TTS) announcements **must** use the shared `no
 
 1. **Synthesizes** the text to MP3 via the Kokoro TTS server.
 2. **Serves** the MP3 from a local in-memory audio server reachable by Sonos over the LAN.
-3. **Plays** the announcement via `media_player.play_media` with `announce: true` and `extra.volume = awake_volume_percent/100`. The Sonos/HA integration handles snapshot, ducking, playback, and seamless queue restoration — no per-plugin volume bookkeeping required.
+3. **Plays** the announcement via `media_player.play_media` with `announce: true` and `extra.volume = awake_volume_percent`. The Sonos/HA integration handles snapshot, ducking, playback, and seamless queue restoration — no per-plugin volume bookkeeping required.
 
 Deferable announcements are dropped entirely while master is asleep; Urgent announcements always play.
 

--- a/homeautomation-go/internal/notify/notify.go
+++ b/homeautomation-go/internal/notify/notify.go
@@ -151,7 +151,7 @@ func (m *Manager) Announce(ctx context.Context, message string, opts ...Announce
 		"media_content_type": "music",
 		"announce":           true,
 		"extra": map[string]interface{}{
-			"volume": float64(targetVolume) / 100.0,
+			"volume": targetVolume,
 		},
 	}); err != nil {
 		return fmt.Errorf("media_player.play_media call failed: %w", err)

--- a/homeautomation-go/internal/notify/notify_test.go
+++ b/homeautomation-go/internal/notify/notify_test.go
@@ -72,6 +72,7 @@ func TestAnnounce_PlaysViaMediaPlayerWithAnnounceFlag(t *testing.T) {
 
 	speakers := []string{"media_player.kitchen", "media_player.front_room"}
 	m := newTestManager(t, mockHA, nil, synth, false)
+	m.cfg.AwakeVolumePercent = 40
 
 	if err := m.Announce(context.Background(), "Test announcement", WithSpeakers(speakers)); err != nil {
 		t.Fatalf("Announce: %v", err)
@@ -106,8 +107,8 @@ func TestAnnounce_PlaysViaMediaPlayerWithAnnounceFlag(t *testing.T) {
 	if !ok {
 		t.Fatalf("extra: want map, got %T (%v)", c.Data["extra"], c.Data["extra"])
 	}
-	wantVol := float64(defaultAwakeVolumePercent) / 100.0
-	if got, _ := extra["volume"].(float64); got != wantVol {
+	wantVol := 40
+	if got, _ := extra["volume"].(int); got != wantVol {
 		t.Errorf("extra.volume: want %v, got %v", wantVol, got)
 	}
 
@@ -229,8 +230,8 @@ func TestAnnounce_DeferableWhileAwake_PlaysAtAwakeVolume(t *testing.T) {
 		t.Fatalf("expected 1 call, got %d: %+v", len(calls), calls)
 	}
 	extra, _ := calls[0].Data["extra"].(map[string]interface{})
-	want := float64(defaultAwakeVolumePercent) / 100.0
-	if got, _ := extra["volume"].(float64); got != want {
+	want := defaultAwakeVolumePercent
+	if got, _ := extra["volume"].(int); got != want {
 		t.Errorf("deferable+awake: want extra.volume %v, got %v", want, got)
 	}
 }
@@ -256,8 +257,8 @@ func TestAnnounce_UrgentWhileAsleep_PlaysAtAwakeVolume(t *testing.T) {
 		t.Fatalf("expected 1 call, got %d: %+v", len(calls), calls)
 	}
 	extra, _ := calls[0].Data["extra"].(map[string]interface{})
-	want := float64(defaultAwakeVolumePercent) / 100.0
-	if got, _ := extra["volume"].(float64); got != want {
+	want := defaultAwakeVolumePercent
+	if got, _ := extra["volume"].(int); got != want {
 		t.Errorf("urgent+asleep: want extra.volume %v, got %v", want, got)
 	}
 }


### PR DESCRIPTION
Resolves #1083

## Summary
- Send Home Assistant Sonos announce volume as the configured 0-100 percent value instead of normalizing to 0.0-1.0
- Update notification tests to assert a 40% config produces `extra.volume: 40`
- Correct the plugin system documentation for the notifier payload

## Test Plan
- `make unit-tests`
- `make pre-commit`

🤖 Generated by the AI assistant