### PR TITLE
Fix #1099: Rename robot vacuum to Casper

### DIFF
--- a/configs/vacuum_config.yaml
+++ b/configs/vacuum_config.yaml
@@ -1,4 +1,4 @@
-# Robot vacuum plugin configuration.
+# Casper vacuum plugin configuration.
 #
 # Today this drives the error-announcement subsystem. Future fields for
 # scheduling, room sequencing, and per-room vacuum/mop parameters will be added
@@ -18,7 +18,7 @@ vacuum:
     repeat_interval: "2h"
 
     # Sentence prefix; the error description is appended after a colon.
-    message_prefix: "Robot vacuum needs attention"
+    message_prefix: "Casper needs attention"
 
     # Speakers to announce on. These match the post-rename speaker layout
     # (Sitting Room replaced the old Dining Room).
@@ -31,7 +31,7 @@ vacuum:
   clear_announcement:
     # Feel-good recovery confirmation after a real error returns to no_error_value.
     # Uses UrgencyDeferable, so it is skipped while master is asleep.
-    message: "You have satisfied the robot"
+    message: "You have satisfied Casper"
     speakers:
       - "media_player.sitting_room"
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -489,7 +489,7 @@ Each plugin corresponds to a Node-RED flow and implements domain-specific automa
 ### 15. Vacuum Plugin ✅
 
 **Responsibilities:**
-- Monitor the robot vacuum's error sensor and announce actionable errors via TTS
+- Monitor Casper's error sensor and announce actionable errors via TTS
 - Announce a short recovery confirmation on configured speakers when an active
   error clears and someone is home
 - Suppress announcements while master is asleep

--- a/docs/human/VISUAL_ARCHITECTURE.md
+++ b/docs/human/VISUAL_ARCHITECTURE.md
@@ -54,7 +54,7 @@ graph TB
             Infrastructure[Infrastructure<br/>internal/plugins/infrastructure/]
             WaterFlow[Water Flow<br/>internal/plugins/waterflow/]
             EVCharger[EV Charger Safety<br/>internal/plugins/evcharger/]
-            Vacuum[Robot Vacuum<br/>internal/plugins/vacuum/]
+            Vacuum[Casper Vacuum<br/>internal/plugins/vacuum/]
             ResetCoord[Reset Coordinator<br/>internal/plugins/reset/]
             SensorConfig[Sensor Config<br/>internal/plugins/sensorconfig/]
         end
@@ -971,7 +971,7 @@ graph LR
         SensorHealthPlugin[Sensor Health Plugin]
         WaterFlowPlugin[Water Flow Plugin<br/>Order: 71]
         EVChargerPlugin[EV Charger Safety Plugin<br/>Order: 5]
-        VacuumPlugin[Robot Vacuum Plugin<br/>Order: 60]
+        VacuumPlugin[Casper Vacuum Plugin<br/>Order: 60]
         InfrastructurePlugin[Infrastructure Plugin]
         ResetCoord[Reset Coordinator<br/>Order: 90]
     end

--- a/docs/reference/PLUGIN_SYSTEM.md
+++ b/docs/reference/PLUGIN_SYSTEM.md
@@ -969,7 +969,7 @@ func createPlugin(ctx *plugin.Context) (plugin.Plugin, error) {
 import "homeautomation/pkg/notify"
 
 // Deferable announcement (dropped while master is asleep; e.g. presence, vacuum errors)
-m.notifier.Announce(m.ctx, "Robot vacuum needs attention: dustbin missing",
+m.notifier.Announce(m.ctx, "Casper needs attention: dustbin missing",
     notify.WithSpeakers([]string{"media_player.kitchen", "media_player.front_room"}),
 )
 

--- a/homeautomation-go/internal/plugins/vacuum/config.go
+++ b/homeautomation-go/internal/plugins/vacuum/config.go
@@ -48,8 +48,8 @@ const (
 	defaultErrorSensorID        = "sensor.valetudo_mellowslimyloris_error"
 	defaultNoErrorValue         = "No error"
 	defaultRepeatInterval       = 2 * time.Hour
-	defaultMessagePrefix        = "Robot vacuum needs attention"
-	defaultClearMessage         = "You have satisfied the robot"
+	defaultMessagePrefix        = "Casper needs attention"
+	defaultClearMessage         = "You have satisfied Casper"
 	defaultClearSpeakerEntityID = "media_player.sitting_room"
 )
 

--- a/homeautomation-go/internal/plugins/vacuum/manager.go
+++ b/homeautomation-go/internal/plugins/vacuum/manager.go
@@ -1,4 +1,4 @@
-// Package vacuum monitors the robot vacuum's error sensor and announces
+// Package vacuum monitors Casper's error sensor and announces
 // actionable errors and recovery confirmations via TTS.
 //
 // The plugin is structured (Manager + YAML config + shadow tracker) so future
@@ -268,7 +268,7 @@ func (m *Manager) maybeAnnounce(errorDesc string) {
 	}
 
 	err := m.alerter.Send(m.ctx, alert.Alert{
-		Title:    "Vacuum Needs Attention",
+		Title:    "Casper Needs Attention",
 		Body:     message,
 		Urgency:  notify.UrgencyDeferable,
 		Tags:     []string{"robot"},

--- a/homeautomation-go/internal/plugins/vacuum/manager_test.go
+++ b/homeautomation-go/internal/plugins/vacuum/manager_test.go
@@ -23,7 +23,7 @@ func newTestConfig() *Config {
 	cfg := &Config{}
 	cfg.Vacuum.ErrorSensorID = testErrorSensor
 	cfg.Vacuum.NoErrorValue = "No error"
-	cfg.Vacuum.Announcement.MessagePrefix = "Robot vacuum needs attention"
+	cfg.Vacuum.Announcement.MessagePrefix = "Casper needs attention"
 	cfg.Vacuum.Announcement.RepeatInterval = 2 * time.Hour
 	cfg.Vacuum.Announcement.Speakers = []string{
 		"media_player.kitchen",
@@ -31,7 +31,7 @@ func newTestConfig() *Config {
 		"media_player.front_room",
 		"media_player.kids_bathroom",
 	}
-	cfg.Vacuum.ClearAnnouncement.Message = "You have satisfied the robot"
+	cfg.Vacuum.ClearAnnouncement.Message = "You have satisfied Casper"
 	cfg.Vacuum.ClearAnnouncement.Speakers = []string{"media_player.sitting_room"}
 	return cfg
 }
@@ -98,7 +98,7 @@ func TestVacuum_TransitionToError_Announces(t *testing.T) {
 	calls := mockAlerter.Calls()
 	require.Len(t, calls, 1, "expected one announcement")
 	assert.Equal(t,
-		"Robot vacuum needs attention: Mop Dock Clean Water Tank empty",
+		"Casper needs attention: Mop Dock Clean Water Tank empty",
 		calls[0].Body)
 	assert.Equal(t,
 		[]string{
@@ -225,7 +225,7 @@ func TestVacuum_ErrorClearsWhileSomeoneHome_AnnouncesClearTTS(t *testing.T) {
 
 	calls := mockNotifier.Calls()
 	require.Len(t, calls, 1, "expected clear confirmation TTS")
-	assert.Equal(t, "You have satisfied the robot", calls[0].Message)
+	assert.Equal(t, "You have satisfied Casper", calls[0].Message)
 	assert.Equal(t, []string{"media_player.sitting_room"}, calls[0].Speakers)
 	assert.Equal(t, notify.UrgencyDeferable, calls[0].Urgency)
 }

--- a/homeautomation-go/internal/plugins/vacuum/register.go
+++ b/homeautomation-go/internal/plugins/vacuum/register.go
@@ -13,7 +13,7 @@ import (
 func init() {
 	plugin.Register(plugin.PluginInfo{
 		Name:        "vacuum",
-		Description: "Robot vacuum monitoring (today: error TTS announcements)",
+		Description: "Casper (robot vacuum) monitoring (today: error TTS announcements)",
 		Priority:    plugin.PriorityDefault,
 		Order:       60,
 		Factory:     createPlugin,

--- a/homeautomation-go/internal/shadowstate/tracker.go
+++ b/homeautomation-go/internal/shadowstate/tracker.go
@@ -2308,7 +2308,7 @@ func (et *EVChargerTracker) GetState() *EVChargerShadowState {
 // Vacuum Tracker
 // ============================================================================
 
-// VacuumTracker manages shadow state for the robot vacuum plugin.
+// VacuumTracker manages shadow state for Casper's vacuum plugin.
 type VacuumTracker struct {
 	ReadOnlyTracker[VacuumOutputs]
 }

--- a/homeautomation-go/internal/shadowstate/types.go
+++ b/homeautomation-go/internal/shadowstate/types.go
@@ -1102,10 +1102,10 @@ type EVChargerRecovery struct {
 }
 
 // ============================================================================
-// Vacuum Output Types - Robot Vacuum Error Announcements
+// Vacuum Output Types - Casper Vacuum Error Announcements
 // ============================================================================
 
-// VacuumOutputs tracks the state of robot vacuum error announcement handling.
+// VacuumOutputs tracks the state of Casper vacuum error announcement handling.
 // Today this only covers error TTS; future fields for schedule/room control
 // will live alongside these.
 type VacuumOutputs struct {

--- a/homeautomation-go/test/integration/scenario_vacuum_error_test.go
+++ b/homeautomation-go/test/integration/scenario_vacuum_error_test.go
@@ -22,7 +22,7 @@ import (
 // Vacuum Error Announcement Tests
 //
 // User story:
-//   "When my robot vacuum reports an actionable error (e.g. 'Mop Dock Clean
+//   "When Casper reports an actionable error (e.g. 'Mop Dock Clean
 //    Water Tank empty'), I want a spoken TTS announcement on common-area
 //    speakers so I can address it. While I'm asleep, suppress the
 //    announcement. Re-announce every 2 hours until the error clears."
@@ -58,7 +58,7 @@ func setupVacuumTest(t *testing.T, fixedTime time.Time) (*vacuumEnv, func()) {
 	cfg := &vacuum.Config{}
 	cfg.Vacuum.ErrorSensorID = vacuumErrorEntity
 	cfg.Vacuum.NoErrorValue = "No error"
-	cfg.Vacuum.Announcement.MessagePrefix = "Robot vacuum needs attention"
+	cfg.Vacuum.Announcement.MessagePrefix = "Casper needs attention"
 	cfg.Vacuum.Announcement.RepeatInterval = 2 * time.Hour
 	cfg.Vacuum.Announcement.Speakers = []string{
 		"media_player.kitchen",
@@ -66,7 +66,7 @@ func setupVacuumTest(t *testing.T, fixedTime time.Time) (*vacuumEnv, func()) {
 		"media_player.front_room",
 		"media_player.kids_bathroom",
 	}
-	cfg.Vacuum.ClearAnnouncement.Message = "You have satisfied the robot"
+	cfg.Vacuum.ClearAnnouncement.Message = "You have satisfied Casper"
 	cfg.Vacuum.ClearAnnouncement.Speakers = []string{"media_player.sitting_room"}
 
 	tp := plugin.FixedTimeProvider{FixedTime: fixedTime}
@@ -220,7 +220,7 @@ func TestScenario_VacuumError_ClearAnnouncesWhenSomeoneHome(t *testing.T) {
 
 	msgs := env.synth.Messages()
 	require.Len(t, msgs, 2, "expected the original error message and the clear confirmation")
-	assert.Equal(t, "You have satisfied the robot", msgs[1])
+	assert.Equal(t, "You have satisfied Casper", msgs[1])
 }
 
 // TestScenario_VacuumError_ClearSkipsWhenNobodyHome verifies the invariant that


### PR DESCRIPTION
Resolves #1099

## Summary
- Renamed user-facing vacuum alert text, notification title, config comment, tests, and docs references from generic robot vacuum wording to Casper.
- Left internal vacuum identifiers and Home Assistant entity IDs unchanged.

## Test Plan
- make unit-tests
- make pre-commit
- make validate-diagrams
- make integration-tests

🤖 Generated by the AI assistant