### PR TITLE
Fix #1113: update retired free energy docs

### DIFF
--- a/docs/flows/ENERGY_MANAGEMENT.md
+++ b/docs/flows/ENERGY_MANAGEMENT.md
@@ -214,7 +214,7 @@ See [LOAD_SHEDDING.md](./LOAD_SHEDDING.md) for thermostat control and thermal ba
 |----------|------|-------------|
 | `batteryEnergyLevel` | string | Battery-based level (black/red/yellow/green) |
 | `solarProductionEnergyLevel` | string | Solar-based level |
-| `isFreeEnergyAvailable` | bool | Legacy metered-grid flag, kept false |
+| `isFreeEnergyAvailable` | bool | Legacy metered-grid flag, retired (always false) |
 | `currentEnergyLevel` | string | Overall combined level |
 | `thisHourSolarGeneration` | number | Current solar kW |
 | `remainingSolarGeneration` | number | Remaining solar kWh |

--- a/docs/flows/LOAD_SHEDDING.md
+++ b/docs/flows/LOAD_SHEDDING.md
@@ -365,6 +365,7 @@ flowchart LR
 | `currentEnergyLevel` | string | Energy Plugin | Overall energy availability |
 | `isAnyoneHome` | bool | State Tracking Plugin | Whether anyone is home (thermal battery guard) |
 | `isEveryoneAsleep` | bool | State Tracking Plugin | Whether everyone is asleep (thermal battery guard) |
+| `isFreeEnergyAvailable` | bool | Energy Plugin | Legacy metered-grid flag, retired (always false); gate logic effectively disabled |
 | `remainingSolarGeneration` | number | Energy Plugin | Remaining solar kWh forecast; gate defers while above threshold |
 
 ### Internal State

--- a/docs/reference/PLUGIN_SYSTEM.md
+++ b/docs/reference/PLUGIN_SYSTEM.md
@@ -285,7 +285,7 @@ defer stateTrackingManager.Stop()  // Stops first (registered first)
 - `batteryEnergyLevel` - Battery charge level category
 - `solarProductionEnergyLevel` - Solar production category
 - `currentEnergyLevel` - Combined energy availability
-- `isFreeEnergyAvailable` - Legacy metered-grid flag, kept false
+- `isFreeEnergyAvailable` - Legacy metered-grid flag, retired (always false)
 
 **HA Entities Subscribed:**
 - `sensor.span_panel_span_storage_battery_percentage_2`
@@ -1137,7 +1137,7 @@ Include a comment block documenting which state variables the plugin reads and w
 //
 // State Variables Written:
 //   - currentEnergyLevel (string)
-//   - isFreeEnergyAvailable (bool, legacy metered-grid flag kept false)
+//   - isFreeEnergyAvailable (bool, legacy metered-grid flag, retired (always false))
 //
 // HA Entities Subscribed:
 //   - sensor.span_panel_span_storage_battery_percentage_2


### PR DESCRIPTION
Resolves #1113

## Summary
- Updated ENERGY_MANAGEMENT.md to describe isFreeEnergyAvailable as a retired legacy metered-grid flag.
- Updated LOAD_SHEDDING.md to document that the retired flag no longer enables gate bypass behavior.

## Test Plan
- make unit-tests

🤖 Generated by the AI assistant