### PR TITLE
Fix #1108: protect subscription helper fallback slices

### DIFF
--- a/homeautomation-go/internal/shadowstate/subscription_helper.go
+++ b/homeautomation-go/internal/shadowstate/subscription_helper.go
@@ -2,6 +2,7 @@ package shadowstate
 
 import (
 	"fmt"
+	"sync"
 
 	"homeautomation/internal/ha"
 	"homeautomation/internal/state"
@@ -32,6 +33,7 @@ type SubscriptionHelper struct {
 	stateSubscriptions []state.Subscription
 
 	// Track subscribed keys for fallback input capture (when registry is nil)
+	subscriptionsMu      sync.RWMutex
 	subscribedStateKeys  []string
 	subscribedHAEntities []string
 }
@@ -84,10 +86,15 @@ func (h *SubscriptionHelper) captureInputs() {
 	// Fallback: capture inputs directly from tracked subscriptions (for tests without registry)
 	inputs := make(map[string]interface{})
 
+	h.subscriptionsMu.RLock()
+	subscribedStateKeys := append([]string(nil), h.subscribedStateKeys...)
+	subscribedHAEntities := append([]string(nil), h.subscribedHAEntities...)
+	h.subscriptionsMu.RUnlock()
+
 	// Capture state variable values
 	if h.stateManager != nil {
 		allValues := h.stateManager.GetAllValues()
-		for _, key := range h.subscribedStateKeys {
+		for _, key := range subscribedStateKeys {
 			if val, ok := allValues[key]; ok {
 				inputs[key] = val
 			}
@@ -96,7 +103,7 @@ func (h *SubscriptionHelper) captureInputs() {
 
 	// Capture HA entity states
 	if h.haClient != nil {
-		for _, entityID := range h.subscribedHAEntities {
+		for _, entityID := range subscribedHAEntities {
 			if state, err := h.haClient.GetState(entityID); err == nil && state != nil {
 				inputs[entityID] = state.State
 			}
@@ -125,7 +132,9 @@ func (h *SubscriptionHelper) SubscribeToSensor(entityID string, handler func(val
 	}
 
 	// Track the entity for fallback input capture
+	h.subscriptionsMu.Lock()
 	h.subscribedHAEntities = append(h.subscribedHAEntities, entityID)
+	h.subscriptionsMu.Unlock()
 
 	sub, err := h.haClient.SubscribeStateChanges(entityID, func(entity string, oldState, newState *ha.State) {
 		if newState == nil {
@@ -165,7 +174,9 @@ func (h *SubscriptionHelper) SubscribeToEntity(entityID string, handler func(ent
 	}
 
 	// Track the entity for fallback input capture
+	h.subscriptionsMu.Lock()
 	h.subscribedHAEntities = append(h.subscribedHAEntities, entityID)
+	h.subscriptionsMu.Unlock()
 
 	sub, err := h.haClient.SubscribeStateChanges(entityID, func(entity string, oldState, newState *ha.State) {
 		// Capture shadow state inputs BEFORE calling the handler
@@ -191,7 +202,9 @@ func (h *SubscriptionHelper) SubscribeToState(key string, handler func(key strin
 	}
 
 	// Track the key for fallback input capture
+	h.subscriptionsMu.Lock()
 	h.subscribedStateKeys = append(h.subscribedStateKeys, key)
+	h.subscriptionsMu.Unlock()
 
 	sub, err := h.stateManager.Subscribe(key, func(k string, oldValue, newValue interface{}) {
 		// Capture shadow state inputs BEFORE calling the handler

--- a/homeautomation-go/internal/shadowstate/subscription_helper_test.go
+++ b/homeautomation-go/internal/shadowstate/subscription_helper_test.go
@@ -315,6 +315,7 @@ func TestSubscriptionHelper_NilRegistry(t *testing.T) {
 }
 
 func TestSubscriptionHelper_FallbackCaptureConcurrentSubscribeToState(t *testing.T) {
+	t.Parallel()
 	logger := zap.NewNop()
 	stateManager := state.NewManager(nil, logger, true)
 	tracker := &lockedMockShadowTracker{}

--- a/homeautomation-go/internal/shadowstate/subscription_helper_test.go
+++ b/homeautomation-go/internal/shadowstate/subscription_helper_test.go
@@ -3,10 +3,12 @@ package shadowstate
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 
 	"homeautomation/internal/ha"
+	"homeautomation/internal/state"
 
 	"go.uber.org/zap"
 )
@@ -26,6 +28,15 @@ func newMockShadowTracker() *mockShadowTracker {
 func (m *mockShadowTracker) UpdateCurrentInputs(inputs map[string]interface{}) {
 	m.inputs = inputs
 	m.updateCount++
+}
+
+type lockedMockShadowTracker struct {
+	mu sync.Mutex
+}
+
+func (m *lockedMockShadowTracker) UpdateCurrentInputs(inputs map[string]interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 }
 
 // mockHAClient implements ha.HAClient for testing
@@ -301,4 +312,39 @@ func TestSubscriptionHelper_NilRegistry(t *testing.T) {
 	if tracker.updateCount != 1 {
 		t.Errorf("Shadow tracker should have been updated via fallback capture, got %d updates", tracker.updateCount)
 	}
+}
+
+func TestSubscriptionHelper_FallbackCaptureConcurrentSubscribeToState(t *testing.T) {
+	logger := zap.NewNop()
+	stateManager := state.NewManager(nil, logger, true)
+	tracker := &lockedMockShadowTracker{}
+	helper := NewSubscriptionHelper(nil, stateManager, nil, tracker, "test", logger)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					helper.captureInputs()
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < 1000; i++ {
+		if err := helper.SubscribeToState("didOwnerJustReturnHome", func(string, interface{}, interface{}) {}); err != nil {
+			close(stop)
+			wg.Wait()
+			t.Fatalf("SubscribeToState failed: %v", err)
+		}
+	}
+
+	close(stop)
+	wg.Wait()
 }


### PR DESCRIPTION
Resolves #1108

## Summary
- Added an RWMutex around SubscriptionHelper fallback subscription tracking slices.
- Snapshot subscribed state keys and HA entities before fallback input capture so event handlers do not iterate slices while setup appends to them.
- Added a race-regression unit test for concurrent fallback capture and state subscription setup.

## Test Plan
- make unit-tests
- make pre-commit

🤖 Generated by the AI assistant