### PR TITLE
Restore /api/notify endpoint accidentally dropped in #1079

### DIFF
--- a/docs/human/VISUAL_ARCHITECTURE.md
+++ b/docs/human/VISUAL_ARCHITECTURE.md
@@ -513,7 +513,7 @@ classDiagram
 
 ## API Server Endpoints
 
-The HTTP API server provides observability into the system state.
+The HTTP API server provides observability into system state and accepts alert dispatch requests.
 
 ```mermaid
 graph LR
@@ -533,6 +533,7 @@ graph LR
         ShadowDayPhase["GET /api/shadow/dayphase"]
         ShadowTV["GET /api/shadow/tv"]
         ShadowSexMode["GET /api/shadow/sexmode"]
+        Notify["POST /api/notify"]
     end
 
     subgraph "Response Types"
@@ -542,6 +543,7 @@ graph LR
         ByPlugin[Variables<br/>by Plugin]
         AllShadow[All Plugin<br/>Shadow States]
         PluginShadow[Single Plugin<br/>Shadow State]
+        NotifyResp["Notify Response<br/>dispatched / suppressed_asleep"]
     end
 
     Root --> Sitemap
@@ -559,12 +561,14 @@ graph LR
     ShadowDayPhase --> PluginShadow
     ShadowTV --> PluginShadow
     ShadowSexMode --> PluginShadow
+    Notify --> NotifyResp
 
     style Root fill:#e1f5ff
     style Health fill:#e8f5e9
     style State fill:#fff3e0
     style States fill:#fff3e0
     style Shadow fill:#f3e5f5
+    style Notify fill:#fce4ec
 ```
 
 ### API Response Structure

--- a/homeautomation-go/cmd/app/run.go
+++ b/homeautomation-go/cmd/app/run.go
@@ -344,16 +344,6 @@ func Run() {
 	subscriptionRegistry := shadowstate.NewSubscriptionRegistry()
 	logger.Info("Subscription Registry created for automatic input tracking")
 
-	// Start HTTP API server
-	apiServer := api.NewServer(client, stateManager, shadowTracker, logBuffer, logger, httpPort, timezone)
-	if err := apiServer.Start(); err != nil {
-		logger.Fatal("Failed to start HTTP API server", zap.Error(err))
-	}
-	defer apiServer.Stop()
-	logger.Info("HTTP API server started",
-		zap.Int("port", httpPort),
-		zap.String("endpoint", fmt.Sprintf("http://localhost:%d/api/state", httpPort)))
-
 	// Display current state
 	displayState(stateManager, logger)
 
@@ -411,6 +401,16 @@ func Run() {
 	logger.Info("Notifier initialized",
 		zap.Int("awake_volume_percent", notifyCfg.AwakeVolumePercent),
 		zap.Int("default_speaker_count", len(notifyCfg.DefaultSpeakers)))
+
+	// Start HTTP API server
+	apiServer := api.NewServer(client, stateManager, shadowTracker, logBuffer, logger, httpPort, timezone, pluginCtx.AlertNotifier)
+	if err := apiServer.Start(); err != nil {
+		logger.Fatal("Failed to start HTTP API server", zap.Error(err))
+	}
+	defer apiServer.Stop()
+	logger.Info("HTTP API server started",
+		zap.Int("port", httpPort),
+		zap.String("endpoint", fmt.Sprintf("http://localhost:%d/api/state", httpPort)))
 
 	// Create all registered plugins using the plugin registry
 	plugins, err := plugin.CreateAll(pluginCtx)

--- a/homeautomation-go/internal/api/security_test.go
+++ b/homeautomation-go/internal/api/security_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"homeautomation/internal/alert"
 	"homeautomation/internal/ha"
 	"homeautomation/internal/logbuffer"
 	"homeautomation/internal/shadowstate"
@@ -18,17 +19,18 @@ import (
 // Security Test Suite for HTTP Interface
 //
 // This file contains security-focused tests that verify the HTTP interface
-// is truly read-only and cannot be used to modify system state.
+// keeps read endpoints read-only and constrains write endpoints to their
+// intended method.
 //
 // Security Properties Verified:
-// 1. All endpoints reject non-GET HTTP methods (POST, PUT, DELETE, PATCH)
-// 2. No endpoint reads or processes request bodies
-// 3. No endpoint modifies internal state
+// 1. Read endpoints reject non-GET HTTP methods (POST, PUT, DELETE, PATCH)
+// 2. Read endpoints do not read or process request bodies
+// 3. Read endpoints do not modify internal state
 // 4. Query parameters cannot trigger state changes
 //
 // Related Issue: #324 - Security review of HTTP interfaces
 
-// allEndpoints lists all HTTP endpoints exposed by the API server
+// allEndpoints lists all read-only HTTP endpoints exposed by the API server.
 var allEndpoints = []string{
 	"/",
 	"/api/state",
@@ -49,7 +51,11 @@ var allEndpoints = []string{
 	"/api/timeline/events",
 }
 
-// nonGetMethods lists HTTP methods that should be rejected by all endpoints
+var writeEndpoints = []string{
+	"/api/notify",
+}
+
+// nonGetMethods lists HTTP methods that should be rejected by all read endpoints.
 var nonGetMethods = []string{
 	http.MethodPost,
 	http.MethodPut,
@@ -80,19 +86,49 @@ func createTestServer(t *testing.T) *Server {
 	shadowTracker.RegisterPlugin("tv", shadowstate.NewTVShadowState())
 
 	buffer := logbuffer.NewBuffer(100)
-	return NewServer(mockClient, stateManager, shadowTracker, buffer, logger, 8080, time.UTC)
+	return NewServer(mockClient, stateManager, shadowTracker, buffer, logger, 8080, time.UTC, &alert.MockAlerter{})
 }
 
-// TestAllEndpointsRejectNonGetMethods verifies that every endpoint rejects
+// TestAllReadEndpointsRejectNonGetMethods verifies that every read endpoint rejects
 // all non-GET HTTP methods with 405 Method Not Allowed.
-//
-// This is the primary security control ensuring the API is read-only.
-func TestAllEndpointsRejectNonGetMethods(t *testing.T) {
+func TestAllReadEndpointsRejectNonGetMethods(t *testing.T) {
 	t.Parallel()
 	server := createTestServer(t)
 
 	for _, endpoint := range allEndpoints {
 		for _, method := range nonGetMethods {
+			endpoint := endpoint // capture for parallel
+			method := method     // capture for parallel
+
+			t.Run(method+" "+endpoint, func(t *testing.T) {
+				t.Parallel()
+				req := httptest.NewRequest(method, endpoint, nil)
+				w := httptest.NewRecorder()
+				server.server.Handler.ServeHTTP(w, req)
+
+				if w.Code != http.StatusMethodNotAllowed {
+					t.Errorf("%s %s: expected status 405, got %d", method, endpoint, w.Code)
+				}
+			})
+		}
+	}
+}
+
+func TestWriteEndpointsRejectNonPostMethods(t *testing.T) {
+	t.Parallel()
+	server := createTestServer(t)
+
+	nonPostMethods := []string{
+		http.MethodGet,
+		http.MethodPut,
+		http.MethodDelete,
+		http.MethodPatch,
+		http.MethodConnect,
+		http.MethodTrace,
+	}
+
+	for _, endpoint := range writeEndpoints {
+		for _, method := range nonPostMethods {
 			endpoint := endpoint // capture for parallel
 			method := method     // capture for parallel
 
@@ -180,7 +216,7 @@ func TestQueryParametersCannotModifyState(t *testing.T) {
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
 	buffer := logbuffer.NewBuffer(100)
-	server := NewServer(mockClient, stateManager, shadowTracker, buffer, logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, buffer, logger, 8080, time.UTC, &alert.MockAlerter{})
 
 	// Set initial state values
 	stateManager.SetBool("isNickHome", true)

--- a/homeautomation-go/internal/api/server.go
+++ b/homeautomation-go/internal/api/server.go
@@ -4,13 +4,18 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
+	"unicode/utf8"
 
+	"homeautomation/internal/alert"
 	"homeautomation/internal/ha"
 	"homeautomation/internal/logbuffer"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
 
@@ -32,10 +37,20 @@ type Server struct {
 	logger        *zap.Logger
 	server        *http.Server
 	timezone      *time.Location
+	alertNotifier alert.Alerter
 }
 
 // NewServer creates a new API server
-func NewServer(haClient ha.HAClient, stateManager *state.Manager, shadowTracker *shadowstate.Tracker, logBuffer *logbuffer.Buffer, logger *zap.Logger, port int, timezone *time.Location) *Server {
+func NewServer(
+	haClient ha.HAClient,
+	stateManager *state.Manager,
+	shadowTracker *shadowstate.Tracker,
+	logBuffer *logbuffer.Buffer,
+	logger *zap.Logger,
+	port int,
+	timezone *time.Location,
+	alertNotifier alert.Alerter,
+) *Server {
 	s := &Server{
 		haClient:      haClient,
 		stateManager:  stateManager,
@@ -43,6 +58,7 @@ func NewServer(haClient ha.HAClient, stateManager *state.Manager, shadowTracker 
 		logBuffer:     logBuffer,
 		logger:        logger,
 		timezone:      timezone,
+		alertNotifier: alertNotifier,
 	}
 
 	mux := http.NewServeMux()
@@ -59,6 +75,7 @@ func NewServer(haClient ha.HAClient, stateManager *state.Manager, shadowTracker 
 	mux.HandleFunc("/api/shadow/statetracking", s.handleGetStateTrackingShadowState)
 	mux.HandleFunc("/api/shadow/dayphase", s.handleGetDayPhaseShadowState)
 	mux.HandleFunc("/api/shadow/tv", s.handleGetTVShadowState)
+	mux.HandleFunc("/api/notify", s.handleNotify)
 	mux.HandleFunc("/health", s.handleHealth)
 	mux.HandleFunc("/dashboard", s.handleDashboard)
 	mux.HandleFunc("/timeline", s.handleTimeline)
@@ -81,6 +98,20 @@ type StateResponse struct {
 	Numbers  map[string]float64 `json:"numbers"`
 	Strings  map[string]string  `json:"strings"`
 	JSONs    map[string]any     `json:"jsons"`
+}
+
+type notifyRequest struct {
+	Title    string   `json:"title"`
+	Body     string   `json:"body"`
+	Urgency  string   `json:"urgency"`
+	Tags     []string `json:"tags"`
+	Speakers []string `json:"speakers"`
+	Priority int      `json:"priority"`
+}
+
+type notifyResponse struct {
+	Dispatched       bool `json:"dispatched"`
+	SuppressedAsleep bool `json:"suppressed_asleep"`
 }
 
 // handleGetState returns all state variables as JSON
@@ -151,6 +182,98 @@ func (s *Server) handleGetState(w http.ResponseWriter, r *http.Request) {
 
 	s.logger.Debug("State request served",
 		zap.String("remote_addr", r.RemoteAddr))
+}
+
+func (s *Server) handleNotify(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 65536)
+
+	var req notifyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if strings.TrimSpace(req.Body) == "" {
+		writeAPIError(w, http.StatusBadRequest, "body field is required")
+		return
+	}
+	if utf8.RuneCountInString(req.Body) > 500 {
+		writeAPIError(w, http.StatusBadRequest, "body must be 500 characters or fewer")
+		return
+	}
+	if len(req.Tags) > 16 {
+		writeAPIError(w, http.StatusBadRequest, "tags must contain 16 items or fewer")
+		return
+	}
+	for _, tag := range req.Tags {
+		if utf8.RuneCountInString(tag) > 256 {
+			writeAPIError(w, http.StatusBadRequest, "each tag must be 256 characters or fewer")
+			return
+		}
+	}
+	if len(req.Speakers) > 16 {
+		writeAPIError(w, http.StatusBadRequest, "speakers must contain 16 items or fewer")
+		return
+	}
+	for _, speaker := range req.Speakers {
+		if utf8.RuneCountInString(speaker) > 256 {
+			writeAPIError(w, http.StatusBadRequest, "each speaker must be 256 characters or fewer")
+			return
+		}
+	}
+	if req.Priority != 0 && (req.Priority < 1 || req.Priority > 5) {
+		writeAPIError(w, http.StatusBadRequest, "priority must be between 1 and 5")
+		return
+	}
+
+	urgency := notify.UrgencyDeferable
+	switch req.Urgency {
+	case "", "deferable":
+	case "urgent":
+		urgency = notify.UrgencyUrgent
+	default:
+		writeAPIError(w, http.StatusBadRequest, "urgency must be deferable or urgent")
+		return
+	}
+
+	err := s.alertNotifier.Send(r.Context(), alert.Alert{
+		Title:    req.Title,
+		Body:     req.Body,
+		Urgency:  urgency,
+		Tags:     req.Tags,
+		Speakers: req.Speakers,
+		Priority: req.Priority,
+	})
+	suppressedAsleep := false
+	if errors.Is(err, notify.ErrSuppressedAsleep) {
+		suppressedAsleep = true
+	} else if err != nil {
+		s.logger.Error("notify request dispatch failed", zap.Error(err))
+		writeAPIError(w, http.StatusInternalServerError, "failed to dispatch notification")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(notifyResponse{Dispatched: true, SuppressedAsleep: suppressedAsleep}); err != nil {
+		s.logger.Error("Failed to encode notify response", zap.Error(err))
+		return
+	}
+
+	s.logger.Info("notify request dispatched",
+		zap.String("remote_addr", r.RemoteAddr),
+		zap.String("title", req.Title),
+		zap.Bool("suppressed_asleep", suppressedAsleep))
+}
+
+func writeAPIError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
 }
 
 // PluginMetadata describes which state variables a plugin uses
@@ -469,6 +592,11 @@ func (s *Server) handleSitemap(w http.ResponseWriter, r *http.Request) {
 			Path:        "/api/timeline/events",
 			Method:      "GET",
 			Description: "Get recent log events from in-memory buffer - query params: since (ISO8601), limit (int, default 1000)",
+		},
+		{
+			Path:        "/api/notify",
+			Method:      "POST",
+			Description: "Dispatch an arbitrary alert to push notification and TTS channels",
 		},
 	}
 

--- a/homeautomation-go/internal/api/server.go
+++ b/homeautomation-go/internal/api/server.go
@@ -109,6 +109,10 @@ type notifyRequest struct {
 	Priority int      `json:"priority"`
 }
 
+// notifyResponse is the JSON body returned by POST /api/notify.
+// Dispatched is true whenever the request was accepted and forwarded to the
+// alerter (including when the alert was suppressed because someone is asleep).
+// Check SuppressedAsleep to determine whether audio/push channels actually fired.
 type notifyResponse struct {
 	Dispatched       bool `json:"dispatched"`
 	SuppressedAsleep bool `json:"suppressed_asleep"`
@@ -204,6 +208,10 @@ func (s *Server) handleNotify(w http.ResponseWriter, r *http.Request) {
 	}
 	if utf8.RuneCountInString(req.Body) > 500 {
 		writeAPIError(w, http.StatusBadRequest, "body must be 500 characters or fewer")
+		return
+	}
+	if utf8.RuneCountInString(req.Title) > 200 {
+		writeAPIError(w, http.StatusBadRequest, "title must be 200 characters or fewer")
 		return
 	}
 	if len(req.Tags) > 16 {

--- a/homeautomation-go/internal/api/server_test.go
+++ b/homeautomation-go/internal/api/server_test.go
@@ -320,6 +320,24 @@ func TestHandleNotify_OversizeBodyReturns400(t *testing.T) {
 	}
 }
 
+func TestHandleNotify_OversizeTitleReturns400(t *testing.T) {
+	t.Parallel()
+	server, mockAlerter := newNotifyTestServer(t, nil)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/notify",
+		strings.NewReader(`{"title":"`+strings.Repeat("a", 201)+`","body":"hello"}`),
+	)
+	w := httptest.NewRecorder()
+	server.handleNotify(w, req)
+
+	assertNotifyError(t, w, http.StatusBadRequest)
+	if len(mockAlerter.Calls()) != 0 {
+		t.Error("Expected no alert calls")
+	}
+}
+
 func TestHandleNotify_SuppressedAsleepReturns200WithFlag(t *testing.T) {
 	t.Parallel()
 	server, mockAlerter := newNotifyTestServer(t, notify.ErrSuppressedAsleep)

--- a/homeautomation-go/internal/api/server_test.go
+++ b/homeautomation-go/internal/api/server_test.go
@@ -2,13 +2,18 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"homeautomation/internal/alert"
 	"homeautomation/internal/ha"
 	"homeautomation/internal/logbuffer"
+	"homeautomation/internal/notify"
 	"homeautomation/internal/shadowstate"
 	"homeautomation/internal/state"
 	"homeautomation/internal/testlogger"
@@ -36,7 +41,7 @@ func TestHandleGetState(t *testing.T) {
 
 	// Create API server
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC, &alert.MockAlerter{})
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/state", nil)
@@ -112,7 +117,7 @@ func TestHandleGetStateMethodNotAllowed(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC, &alert.MockAlerter{})
 
 	// Test POST method (should be rejected)
 	req := httptest.NewRequest(http.MethodPost, "/api/state", nil)
@@ -125,6 +130,261 @@ func TestHandleGetStateMethodNotAllowed(t *testing.T) {
 	}
 }
 
+func TestHandleNotify_HappyPath(t *testing.T) {
+	t.Parallel()
+	server, mockAlerter := newNotifyTestServer(t, nil)
+
+	payload := `{
+		"title": "API test",
+		"body": "Notification API works.",
+		"urgency": "deferable",
+		"tags": ["test", "warning"],
+		"speakers": ["media_player.bedroom", "media_player.kitchen"],
+		"priority": 3
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/api/notify", strings.NewReader(payload))
+	w := httptest.NewRecorder()
+
+	server.handleNotify(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d", w.Code)
+	}
+
+	var response notifyResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if !response.Dispatched {
+		t.Error("Expected dispatched to be true")
+	}
+	if response.SuppressedAsleep {
+		t.Error("Expected suppressed_asleep to be false")
+	}
+
+	calls := mockAlerter.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("Expected 1 alert call, got %d", len(calls))
+	}
+	call := calls[0]
+	if call.Title != "API test" {
+		t.Errorf("Expected title API test, got %q", call.Title)
+	}
+	if call.Body != "Notification API works." {
+		t.Errorf("Expected body Notification API works., got %q", call.Body)
+	}
+	if call.Urgency != notify.UrgencyDeferable {
+		t.Errorf("Expected deferable urgency, got %v", call.Urgency)
+	}
+	if call.Priority != 3 {
+		t.Errorf("Expected priority 3, got %d", call.Priority)
+	}
+	if len(call.Tags) != 2 || call.Tags[0] != "test" || call.Tags[1] != "warning" {
+		t.Errorf("Unexpected tags: %#v", call.Tags)
+	}
+	if len(call.Speakers) != 2 || call.Speakers[0] != "media_player.bedroom" || call.Speakers[1] != "media_player.kitchen" {
+		t.Errorf("Unexpected speakers: %#v", call.Speakers)
+	}
+}
+
+func TestHandleNotify_DefaultsUrgency(t *testing.T) {
+	t.Parallel()
+	server, mockAlerter := newNotifyTestServer(t, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/notify", strings.NewReader(`{"body":"hello"}`))
+	w := httptest.NewRecorder()
+	server.handleNotify(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d", w.Code)
+	}
+	calls := mockAlerter.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("Expected 1 alert call, got %d", len(calls))
+	}
+	if calls[0].Urgency != notify.UrgencyDeferable {
+		t.Errorf("Expected deferable urgency, got %v", calls[0].Urgency)
+	}
+}
+
+func TestHandleNotify_UrgentMaps(t *testing.T) {
+	t.Parallel()
+	server, mockAlerter := newNotifyTestServer(t, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/notify", strings.NewReader(`{"body":"hello","urgency":"urgent"}`))
+	w := httptest.NewRecorder()
+	server.handleNotify(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d", w.Code)
+	}
+	calls := mockAlerter.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("Expected 1 alert call, got %d", len(calls))
+	}
+	if calls[0].Urgency != notify.UrgencyUrgent {
+		t.Errorf("Expected urgent urgency, got %v", calls[0].Urgency)
+	}
+}
+
+func TestHandleNotify_EmptyBodyReturns400(t *testing.T) {
+	t.Parallel()
+	server, mockAlerter := newNotifyTestServer(t, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/notify", strings.NewReader(`{"title":"x"}`))
+	w := httptest.NewRecorder()
+	server.handleNotify(w, req)
+
+	assertNotifyError(t, w, http.StatusBadRequest)
+	if len(mockAlerter.Calls()) != 0 {
+		t.Error("Expected no alert calls")
+	}
+}
+
+func TestHandleNotify_MalformedJSONReturns400(t *testing.T) {
+	t.Parallel()
+	server, mockAlerter := newNotifyTestServer(t, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/notify", strings.NewReader(`{"body":`))
+	w := httptest.NewRecorder()
+	server.handleNotify(w, req)
+
+	assertNotifyError(t, w, http.StatusBadRequest)
+	if len(mockAlerter.Calls()) != 0 {
+		t.Error("Expected no alert calls")
+	}
+}
+
+func TestHandleNotify_BadUrgencyReturns400(t *testing.T) {
+	t.Parallel()
+	server, mockAlerter := newNotifyTestServer(t, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/notify", strings.NewReader(`{"body":"hello","urgency":"later"}`))
+	w := httptest.NewRecorder()
+	server.handleNotify(w, req)
+
+	assertNotifyError(t, w, http.StatusBadRequest)
+	if len(mockAlerter.Calls()) != 0 {
+		t.Error("Expected no alert calls")
+	}
+}
+
+func TestHandleNotify_BadPriorityReturns400(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		priority int
+	}{
+		{name: "negative", priority: -1},
+		{name: "above max", priority: 6},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			server, mockAlerter := newNotifyTestServer(t, nil)
+
+			req := httptest.NewRequest(
+				http.MethodPost,
+				"/api/notify",
+				strings.NewReader(fmt.Sprintf(`{"body":"hello","priority":%d}`, tc.priority)),
+			)
+			w := httptest.NewRecorder()
+			server.handleNotify(w, req)
+
+			assertNotifyError(t, w, http.StatusBadRequest)
+			if len(mockAlerter.Calls()) != 0 {
+				t.Error("Expected no alert calls")
+			}
+		})
+	}
+}
+
+func TestHandleNotify_OversizeBodyReturns400(t *testing.T) {
+	t.Parallel()
+	server, mockAlerter := newNotifyTestServer(t, nil)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/notify",
+		strings.NewReader(`{"body":"`+strings.Repeat("a", 501)+`"}`),
+	)
+	w := httptest.NewRecorder()
+	server.handleNotify(w, req)
+
+	assertNotifyError(t, w, http.StatusBadRequest)
+	if len(mockAlerter.Calls()) != 0 {
+		t.Error("Expected no alert calls")
+	}
+}
+
+func TestHandleNotify_SuppressedAsleepReturns200WithFlag(t *testing.T) {
+	t.Parallel()
+	server, mockAlerter := newNotifyTestServer(t, notify.ErrSuppressedAsleep)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/notify", strings.NewReader(`{"body":"hello"}`))
+	w := httptest.NewRecorder()
+	server.handleNotify(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d", w.Code)
+	}
+	var response notifyResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if !response.Dispatched {
+		t.Error("Expected dispatched to be true")
+	}
+	if !response.SuppressedAsleep {
+		t.Error("Expected suppressed_asleep to be true")
+	}
+	if len(mockAlerter.Calls()) != 1 {
+		t.Errorf("Expected 1 alert call, got %d", len(mockAlerter.Calls()))
+	}
+}
+
+func TestHandleNotify_OtherErrorReturns500(t *testing.T) {
+	t.Parallel()
+	server, mockAlerter := newNotifyTestServer(t, errors.New("boom"))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/notify", strings.NewReader(`{"body":"hello"}`))
+	w := httptest.NewRecorder()
+	server.handleNotify(w, req)
+
+	assertNotifyError(t, w, http.StatusInternalServerError)
+	if len(mockAlerter.Calls()) != 1 {
+		t.Errorf("Expected 1 alert call, got %d", len(mockAlerter.Calls()))
+	}
+}
+
+func newNotifyTestServer(t *testing.T, sendErr error) (*Server, *alert.MockAlerter) {
+	t.Helper()
+	logger := testlogger.New()
+	mockClient := ha.NewMockClient()
+	stateManager := state.NewManager(mockClient, logger, false)
+	shadowTracker := shadowstate.NewTracker()
+	mockAlerter := &alert.MockAlerter{Err: sendErr}
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC, mockAlerter)
+	return server, mockAlerter
+}
+
+func assertNotifyError(t *testing.T, w *httptest.ResponseRecorder, wantStatus int) {
+	t.Helper()
+	if w.Code != wantStatus {
+		t.Fatalf("Expected status %d, got %d", wantStatus, w.Code)
+	}
+	var response map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode error response: %v", err)
+	}
+	if response["error"] == "" {
+		t.Error("Expected error response")
+	}
+}
+
 func TestHandleHealth(t *testing.T) {
 	t.Parallel()
 	logger := testlogger.New()
@@ -132,7 +392,7 @@ func TestHandleHealth(t *testing.T) {
 	mockClient.Connect() // Connect so IsHealthy returns true
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC, &alert.MockAlerter{})
 
 	t.Run("healthy when connected", func(t *testing.T) {
 
@@ -190,7 +450,7 @@ func TestHandleSitemap(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC, &alert.MockAlerter{})
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
@@ -242,7 +502,7 @@ func TestHandleSitemapHTML(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC, &alert.MockAlerter{})
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Accept", "text/html")
@@ -296,7 +556,7 @@ func TestHandleSitemapMethodNotAllowed(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC, &alert.MockAlerter{})
 
 	// Test POST method (should be rejected)
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -315,7 +575,7 @@ func TestHandleSitemapNonRootPath(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC, &alert.MockAlerter{})
 
 	// Test non-root path (should return 404 without sitemap)
 	req := httptest.NewRequest(http.MethodGet, "/nonexistent", nil)
@@ -372,7 +632,7 @@ func TestHandleGetStatesByPlugin(t *testing.T) {
 
 	// Create API server
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC, &alert.MockAlerter{})
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/states", nil)
@@ -505,7 +765,7 @@ func TestHandleGetStatesByPluginMethodNotAllowed(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC, &alert.MockAlerter{})
 
 	// Test POST method (should be rejected)
 	req := httptest.NewRequest(http.MethodPost, "/api/states", nil)
@@ -527,7 +787,7 @@ func TestHandleGetStatesByPluginEmptyState(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC, &alert.MockAlerter{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/states", nil)
 	w := httptest.NewRecorder()
@@ -635,7 +895,7 @@ func TestHandleGetLightingShadowState(t *testing.T) {
 	shadowTracker.RegisterPlugin("lighting", lightingState)
 
 	// Create API server
-	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC, &alert.MockAlerter{})
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/shadow/lighting", nil)
@@ -687,7 +947,7 @@ func TestHandleGetLightingShadowState_NotFound(t *testing.T) {
 	shadowTracker := shadowstate.NewTracker()
 
 	// Create API server
-	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC, &alert.MockAlerter{})
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/shadow/lighting", nil)
@@ -727,7 +987,7 @@ func TestHandleGetSecurityShadowState(t *testing.T) {
 	shadowTracker.RegisterPlugin("security", securityState)
 
 	// Create API server
-	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC, &alert.MockAlerter{})
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/shadow/security", nil)
@@ -787,7 +1047,7 @@ func TestHandleGetSecurityShadowState_NotFound(t *testing.T) {
 	shadowTracker := shadowstate.NewTracker()
 
 	// Create API server
-	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC, &alert.MockAlerter{})
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/shadow/security", nil)
@@ -828,7 +1088,7 @@ func TestHandleGetAllShadowStates(t *testing.T) {
 	shadowTracker.RegisterPlugin("security", securityState)
 
 	// Create API server
-	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC, &alert.MockAlerter{})
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/api/shadow", nil)
@@ -890,7 +1150,7 @@ func TestAddLocalTimestamps(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, estLocation)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, estLocation, &alert.MockAlerter{})
 
 	// Test cases
 	tests := []struct {
@@ -1002,7 +1262,7 @@ func TestAddLocalTimestamps(t *testing.T) {
 
 			if tc.name == "nil timezone returns original" {
 				// Test with nil timezone
-				nilTzServer := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, nil)
+				nilTzServer := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, nil, &alert.MockAlerter{})
 				result := nilTzServer.addLocalTimestamps(tc.input)
 				m := result.(map[string]interface{})
 				if _, ok := m["tsLocal"]; ok {
@@ -1036,7 +1296,7 @@ func TestHandleDashboard(t *testing.T) {
 	shadowTracker.RegisterPlugin("lighting", lightingState)
 
 	// Create API server
-	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC, &alert.MockAlerter{})
 
 	// Create test request
 	req := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
@@ -1088,7 +1348,7 @@ func TestHandleDashboardMethodNotAllowed(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, time.UTC, &alert.MockAlerter{})
 
 	// Test POST method (should be rejected)
 	req := httptest.NewRequest(http.MethodPost, "/dashboard", nil)
@@ -1116,7 +1376,7 @@ func TestWriteJSONWithLocalTimestamps(t *testing.T) {
 	mockClient := ha.NewMockClient()
 	stateManager := state.NewManager(mockClient, logger, false)
 	shadowTracker := shadowstate.NewTracker()
-	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, estLocation)
+	server := NewServer(mockClient, stateManager, shadowTracker, logbuffer.NewBuffer(100), logger, 8080, estLocation, &alert.MockAlerter{})
 
 	// Create a test struct with a timestamp
 	type TestData struct {
@@ -1184,7 +1444,7 @@ func TestHandleTimelineEvents(t *testing.T) {
 		})
 	}
 
-	server := NewServer(mockClient, stateManager, shadowTracker, buffer, logger, 8080, time.UTC)
+	server := NewServer(mockClient, stateManager, shadowTracker, buffer, logger, 8080, time.UTC, &alert.MockAlerter{})
 
 	t.Run("basic request", func(t *testing.T) {
 


### PR DESCRIPTION
## Summary

Restores the `POST /api/notify` HTTP endpoint that was added in #1067 (commit `703685c`) and accidentally reverted by #1079 (commit `33f45a9`, "feat(environmental): TTS-friendly humidity alerts") during conflict resolution.

The downstream `home-automation-plus-security` rebuilds against upstream `main` HEAD on every push, so the endpoint disappeared from production once #1079 merged even though the downstream repo itself was healthy. Restoring upstream brings the endpoint back to prod automatically via the existing `notify-pr-merged.yml` → `docker-build.yml` `repository_dispatch` chain.

## What changed

- `homeautomation-go/internal/api/server.go` — re-adds `handleNotify`, `notifyRequest`/`notifyResponse`, the `mux.HandleFunc("/api/notify", ...)` registration, the `alertNotifier alert.Alerter` field on `Server`, the new `NewServer` parameter, and the sitemap entry.
- `homeautomation-go/cmd/app/run.go` — moves the `api.NewServer(...)` call to after `pluginCtx.AlertNotifier` is constructed (the call site had moved relative to #1067 because of #1090's Kokoro TTS pipeline restore) and threads `pluginCtx.AlertNotifier` through.
- `homeautomation-go/internal/api/server_test.go` — restores the `TestHandleNotify_*` unit tests and the `newNotifyTestServer` helper, and updates all existing `NewServer(...)` test call sites to pass `&alert.MockAlerter{}`.
- `homeautomation-go/internal/api/security_test.go` — restores `TestWriteEndpointsRejectNonPostMethods`, adds `/api/notify` to the `writeEndpoints` slice, updates `createTestServer` to wire in the mock alerter, and renames `TestAllEndpointsRejectNonGetMethods` to `TestAllReadEndpointsRejectNonGetMethods` to match its read-only-only scope.
- `docs/human/VISUAL_ARCHITECTURE.md` — re-adds the `POST /api/notify` node, response node, edge, and `style Notify fill:#fce4ec` rule, and updates the section description to reflect that the API is no longer read-only.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean
- [x] Unit tests: `go test -race ./cmd/... ./internal/... ./pkg/...` — all passed
- [x] Integration tests: `go test -race ./test/integration/...` — all passed
- [x] Coverage: 71.4% (≥ 65% threshold)
- [x] `make validate-diagrams` — generated diagrams up to date
- [x] `make yamllint-local` — config files pass
- [ ] After merge: confirm `home-automation-plus-security` rebuilds via `repository_dispatch` and the prod container's `Starting Home Automation` log line in Gravwell shows the new commit
- [ ] After merge: smoke `curl -X POST -d '{"body":"test"}' https://home-automation.featherback-mermaid.ts.net/api/notify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)