### PR TITLE
Stop kitchen scene reactivation from overriding manual brightness

### DIFF
--- a/configs/hue_config.yaml
+++ b/configs/hue_config.yaml
@@ -168,6 +168,11 @@ rooms:
         value: true
     increase_brightness_if_true: ~
     transition_seconds: 5
+    # The kitchen mmWave radar (Apollo MTR) is unreliable for stationary people:
+    # it briefly drops detection then re-detects. Without this flag, every
+    # re-detection re-activates the scene and overrides any manual brightness
+    # the user dialed in. Edge-trigger so on→on reactivations are skipped.
+    skip_reactivation_when_on: true
 
   - hue_group: C Office
     hass_area_id: c_office

--- a/docs/flows/LIGHTING_CONTROL.md
+++ b/docs/flows/LIGHTING_CONTROL.md
@@ -203,6 +203,19 @@ flowchart TD
     style protect fill:#e74c3c,color:#fff
 ```
 
+## Edge-Triggered Activation (skip_reactivation_when_on)
+
+Some rooms use presence sensors (e.g. mmWave radar) that briefly drop detection on stationary people, then re-detect. Without protection, every re-detection re-fires the scene and overrides manual brightness adjustments.
+
+The per-room `skip_reactivation_when_on: true` config flag makes activation **edge-triggered**: if the room's last applied action was already `"on"`, a repeat `"on"` evaluation from an occupancy or condition trigger is skipped, preserving any brightness the user dialed in since last activation.
+
+**Exceptions — triggers that always re-fire regardless of this flag:**
+- `dayPhase` changes (different target scene)
+- `sunevent` changes
+- Empty/reset triggers (startup initialization)
+
+Currently used by: Kitchen (Apollo MTR mmWave radar)
+
 ## Transition Timing
 
 Light transitions use appropriate timing for natural progression:

--- a/homeautomation-go/internal/plugins/lighting/config.go
+++ b/homeautomation-go/internal/plugins/lighting/config.go
@@ -22,6 +22,12 @@ type RoomConfig struct {
 	Conditions               []LightingCondition `yaml:"conditions"`                  // Ordered list of conditions (first match wins)
 	IncreaseBrightnessIfTrue interface{}         `yaml:"increase_brightness_if_true"` // Can be string or []string
 	TransitionSeconds        *int                `yaml:"transition_seconds"`          // Pointer to handle nil/~ values
+	// SkipReactivationWhenOn opts the room into edge-triggered scene activation.
+	// When true and the room's last applied action was already "on", a repeat "on"
+	// evaluation from an occupancy/condition trigger is skipped — preserving any
+	// manual brightness adjustments. Day phase and global triggers still re-fire.
+	// Used by rooms with unreliable presence sensors (e.g. mmWave radar).
+	SkipReactivationWhenOn bool `yaml:"skip_reactivation_when_on"`
 }
 
 // GetConditionVariables returns a list of all unique state variable names used in conditions

--- a/homeautomation-go/internal/plugins/lighting/manager.go
+++ b/homeautomation-go/internal/plugins/lighting/manager.go
@@ -33,6 +33,12 @@ type Manager struct {
 	// retry loops overriding newer actions for the same room.
 	roomContexts   map[string]context.CancelFunc
 	roomContextsMu sync.Mutex
+
+	// Tracks the last applied action ("on" or "off") per room. Used by rooms
+	// with skip_reactivation_when_on=true to skip duplicate on→on activations
+	// caused by unreliable presence sensors.
+	lastRoomAction   map[string]string
+	lastRoomActionMu sync.Mutex
 }
 
 // NewManager creates a new Lighting Control manager
@@ -40,15 +46,16 @@ func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.M
 	shadowTracker := shadowstate.NewLightingTracker()
 
 	return &Manager{
-		haClient:      haClient,
-		stateManager:  stateManager,
-		config:        config,
-		logger:        logger.Named("lighting"),
-		readOnly:      readOnly,
-		shadowTracker: shadowTracker,
-		subHelper:     shadowstate.NewSubscriptionHelper(haClient, stateManager, registry, shadowTracker, "lighting", logger.Named("lighting")),
-		ctx:           ctx,
-		roomContexts:  make(map[string]context.CancelFunc),
+		haClient:       haClient,
+		stateManager:   stateManager,
+		config:         config,
+		logger:         logger.Named("lighting"),
+		readOnly:       readOnly,
+		shadowTracker:  shadowTracker,
+		subHelper:      shadowstate.NewSubscriptionHelper(haClient, stateManager, registry, shadowTracker, "lighting", logger.Named("lighting")),
+		ctx:            ctx,
+		roomContexts:   make(map[string]context.CancelFunc),
+		lastRoomAction: make(map[string]string),
 	}
 }
 
@@ -344,6 +351,27 @@ func (m *Manager) evaluateAndActivateRoom(room *RoomConfig, dayPhase string, tri
 		zap.String("action", action),
 		zap.String("matched_variable", matchedVar))
 
+	// Edge-trigger optimization for rooms with unreliable presence sensors
+	// (e.g. mmWave radar that drops detection on stationary people). Skip a
+	// duplicate on→on reactivation triggered by a condition variable so we
+	// don't override the user's manual brightness adjustments. Global triggers
+	// (dayPhase/sunevent) still re-fire because the target scene may differ.
+	if room.SkipReactivationWhenOn && action == "on" && !isGlobalTrigger(trigger) {
+		m.lastRoomActionMu.Lock()
+		lastAction := m.lastRoomAction[room.HueGroup]
+		m.lastRoomActionMu.Unlock()
+		if lastAction == "on" {
+			m.logger.Info("Skipping scene reactivation - room already on, preserving manual adjustments",
+				zap.String("room", room.HueGroup),
+				zap.String("trigger", trigger),
+				zap.String("matched_condition", matchedVar))
+			m.recordAction(room.HueGroup, "skip_reactivation",
+				fmt.Sprintf("Room already on; skipping to preserve manual brightness (trigger=%s)", trigger),
+				"", false, trigger)
+			return
+		}
+	}
+
 	switch action {
 	case "on":
 		m.logger.Info("Room should be turned on with scene",
@@ -351,11 +379,13 @@ func (m *Manager) evaluateAndActivateRoom(room *RoomConfig, dayPhase string, tri
 			zap.String("day_phase", dayPhase),
 			zap.String("matched_condition", matchedVar))
 		m.activateScene(roomCtx, room, dayPhase, trigger)
+		m.setLastRoomAction(room.HueGroup, "on")
 	case "off":
 		m.logger.Info("Room should be turned off",
 			zap.String("room", room.HueGroup),
 			zap.String("matched_condition", matchedVar))
 		m.turnOffRoom(roomCtx, room, trigger)
+		m.setLastRoomAction(room.HueGroup, "off")
 	case "skip":
 		// Skip action: do nothing for this room (e.g., when Hue Sync is controlling the lights)
 		// Previous operation cancelled by getRoomContext, no new action needed
@@ -459,6 +489,26 @@ func toSnakeCase(str string) string {
 // scenes after someone returns home. Long transitions on lights that are off can
 // silently fail on Hue bridges, and users want lights up quickly when arriving.
 const maxReturnHomeTransition = 5
+
+// isGlobalTrigger returns true for triggers that affect all rooms and should
+// always re-evaluate, even when a room has skip_reactivation_when_on=true.
+// Day phase and sun events change the target scene itself, so they must
+// re-fire. Matches the set treated as global in isTopicRelevant.
+func isGlobalTrigger(trigger string) bool {
+	switch trigger {
+	case "dayPhase", "sunevent", "", "reset":
+		return true
+	}
+	return false
+}
+
+// setLastRoomAction records the most recent action applied to a room, used
+// to detect on→on reactivations from unreliable presence sensors.
+func (m *Manager) setLastRoomAction(roomName, action string) {
+	m.lastRoomActionMu.Lock()
+	defer m.lastRoomActionMu.Unlock()
+	m.lastRoomAction[roomName] = action
+}
 
 // isPresenceTrigger returns true if the trigger variable indicates a presence change
 // (someone arriving/leaving), which means lights may be transitioning from off to on.

--- a/homeautomation-go/internal/plugins/lighting/occupancy_scenario_test.go
+++ b/homeautomation-go/internal/plugins/lighting/occupancy_scenario_test.go
@@ -218,6 +218,8 @@ func TestScenario_KitchenSkipsReactivationWhenAlreadyOn(t *testing.T) {
 
 	// Snapshot AFTER the initial activation so we only observe what happens
 	// during the radar glitch sequence.
+	// NOTE: MockClient dispatches handlers synchronously, so snapshot is taken
+	// only after the GIVEN SetBool handler has fully completed.
 	snapshot := mockClient.ServiceCallCount()
 
 	t.Log("WHEN: radar glitches (false) then re-detects (true)")
@@ -256,6 +258,8 @@ func TestScenario_KitchenStillRespondsToDayPhaseChange(t *testing.T) {
 	err := manager.stateManager.SetBool("isKitchenOccupied", true)
 	assert.NoError(t, err)
 
+	// NOTE: MockClient dispatches handlers synchronously, so snapshot is taken
+	// only after the GIVEN SetBool handler has fully completed.
 	snapshot := mockClient.ServiceCallCount()
 
 	t.Log("WHEN: dayPhase changes to evening")

--- a/homeautomation-go/internal/plugins/lighting/occupancy_scenario_test.go
+++ b/homeautomation-go/internal/plugins/lighting/occupancy_scenario_test.go
@@ -38,7 +38,8 @@ func createOccupancyTestConfig() *HueConfig {
 					{Action: "off", Variable: "isAnyoneHomeAndAwake", Value: false},
 					{Action: "on", Variable: "isKitchenOccupied", Value: true},
 				},
-				TransitionSeconds: &transition5,
+				TransitionSeconds:      &transition5,
+				SkipReactivationWhenOn: true,
 			},
 		},
 	}
@@ -193,6 +194,86 @@ func TestScenario_OccupancyChangeOnlyAffectsRelevantRoom(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestScenario_KitchenSkipsReactivationWhenAlreadyOn validates the fix for the
+// "lights go down on someone" bug. The kitchen mmWave radar can briefly drop
+// detection on a stationary person and then re-detect them. Without edge-
+// triggered activation, every re-detection re-fires the scene and overrides
+// any manual brightness the user set. The skip_reactivation_when_on flag
+// makes a duplicate on→on evaluation a no-op so manual adjustments stick.
+//
+// GIVEN: Kitchen scene has been activated (lights on)
+// WHEN:  isKitchenOccupied flips false (radar glitch), then back true (re-detect)
+// THEN:  No second scene.turn_on for the kitchen is issued
+func TestScenario_KitchenSkipsReactivationWhenAlreadyOn(t *testing.T) {
+	t.Parallel()
+	config := createOccupancyTestConfig()
+	manager, mockClient, _ := setupOccupancyManager(t, config, nil)
+	defer manager.Stop()
+
+	t.Log("GIVEN: Kitchen is occupied with scene already active")
+	err := manager.stateManager.SetBool("isKitchenOccupied", true)
+	assert.NoError(t, err)
+
+	// Snapshot AFTER the initial activation so we only observe what happens
+	// during the radar glitch sequence.
+	snapshot := mockClient.ServiceCallCount()
+
+	t.Log("WHEN: radar glitches (false) then re-detects (true)")
+	err = manager.stateManager.SetBool("isKitchenOccupied", false)
+	assert.NoError(t, err)
+	err = manager.stateManager.SetBool("isKitchenOccupied", true)
+	assert.NoError(t, err)
+
+	t.Log("THEN: no additional scene.turn_on for kitchen — user's brightness preserved")
+	calls := mockClient.GetServiceCallsSince(snapshot)
+	for _, call := range calls {
+		if call.Domain == "scene" && call.Service == "turn_on" {
+			if entityID, ok := call.Data["entity_id"].(string); ok {
+				assert.NotContains(t, entityID, "kitchen",
+					"Kitchen scene must NOT be re-activated after radar glitch — would override manual brightness. Got: %s", entityID)
+			}
+		}
+	}
+}
+
+// TestScenario_KitchenStillRespondsToDayPhaseChange validates that the
+// skip-reactivation flag does not break legitimate scene changes. Day phase
+// transitions target a different scene (e.g. kitchen_day → kitchen_evening)
+// and must always fire even when the room is already on.
+//
+// GIVEN: Kitchen is occupied with day scene active
+// WHEN:  dayPhase changes to evening
+// THEN:  scene.kitchen_evening IS activated
+func TestScenario_KitchenStillRespondsToDayPhaseChange(t *testing.T) {
+	t.Parallel()
+	config := createOccupancyTestConfig()
+	manager, mockClient, _ := setupOccupancyManager(t, config, nil)
+	defer manager.Stop()
+
+	t.Log("GIVEN: Kitchen is occupied with day scene active")
+	err := manager.stateManager.SetBool("isKitchenOccupied", true)
+	assert.NoError(t, err)
+
+	snapshot := mockClient.ServiceCallCount()
+
+	t.Log("WHEN: dayPhase changes to evening")
+	err = manager.stateManager.SetString("dayPhase", "evening")
+	assert.NoError(t, err)
+
+	t.Log("THEN: scene.kitchen_evening is activated (global trigger bypasses skip)")
+	calls := mockClient.GetServiceCallsSince(snapshot)
+	found := false
+	for _, call := range calls {
+		if call.Domain == "scene" && call.Service == "turn_on" {
+			if entityID, ok := call.Data["entity_id"].(string); ok && entityID == "scene.kitchen_evening" {
+				found = true
+				break
+			}
+		}
+	}
+	assert.True(t, found, "Expected scene.kitchen_evening to fire on dayPhase change. Calls: %+v", calls)
 }
 
 func intPtr(i int) *int { return &i }


### PR DESCRIPTION
## Problem

The kitchen mmWave radar (Apollo MTR) is unreliable for stationary people — it briefly reports "no presence" while someone is actually in the room, then re-detects them. This causes a visible bug:

1. You're in the kitchen; the lighting plugin has activated the day-phase scene.
2. You manually raise the kitchen brightness (app/voice) past the scene default.
3. Radar drops detection → `isKitchenOccupied=false` → no condition matches → lights stay where you set them. (Good.)
4. Radar re-detects → `isKitchenOccupied=true` → lighting plugin unconditionally re-fires `scene.turn_on` → Hue resets brightness back to the scene default.

Net effect: **the lights "turn down" on someone who is already in the room.** This PR stops that.

## Fix

Make occupancy-driven scene activation idempotent. New per-room config flag `skip_reactivation_when_on`:

- When set and the room's last applied action was already `on`, a repeat `on` evaluation from a condition variable is skipped — preserving manual brightness adjustments.
- Day phase / sun event triggers still re-fire because the target scene itself changes (e.g. `kitchen_day` → `kitchen_evening`).
- Implemented in `evaluateAndActivateRoom` as an early-return guard plus per-room last-action tracking (`map[string]string` guarded by a mutex). The skip is recorded to shadow state for `/api/shadow/lighting` visibility.

Enabled on **Kitchen only** per the current need; other rooms are unchanged.

## Behavior matrix (Kitchen)

| Trigger | Prior action | New action | Outcome |
|---|---|---|---|
| `isKitchenOccupied` flips true (initial entry) | `off` / none | `on` | Fire scene |
| Radar glitch: `isKitchenOccupied` flips false | `on` | `""` (no match) | No-op, last action stays `on` |
| Radar re-detects: `isKitchenOccupied` flips true | `on` | `on` | **SKIP — bug fix** |
| `isAnyoneHomeAndAwake` flips false | any | `off` | Turn off, last action `off` |
| `dayPhase` change while occupied | `on` | `on` | Fire new scene (global trigger bypasses skip) |

## Test plan

- [x] New unit tests `TestScenario_KitchenSkipsReactivationWhenAlreadyOn` (validates the fix — verified to fail with flag off) and `TestScenario_KitchenStillRespondsToDayPhaseChange` (validates day phase still re-fires)
- [x] Unit tests pass with 74.7% coverage
- [x] All 10 lighting integration tests pass
- [x] Pre-push hook (full unit + integration + coverage) passes
- [ ] Post-deploy: in production, walk out of camera range briefly while kitchen lights are at a manually-set brightness; lights should stay where they are. Verify via Gravwell: `tag=home-automation grep "Skipping scene reactivation"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)