### PR TITLE
Fix #1114: Protect SubscriptionHelper subscription slices

### DIFF
--- a/docs/reference/CONCURRENCY_LESSONS.md
+++ b/docs/reference/CONCURRENCY_LESSONS.md
@@ -1471,6 +1471,9 @@ c.entityDispatchMu.Unlock()
 
 ## Change Log
 
+### 2026-05-17 (PR #1116)
+- **Fix data race on SubscriptionHelper subscription slices**: `haSubscriptions`, `stateSubscriptions`, `subscribedStateKeys`, and `subscribedHAEntities` were read and written concurrently without synchronization. Added `subscriptionsMu sync.RWMutex` to `SubscriptionHelper`; all appends hold a write lock and all reads (including `captureInputs`, `GetHASubscriptions`, `GetStateSubscriptions`, `UnsubscribeAll`) take a copy under a read lock before iterating. Applied to `internal/shadowstate/subscription_helper.go`. (Existing Lesson 3 covers the RWMutex pattern; this entry records where it was applied.)
+
 ### 2026-05-05 (PR #1082)
 - **Fix race in Lesson 20 teardown**: `Disconnect()` previously closed per-entity queue channels while `receiveMessages` / `handleEvent` could still be sending to them — a use-after-close channel panic. Fix adds two primitives:
   - `lifecycleMu sync.Mutex` (lock ordering position **1**, outermost) serializes concurrent `Connect()` / `Disconnect()` calls

--- a/homeautomation-go/internal/shadowstate/subscription_helper.go
+++ b/homeautomation-go/internal/shadowstate/subscription_helper.go
@@ -2,6 +2,7 @@ package shadowstate
 
 import (
 	"fmt"
+	"sync"
 
 	"homeautomation/internal/ha"
 	"homeautomation/internal/state"
@@ -28,6 +29,7 @@ type SubscriptionHelper struct {
 	logger        *zap.Logger
 
 	// Track subscriptions for cleanup
+	subscriptionsMu    sync.RWMutex
 	haSubscriptions    []ha.Subscription
 	stateSubscriptions []state.Subscription
 
@@ -83,11 +85,15 @@ func (h *SubscriptionHelper) captureInputs() {
 
 	// Fallback: capture inputs directly from tracked subscriptions (for tests without registry)
 	inputs := make(map[string]interface{})
+	h.subscriptionsMu.RLock()
+	subscribedStateKeys := append([]string(nil), h.subscribedStateKeys...)
+	subscribedHAEntities := append([]string(nil), h.subscribedHAEntities...)
+	h.subscriptionsMu.RUnlock()
 
 	// Capture state variable values
 	if h.stateManager != nil {
 		allValues := h.stateManager.GetAllValues()
-		for _, key := range h.subscribedStateKeys {
+		for _, key := range subscribedStateKeys {
 			if val, ok := allValues[key]; ok {
 				inputs[key] = val
 			}
@@ -96,7 +102,7 @@ func (h *SubscriptionHelper) captureInputs() {
 
 	// Capture HA entity states
 	if h.haClient != nil {
-		for _, entityID := range h.subscribedHAEntities {
+		for _, entityID := range subscribedHAEntities {
 			if state, err := h.haClient.GetState(entityID); err == nil && state != nil {
 				inputs[entityID] = state.State
 			}
@@ -125,7 +131,9 @@ func (h *SubscriptionHelper) SubscribeToSensor(entityID string, handler func(val
 	}
 
 	// Track the entity for fallback input capture
+	h.subscriptionsMu.Lock()
 	h.subscribedHAEntities = append(h.subscribedHAEntities, entityID)
+	h.subscriptionsMu.Unlock()
 
 	sub, err := h.haClient.SubscribeStateChanges(entityID, func(entity string, oldState, newState *ha.State) {
 		if newState == nil {
@@ -152,7 +160,9 @@ func (h *SubscriptionHelper) SubscribeToSensor(entityID string, handler func(val
 		return fmt.Errorf("failed to subscribe to %s: %w", entityID, err)
 	}
 
+	h.subscriptionsMu.Lock()
 	h.haSubscriptions = append(h.haSubscriptions, sub)
+	h.subscriptionsMu.Unlock()
 	return nil
 }
 
@@ -165,7 +175,9 @@ func (h *SubscriptionHelper) SubscribeToEntity(entityID string, handler func(ent
 	}
 
 	// Track the entity for fallback input capture
+	h.subscriptionsMu.Lock()
 	h.subscribedHAEntities = append(h.subscribedHAEntities, entityID)
+	h.subscriptionsMu.Unlock()
 
 	sub, err := h.haClient.SubscribeStateChanges(entityID, func(entity string, oldState, newState *ha.State) {
 		// Capture shadow state inputs BEFORE calling the handler
@@ -178,7 +190,9 @@ func (h *SubscriptionHelper) SubscribeToEntity(entityID string, handler func(ent
 		return fmt.Errorf("failed to subscribe to %s: %w", entityID, err)
 	}
 
+	h.subscriptionsMu.Lock()
 	h.haSubscriptions = append(h.haSubscriptions, sub)
+	h.subscriptionsMu.Unlock()
 	return nil
 }
 
@@ -191,7 +205,9 @@ func (h *SubscriptionHelper) SubscribeToState(key string, handler func(key strin
 	}
 
 	// Track the key for fallback input capture
+	h.subscriptionsMu.Lock()
 	h.subscribedStateKeys = append(h.subscribedStateKeys, key)
+	h.subscriptionsMu.Unlock()
 
 	sub, err := h.stateManager.Subscribe(key, func(k string, oldValue, newValue interface{}) {
 		// Capture shadow state inputs BEFORE calling the handler
@@ -204,29 +220,40 @@ func (h *SubscriptionHelper) SubscribeToState(key string, handler func(key strin
 		return fmt.Errorf("failed to subscribe to %s: %w", key, err)
 	}
 
+	h.subscriptionsMu.Lock()
 	h.stateSubscriptions = append(h.stateSubscriptions, sub)
+	h.subscriptionsMu.Unlock()
 	return nil
 }
 
 // GetHASubscriptions returns all HA subscriptions (for manual cleanup if needed)
 func (h *SubscriptionHelper) GetHASubscriptions() []ha.Subscription {
-	return h.haSubscriptions
+	h.subscriptionsMu.RLock()
+	defer h.subscriptionsMu.RUnlock()
+	return append([]ha.Subscription(nil), h.haSubscriptions...)
 }
 
 // GetStateSubscriptions returns all state subscriptions (for manual cleanup if needed)
 func (h *SubscriptionHelper) GetStateSubscriptions() []state.Subscription {
-	return h.stateSubscriptions
+	h.subscriptionsMu.RLock()
+	defer h.subscriptionsMu.RUnlock()
+	return append([]state.Subscription(nil), h.stateSubscriptions...)
 }
 
 // UnsubscribeAll cleans up all subscriptions
 func (h *SubscriptionHelper) UnsubscribeAll() {
-	for _, sub := range h.haSubscriptions {
-		sub.Unsubscribe()
-	}
+	h.subscriptionsMu.Lock()
+	haSubscriptions := append([]ha.Subscription(nil), h.haSubscriptions...)
+	stateSubscriptions := append([]state.Subscription(nil), h.stateSubscriptions...)
 	h.haSubscriptions = nil
+	h.stateSubscriptions = nil
+	h.subscriptionsMu.Unlock()
 
-	for _, sub := range h.stateSubscriptions {
+	for _, sub := range haSubscriptions {
 		sub.Unsubscribe()
 	}
-	h.stateSubscriptions = nil
+
+	for _, sub := range stateSubscriptions {
+		sub.Unsubscribe()
+	}
 }


### PR DESCRIPTION
Resolves #1114

## Summary
- Added a mutex to guard SubscriptionHelper cleanup subscription slices.
- Snapshot fallback input tracking slices before capture.
- Return copied subscription slices from getters and clear cleanup slices under lock before unsubscribing.

## Test Plan
- make unit-tests
- make pre-commit

🤖 Generated by the AI assistant