### PR TITLE
chore: update AI CLI pins

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,9 +38,9 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     && rm -rf /var/lib/apt/lists/*
 
 # Pin AI CLI versions so Dockerfile, post-create script, and updater workflow stay in sync
-ARG CLAUDE_CODE_VERSION=2.1.126
-ARG CODEX_CLI_VERSION=0.128.0
-ARG CRUSH_CLI_VERSION=0.65.2
+ARG CLAUDE_CODE_VERSION=2.1.138
+ARG CODEX_CLI_VERSION=0.130.0
+ARG CRUSH_CLI_VERSION=0.66.1
 
 # Install Node.js LTS (needed for Claude Code plugins and Playwright build step)
 ARG NODE_VERSION=20

--- a/.github/ci/versions.env
+++ b/.github/ci/versions.env
@@ -2,7 +2,7 @@
 # Single source of truth for `.github/ci/Dockerfile` build args.
 # Also sourced by `update-ai-clis.yml` when bumping pins.
 # Keep in sync with `.devcontainer/Dockerfile` via its own ARG lines.
-CLAUDE_CODE_VERSION=2.1.126
-CODEX_CLI_VERSION=0.128.0
-CRUSH_CLI_VERSION=0.65.2
+CLAUDE_CODE_VERSION=2.1.138
+CODEX_CLI_VERSION=0.130.0
+CRUSH_CLI_VERSION=0.66.1
 NODE_MAJOR=20


### PR DESCRIPTION
Automated weekly update of the pinned AI CLI versions.

Updated in `.github/ci/versions.env` (the single source of
truth for both the CI agent image and the devcontainer) and
mirrored into `.devcontainer/Dockerfile`'s ARG defaults.

- **Claude Code:** 2.1.126 → 2.1.138
- **Crush:** 0.65.2 → 0.66.1
- **Codex:** 0.128.0 → 0.130.0

🤖 Generated automatically by the `update-ai-clis` workflow.