### PR TITLE
fix(ai-assistant): use REST pulls endpoint for author_association

### DIFF
--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -294,20 +294,30 @@ jobs:
 
           if [ "$EVENT_NAME" = "push" ]; then
             # Pull all open PRs and dedupe out anything already being worked on.
-            # Include authorAssociation so we can scope to trusted authors only —
+            # Include author_association so we can scope to trusted authors only —
             # PR_BODY is interpolated into the agent prompt and WORKFLOW_PAT has
             # force-push rights, so external-contributor PRs are excluded here
             # for the same reason the authorize job gates the comment path.
+            #
+            # `gh pr list --json` does NOT expose author_association; the REST
+            # `/repos/{owner}/{repo}/pulls` endpoint does. Use it directly.
             JQ_LIST_FILTER='[.[] | {
               pr_number: .number,
-              head_ref: .headRefName,
-              author_assoc: .authorAssociation,
+              head_ref: .head.ref,
+              author_assoc: .author_association,
               has_resolving: ([.labels[].name] | contains(["ai-resolving"]))
             }]'
-            ALL_PRS=$(gh pr list --repo "$REPO" --state open \
-              --json number,headRefName,labels,authorAssociation --jq "$JQ_LIST_FILTER")
-            ELIGIBLE=$(echo "$ALL_PRS" | jq -r \
-              '.[] | select(.has_resolving | not) | select(.author_assoc | IN("OWNER","MEMBER","COLLABORATOR")) | .pr_number')
+            # per_page=100 caps the page size; this repo will not have more
+            # than 100 open PRs at once, so a single page is fine. (Avoid
+            # --paginate: it concatenates pages as separate JSON arrays,
+            # which breaks the single-array filter below.)
+            ALL_PRS=$(gh api "repos/${REPO}/pulls?state=open&per_page=100" \
+              --jq "$JQ_LIST_FILTER")
+            JQ_ELIGIBLE='.[]
+              | select(.has_resolving | not)
+              | select(.author_assoc | IN("OWNER","MEMBER","COLLABORATOR"))
+              | .pr_number'
+            ELIGIBLE=$(echo "$ALL_PRS" | jq -r "$JQ_ELIGIBLE")
             for pr_n in $ELIGIBLE; do
               STATE=$(poll_pr_state "$pr_n")
               MERGE_STATE="${STATE#*|}"

--- a/docs/operations/AI_GHA_PIPELINES.md
+++ b/docs/operations/AI_GHA_PIPELINES.md
@@ -129,7 +129,7 @@ Builds the list of PRs that `resolve-pr-conflicts` should fan out over. Runs for
 - `issue_comment` event where the comment is on a PR, the actor is authorized, and the body contains a plain-text `/autoresolve`.
 
 **Workflow**:
-1. **Push path**: `gh pr list` enumerates open PRs. For each PR (excluding any already labeled `ai-resolving`), poll `gh pr view --json mergeStateStatus,mergeable` up to ~30s — GitHub computes mergeability asynchronously, so freshly-affected PRs return `UNKNOWN` for several seconds. Keep PRs whose `mergeStateStatus == DIRTY`.
+1. **Push path**: `gh api repos/{owner}/{repo}/pulls` enumerates open PRs (REST endpoint used because `gh pr list --json` does not expose `author_association`, which gates trusted-author filtering). For each PR (excluding any already labeled `ai-resolving`), poll `gh pr view --json mergeStateStatus,mergeable` up to ~30s — GitHub computes mergeability asynchronously, so freshly-affected PRs return `UNKNOWN` for several seconds. Keep PRs whose `mergeStateStatus == DIRTY`.
 2. **Comment path**: emit a single-element list with the commented PR. The agent itself re-confirms the conflict and exits cleanly if the PR is already mergeable.
 
 Outputs a JSON array `[{pr_number, head_ref}, …]` consumed by `resolve-pr-conflicts` as a matrix.


### PR DESCRIPTION
## Summary

`gh pr list --json authorAssociation` was added to `prepare-targets` during PR #1085's merge-decision review to scope auto-fire to trusted authors. But that field is not supported by `gh pr list`, so every push to main fails:

```
Unknown JSON field: "authorAssociation"
```

(See the failing run on the PR #1085 merge: https://github.com/NickBorgers/home-automation/actions/runs/25382480410)

The REST `/repos/{owner}/{repo}/pulls?state=open` endpoint exposes `author_association` directly. Switching to it preserves the security intent (skip non-OWNER/MEMBER/COLLABORATOR PRs on the push path) without the broken field.

Verified locally:
```
$ gh api "repos/NickBorgers/home-automation/pulls?state=open" --jq '...filter...'
1086 1084 1082 1073 994
```

Also factored the eligibility jq into `JQ_ELIGIBLE` to stay under the 120-char line limit.

## Test plan

- [ ] After merge, the next push to main runs `prepare-targets` cleanly and dispatches `resolve-pr-conflicts` onto the DIRTY backlog (1084, 1082, 994).
- [ ] `/autoresolve` comment path continues to work — that path doesn't call the broken filter (it uses `gh pr view` for the head ref).

🤖 Generated with [Claude Code](https://claude.com/claude-code)