### PR TITLE
config(energy): realign thresholds for battery arbitrage

### DIFF
--- a/configs/energy_config.yaml
+++ b/configs/energy_config.yaml
@@ -34,7 +34,7 @@ energy:
         blue: 112
         brightness_pct: 70
     - condition_name: red
-      battery_minimum_percentage: 40
+      battery_minimum_percentage: 19
       energy_production_minimum_kw: 0
       remaining_energy_production_minimum_kwh: 0
       light_config:
@@ -43,7 +43,7 @@ energy:
         blue: 0
         brightness_pct: 30
     - condition_name: yellow
-      battery_minimum_percentage: 60
+      battery_minimum_percentage: 20
       energy_production_minimum_kw: 0
       remaining_energy_production_minimum_kwh: 0
       light_config:
@@ -52,7 +52,7 @@ energy:
         blue: 0
         brightness_pct: 30
     - condition_name: green
-      battery_minimum_percentage: 80
+      battery_minimum_percentage: 40
       energy_production_minimum_kw: 0
       remaining_energy_production_minimum_kwh: 10
       light_config:
@@ -61,7 +61,7 @@ energy:
         blue: 0
         brightness_pct: 60
     - condition_name: white
-      battery_minimum_percentage: 95
+      battery_minimum_percentage: 70
       energy_production_minimum_kw: 4
       remaining_energy_production_minimum_kwh: 20
       light_config:


### PR DESCRIPTION
## Summary
- Old thresholds (red=40, yellow=60, green=80, white=95) assumed a deep reserve for power-outage backup. Under the new energy plan, the battery intentionally cycles down to ~20% nightly for grid arbitrage — so routine cycling was tripping `red`/`black` and triggering loadshedding's 65-80°F wide-band HVAC hold, leaving the house uncomfortably hot.
- New thresholds anchor `red` exactly at the 19% arbitrage floor. At 20%+ we sit in yellow or higher (no HVAC shed). At 19% we enter red and load shedding engages. Below 19% rolls to black, which uses the same load-shed code path so HVAC reaction is identical.

| Level   | Old | New |
|---------|----:|----:|
| red     | 40  | **19** |
| yellow  | 60  | **20** |
| green   | 80  | **40** |
| white   | 95  | **70** |

- Solar criteria, indicator-light colors, and `loadshedding/manager.go` are unchanged.

| Battery % | Resulting level | HVAC reaction |
|-----------|-----------------|---------------|
| 70%+ (with solar criteria met) | white | Thermal battery active |
| 40–69%    | green | Normal |
| 20–39%    | yellow | Non-HVAC loads shed only |
| 19%       | **red** | Load shedding → 65-80°F wide band |
| 0–18%     | black | Load shedding → 65-80°F wide band |

## Test plan
- [x] `make unit-tests` — passes (74.6% coverage)
- [x] `make integration-tests` — passes
- [x] Pre-commit + pre-push hooks pass
- [ ] After deploy: confirm `Energy level changed` log shows `yellow` (not red) at evening arbitrage battery levels (~25-35%)
- [ ] After deploy: confirm `switch.most_of_house_thermostat_hold` stays off during normal arbitrage operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)