### PR TITLE
feat(ai-assistant): auto-resolve PR conflicts after main moves

### DIFF
--- a/.github/ci/prompts/resolve-pr-conflicts.md
+++ b/.github/ci/prompts/resolve-pr-conflicts.md
@@ -1,0 +1,85 @@
+You are an autonomous agent resolving a merge conflict on PR #${PR_NUMBER} in ${REPO}.
+
+PR TITLE: ${PR_TITLE}
+
+PR BODY:
+${PR_BODY}
+
+PR HEAD BRANCH: ${HEAD_REF}
+BASE BRANCH:    ${BASE_REF}
+TRIGGERING SHA: ${TRIGGERING_SHA}
+
+CRITICAL: BEFORE PUSHING ANY CHANGES, verify the PR head SHA hasn't moved
+since this workflow started. Run:
+
+  git fetch origin ${HEAD_REF}
+  CURRENT_HEAD=$(git rev-parse origin/${HEAD_REF})
+  if [ "$CURRENT_HEAD" != "${TRIGGERING_SHA}" ]; then
+    git rebase --abort 2>/dev/null || true
+    gh pr comment ${PR_NUMBER} --body 'Aborted automated conflict resolution: the PR head moved (${TRIGGERING_SHA} → '"$CURRENT_HEAD"') after this workflow started. Re-run /autoresolve once your push has settled if you still want help.'
+    exit 0
+  fi
+
+YOUR TASK:
+
+1. Confirm the PR is still conflicting:
+     gh pr view ${PR_NUMBER} --json mergeStateStatus,mergeable
+   If mergeStateStatus is anything other than DIRTY (e.g., CLEAN, BEHIND, BLOCKED, UNSTABLE),
+   comment on the PR explaining there is no conflict to resolve and exit cleanly.
+
+2. Check out the PR head:
+     git fetch origin ${HEAD_REF}
+     git checkout ${HEAD_REF}
+     git fetch origin ${BASE_REF}
+
+3. Rebase onto the latest base. Prefer rebase over merge to keep ai/issue-XXXX branches linear:
+     git rebase origin/${BASE_REF}
+
+4. For each conflicted file, resolve in-context:
+   - Read both sides of the conflict markers AND the surrounding code on the new base.
+   - Write a resolution that preserves the PR's stated intent (re-read the PR body / linked
+     issue if you are unsure what behavior the PR is meant to deliver).
+   - Apply the same scope discipline as a fresh implementation: minimum diff, no
+     refactors, no unrelated cleanups.
+   - Then: git add <file> && git rebase --continue. Loop until the rebase reports clean.
+
+5. If the rebase cannot be completed because the PR's intent has been superseded by what
+   landed on ${BASE_REF} (e.g. the bug it fixes was already fixed differently, or the
+   feature was removed), abort and let a human decide:
+     git rebase --abort
+     gh pr comment ${PR_NUMBER} --body '<explain why automated resolution is not safe and recommend close/redo>'
+     exit 0
+
+6. Validate locally before pushing:
+     make unit-tests
+   If tests fail because of the rebase, fix them while staying scoped to the PR's intent.
+   Re-run until clean. Do not skip hooks. Do not lower coverage thresholds.
+
+7. Push the rebased branch:
+     git push --force-with-lease origin ${HEAD_REF}
+   --force-with-lease will fail if anything has been pushed to the branch since you fetched
+   it; treat that failure as the "author pushed newer commits" path above and abort cleanly
+   with a comment.
+
+8. Post a status comment on the PR:
+     gh pr comment ${PR_NUMBER} --body 'Rebased ${HEAD_REF} onto ${BASE_REF}.
+
+   Conflicts resolved:
+   - <file>: <one-line description of how each conflict was resolved>
+
+   Verification: make unit-tests passed.
+   New head SHA: <new sha>'
+
+IMPORTANT RULES FOR THIS REPOSITORY:
+- Use `make unit-tests` NOT `go test` (caching).
+- Use `make integration-tests` if integration tests are affected by the rebase.
+- Use `make pre-commit` for linting/formatting if you had to touch source files.
+- Follow the shadow state pattern (docs/reference/SHADOW_STATE.md).
+- Never use `git push --no-verify`.
+- Write the minimum change that resolves the conflict. Do NOT use the rebase as an excuse
+  to refactor adjacent code or expand the PR's scope.
+- Do not re-implement parts of the PR — your job is to reconcile the existing diff with
+  the new base, not redesign the feature.
+
+If you cannot resolve the conflict safely, leave the branch untouched and comment
+explaining what you found. A skipped rebase is always better than a wrong rebase.

--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -5,10 +5,12 @@ on:
     types: [created]
   issues:
     types: [opened, assigned, unlabeled]
-
-concurrency:
-  group: ai-interactive-${{ github.event.issue.number }}
-  cancel-in-progress: true
+  # Auto-fire conflict resolution: every merge to main is a chance for other
+  # open PRs to flip from MERGEABLE to DIRTY, and GitHub does not emit a
+  # dedicated event for that flip. The prepare-targets job enumerates open
+  # PRs after each push and dispatches resolve-pr-conflicts onto the dirty ones.
+  push:
+    branches: [main]
 
 # SECURITY NOTE: This workflow grants the AI assistant access to secrets and write permissions.
 # Authorization checks are implemented to prevent prompt injection from untrusted users.
@@ -23,9 +25,16 @@ jobs:
   # This prevents prompt injection attacks from untrusted external users
   authorize:
     runs-on: ubuntu-latest
+    # The push path doesn't need authorization (branch protection on main
+    # already restricts who can push) and doesn't use this job's outputs;
+    # prepare-targets gates itself on event_name == 'push' directly.
+    if: github.event_name != 'push'
     outputs:
       authorized: ${{ steps.check-auth.outputs.authorized }}
       should_run_ai: ${{ steps.check-auth.outputs.should_run_ai }}
+      # 'pr' when the comment is on a PR, 'issue' when on a plain issue, '' otherwise.
+      # Used by downstream jobs to dispatch /autoresolve to the right handler.
+      comment_target: ${{ steps.check-auth.outputs.comment_target }}
     steps:
       - name: Checkout for access to helper scripts
         uses: actions/checkout@v4
@@ -40,15 +49,24 @@ jobs:
           LABEL_NAME: ${{ github.event.label.name || '' }}
           ISSUE_STATE: ${{ github.event.issue.state || '' }}
           ACTION_TYPE: ${{ github.event.action || '' }}
+          IS_PR_COMMENT: ${{ github.event.issue.pull_request != null }}
           TRIGGER_TOKEN: "/autoresolve"
         run: |
           EVENT_NAME="${{ github.event_name }}"
           SHOULD_RUN="true"
+          COMMENT_TARGET=""
 
           case "$EVENT_NAME" in
             issue_comment)
               AUTHOR_ASSOC="${{ github.event.comment.author_association }}"
               ACTOR="${{ github.event.comment.user.login }}"
+              # GitHub fires issue_comment for both issue and PR comments;
+              # the issue.pull_request field disambiguates.
+              if [ "$IS_PR_COMMENT" = "true" ]; then
+                COMMENT_TARGET="pr"
+              else
+                COMMENT_TARGET="issue"
+              fi
               ;;
             issues)
               AUTHOR_ASSOC="${{ github.event.issue.author_association }}"
@@ -58,6 +76,7 @@ jobs:
               echo "Unknown event type: $EVENT_NAME"
               echo "authorized=false" >> $GITHUB_OUTPUT
               echo "should_run_ai=false" >> $GITHUB_OUTPUT
+              echo "comment_target=" >> $GITHUB_OUTPUT
               exit 0
               ;;
           esac
@@ -66,6 +85,7 @@ jobs:
           echo "Actor: $ACTOR"
           echo "Author association: $AUTHOR_ASSOC"
           echo "Trigger token: $TRIGGER_TOKEN"
+          echo "Comment target: ${COMMENT_TARGET:-n/a}"
 
           # Allow: OWNER, MEMBER, COLLABORATOR
           # Deny: CONTRIBUTOR, FIRST_TIMER, FIRST_TIME_CONTRIBUTOR, MANNEQUIN, NONE
@@ -127,6 +147,7 @@ jobs:
           fi
 
           echo "should_run_ai=$SHOULD_RUN" >> $GITHUB_OUTPUT
+          echo "comment_target=$COMMENT_TARGET" >> $GITHUB_OUTPUT
 
   # Auto-resolve new issues by opening a PR
   resolve-issue:
@@ -141,6 +162,12 @@ jobs:
          github.event.label.name == 'ai-started' &&
          github.event.issue.state == 'open')
       )
+    # Per-issue concurrency: a re-trigger on the same issue cancels the prior
+    # in-flight run. Replaces the previous workflow-level concurrency block —
+    # job-level keeps push-triggered conflict resolution unaffected.
+    concurrency:
+      group: ai-resolve-issue-${{ github.event.issue.number }}
+      cancel-in-progress: true
     runs-on: [self-hosted, homelab]
     timeout-minutes: 120
     permissions:
@@ -201,4 +228,185 @@ jobs:
         with:
           name: resolve-issue-conversation-log
           path: ${{ runner.temp }}/resolve-issue-conversation.jsonl
+          retention-days: 7
+
+  # Build the list of PRs that resolve-pr-conflicts should run against.
+  # Two entry paths:
+  #   - push to main:    enumerate open PRs, keep the DIRTY ones (the only
+  #                      reliable signal that a PR's mergeable flipped, since
+  #                      GitHub doesn't emit an event for that flip).
+  #   - /autoresolve PR comment: emit a single-element list with the commented PR.
+  prepare-targets:
+    needs: [authorize]
+    if: |
+      always() && (
+        github.event_name == 'push' || (
+          needs.authorize.result == 'success' &&
+          needs.authorize.outputs.authorized == 'true' &&
+          needs.authorize.outputs.should_run_ai == 'true' &&
+          needs.authorize.outputs.comment_target == 'pr'
+        )
+      )
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.build.outputs.targets }}
+      has_targets: ${{ steps.build.outputs.has_targets }}
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Build resolve-pr-conflicts target matrix
+        id: build
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+
+          # GitHub computes mergeability asynchronously. Right after a push
+          # to main, freshly-affected PRs return mergeable=UNKNOWN for several
+          # seconds. Poll up to ~30s per PR; gh pr view forces computation.
+          poll_pr_state() {
+            local n=$1
+            local state mergeable merge_state
+            for i in 1 2 3 4 5 6; do
+              state=$(gh pr view "$n" --repo "$REPO" --json mergeStateStatus,mergeable 2>/dev/null \
+                --jq '"\(.mergeable)|\(.mergeStateStatus)"' || echo "UNKNOWN|UNKNOWN")
+              mergeable="${state%%|*}"
+              if [ "$mergeable" != "UNKNOWN" ]; then
+                printf '%s' "$state"
+                return 0
+              fi
+              sleep 5
+            done
+            printf '%s' "$state"
+          }
+
+          TARGETS='[]'
+
+          if [ "$EVENT_NAME" = "push" ]; then
+            # Pull all open PRs and dedupe out anything already being worked on.
+            JQ_LIST_FILTER='[.[] | {
+              pr_number: .number,
+              head_ref: .headRefName,
+              has_resolving: ([.labels[].name] | contains(["ai-resolving"]))
+            }]'
+            ALL_PRS=$(gh pr list --repo "$REPO" --state open \
+              --json number,headRefName,labels --jq "$JQ_LIST_FILTER")
+            ELIGIBLE=$(echo "$ALL_PRS" | jq -r '.[] | select(.has_resolving | not) | .pr_number')
+            for pr_n in $ELIGIBLE; do
+              STATE=$(poll_pr_state "$pr_n")
+              MERGE_STATE="${STATE#*|}"
+              echo "PR #$pr_n: $STATE"
+              if [ "$MERGE_STATE" = "DIRTY" ]; then
+                HEAD_REF=$(echo "$ALL_PRS" | jq -r \
+                  ".[] | select(.pr_number == $pr_n) | .head_ref")
+                TARGETS=$(echo "$TARGETS" | jq \
+                  --argjson n "$pr_n" --arg ref "$HEAD_REF" \
+                  '. + [{pr_number: $n, head_ref: $ref}]')
+              fi
+            done
+          else
+            # Comment path. Resolve head_ref now so the matrix entry is
+            # self-contained — the agent will re-confirm DIRTY state itself
+            # and exit cleanly if the PR is already mergeable.
+            HEAD_REF=$(gh pr view "$COMMENT_PR_NUMBER" --repo "$REPO" --json headRefName --jq '.headRefName')
+            TARGETS=$(jq -nc --argjson n "$COMMENT_PR_NUMBER" --arg ref "$HEAD_REF" \
+              '[{pr_number: $n, head_ref: $ref}]')
+          fi
+
+          COUNT=$(echo "$TARGETS" | jq 'length')
+          echo "Targets ($COUNT):"
+          echo "$TARGETS" | jq .
+          echo "targets=$(echo "$TARGETS" | jq -c .)" >> "$GITHUB_OUTPUT"
+          if [ "$COUNT" -gt 0 ]; then
+            echo "has_targets=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_targets=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Reconcile a conflicting PR with its base branch via rebase + push.
+  # One matrix job per target produced by prepare-targets.
+  resolve-pr-conflicts:
+    needs: [prepare-targets]
+    if: needs.prepare-targets.outputs.has_targets == 'true'
+    strategy:
+      fail-fast: false
+      # max-parallel: 1 keeps a flood of DIRTY PRs after a big merge from
+      # spawning N parallel agents on the self-hosted runner. Each PR's
+      # rebase is fast; sequencing is fine.
+      max-parallel: 1
+      matrix:
+        target: ${{ fromJSON(needs.prepare-targets.outputs.targets) }}
+    concurrency:
+      group: ai-pr-resolve-${{ matrix.target.pr_number }}
+      cancel-in-progress: true
+    runs-on: [self-hosted, homelab]
+    timeout-minutes: 120
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+      packages: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.WORKFLOW_PAT }}
+
+      - name: Add ai-resolving label
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+        run: |
+          gh label create "ai-resolving" --color "fbca04" \
+            --description "AI assistant is rebasing this PR onto its base" \
+            --repo ${{ github.repository }} 2>/dev/null || true
+          gh pr edit ${{ matrix.target.pr_number }} --add-label "ai-resolving" \
+            --repo ${{ github.repository }}
+
+      - name: Resolve PR conflicts with AI assistant
+        uses: ./.github/actions/run-ci-agent
+        with:
+          image: ${{ env.CI_IMAGE }}
+          prompt_file: .github/ci/prompts/resolve-pr-conflicts.md
+          output_file: ${{ runner.temp }}/resolve-pr-conflicts-conversation.jsonl
+          env: |
+            AI_API_KEY=${{ vars.AI_API_KEY }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
+            PR_NUMBER=${{ matrix.target.pr_number }}
+            HEAD_REF=${{ matrix.target.head_ref }}
+            REPO=${{ github.repository }}
+            AI_TOOL=codex
+            CODEX_MODEL=gpt-5.5
+          # Fetch PR metadata inside the container so the prompt template
+          # has PR_TITLE, PR_BODY, BASE_REF, and TRIGGERING_SHA available
+          # without passing multi-line strings through the workflow YAML.
+          pre_script: |
+            PR_JSON=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
+            PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+            PR_BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
+            BASE_REF=$(echo "$PR_JSON" | jq -r '.base.ref')
+            TRIGGERING_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
+            export PR_TITLE PR_BODY BASE_REF TRIGGERING_SHA
+
+      - name: Remove ai-resolving label
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+        run: |
+          gh pr edit ${{ matrix.target.pr_number }} --remove-label "ai-resolving" \
+            --repo ${{ github.repository }} 2>/dev/null || true
+
+      - name: Upload PR conflict resolution conversation log
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: resolve-pr-conflicts-conversation-log-${{ matrix.target.pr_number }}
+          path: ${{ runner.temp }}/resolve-pr-conflicts-conversation.jsonl
           retention-days: 7

--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -247,6 +247,12 @@ jobs:
           needs.authorize.outputs.comment_target == 'pr'
         )
       )
+    # Dedupe rapid consecutive pushes to main — the second push cancels the
+    # first enumeration so we don't fan out duplicate matrix runs over the
+    # same dirty PRs. Comment-path runs are per-PR so they never collide.
+    concurrency:
+      group: ai-prepare-targets-${{ github.event_name == 'push' && 'push' || github.event.issue.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     outputs:
       targets: ${{ steps.build.outputs.targets }}
@@ -288,14 +294,20 @@ jobs:
 
           if [ "$EVENT_NAME" = "push" ]; then
             # Pull all open PRs and dedupe out anything already being worked on.
+            # Include authorAssociation so we can scope to trusted authors only —
+            # PR_BODY is interpolated into the agent prompt and WORKFLOW_PAT has
+            # force-push rights, so external-contributor PRs are excluded here
+            # for the same reason the authorize job gates the comment path.
             JQ_LIST_FILTER='[.[] | {
               pr_number: .number,
               head_ref: .headRefName,
+              author_assoc: .authorAssociation,
               has_resolving: ([.labels[].name] | contains(["ai-resolving"]))
             }]'
             ALL_PRS=$(gh pr list --repo "$REPO" --state open \
-              --json number,headRefName,labels --jq "$JQ_LIST_FILTER")
-            ELIGIBLE=$(echo "$ALL_PRS" | jq -r '.[] | select(.has_resolving | not) | .pr_number')
+              --json number,headRefName,labels,authorAssociation --jq "$JQ_LIST_FILTER")
+            ELIGIBLE=$(echo "$ALL_PRS" | jq -r \
+              '.[] | select(.has_resolving | not) | select(.author_assoc | IN("OWNER","MEMBER","COLLABORATOR")) | .pr_number')
             for pr_n in $ELIGIBLE; do
               STATE=$(poll_pr_state "$pr_n")
               MERGE_STATE="${STATE#*|}"

--- a/docs/operations/AI_GHA_PIPELINES.md
+++ b/docs/operations/AI_GHA_PIPELINES.md
@@ -102,7 +102,7 @@ concurrency:
 `cancel-in-progress: true` prevents queued work from racing stale context.
 
 **When the guard trips (GitHub Actions summary messaging):**
-- In-flight runs flip to the yellow `Cancelled` badge within seconds; the GitHub Actions run summary surfaces the callout "Superseded by another run in ai-interactive-<number>," so you immediately know a newer request preempted it.
+- In-flight runs flip to the yellow `Cancelled` badge within seconds; the GitHub Actions run summary surfaces the callout "Superseded by another run in `ai-resolve-issue-<number>` or `ai-pr-resolve-<number>`," so you immediately know a newer request preempted it.
 - Runs blocked before they start show up in the Actions summary as `Skipped by concurrency guard` with the same superseded message, making it obvious the skip was intentional and not a workflow failure.
 - Only the newest comment gets a response; stale runs never emit results because GitHub immediately launches a fresh execution with the latest payload.
 - Treat the coloured cancellation/skip messaging as confirmation that the guard worked — no manual cleanup required.

--- a/docs/operations/AI_GHA_PIPELINES.md
+++ b/docs/operations/AI_GHA_PIPELINES.md
@@ -54,7 +54,7 @@ Key security measures:
 
 | Workflow | File | Trigger | Purpose |
 |----------|------|---------|---------|
-| AI Assistant | `ai-assistant.yml` | New issues, ai-started label removal, `/autoresolve` comments | Auto-resolve issues, respond to comments |
+| AI Assistant | `ai-assistant.yml` | New issues, ai-started label removal, `/autoresolve` comments, pushes to main | Auto-resolve issues, rebase conflicting PRs |
 | AI Code Review | `ai-code-review.yml` | PR Tests completion, PR reopened, `/review` comment | Multi-agent code review, fix failures, merge decision |
 | PR Tests | `pr-tests.yml` | PRs, pushes to all branches | Run tests, trigger review pipeline |
 | AI Diagnose Workflow Failure | `ai-diagnose-workflow-failure.yml` | Any workflow failure | Diagnose Actions config problems (not test failures) |
@@ -68,11 +68,12 @@ The main workflow that enables the AI assistant to respond to requests and autom
 
 ### Triggers
 
-The workflow has three primary trigger paths, all gated by the `authorize` job:
+The workflow has four primary trigger paths:
 
-- **Issue opened / assigned** (`issues: opened` / `issues: assigned`): Any issue opened by an authorized actor (OWNER / MEMBER / COLLABORATOR) fires the AI automatically. **No opt-in keyword required** in the title or body. This is the primary path for "please fix this."
+- **Issue opened / assigned** (`issues: opened` / `issues: assigned`): Any issue opened by an authorized actor (OWNER / MEMBER / COLLABORATOR) fires the AI automatically. **No opt-in keyword required** in the title or body. This is the primary path for "please fix this." Routed to `resolve-issue`.
 - **`ai-started` label removed** (`issues: unlabeled`): The `resolve-issue` job stamps every issue it processes with an `ai-started` label. Removing that label from an open issue is the "try again" gesture — it re-fires the `resolve-issue` job so the AI takes another pass (useful when the previous attempt got stuck or produced the wrong PR). The unlabeled trigger is ignored unless the removed label is literally `ai-started` **and** the issue is still open.
-- **`/autoresolve` in a comment or review** (fallback): When a comment, PR review, or PR review comment contains a plain-text `/autoresolve` token, the AI fires against that comment's context (PR branch or issue thread). This is the fallback path for directing the AI at an existing thread after opening. The `authorize` job strips fenced code blocks, inline code, HTML `<code>` blocks, markdown links, and HTML `<a>` links before searching for the token, so pasted examples and docs never retrigger the workflow.
+- **`/autoresolve` in a comment** (fallback): When a comment contains a plain-text `/autoresolve` token, the AI fires against that comment's context. On an **issue**, it routes to `resolve-issue` (open a PR for the issue). On a **PR**, it routes to `resolve-pr-conflicts` (rebase the PR onto its base, resolve conflicts, run tests, force-push). The `authorize` job strips fenced code blocks, inline code, HTML `<code>` blocks, markdown links, and HTML `<a>` links before searching for the token, so pasted examples and docs never retrigger the workflow.
+- **Push to `main`** (auto-fire conflicts): Every merge to `main` runs `prepare-targets`, which scans open PRs for `mergeStateStatus == DIRTY` and dispatches `resolve-pr-conflicts` onto each. This catches the common case where parallel PRs touch overlapping files — as one merges, the rest flip to DIRTY without any explicit user action. GitHub does not emit a dedicated "PR became DIRTY" event, so push-to-main is the closest reliable signal. There is no authorization gate on this path; branch protection on `main` already restricts who can push.
 
 Why `/autoresolve` and not `@something`? `@ai`, `@autoresolve`, and similar tags are all real GitHub usernames — using them in comments would ping live users. The slash-command style is unambiguously a bot directive and pings nobody.
 
@@ -80,17 +81,25 @@ The authorize job also short-circuits any comment whose body matches a known aut
 
 ### Concurrency Control
 
+Concurrency is scoped per job, not at the workflow level, so the issue and PR-conflict paths don't interfere:
+
 ```yaml
+# resolve-issue (issue events)
 concurrency:
-  group: ai-interactive-${{ issue_or_pr_number }}
-  cancel-in-progress: true  # Cancel in-flight runs so the newest request executes
+  group: ai-resolve-issue-${{ issue_number }}
+  cancel-in-progress: true
+
+# resolve-pr-conflicts (one matrix instance per PR)
+concurrency:
+  group: ai-pr-resolve-${{ matrix.target.pr_number }}
+  cancel-in-progress: true
 ```
 
-Scoped by issue/PR number so that:
-- Two rapid triggers on the **same** PR/issue cannot overlap; the newer invocation cancels the prior run and starts immediately
-- Triggers on **different** PRs/issues run in parallel (separate concurrency groups)
+- Two rapid triggers on the **same** issue or PR cancel the prior run and start the newer one with the freshest state.
+- Triggers on **different** PRs/issues run in parallel.
+- `resolve-pr-conflicts` runs with `max-parallel: 1` so a flood of DIRTY PRs after a big merge doesn't spawn N parallel agents on the self-hosted runner. Each PR's rebase is fast; sequencing is fine.
 
-`cancel-in-progress: true` prevents queued work from racing stale context — the AI assistant immediately restarts with the newest request so the freshest state is always the one being processed.
+`cancel-in-progress: true` prevents queued work from racing stale context.
 
 **When the guard trips (GitHub Actions summary messaging):**
 - In-flight runs flip to the yellow `Cancelled` badge within seconds; the GitHub Actions run summary surfaces the callout "Superseded by another run in ai-interactive-<number>," so you immediately know a newer request preempted it.
@@ -111,28 +120,41 @@ Builds and caches a devcontainer image to speed up subsequent runs.
 - **Output**: `should_build_devcontainer` — consumed by downstream steps via conditional `if` guards
 - **Why it matters**: The guard keeps routine comments (status updates, reactions, etc.) from burning self-hosted minutes — the container build triggers only when the AI assistant is actually going to run.
 
-#### 1.2 `ai`
+#### 1.2 `prepare-targets`
 
-Responds to `/autoresolve` invocations in comments, PR reviews, and PR review comments. Does **not** handle issue events — those are routed to `resolve-issue` below.
+Builds the list of PRs that `resolve-pr-conflicts` should fan out over. Runs for both auto-fire and manual paths.
 
-**Condition**: Executes only when `needs.authorize.outputs.should_run_ai == 'true'` AND the event type is `issue_comment`, `pull_request_review_comment`, or `pull_request_review`. The authorize job has already verified the comment body contains a plain-text `/autoresolve` and does not match an auto-generated review heading, so this job's `if:` is intentionally thin.
+**Condition**:
+- `push` event on `main` — no authorization needed (branch protection gates pushes), OR
+- `issue_comment` event where the comment is on a PR, the actor is authorized, and the body contains a plain-text `/autoresolve`.
 
 **Workflow**:
-1. Detects if the context is a PR or issue
-2. Checks out the appropriate branch (PR head or default)
-3. Runs the AI assistant inside the devcontainer
-4. Implements requested changes or responds to questions
-5. For PRs: commits and pushes changes to the PR branch
-6. For issues: creates branches and opens PRs as needed
+1. **Push path**: `gh pr list` enumerates open PRs. For each PR (excluding any already labeled `ai-resolving`), poll `gh pr view --json mergeStateStatus,mergeable` up to ~30s — GitHub computes mergeability asynchronously, so freshly-affected PRs return `UNKNOWN` for several seconds. Keep PRs whose `mergeStateStatus == DIRTY`.
+2. **Comment path**: emit a single-element list with the commented PR. The agent itself re-confirms the conflict and exits cleanly if the PR is already mergeable.
 
-**Key Configuration**:
-```yaml
-bash .devcontainer/run-ai.sh "$PROMPT"
-```
+Outputs a JSON array `[{pr_number, head_ref}, …]` consumed by `resolve-pr-conflicts` as a matrix.
 
-`run-ai.sh` is a tool-agnostic wrapper that dispatches to whichever CLI is currently configured. It reads `.devcontainer/ai-tool.env` to decide which tool to invoke and translates the generic `AI_API_KEY` env var into the tool-specific name (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.). See [Swapping the Backing AI Tool](#swapping-the-backing-ai-tool) below.
+#### 1.3 `resolve-pr-conflicts`
 
-#### 1.3 `resolve-issue`
+Rebases a conflicting PR onto its base, resolves conflicts in-context, runs `make unit-tests`, and force-pushes the rebased branch. One matrix instance per target from `prepare-targets`.
+
+**Condition**: `needs.prepare-targets.outputs.has_targets == 'true'`.
+
+**Workflow**:
+1. Adds the `ai-resolving` label so concurrent push-triggered runs skip this PR (the `prepare-targets` filter excludes labeled PRs).
+2. Runs the agent (`.github/ci/prompts/resolve-pr-conflicts.md`) inside the CI image:
+   - Verifies the PR head SHA hasn't moved since the trigger fired; if it has, aborts cleanly with a comment.
+   - Confirms `mergeStateStatus == DIRTY`; if already mergeable, comments "no conflict" and exits.
+   - `git rebase origin/<base_ref>`, resolves each conflict by reading both sides plus surrounding code on the new base, preserving the PR's stated intent.
+   - `make unit-tests` to validate, then `git push --force-with-lease`. Hooks run normally; never `--no-verify`.
+   - Comments on the PR with what was resolved and the new head SHA.
+3. Removes the `ai-resolving` label (`if: always()`).
+
+**Why `--force-with-lease`**: refuses to push if anyone else has pushed to the branch since we fetched it. If that fails, treat it as the "author pushed newer commits" path and abort cleanly — never overwrite a human's commit.
+
+**Why `max-parallel: 1`**: a flood of DIRTY PRs right after a big merge would otherwise spawn N parallel agents on the self-hosted runner. Sequencing keeps load bounded; each rebase is fast.
+
+#### 1.4 `resolve-issue`
 
 Automatically resolves newly opened issues and re-runs on explicit retry requests.
 
@@ -156,10 +178,16 @@ Automatically resolves newly opened issues and re-runs on explicit retry request
 
 **Timeout**: 120 minutes
 
+### Labels
+
+- **`ai-started`** (sticky): added by `resolve-issue` to every issue it processes; removed by hand to retry.
+- **`ai-resolving`** (transient): added by `resolve-pr-conflicts` at job start, removed at job end. Used by `prepare-targets` to skip in-flight PRs so a second push to main mid-rebase doesn't re-fire the agent on the same branch.
+
 ### Artifacts
 
-- `ai-conversation-log`: Full conversation log in JSONL format
-- Retention: 7 days
+- `resolve-issue-conversation-log`: full conversation log from issue resolution.
+- `resolve-pr-conflicts-conversation-log-<pr_number>`: full conversation log from each PR conflict resolution (one per matrix instance).
+- Retention: 7 days.
 
 ---
 
@@ -717,6 +745,8 @@ Required approvals: 0  # AI assistant provides automated review
 | AI doesn't respond on a comment | Body missing a plain-text `/autoresolve` token, or token is inside a code block / link | Post a comment with `/autoresolve` as plain text (not inside backticks or a markdown link) |
 | AI didn't run on a newly opened issue | Issue author is not an OWNER / MEMBER / COLLABORATOR | Check the `authorize` job logs — external contributors' issues are intentionally skipped |
 | Want to re-run AI on an issue after it finished | `resolve-issue` only fires once per issue open | Remove the `ai-started` label from the (still-open) issue — that re-fires `resolve-issue` |
+| `resolve-pr-conflicts` skipped a DIRTY PR | PR has the `ai-resolving` label (a previous run is still in flight, or crashed without cleanup) | Wait for the in-flight run, or hand-remove the label and post `/autoresolve` on the PR |
+| `resolve-pr-conflicts` aborted with "head moved" | Author pushed to the PR branch while the agent was working | Normal — the agent yields to humans. Re-comment `/autoresolve` once your push has landed |
 | Workflow failure issue not created | Diagnosed as TEST_FAILURE or CONFIG_FAILURE | Expected - these are handled by AI Code Review |
 
 ### Manual Triggers

--- a/docs/operations/CI_CD_SECURITY.md
+++ b/docs/operations/CI_CD_SECURITY.md
@@ -63,6 +63,8 @@ jobs:
 - External users' issues/comments are ignored
 - No secrets exposed to unauthorized users
 
+**Push-triggered conflict resolution:** the `prepare-targets` and `resolve-pr-conflicts` jobs also fire on `push` to `main` to auto-rebase open PRs that have flipped to `mergeStateStatus == DIRTY`. This path bypasses the `authorize` job because branch protection on `main` already restricts who can push — there is no untrusted-input surface to gate. The agent only operates on existing PRs (rebase + force-push of the PR branch); it cannot create new PRs or land code on `main`.
+
 #### `ai-code-review.yml` (PR Review Pipeline, workflow name `AI Code Review`)
 
 ```yaml


### PR DESCRIPTION
## Summary

- Adds a `push: branches: [main]` trigger to `ai-assistant.yml`. After every merge, `prepare-targets` enumerates open PRs, polls each for `mergeStateStatus` (GitHub computes mergeability asynchronously), and emits the DIRTY ones as a matrix for `resolve-pr-conflicts`.
- Reuses the existing `/autoresolve` keyword: posting it as a comment on a PR (vs. an issue) routes to the new `resolve-pr-conflicts` agent.
- `resolve-pr-conflicts` rebases the PR onto its base, resolves conflicts in-context against the new base while preserving the PR's stated intent, runs `make unit-tests`, and force-pushes with `--force-with-lease`. Yields to humans if the PR head moved during the run.
- Dedupe via a new transient `ai-resolving` label so back-to-back pushes don't re-fire on a PR that's already being rebased. Per-PR concurrency + `max-parallel: 1` keeps the self-hosted runner from getting flooded.
- Updates `AI_GHA_PIPELINES.md` and `CI_CD_SECURITY.md` to describe the new entry points, jobs, labels, and threat model.

## Why

Multiple AI-generated PRs opened back-to-back regularly hit merge conflicts when one of them lands first (e.g. PRs 1084 / 1082 / 994 from this morning). GitHub does not emit a "PR became DIRTY" event, so `push` to `main` is the closest reliable signal — and the only one the user does not have to invoke by hand.

## Test plan

- [ ] Open a throwaway PR that conflicts with `main`. Comment `/autoresolve` and verify the PR ends up rebased + mergeable + with a status comment.
- [ ] Merge a PR that touches the same file as another open PR. Verify the push trigger auto-rebases the second PR within ~1 min.
- [ ] Comment `/autoresolve` on a regular issue. Verify only `resolve-issue` runs (not `resolve-pr-conflicts`).
- [ ] Trigger on a PR that's already `MERGEABLE`. Verify the agent comments "no conflict" and exits without force-pushing.
- [ ] Push a manual commit to a PR while `resolve-pr-conflicts` is running. Verify the agent detects the moved HEAD, comments, and does NOT force-push.
- [ ] Apply to the live backlog (PRs 1084, 1082, 994) once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)