### PR TITLE
Wide-band thermal battery hysteresis on green-level dips

### DIFF
--- a/docs/flows/LOAD_SHEDDING.md
+++ b/docs/flows/LOAD_SHEDDING.md
@@ -27,12 +27,12 @@ flowchart TD
 
     currentLevel --> checkLevel
     checkLevel -->|red, black| enableLS
-    checkLevel -->|green| disableLS
+    checkLevel -->|green| greenAction["Disable load shedding<br/>+ Thermal battery: enter hysteresis if active"]
     checkLevel -->|white| thermalBattery["Disable load shedding<br/>+ Activate thermal battery"]
     checkLevel -->|yellow| shedPartial["Shed non-HVAC loads<br/>Deactivate thermal battery<br/>HVAC maintains current state"]
 
     style enableLS fill:#e74c3c,color:#fff
-    style disableLS fill:#27ae60,color:#fff
+    style greenAction fill:#27ae60,color:#fff
     style thermalBattery fill:#3498db,color:#fff
     style shedPartial fill:#f39c12,color:#fff
 ```
@@ -247,10 +247,20 @@ Original setpoints are saved and restored on deactivation.
 
 ### Deactivation Triggers
 
-Thermal battery deactivates — or, if deferred, the pending activation is cancelled — when:
-- Energy level drops below white (green, yellow, red, or black)
+Thermal battery **hard-deactivates** — or, if deferred, the pending activation is cancelled — when:
+- Energy level drops to **yellow, red, or black**
 - Nobody is home (`isAnyoneHome` → false)
 - Everyone falls asleep (`isEveryoneAsleep` → true)
+
+**Green dip → Hysteresis (not deactivation)**
+
+When energy dips white→green while the thermal battery is active, the plugin enters a 4-hour hysteresis window instead of reverting setpoints. During hysteresis:
+- `heat_cool`/`auto` thermostats: band is widened (saved low + shifted high, or shifted low + saved high) so neither heating nor cooling engages
+- `heat`/`cool` thermostats: setpoint reverts to saved value to stop the equipment
+- Thermostat holds **remain enabled**
+- If energy returns to white during the window, preheat resumes (saved setpoints and step counter are still valid)
+- If energy drops to yellow/red/black, hard deactivation runs immediately (hysteresis timer cancelled, setpoints reverted)
+- If the window expires without recovery, holds are released and the climate schedule resumes (no explicit setpoint revert — the schedule is more correct than a stale saved value)
 
 Any in-progress stepping goroutine and any deferred-activation recheck timer are cancelled on deactivation.
 
@@ -366,6 +376,8 @@ flowchart LR
 | `nonHVACLoadsShed` | bool | Whether non-HVAC loads (EV charger, dehumidifier) are shed |
 | `lastAction` | time | Timestamp of last action (rate limiting) |
 | `thermalBatteryActive` | bool | Whether thermal battery is currently active |
+| `thermalBatteryHysteresisActive` | bool | Whether thermal battery is in wide-band hysteresis after a green dip |
+| `thermalBatteryHysteresisExpiresAt` | time | When the current hysteresis window expires |
 | `savedSetpoints` | map | Original thermostat setpoints saved for restoration |
 
 ## Related Documentation

--- a/homeautomation-go/internal/plugins/loadshedding/manager.go
+++ b/homeautomation-go/internal/plugins/loadshedding/manager.go
@@ -80,6 +80,13 @@ const (
 	thermalBatteryDefaultSolarTailThresholdKWh = 28.0             // activate when remaining solar forecast drops below this (~3hr window before solar ends)
 	thermalBatteryHourlyComfortMargin          = 5.0              // °F outside comfort band to consider "stress" (hourly)
 	thermalBatteryDeferredRecheckDefault       = 15 * time.Minute // how often to re-evaluate while deferred
+
+	// Thermal battery: hysteresis window after a transient white→green dip.
+	// On a green dip, instead of reverting setpoints (which can trigger HVAC counter-runs),
+	// we widen the band so neither heating nor cooling engages, and hold for this duration.
+	// If energy returns to white during the window, preheat resumes; if it drops further
+	// (yellow/red/black) or the window expires, holds are disabled and the schedule resumes.
+	thermalBatteryHysteresisDefault = 4 * time.Hour
 )
 
 // deferredAction represents a pending action that was rate-limited
@@ -135,6 +142,13 @@ type Manager struct {
 	thermalBatteryDeferred                bool          // true when activation is deferred waiting for solar tail
 	thermalBatteryDeferCancel             chan struct{} // signal to stop deferred timer goroutine
 
+	// Hysteresis state (guarded by thermalBatteryMu). When in hysteresis, thermal battery
+	// is still considered "active" but setpoints are widened so HVAC stays idle.
+	thermalBatteryHysteresisActive    bool
+	thermalBatteryHysteresisCancel    chan struct{}
+	thermalBatteryHysteresisExpiresAt time.Time
+	thermalBatteryHysteresisDuration  time.Duration
+
 	// Forecast cache for thermal battery.
 	// forecastMu is intentionally held across the network call in getForecastHighLow.
 	// This is acceptable because: (1) callers are serialized via state-change handlers,
@@ -179,6 +193,7 @@ func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.M
 		thermalBatteryMaxStepWaitDur:          thermalBatteryMaxStepWait,
 		thermalBatterySolarTailThresholdKWh:   thermalBatteryDefaultSolarTailThresholdKWh,
 		thermalBatteryDeferredRecheckInterval: thermalBatteryDeferredRecheckDefault,
+		thermalBatteryHysteresisDuration:      thermalBatteryHysteresisDefault,
 	}
 }
 
@@ -225,6 +240,11 @@ func (m *Manager) SetThermalBatteryDeferredRecheckIntervalForTesting(d time.Dura
 	m.thermalBatteryDeferredRecheckInterval = d
 }
 
+// SetThermalBatteryHysteresisDurationForTesting allows tests to use a shorter hysteresis window.
+func (m *Manager) SetThermalBatteryHysteresisDurationForTesting(d time.Duration) {
+	m.thermalBatteryHysteresisDuration = d
+}
+
 // IsLoadSheddingOn returns whether load shedding is currently active (thread-safe)
 func (m *Manager) IsLoadSheddingOn() bool {
 	m.stateMu.Lock()
@@ -239,6 +259,15 @@ func (m *Manager) Start() error {
 	}
 
 	m.logger.Info("Starting Load Shedding Manager")
+
+	// Restart safety: if a previous process left thermostat holds enabled (mid-thermal-battery
+	// or mid-hysteresis), clear them so the climate schedule resumes. Skip when current
+	// energy is red/black — load shedding may legitimately have those holds enabled, and
+	// the energy-change handler below will re-evaluate and re-establish them as needed.
+	if level, err := m.stateManager.GetString("currentEnergyLevel"); err == nil &&
+		level != energyStateRed && level != energyStateBlack {
+		m.clearStaleThermostatHolds()
+	}
 
 	// Subscribe to energy level changes (shadow inputs captured automatically)
 	if err := m.subHelper.SubscribeToState("currentEnergyLevel", m.handleEnergyChange); err != nil {
@@ -279,10 +308,11 @@ func (m *Manager) Stop() {
 
 	m.logger.Info("Stopping Load Shedding Manager")
 
-	// Stop any thermal battery stepping or deferred timer goroutines
+	// Stop any thermal battery stepping, deferred, or hysteresis timer goroutines
 	m.thermalBatteryMu.Lock()
 	m.stopThermalBatteryStepping()
 	m.stopDeferredActivationTimer()
+	m.stopHysteresisTimer()
 	m.thermalBatteryMu.Unlock()
 
 	// Cancel any pending deferred action
@@ -329,7 +359,11 @@ func (m *Manager) handleEnergyChangeWithTrigger(key string, oldValue, newValue i
 		m.deactivateThermalBattery("energy level dropped to " + newLevel)
 		m.enableLoadShedding(newLevel, trigger)
 	case energyStateGreen:
-		m.deactivateThermalBattery("energy level dropped to green")
+		// Green is still a healthy state (battery ≥80% AND ≥10 kWh remaining solar).
+		// Don't snap thermostats back — entering hysteresis widens the setpoint band so
+		// HVAC stays idle, avoiding counter-runs from a transient white→green oscillation.
+		// If thermal battery isn't active, this is a no-op.
+		m.enterThermalBatteryHysteresis()
 		m.restoreNonHVACLoads(newLevel)
 		m.disableLoadShedding(newLevel, trigger)
 	case energyStateWhite:
@@ -617,20 +651,12 @@ func (m *Manager) disableLoadShedding(energyLevel string, trigger string) {
 		return
 	}
 
-	// Check current thermostat hold state
-	holdOn, err := m.checkThermostatHoldState()
-	if err != nil {
-		m.logger.Warn("Failed to check thermostat hold state, proceeding with action",
-			zap.Error(err))
-	} else if !holdOn {
-		m.logger.Info("⏭  Action skipped: Thermostat holds already disabled",
-			zap.String("reason", "Thermostats already in desired state"))
-		// Update our state tracking to match reality
-		m.stateMu.Lock()
-		m.loadSheddingOn = false
-		m.stateMu.Unlock()
-		return
-	}
+	// Note: we used to bail here if HA showed holds already off, on the assumption
+	// "holds off → load shedding fully disabled". That assumption no longer holds —
+	// thermal-battery hysteresis and the Start() stale-hold cleanup can independently
+	// turn holds off, leaving EV/dehumidifier still shed. executeDisableLoadShedding
+	// is idempotent on holds (turn_off-when-off is a no-op in HA), so we always run
+	// the full disable to guarantee EV/dehumidifier get restored.
 
 	// Check rate limiting - if rate limited, schedule deferred action
 	passed, timeRemaining := m.checkRateLimit()

--- a/homeautomation-go/internal/plugins/loadshedding/thermal_battery.go
+++ b/homeautomation-go/internal/plugins/loadshedding/thermal_battery.go
@@ -323,6 +323,13 @@ func (m *Manager) activateThermalBattery() {
 	defer m.thermalBatteryMu.Unlock()
 
 	if m.thermalBatteryActive {
+		// If we're in hysteresis, energy returning to white means resume preheat:
+		// cancel the hysteresis timer and re-apply the most recent step to the same
+		// saved setpoints, restoring the shifted band.
+		if m.thermalBatteryHysteresisActive {
+			m.resumePreheatFromHysteresisLocked()
+			return
+		}
 		m.logger.Info("Thermal battery already active, skipping activation")
 		return
 	}
@@ -355,22 +362,8 @@ func (m *Manager) activateThermalBattery() {
 	// capture schedule-based values as our baseline, not stale shifted values.
 	// The load shedding guard above ensures we only reach here when load shedding is inactive,
 	// so we won't interfere with active load shedding holds.
-	holdOn, err := m.checkThermostatHoldState()
-	if err != nil {
-		m.logger.Warn("Failed to check thermostat hold state for thermal battery", zap.Error(err))
-	} else if holdOn {
-		m.logger.Info("Thermal battery: holds are on (likely stale from previous session), reverting to schedule",
-			zap.Strings("entities", []string{thermostatHoldHouse, thermostatHoldSuite}))
-		if !m.readOnly {
-			if err := m.haClient.CallService(m.ctx, "switch", "turn_off", map[string]interface{}{
-				"entity_id": []string{thermostatHoldHouse, thermostatHoldSuite},
-			}); err != nil {
-				m.logger.Error("Failed to revert thermostat holds for thermal battery", zap.Error(err))
-				return
-			}
-			// Wait for the thermostat to revert to its scheduled setpoints
-			time.Sleep(m.thermalBatteryHoldRevertDelay)
-		}
+	if !m.clearStaleThermostatHolds() {
+		return
 	}
 
 	// Guard: no one is home
@@ -942,7 +935,9 @@ func (m *Manager) stopThermalBatteryStepping() {
 }
 
 // deactivateThermalBattery reverts HVAC setpoints to their original values and clears
-// any deferred activation state. Safe to call when not active (no-op) or when deferred.
+// any deferred or hysteresis state. Safe to call when not active (no-op) or when deferred.
+// Used for hard-stop reasons (yellow/red/black drop, presence change) — the hysteresis-
+// expiry path uses completeHysteresis instead, which does not revert setpoints.
 func (m *Manager) deactivateThermalBattery(reason string) {
 	m.thermalBatteryMu.Lock()
 	defer m.thermalBatteryMu.Unlock()
@@ -953,6 +948,14 @@ func (m *Manager) deactivateThermalBattery(reason string) {
 		m.stopDeferredActivationTimer()
 		m.thermalBatteryDeferred = false
 		m.shadowTracker.RecordThermalBatteryDeferredCleared()
+	}
+
+	// Cancel any in-flight hysteresis. We're doing a hard deactivation, so the
+	// setpoint revert below is correct even though hysteresis had widened the band.
+	if m.thermalBatteryHysteresisActive {
+		m.stopHysteresisTimer()
+		m.thermalBatteryHysteresisActive = false
+		m.thermalBatteryHysteresisExpiresAt = time.Time{}
 	}
 
 	if !m.thermalBatteryActive {
@@ -1027,6 +1030,225 @@ func (m *Manager) deactivateThermalBattery(reason string) {
 		zap.String("reason", reason))
 
 	m.shadowTracker.RecordThermalBatteryDeactivation()
+}
+
+// enterThermalBatteryHysteresis is called when energy dips white→green while thermal
+// battery is active. Instead of reverting setpoints (which can trigger HVAC counter-runs),
+// it widens the band so neither heating nor cooling engages, and starts a timer that
+// completes hysteresis after thermalBatteryHysteresisDuration. If thermal battery is
+// not active or already in hysteresis, this is a no-op.
+func (m *Manager) enterThermalBatteryHysteresis() {
+	m.thermalBatteryMu.Lock()
+	defer m.thermalBatteryMu.Unlock()
+
+	if !m.thermalBatteryActive {
+		return
+	}
+	if m.thermalBatteryHysteresisActive {
+		return
+	}
+	if m.savedSetpoints == nil {
+		return
+	}
+
+	// Stop any in-flight stepping; we are entering coast mode.
+	m.stopThermalBatteryStepping()
+
+	currentOffset := float64(m.thermalBatteryStepsDone) * thermalBatteryStepSize
+	if currentOffset > thermalBatteryOffset {
+		currentOffset = thermalBatteryOffset
+	}
+
+	if !m.readOnly {
+		for entityID, sp := range m.savedSetpoints {
+			data := map[string]interface{}{
+				"entity_id": entityID,
+			}
+
+			switch sp.HVACMode {
+			case "heat_cool", "auto":
+				// Wide band: keep the side we'd been preheating toward at the shifted value,
+				// and loosen the opposite side back to the saved (original) value.
+				var lowVal, highVal float64
+				if m.thermalBatteryDirection == "up" {
+					lowVal = sp.TargetLow                   // original (lower) low — stop heating
+					highVal = sp.TargetHigh + currentOffset // shifted (higher) high — keep room
+				} else {
+					lowVal = sp.TargetLow - currentOffset // shifted (lower) low — keep room
+					highVal = sp.TargetHigh               // original (higher) high — stop cooling
+				}
+				data["target_temp_low"] = lowVal
+				data["target_temp_high"] = highVal
+				m.logger.Info("Thermal battery: widening band for hysteresis",
+					zap.String("entity", entityID),
+					zap.Float64("wide_low", lowVal),
+					zap.Float64("wide_high", highVal))
+			case "heat", "cool":
+				// Single-stage thermostats have only one setpoint; revert to the saved
+				// target so the equipment stops calling for heating/cooling.
+				data["temperature"] = sp.TargetTemp
+				m.logger.Info("Thermal battery: reverting setpoint for hysteresis",
+					zap.String("entity", entityID),
+					zap.Float64("target", sp.TargetTemp))
+			default:
+				continue
+			}
+
+			if err := m.haClient.CallService(m.ctx, "climate", "set_temperature", data); err != nil {
+				m.logger.Error("Failed to widen thermostat for hysteresis",
+					zap.String("entity", entityID), zap.Error(err))
+			}
+		}
+	}
+
+	m.thermalBatteryHysteresisActive = true
+	m.thermalBatteryHysteresisExpiresAt = time.Now().Add(m.thermalBatteryHysteresisDuration)
+
+	cancelCh := make(chan struct{})
+	m.thermalBatteryHysteresisCancel = cancelCh
+	go m.runHysteresisTimer(cancelCh)
+
+	m.logger.Info("=== THERMAL BATTERY HYSTERESIS ENTERED ===",
+		zap.Duration("duration", m.thermalBatteryHysteresisDuration),
+		zap.Time("expires_at", m.thermalBatteryHysteresisExpiresAt))
+
+	m.shadowTracker.RecordThermalBatteryHysteresisEntered(m.thermalBatteryHysteresisExpiresAt)
+}
+
+// runHysteresisTimer waits for the hysteresis duration, then completes hysteresis.
+// Exits early on cancellation (energy returned to white, or hard deactivation).
+func (m *Manager) runHysteresisTimer(cancelCh <-chan struct{}) {
+	timer := time.NewTimer(m.thermalBatteryHysteresisDuration)
+	defer timer.Stop()
+
+	select {
+	case <-cancelCh:
+		return
+	case <-m.ctx.Done():
+		return
+	case <-timer.C:
+		m.completeHysteresis()
+	}
+}
+
+// stopHysteresisTimer cancels the hysteresis goroutine if running.
+// Must be called with thermalBatteryMu held.
+func (m *Manager) stopHysteresisTimer() {
+	if m.thermalBatteryHysteresisCancel != nil {
+		close(m.thermalBatteryHysteresisCancel)
+		m.thermalBatteryHysteresisCancel = nil
+	}
+}
+
+// completeHysteresis ends the hysteresis window successfully (timer expired):
+// disables thermostat holds so the climate schedule resumes, and clears thermal
+// battery active state. Does NOT explicitly revert setpoints — releasing the hold
+// returns the thermostat to its schedule, which is more correct than restoring
+// a possibly stale "saved" value from N hours ago.
+func (m *Manager) completeHysteresis() {
+	m.thermalBatteryMu.Lock()
+	defer m.thermalBatteryMu.Unlock()
+
+	if !m.thermalBatteryHysteresisActive {
+		return
+	}
+
+	m.logger.Info("Thermal battery hysteresis window expired, releasing holds")
+
+	if !m.readOnly {
+		if err := m.haClient.CallService(m.ctx, "switch", "turn_off", map[string]interface{}{
+			"entity_id": []string{thermostatHoldHouse, thermostatHoldSuite},
+		}); err != nil {
+			m.logger.Error("Failed to disable thermostat hold mode after hysteresis", zap.Error(err))
+		}
+	}
+
+	m.thermalBatteryHysteresisActive = false
+	m.thermalBatteryHysteresisCancel = nil
+	m.thermalBatteryHysteresisExpiresAt = time.Time{}
+
+	m.thermalBatteryActive = false
+	m.savedSetpoints = nil
+	m.thermalBatteryStepsDone = 0
+	m.thermalBatteryTargetSteps = 0
+	m.thermalBatteryDirection = ""
+	m.thermalBatteryStepStart = time.Time{}
+
+	m.logger.Info("=== THERMAL BATTERY DEACTIVATED ===",
+		zap.String("reason", "hysteresis window expired"))
+
+	m.shadowTracker.RecordThermalBatteryDeactivation()
+}
+
+// resumePreheatFromHysteresisLocked re-applies the previously-active preheat band
+// after energy returns to white during hysteresis. The savedSetpoints, direction,
+// and step counter are still valid from the original activation, so we just re-issue
+// the most recent step. Must be called with thermalBatteryMu held.
+func (m *Manager) resumePreheatFromHysteresisLocked() {
+	m.logger.Info("Thermal battery: resuming preheat from hysteresis")
+
+	if m.thermalBatteryHysteresisCancel != nil {
+		close(m.thermalBatteryHysteresisCancel)
+		m.thermalBatteryHysteresisCancel = nil
+	}
+	m.thermalBatteryHysteresisActive = false
+	m.thermalBatteryHysteresisExpiresAt = time.Time{}
+
+	step := m.thermalBatteryStepsDone
+	if step < 1 {
+		step = 1
+	}
+	if err := m.applyThermalBatteryStep(step, m.thermalBatteryDirection); err != nil {
+		m.logger.Error("Failed to resume preheat band from hysteresis", zap.Error(err))
+		return
+	}
+
+	// If steps still remain, restart the stepping goroutine.
+	if m.thermalBatteryStepsDone < m.thermalBatteryTargetSteps && m.thermalBatteryStepCancel == nil {
+		cancelCh := make(chan struct{})
+		m.thermalBatteryStepCancel = cancelCh
+		m.thermalBatteryStepStart = time.Now()
+		go m.runThermalBatteryStepping(cancelCh)
+	}
+
+	m.shadowTracker.RecordThermalBatteryHysteresisResumed()
+}
+
+// clearStaleThermostatHolds detects thermostat holds left on from a previous process
+// (e.g., service restart mid-thermal-battery) and turns them off so the thermostat
+// reverts to its scheduled setpoints. Safe to call when no holds are on (no-op).
+//
+// Returns true if it is safe to proceed (no error or recovery succeeded), false if
+// a service call to turn off holds failed and the caller should abort.
+//
+// IMPORTANT: this must NOT run while load shedding is active — load shedding
+// legitimately uses the same hold switches. Callers must guard against that.
+func (m *Manager) clearStaleThermostatHolds() bool {
+	holdOn, err := m.checkThermostatHoldState()
+	if err != nil {
+		m.logger.Warn("Failed to check thermostat hold state", zap.Error(err))
+		return true
+	}
+	if !holdOn {
+		return true
+	}
+
+	m.logger.Info("Clearing stale thermostat holds (likely from previous session), reverting to schedule",
+		zap.Strings("entities", []string{thermostatHoldHouse, thermostatHoldSuite}))
+
+	if m.readOnly {
+		return true
+	}
+
+	if err := m.haClient.CallService(m.ctx, "switch", "turn_off", map[string]interface{}{
+		"entity_id": []string{thermostatHoldHouse, thermostatHoldSuite},
+	}); err != nil {
+		m.logger.Error("Failed to revert stale thermostat holds", zap.Error(err))
+		return false
+	}
+	// Wait for the thermostat to revert to its scheduled setpoints
+	time.Sleep(m.thermalBatteryHoldRevertDelay)
+	return true
 }
 
 // handlePresenceChange handles changes to presence/sleep states.

--- a/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
+++ b/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
@@ -1237,7 +1237,7 @@ func TestThermalBattery_SteppingCancelledByPresenceChange(t *testing.T) {
 	assert.Equal(t, 2, revertCalls, "Should revert both thermostats")
 }
 
-func TestThermalBattery_RevertsStaleHoldsOnActivation(t *testing.T) {
+func TestThermalBattery_ActivationClearsHoldsSetAfterStart(t *testing.T) {
 	t.Parallel()
 	env := setupThermalBatteryEnv(t)
 

--- a/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
+++ b/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
@@ -112,12 +112,14 @@ func TestThermalBattery_ActivatesOnWhiteEnergyLevel(t *testing.T) {
 	assert.Len(t, shadow.Outputs.ThermalBattery.SavedSetpoints, 2)
 }
 
-func TestThermalBattery_DeactivatesOnGreenEnergyLevel(t *testing.T) {
+func TestThermalBattery_GreenDipEntersHysteresis_CoolMode(t *testing.T) {
 	t.Parallel()
 	env := setupThermalBatteryEnv(t)
 
 	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, nil)
 	ls.lastAction = time.Now().Add(-2 * time.Hour) // Avoid rate limiting
+	// Long hysteresis so the timer doesn't fire during the test
+	ls.SetThermalBatteryHysteresisDurationForTesting(1 * time.Hour)
 	err := ls.Start()
 	require.NoError(t, err)
 	defer ls.Stop()
@@ -129,52 +131,295 @@ func TestThermalBattery_DeactivatesOnGreenEnergyLevel(t *testing.T) {
 
 	snapshot := env.MockHA.ServiceCallCount()
 
-	// Drop to green
+	// Drop to green — should ENTER HYSTERESIS, not deactivate
 	err = env.StateMgr.SetString("currentEnergyLevel", "green")
 	require.NoError(t, err)
 
-	// Verify thermal battery is deactivated
-	assert.False(t, ls.IsThermalBatteryActive(), "Thermal battery should be inactive after green")
+	// Thermal battery is still considered active during hysteresis
+	assert.True(t, ls.IsThermalBatteryActive(),
+		"Thermal battery should remain active in hysteresis after green dip")
 
-	// Verify setpoints were reverted and hold was disabled
+	// In cool mode (single-stage), hysteresis reverts the setpoint to the saved value
+	// so the AC stops. Hold MUST remain enabled (no turn_off call yet).
 	calls := env.MockHA.GetServiceCallsSince(snapshot)
-	revertCalls := 0
-	holdOffCalls := 0
-	lastRevertIndex := -1
-	holdOffIndex := -1
-	for i, call := range calls {
+	tempReverts := 0
+	holdOffCount := 0
+	for _, call := range calls {
 		if call.Domain == "climate" && call.Service == "set_temperature" {
-			revertCalls++
-			lastRevertIndex = i
+			tempReverts++
 			entityID, _ := call.Data["entity_id"].(string)
 			temp, _ := call.Data["temperature"].(float64)
-
 			switch entityID {
 			case climateHouse:
-				assert.Equal(t, 72.0, temp, "House thermostat should be reverted to 72")
+				assert.Equal(t, 72.0, temp, "House should revert to saved 72")
 			case climateSuite:
-				assert.Equal(t, 71.0, temp, "Suite thermostat should be reverted to 71")
+				assert.Equal(t, 71.0, temp, "Suite should revert to saved 71")
 			}
 		}
 		if call.Domain == "switch" && call.Service == "turn_off" {
 			if entities, ok := call.Data["entity_id"].([]string); ok {
 				for _, e := range entities {
 					if e == thermostatHoldHouse || e == thermostatHoldSuite {
-						holdOffCalls++
-						holdOffIndex = i
-						break
+						holdOffCount++
+						break // one call counts once, not per-entity
 					}
 				}
 			}
 		}
 	}
-	assert.Equal(t, 2, revertCalls, "Should have made 2 climate.set_temperature calls to revert")
-	assert.Equal(t, 1, holdOffCalls, "Should have made 1 switch.turn_off call to disable thermostat holds")
-	assert.Greater(t, holdOffIndex, lastRevertIndex, "Hold should be disabled after setpoints are reverted")
+	assert.Equal(t, 2, tempReverts, "Should revert single-stage setpoints to saved values during hysteresis")
+	assert.Equal(t, 0, holdOffCount, "Hold MUST remain enabled during hysteresis")
 
-	// Verify shadow state
+	shadow := ls.GetShadowState()
+	assert.True(t, shadow.Outputs.ThermalBattery.Active, "Active flag stays true during hysteresis")
+	assert.True(t, shadow.Outputs.ThermalBattery.HysteresisActive, "Shadow shows hysteresis active")
+	assert.False(t, shadow.Outputs.ThermalBattery.HysteresisExpiresAt.IsZero(), "ExpiresAt is set")
+}
+
+func TestThermalBattery_GreenDipEntersHysteresis_HeatCoolMode_WideBand(t *testing.T) {
+	t.Parallel()
+	// Heat_cool mode is where wide-band hysteresis matters most.
+	// Saved 69/72, preheat shifts UP to 70/73. Wide band on green dip: 69/73
+	// (low reverts to saved, high stays at shifted) — neither heating nor cooling
+	// engages because indoor temp sits inside that wider band.
+	env := setupHeatCoolEnvWithForecast(t, "", 45.0, 25.0)
+
+	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, nil)
+	ls.SetThermalBatteryHysteresisDurationForTesting(1 * time.Hour)
+	err := ls.Start()
+	require.NoError(t, err)
+	defer ls.Stop()
+
+	err = env.StateMgr.SetString("currentEnergyLevel", "white")
+	require.NoError(t, err)
+	assert.True(t, ls.IsThermalBatteryActive())
+
+	snapshot := env.MockHA.ServiceCallCount()
+
+	err = env.StateMgr.SetString("currentEnergyLevel", "green")
+	require.NoError(t, err)
+
+	assert.True(t, ls.IsThermalBatteryActive(), "Should stay active during hysteresis")
+
+	calls := env.MockHA.GetServiceCallsSince(snapshot)
+	wideCalls := 0
+	holdOffCount := 0
+	for _, call := range calls {
+		if call.Domain == "climate" && call.Service == "set_temperature" {
+			wideCalls++
+			low, _ := call.Data["target_temp_low"].(float64)
+			high, _ := call.Data["target_temp_high"].(float64)
+			assert.Equal(t, 69.0, low, "Wide low = saved low (69) — heat off")
+			assert.Equal(t, 73.0, high, "Wide high = shifted high (73) — cool off")
+		}
+		if call.Domain == "switch" && call.Service == "turn_off" {
+			if entities, ok := call.Data["entity_id"].([]string); ok {
+				for _, e := range entities {
+					if e == thermostatHoldHouse || e == thermostatHoldSuite {
+						holdOffCount++
+						break // one call counts once, not per-entity
+					}
+				}
+			}
+		}
+	}
+	assert.Equal(t, 2, wideCalls, "Should widen both thermostats")
+	assert.Equal(t, 0, holdOffCount, "Hold MUST remain enabled during hysteresis")
+}
+
+func TestThermalBattery_HysteresisExpiry_ReleasesHoldsWithoutRevert(t *testing.T) {
+	t.Parallel()
+	env := setupHeatCoolEnvWithForecast(t, "", 45.0, 25.0)
+
+	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, nil)
+	// Very short hysteresis so the timer fires during the test
+	ls.SetThermalBatteryHysteresisDurationForTesting(50 * time.Millisecond)
+	err := ls.Start()
+	require.NoError(t, err)
+	defer ls.Stop()
+
+	err = env.StateMgr.SetString("currentEnergyLevel", "white")
+	require.NoError(t, err)
+	assert.True(t, ls.IsThermalBatteryActive())
+
+	// Enter hysteresis
+	err = env.StateMgr.SetString("currentEnergyLevel", "green")
+	require.NoError(t, err)
+
+	snapshot := env.MockHA.ServiceCallCount()
+
+	// Wait for hysteresis to expire
+	require.Eventually(t, func() bool {
+		return !ls.IsThermalBatteryActive()
+	}, 2*time.Second, 10*time.Millisecond, "Thermal battery should deactivate after hysteresis expiry")
+
+	// On expiry: hold MUST be disabled, but no climate.set_temperature calls
+	// (we trust the schedule to take over).
+	calls := env.MockHA.GetServiceCallsSince(snapshot)
+	holdOffCount := 0
+	revertCalls := 0
+	for _, call := range calls {
+		if call.Domain == "climate" && call.Service == "set_temperature" {
+			revertCalls++
+		}
+		if call.Domain == "switch" && call.Service == "turn_off" {
+			if entities, ok := call.Data["entity_id"].([]string); ok {
+				for _, e := range entities {
+					if e == thermostatHoldHouse || e == thermostatHoldSuite {
+						holdOffCount++
+						break // one call counts once, not per-entity
+					}
+				}
+			}
+		}
+	}
+	assert.Equal(t, 0, revertCalls, "Expiry must NOT explicitly revert setpoints — schedule resumes via hold off")
+	assert.Equal(t, 1, holdOffCount, "Expiry must disable thermostat holds")
+
 	shadow := ls.GetShadowState()
 	assert.False(t, shadow.Outputs.ThermalBattery.Active)
+	assert.False(t, shadow.Outputs.ThermalBattery.HysteresisActive)
+}
+
+func TestThermalBattery_WhiteRecoveryDuringHysteresis_ResumesPreheat(t *testing.T) {
+	t.Parallel()
+	env := setupHeatCoolEnvWithForecast(t, "", 45.0, 25.0)
+
+	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, nil)
+	ls.SetThermalBatteryHysteresisDurationForTesting(1 * time.Hour)
+	err := ls.Start()
+	require.NoError(t, err)
+	defer ls.Stop()
+
+	// Activate, then dip to green to enter hysteresis
+	err = env.StateMgr.SetString("currentEnergyLevel", "white")
+	require.NoError(t, err)
+	assert.True(t, ls.IsThermalBatteryActive())
+
+	err = env.StateMgr.SetString("currentEnergyLevel", "green")
+	require.NoError(t, err)
+
+	snapshot := env.MockHA.ServiceCallCount()
+
+	// White returns — should resume preheat band (re-apply step 1 → 70/73)
+	err = env.StateMgr.SetString("currentEnergyLevel", "white")
+	require.NoError(t, err)
+
+	assert.True(t, ls.IsThermalBatteryActive(), "Should remain active after recovery")
+
+	calls := env.MockHA.GetServiceCallsSince(snapshot)
+	resumeCalls := 0
+	for _, call := range calls {
+		if call.Domain == "climate" && call.Service == "set_temperature" {
+			resumeCalls++
+			low, _ := call.Data["target_temp_low"].(float64)
+			high, _ := call.Data["target_temp_high"].(float64)
+			assert.Equal(t, 70.0, low, "Should re-apply preheat step (low=70)")
+			assert.Equal(t, 73.0, high, "Should re-apply preheat step (high=73)")
+		}
+	}
+	assert.Equal(t, 2, resumeCalls, "Should re-apply preheat band to both thermostats")
+
+	shadow := ls.GetShadowState()
+	assert.True(t, shadow.Outputs.ThermalBattery.Active)
+	assert.False(t, shadow.Outputs.ThermalBattery.HysteresisActive,
+		"Hysteresis should be cleared after recovery")
+}
+
+func TestThermalBattery_YellowDropDuringHysteresis_ImmediateRevert(t *testing.T) {
+	t.Parallel()
+	env := setupHeatCoolEnvWithForecast(t, "", 45.0, 25.0)
+
+	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, nil)
+	ls.lastAction = time.Now().Add(-2 * time.Hour)
+	ls.SetThermalBatteryHysteresisDurationForTesting(1 * time.Hour)
+	err := ls.Start()
+	require.NoError(t, err)
+	defer ls.Stop()
+
+	err = env.StateMgr.SetString("currentEnergyLevel", "white")
+	require.NoError(t, err)
+	assert.True(t, ls.IsThermalBatteryActive())
+
+	// Enter hysteresis
+	err = env.StateMgr.SetString("currentEnergyLevel", "green")
+	require.NoError(t, err)
+	assert.True(t, ls.IsThermalBatteryActive())
+
+	snapshot := env.MockHA.ServiceCallCount()
+
+	// Drop to yellow during hysteresis — should hard-deactivate (cancel timer + revert)
+	err = env.StateMgr.SetString("currentEnergyLevel", "yellow")
+	require.NoError(t, err)
+
+	assert.False(t, ls.IsThermalBatteryActive(),
+		"Yellow drop must hard-deactivate even during hysteresis")
+
+	calls := env.MockHA.GetServiceCallsSince(snapshot)
+	revertCalls := 0
+	for _, call := range calls {
+		if call.Domain == "climate" && call.Service == "set_temperature" {
+			revertCalls++
+			low, _ := call.Data["target_temp_low"].(float64)
+			high, _ := call.Data["target_temp_high"].(float64)
+			assert.Equal(t, 69.0, low, "Should revert to saved low (69)")
+			assert.Equal(t, 72.0, high, "Should revert to saved high (72)")
+		}
+	}
+	assert.Equal(t, 2, revertCalls, "Should revert both thermostats on yellow drop")
+
+	shadow := ls.GetShadowState()
+	assert.False(t, shadow.Outputs.ThermalBattery.Active)
+	assert.False(t, shadow.Outputs.ThermalBattery.HysteresisActive)
+}
+
+func TestThermalBattery_StartClearsStaleHolds(t *testing.T) {
+	t.Parallel()
+	// Simulate restart: holds are ON in HA (from a previous session that crashed
+	// during thermal battery or hysteresis), no other thermal-battery activity.
+	env := testutil.NewEnv(t)
+	env.MockHA.SetState(thermostatHoldHouse, "on", nil)
+	env.MockHA.SetState(thermostatHoldSuite, "on", nil)
+	env.MockHA.SetState(climateHouse, "heat_cool", map[string]interface{}{
+		"target_temp_low": 69.0, "target_temp_high": 72.0,
+		"current_temperature": 70.0, "hvac_action": "idle",
+	})
+	env.MockHA.SetState(climateSuite, "heat_cool", map[string]interface{}{
+		"target_temp_low": 69.0, "target_temp_high": 72.0,
+		"current_temperature": 70.0, "hvac_action": "idle",
+	})
+	require.NoError(t, env.StateMgr.SyncFromHA())
+
+	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, nil)
+	ls.SetThermalBatteryHoldRevertDelayForTesting(0)
+	snapshot := env.MockHA.ServiceCallCount()
+
+	require.NoError(t, ls.Start())
+	defer ls.Stop()
+
+	// Start() must turn off both holds unconditionally — even though no activation
+	// is being attempted (currentEnergyLevel is empty / not white).
+	calls := env.MockHA.GetServiceCallsSince(snapshot)
+	holdOffCount := 0
+	for _, call := range calls {
+		if call.Domain == "switch" && call.Service == "turn_off" {
+			if entities, ok := call.Data["entity_id"].([]string); ok {
+				houseSeen, suiteSeen := false, false
+				for _, e := range entities {
+					if e == thermostatHoldHouse {
+						houseSeen = true
+					}
+					if e == thermostatHoldSuite {
+						suiteSeen = true
+					}
+				}
+				if houseSeen && suiteSeen {
+					holdOffCount++
+				}
+			}
+		}
+	}
+	assert.Equal(t, 1, holdOffCount, "Start() must clear stale holds on both thermostats")
 }
 
 func TestThermalBattery_DeactivatesOnRedEnergyLevel(t *testing.T) {
@@ -578,7 +823,9 @@ func TestThermalBattery_HeatCoolMode_BothUnavailable(t *testing.T) {
 
 func TestThermalBattery_HeatCoolMode_DeactivationRestoresOriginal(t *testing.T) {
 	t.Parallel()
-	// Activate with cold forecast, then deactivate → verify original 69/72 restored
+	// Activate with cold forecast, then hard-deactivate via yellow drop
+	// → verify original 69/72 restored. (Green now enters hysteresis instead of
+	// reverting; yellow/red/black are the hard-deactivation triggers.)
 	env := setupHeatCoolEnvWithForecast(t, "", 45.0, 25.0)
 
 	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, nil)
@@ -594,8 +841,8 @@ func TestThermalBattery_HeatCoolMode_DeactivationRestoresOriginal(t *testing.T) 
 
 	snapshot := env.MockHA.ServiceCallCount()
 
-	// Deactivate by dropping to green
-	err = env.StateMgr.SetString("currentEnergyLevel", "green")
+	// Hard-deactivate via yellow drop
+	err = env.StateMgr.SetString("currentEnergyLevel", "yellow")
 	require.NoError(t, err)
 
 	assert.False(t, ls.IsThermalBatteryActive())
@@ -920,8 +1167,8 @@ func TestThermalBattery_DeactivationMidStep(t *testing.T) {
 
 	snapshot := env.MockHA.ServiceCallCount()
 
-	// Deactivate by dropping to green
-	err = env.StateMgr.SetString("currentEnergyLevel", "green")
+	// Hard-deactivate by dropping to yellow (green now enters hysteresis instead)
+	err = env.StateMgr.SetString("currentEnergyLevel", "yellow")
 	require.NoError(t, err)
 
 	assert.False(t, ls.IsThermalBatteryActive())
@@ -994,15 +1241,17 @@ func TestThermalBattery_RevertsStaleHoldsOnActivation(t *testing.T) {
 	t.Parallel()
 	env := setupThermalBatteryEnv(t)
 
-	// Simulate stale holds from a previous session (e.g., app restarted while thermal battery was active)
-	env.MockHA.SetState(thermostatHoldHouse, "on", nil)
-	env.MockHA.SetState(thermostatHoldSuite, "on", nil)
-
 	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, nil)
 	ls.SetThermalBatteryHoldRevertDelayForTesting(0)
 	err := ls.Start()
 	require.NoError(t, err)
 	defer ls.Stop()
+
+	// Simulate user manually toggling holds ON between Start() and the activation
+	// trigger (Start's stale-hold cleanup ran with holds=off; defense-in-depth in
+	// activateThermalBattery should still catch this).
+	env.MockHA.SetState(thermostatHoldHouse, "on", nil)
+	env.MockHA.SetState(thermostatHoldSuite, "on", nil)
 
 	snapshot := env.MockHA.ServiceCallCount()
 

--- a/homeautomation-go/internal/shadowstate/tracker.go
+++ b/homeautomation-go/internal/shadowstate/tracker.go
@@ -456,6 +456,30 @@ func (lst *LoadSheddingTracker) RecordThermalBatteryDeferredCleared() {
 	lst.State().Metadata.LastUpdated = now
 }
 
+// RecordThermalBatteryHysteresisEntered records that the thermal battery has entered
+// hysteresis (wide band, no HVAC engagement) after a transient white→green dip.
+func (lst *LoadSheddingTracker) RecordThermalBatteryHysteresisEntered(expiresAt time.Time) {
+	lst.Lock()
+	defer lst.Unlock()
+
+	now := time.Now()
+	lst.State().Outputs.ThermalBattery.HysteresisActive = true
+	lst.State().Outputs.ThermalBattery.HysteresisExpiresAt = expiresAt
+	lst.State().Metadata.LastUpdated = now
+}
+
+// RecordThermalBatteryHysteresisResumed records that hysteresis ended early because
+// energy returned to white and preheat was resumed.
+func (lst *LoadSheddingTracker) RecordThermalBatteryHysteresisResumed() {
+	lst.Lock()
+	defer lst.Unlock()
+
+	now := time.Now()
+	lst.State().Outputs.ThermalBattery.HysteresisActive = false
+	lst.State().Outputs.ThermalBattery.HysteresisExpiresAt = time.Time{}
+	lst.State().Metadata.LastUpdated = now
+}
+
 // GetState returns the current shadow state (thread-safe copy)
 func (lst *LoadSheddingTracker) GetState() *LoadSheddingShadowState {
 	lst.RLock()

--- a/homeautomation-go/internal/shadowstate/types.go
+++ b/homeautomation-go/internal/shadowstate/types.go
@@ -493,6 +493,11 @@ type ThermalBatteryState struct {
 	ForecastStress        string                   `json:"forecastStress,omitempty"`        // description of the upcoming stress event
 	RemainingSolarKWh     float64                  `json:"remainingSolarKWh,omitempty"`     // remaining solar production forecast at defer time
 	SolarTailThresholdKWh float64                  `json:"solarTailThresholdKWh,omitempty"` // configured activation threshold
+
+	// Hysteresis state: after a transient white→green dip, the band is widened so HVAC
+	// stays idle. Active=true throughout; HysteresisActive distinguishes coast from charge.
+	HysteresisActive    bool      `json:"hysteresisActive,omitempty"`
+	HysteresisExpiresAt time.Time `json:"hysteresisExpiresAt,omitempty"`
 }
 
 // SavedSetpoint records the original thermostat setpoint before thermal battery offset was applied

--- a/homeautomation-go/test/integration/scenario_thermal_battery_hysteresis_test.go
+++ b/homeautomation-go/test/integration/scenario_thermal_battery_hysteresis_test.go
@@ -1,0 +1,217 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"homeautomation/internal/plugins/loadshedding"
+	"homeautomation/internal/shadowstate"
+	"homeautomation/internal/state"
+	"homeautomation/internal/testlogger"
+	"homeautomation/pkg/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// Thermal Battery Hysteresis User-Story Integration Tests
+//
+// Validates the wide-band hysteresis behavior end-to-end through real state
+// subscriptions: white→green dip widens setpoints (no HVAC counter-run),
+// white recovery resumes the preheat band, yellow drop hard-deactivates.
+//
+// Reference incident: 2026-05-06 evening saw white→green→white oscillation
+// trigger a 16-min AC counter-run on the primary suite zone immediately upon
+// the original deactivation. With hysteresis, the green dip should now coast.
+// ============================================================================
+
+// setupThermalBatteryHysteresisTest creates a load-shedding manager wired into
+// a real mock HA server with thermostats in heat_cool mode and presence flags set.
+// Uses the outdoor-temp fallback path for thermal-battery direction (35°F → UP shift)
+// because the integration MockHAServer does not support custom forecast responses.
+func setupThermalBatteryHysteresisTest(t *testing.T) (*MockHAServer, *loadshedding.Manager, *state.Manager, func()) {
+	server, client, manager, baseCleanup := setupTest(t)
+
+	// Seed HA state for thermal battery preconditions
+	server.SetState("switch.most_of_house_thermostat_hold", "off", nil)
+	server.SetState("switch.primary_suite_thermostat_hold", "off", nil)
+	// Heat_cool mode with realistic owner setpoints (69/72, 3°F dead band)
+	houseAttrs := map[string]interface{}{
+		"target_temp_low":     69.0,
+		"target_temp_high":    72.0,
+		"current_temperature": 70.0,
+		"hvac_action":         "idle",
+	}
+	suiteAttrs := map[string]interface{}{
+		"target_temp_low":     69.0,
+		"target_temp_high":    72.0,
+		"current_temperature": 71.0,
+		"hvac_action":         "idle",
+	}
+	server.SetState("climate.most_of_house_thermostat", "heat_cool", houseAttrs)
+	server.SetState("climate.primary_suite_thermostat", "heat_cool", suiteAttrs)
+	// Outdoor temp 35°F triggers UP direction via fallback path (no forecast configured)
+	server.SetState("sensor.weather_station_temperature", "35.0", nil)
+
+	require.NoError(t, manager.SyncFromHA())
+	require.NoError(t, manager.SetBool("isAnyoneHome", true))
+	require.NoError(t, manager.SetBool("isEveryoneAsleep", false))
+
+	logger := testlogger.New()
+	registry := shadowstate.NewSubscriptionRegistry()
+	ls := loadshedding.NewManager(context.Background(), client, manager, logger, false, registry, nil)
+	// Long enough to outlast the test, but bounded so we never hang.
+	ls.SetThermalBatteryHysteresisDurationForTesting(30 * time.Second)
+	require.NoError(t, ls.Start())
+
+	cleanup := func() {
+		ls.Stop()
+		baseCleanup()
+	}
+	return server, ls, manager, cleanup
+}
+
+// climateSetpointForEntity returns the most recent climate.set_temperature call
+// for the given entity, or nil if none. Used to read the current shifted setpoints.
+func climateSetpointForEntity(calls []testutil.ServiceCall, entityID string) *testutil.ServiceCall {
+	for i := len(calls) - 1; i >= 0; i-- {
+		call := calls[i]
+		if call.Domain != "climate" || call.Service != "set_temperature" {
+			continue
+		}
+		if id, ok := call.ServiceData["entity_id"].(string); ok && id == entityID {
+			return &call
+		}
+	}
+	return nil
+}
+
+// TestScenario_ThermalBatteryHysteresis_GreenDipCoastsThenResumesOnWhite
+// validates the user story: a transient white→green→white oscillation should
+// NOT cause HVAC counter-runs, and preheat should resume cleanly on recovery.
+func TestScenario_ThermalBatteryHysteresis_GreenDipCoastsThenResumesOnWhite(t *testing.T) {
+	t.Parallel()
+	server, ls, manager, cleanup := setupThermalBatteryHysteresisTest(t)
+	defer cleanup()
+
+	// GIVEN: Energy reaches white, thermal battery preheats to 70/73
+	t.Log("GIVEN: Energy at white, thermal battery activates with UP shift")
+	require.NoError(t, manager.SetString("currentEnergyLevel", "white"))
+
+	require.Eventually(t, func() bool { return ls.IsThermalBatteryActive() },
+		5*time.Second, 10*time.Millisecond, "Thermal battery should activate at white")
+
+	// Verify preheat band applied (69/72 → 70/73 after first step)
+	t.Log("Verifying preheat band 70/73 applied")
+	require.Eventually(t, func() bool {
+		call := climateSetpointForEntity(server.GetServiceCalls(), "climate.most_of_house_thermostat")
+		if call == nil {
+			return false
+		}
+		low, _ := call.ServiceData["target_temp_low"].(float64)
+		high, _ := call.ServiceData["target_temp_high"].(float64)
+		return low == 70.0 && high == 73.0
+	}, 5*time.Second, 10*time.Millisecond, "Should apply preheat band 70/73")
+
+	snapshot := len(server.GetServiceCalls())
+
+	// WHEN: Energy dips white→green (transient)
+	t.Log("WHEN: Energy drops to green (transient dip)")
+	require.NoError(t, manager.SetString("currentEnergyLevel", "green"))
+
+	// THEN: Thermal battery enters hysteresis — wide band 69/73, holds remain on
+	t.Log("THEN: Wide band 69/73 set, thermal battery still considered active")
+	require.Eventually(t, func() bool {
+		call := climateSetpointForEntity(server.GetServiceCallsSince(snapshot), "climate.most_of_house_thermostat")
+		if call == nil {
+			return false
+		}
+		low, _ := call.ServiceData["target_temp_low"].(float64)
+		high, _ := call.ServiceData["target_temp_high"].(float64)
+		return low == 69.0 && high == 73.0
+	}, 5*time.Second, 10*time.Millisecond, "Should widen band to 69/73 (saved low, shifted high)")
+
+	assert.True(t, ls.IsThermalBatteryActive(),
+		"INVARIANT: Thermal battery must remain ACTIVE during hysteresis")
+
+	// Holds must NOT be disabled during hysteresis
+	for _, call := range server.GetServiceCallsSince(snapshot) {
+		if call.Domain == "switch" && call.Service == "turn_off" {
+			if eids, ok := call.ServiceData["entity_id"].([]string); ok {
+				for _, e := range eids {
+					if e == "switch.most_of_house_thermostat_hold" || e == "switch.primary_suite_thermostat_hold" {
+						t.Errorf("INVARIANT VIOLATED: Hold must remain enabled during hysteresis (got turn_off for %s)", e)
+					}
+				}
+			}
+		}
+	}
+
+	resumeSnapshot := len(server.GetServiceCalls())
+
+	// WHEN: Energy returns to white during hysteresis
+	t.Log("WHEN: Energy returns to white during hysteresis")
+	require.NoError(t, manager.SetString("currentEnergyLevel", "white"))
+
+	// THEN: Preheat band 70/73 is re-applied (no fresh capture, no notification re-fire)
+	t.Log("THEN: Preheat band 70/73 resumes")
+	require.Eventually(t, func() bool {
+		call := climateSetpointForEntity(server.GetServiceCallsSince(resumeSnapshot), "climate.most_of_house_thermostat")
+		if call == nil {
+			return false
+		}
+		low, _ := call.ServiceData["target_temp_low"].(float64)
+		high, _ := call.ServiceData["target_temp_high"].(float64)
+		return low == 70.0 && high == 73.0
+	}, 5*time.Second, 10*time.Millisecond, "Should resume preheat band 70/73 on white recovery")
+
+	assert.True(t, ls.IsThermalBatteryActive(), "Should remain active after recovery")
+	shadow := ls.GetShadowState()
+	assert.False(t, shadow.Outputs.ThermalBattery.HysteresisActive,
+		"Hysteresis should be cleared after white recovery")
+}
+
+// TestScenario_ThermalBatteryHysteresis_YellowDropHardDeactivates
+// validates that a real load-shedding signal (yellow) during hysteresis still
+// hard-deactivates the thermal battery and reverts setpoints.
+func TestScenario_ThermalBatteryHysteresis_YellowDropHardDeactivates(t *testing.T) {
+	t.Parallel()
+	server, ls, manager, cleanup := setupThermalBatteryHysteresisTest(t)
+	defer cleanup()
+
+	// GIVEN: thermal battery active and in hysteresis after a green dip
+	require.NoError(t, manager.SetString("currentEnergyLevel", "white"))
+	require.Eventually(t, func() bool { return ls.IsThermalBatteryActive() },
+		5*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, manager.SetString("currentEnergyLevel", "green"))
+	require.Eventually(t, func() bool {
+		return ls.GetShadowState().Outputs.ThermalBattery.HysteresisActive
+	}, 5*time.Second, 10*time.Millisecond, "Hysteresis should engage on green")
+
+	snapshot := len(server.GetServiceCalls())
+
+	// WHEN: Energy drops to yellow (real load-shedding signal)
+	t.Log("WHEN: Energy drops to yellow during hysteresis")
+	require.NoError(t, manager.SetString("currentEnergyLevel", "yellow"))
+
+	// THEN: Hard deactivation — setpoints reverted to original 69/72, hysteresis cleared
+	t.Log("THEN: Setpoints reverted to original 69/72")
+	require.Eventually(t, func() bool {
+		call := climateSetpointForEntity(server.GetServiceCallsSince(snapshot), "climate.most_of_house_thermostat")
+		if call == nil {
+			return false
+		}
+		low, _ := call.ServiceData["target_temp_low"].(float64)
+		high, _ := call.ServiceData["target_temp_high"].(float64)
+		return low == 69.0 && high == 72.0
+	}, 5*time.Second, 10*time.Millisecond, "Yellow drop should revert to original 69/72")
+
+	require.Eventually(t, func() bool { return !ls.IsThermalBatteryActive() },
+		5*time.Second, 10*time.Millisecond, "Yellow drop must hard-deactivate")
+
+	shadow := ls.GetShadowState()
+	assert.False(t, shadow.Outputs.ThermalBattery.HysteresisActive)
+}

--- a/homeautomation-go/test/integration/scenario_thermal_battery_hysteresis_test.go
+++ b/homeautomation-go/test/integration/scenario_thermal_battery_hysteresis_test.go
@@ -115,7 +115,7 @@ func TestScenario_ThermalBatteryHysteresis_GreenDipCoastsThenResumesOnWhite(t *t
 		return low == 70.0 && high == 73.0
 	}, 5*time.Second, 10*time.Millisecond, "Should apply preheat band 70/73")
 
-	snapshot := len(server.GetServiceCalls())
+	snapshot := server.ServiceCallCount()
 
 	// WHEN: Energy dips white→green (transient)
 	t.Log("WHEN: Energy drops to green (transient dip)")
@@ -149,7 +149,7 @@ func TestScenario_ThermalBatteryHysteresis_GreenDipCoastsThenResumesOnWhite(t *t
 		}
 	}
 
-	resumeSnapshot := len(server.GetServiceCalls())
+	resumeSnapshot := server.ServiceCallCount()
 
 	// WHEN: Energy returns to white during hysteresis
 	t.Log("WHEN: Energy returns to white during hysteresis")
@@ -191,7 +191,7 @@ func TestScenario_ThermalBatteryHysteresis_YellowDropHardDeactivates(t *testing.
 		return ls.GetShadowState().Outputs.ThermalBattery.HysteresisActive
 	}, 5*time.Second, 10*time.Millisecond, "Hysteresis should engage on green")
 
-	snapshot := len(server.GetServiceCalls())
+	snapshot := server.ServiceCallCount()
 
 	// WHEN: Energy drops to yellow (real load-shedding signal)
 	t.Log("WHEN: Energy drops to yellow during hysteresis")


### PR DESCRIPTION
## Summary

- White→green→white oscillation no longer triggers HVAC counter-runs. Green dips while thermal battery is active enter a 4-hour hysteresis window with a *widened* setpoint band (saved low, shifted high) so neither heating nor cooling engages.
- Recovery to white re-applies the preheat band cleanly; drop to yellow/red/black hard-deactivates as before.
- Hysteresis expiry releases holds and lets the climate schedule resume — no explicit setpoint restore (heat-pump schedule variance is ≤2°F).
- Lifted orphan-hold cleanup to plugin `Start()` for restart safety; skipped when energy is red/black to preserve legitimate load-shedding holds.

## Why now

On 2026-05-06 the thermal battery cycled white→green at 19:08 CDT and reverted setpoints. Indoor was at 74°F; the revert dropped the cool ceiling to 74°F and the AC engaged for 16 minutes (verified via HA history API: `hvac_action=cooling` from 00:09:11 UTC). The green dip was just a normal evening battery oscillation — not a real energy shortage.

## Test plan

- [x] `make unit-tests` (74.9% coverage, ≥65% gate)
- [x] `make integration-tests`
- [x] `make pre-push`
- [x] New unit tests cover: green dip entering hysteresis (cool + heat_cool wide-band), expiry releasing holds without revert, white recovery resuming preheat, yellow drop hard-deactivating during hysteresis, `Start()` clearing stale holds
- [x] New integration scenario test in `scenario_thermal_battery_hysteresis_test.go` validates end-to-end flow through real state subscriptions
- [ ] After merge: watch Gravwell `tag=home-automation grep "hysteresis"` for first white→green transition
- [ ] After merge: cross-check via HA history that `target_temp_low/high` widens (not reverts) and `hvac_action=idle` through the hysteresis window

## Out of scope

- Skip-when-already-warm activation guard. Per discussion, low value (only marginal days like 2026-05-06).
- Persisting state across restarts. The existing orphan-hold cleanup, now lifted to `Start()`, makes this unnecessary.
- The free-energy-time activation path. Will be naturally suppressed once `isFreeEnergyAvailable` becomes permanently false at night under the upcoming utility plan change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)