### PR TITLE
fix(ci): refactor ha-deprecation-check onto run-ci-agent action

### DIFF
--- a/.github/workflows/ha-deprecation-check.yml
+++ b/.github/workflows/ha-deprecation-check.yml
@@ -56,59 +56,30 @@ jobs:
             exit 1
           fi
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull CI image
-        run: docker pull "${CI_IMAGE}"
-
       # Note: GH_TOKEN uses WORKFLOW_PAT so created issues trigger the resolve-issue job in the AI assistant workflow
       # (issues created with GITHUB_TOKEN don't trigger other workflows)
       - name: Check for deprecated HA APIs with AI assistant
-        env:
-          AI_API_KEY: ${{ vars.AI_API_KEY }}
-          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
-          REPO: ${{ github.repository }}
-          HA_VERSION: ${{ inputs.ha_version || '' }}
-        run: |
-          set -euo pipefail
-          OUTPUT_DIR="${{ runner.temp }}/deprecation-output"
-          mkdir -p "$OUTPUT_DIR"
-
+        uses: ./.github/actions/run-ci-agent
+        with:
+          image: ${{ env.CI_IMAGE }}
+          prompt_file: .github/ci/prompts/deprecation-check.md
+          output_file: ${{ runner.temp }}/deprecation-output/deprecation-check-output.jsonl
+          env: |
+            AI_API_KEY=${{ vars.AI_API_KEY }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
+            REPO=${{ github.repository }}
+            HA_VERSION=${{ inputs.ha_version || '' }}
           # The HA_VERSION_LINE paragraph swaps based on whether a specific
           # HA version was passed as an input. Computing it here (rather than
           # embedding `$(…)` command substitution inside the prompt template)
           # keeps the prompt file purely textual and envsubst-safe.
-          if [ -n "$HA_VERSION" ]; then
-            HA_VERSION_LINE=$(printf 'CHECK SPECIFIC VERSION: %s\nFetch the release notes for HA %s from https://www.home-assistant.io/blog/' "$HA_VERSION" "$HA_VERSION")
-          else
-            HA_VERSION_LINE="Check the LAST 3 HA releases."
-          fi
-          export HA_VERSION_LINE
-
-          docker run --rm \
-            --network host \
-            --workdir /workspace \
-            -v "${{ github.workspace }}:/workspace" \
-            -v "$OUTPUT_DIR:/tmp/deprecation-output" \
-            -e AI_API_KEY \
-            -e GH_TOKEN \
-            -e REPO \
-            -e HA_VERSION \
-            -e HA_VERSION_LINE \
-            "${CI_IMAGE}" \
-            -lc '
-              set -euo pipefail
-              source .devcontainer/configure-ai.sh
-
-              PROMPT=$(envsubst < .github/ci/prompts/deprecation-check.md)
-              bash .devcontainer/run-ai.sh "$PROMPT" 2>&1 \
-                | tee /tmp/deprecation-output/deprecation-check-output.jsonl
-            '
+          pre_script: |
+            if [ -n "${HA_VERSION}" ]; then
+              HA_VERSION_LINE=$(printf 'CHECK SPECIFIC VERSION: %s\nFetch the release notes for HA %s from https://www.home-assistant.io/blog/' "$HA_VERSION" "$HA_VERSION")
+            else
+              HA_VERSION_LINE="Check the LAST 3 HA releases."
+            fi
+            export HA_VERSION_LINE
 
       - name: Upload deprecation check output
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Fixes scheduled `HA Deprecation Check` failures (`tee: …: Permission denied`) by switching the workflow to the existing `./.github/actions/run-ci-agent` composite action.
- Root cause: the CI image runs as UID 1000 (`ci`) but `runner.temp` dirs in the `ci-runner` container are owned by UID 1001 — the bind-mounted output dir was unwritable, so `tee` failed under `pipefail` and the validate step couldn't find the JSONL artifact. Commit `afccf48` previously fixed this with `chmod 777`; commit `31daeed` removed it on the wrong assumption that `runner.temp` made the mount writable on its own.
- The composite action already handles this correctly (stages output in a `chmod 777` dir under `RUNNER_TEMP`, copies back after exit) and is the same pattern `ai-assistant.yml` uses. Also drops the duplicated GHCR login / pull / docker run / tee plumbing. `HA_VERSION_LINE` derivation moved into the action's `pre_script` unchanged.

Failing run: https://github.com/NickBorgers/home-automation/actions/runs/25371518740

## Test plan
- [ ] After merge: trigger `gh workflow run "HA Deprecation Check"` (no input). Expect `Run agent` to exit 0, the `deprecation-check-output` artifact to be uploaded with non-empty JSONL, and `Validate deprecation check result` to match one of `RESULT: NO_DEPRECATIONS_FOUND` / `ISSUES_CREATED` / `ALL_DUPLICATES`.
- [ ] Re-trigger with `-f ha_version=2026.3` to exercise the `HA_VERSION` branch of the pre-script and confirm `HA_VERSION_LINE` substitution still produces the "CHECK SPECIFIC VERSION" prompt paragraph.
- [ ] Spot-check the uploaded artifact contains the JSONL stream from `run-ai.sh` (i.e., the bug is actually fixed, not just papered over).

🤖 Generated with [Claude Code](https://claude.com/claude-code)