### PR TITLE
Fix #1093: Use central speaker defaults for safety alerts

### DIFF
--- a/homeautomation-go/internal/plugins/evcharger/manager.go
+++ b/homeautomation-go/internal/plugins/evcharger/manager.go
@@ -300,13 +300,6 @@ func (m *Manager) sendAlertNotifications(conditionType, sensor string) {
 	m.lastNotificationTime = time.Now()
 	m.mu.Unlock()
 
-	// Intentionally excludes kids_bathroom — EV charging alerts are adult safety concerns.
-	speakers := []string{
-		"media_player.bedroom",
-		"media_player.kitchen",
-		"media_player.dining_room",
-	}
-
 	message := fmt.Sprintf("Warning: EV charger %s detected. The charger has been automatically turned off.", conditionType)
 
 	if m.alerter != nil {
@@ -315,7 +308,6 @@ func (m *Manager) sendAlertNotifications(conditionType, sensor string) {
 			Body:     message,
 			Urgency:  notify.UrgencyUrgent,
 			Tags:     []string{"rotating_light", "electric_plug", "warning"},
-			Speakers: speakers,
 			Priority: ntfy.PriorityUrgent,
 		}); err != nil {
 			m.logger.Error("Failed to send alert notification", zap.String("condition", conditionType), zap.Error(err))

--- a/homeautomation-go/internal/plugins/security/manager.go
+++ b/homeautomation-go/internal/plugins/security/manager.go
@@ -427,19 +427,12 @@ func (m *Manager) sendTTSNotification(message string) {
 		m.logger.Warn("alerter not configured, skipping security announcement")
 		return
 	}
-	speakers := []string{
-		"media_player.bedroom",
-		"media_player.kitchen",
-		"media_player.dining_room",
-		"media_player.kids_bathroom",
-	}
 	if err := m.alerter.Send(m.ctx, alert.Alert{
 		Title:    "Security Alert",
 		Body:     message,
 		Urgency:  notify.UrgencyUrgent,
 		Tags:     []string{"rotating_light"},
 		Priority: ntfy.PriorityUrgent,
-		Speakers: speakers,
 	}); err != nil {
 		m.logger.Error("Failed to send security announcement", zap.Error(err), zap.String("message", message))
 		return

--- a/homeautomation-go/internal/plugins/waterflow/manager.go
+++ b/homeautomation-go/internal/plugins/waterflow/manager.go
@@ -424,18 +424,11 @@ func (m *Manager) sendAlertNotification(alertType, message string) {
 	defer m.mu.Lock()
 
 	if m.alerter != nil {
-		speakers := []string{
-			"media_player.bedroom",
-			"media_player.kitchen",
-			"media_player.dining_room",
-			"media_player.kids_bathroom",
-		}
 		if err := m.alerter.Send(m.ctx, alert.Alert{
 			Title:    title,
 			Body:     ttsMessage,
 			Urgency:  urgency,
 			Tags:     tags,
-			Speakers: speakers,
 			Priority: priority,
 		}); err != nil {
 			m.logger.Error("Failed to send water flow alert notification",


### PR DESCRIPTION
Resolves #1093

## Summary
- Removed plugin-specific TTS speaker overrides from waterflow, security, and EV charger alerts
- Let those alerts fall through to notify.Config.DefaultSpeakers so all central default speakers are used

## Test Plan
- make unit-tests

🤖 Generated by the AI assistant