### PR TITLE
fix: derive isAnyoneHomeAndAwake from debounced isAnyoneHome

### DIFF
--- a/homeautomation-go/internal/state/computed.go
+++ b/homeautomation-go/internal/state/computed.go
@@ -10,11 +10,22 @@ import (
 // subscriptions to automatically recompute them when dependencies change.
 //
 // Computed state variables are derived from other state variables:
-// - isAnyoneHomeAndAwake = (isAnyOwnerHome && !isAnyoneAsleep) || isAssistantHere || wakeSequenceLatch
+// - isAnyoneHomeAndAwake = (isAnyoneHome && !isAnyoneAsleep) || isAssistantHere || wakeSequenceLatch
+//
+// Note: We derive from the *debounced* isAnyoneHome (= isAnyOwnerHome || isAssistantHere
+// with a 5-minute departure debounce) rather than the raw isAnyOwnerHome. The debounce
+// absorbs GPS/WiFi presence bounce, and propagating it here keeps downstream consumers
+// (lighting whole-house off-sweep, sleep detection, etc.) on a single coherent signal.
+// Without this, the lighting plugin reacted to un-debounced owner departures and turned
+// the bedroom light off seconds after the last owner left, which the sleep-detection
+// timer then misread as "going to bed" — its isAnyoneHome guard was still in the
+// debounce window. (2026-05-17 incident; PR #1119.)
 //
 // Note: Assistant doesn't have a sleep state tracked, so their presence means someone
 // is home AND awake by definition. The formula accounts for this by including
-// isAssistantHere as an independent condition.
+// isAssistantHere as an independent condition (and not relying solely on the
+// (isAnyoneHome && !isAnyoneAsleep) term, which would be false if the owner is asleep
+// even when an assistant is present).
 //
 // Wake Sequence Latch:
 // When Nick's alarm triggers (isWakeSequenceActive becomes true), the rest of the
@@ -35,8 +46,10 @@ func (m *Manager) SetupComputedState() error {
 		return err
 	}
 
-	// Subscribe to dependency changes
-	_, err := m.Subscribe("isAnyOwnerHome", func(key string, oldValue, newValue interface{}) {
+	// Subscribe to dependency changes. We listen on isAnyoneHome (debounced)
+	// rather than isAnyOwnerHome so the cascade inherits the 5-minute
+	// departure debounce. See doc comment above.
+	_, err := m.Subscribe("isAnyoneHome", func(key string, oldValue, newValue interface{}) {
 		if err := m.recomputeAnyoneHomeAndAwake(); err != nil {
 			m.logger.Error("Failed to recompute isAnyoneHomeAndAwake",
 				zap.String("trigger", key),
@@ -129,17 +142,20 @@ func (m *Manager) SetupComputedState() error {
 }
 
 // recomputeAnyoneHomeAndAwake computes isAnyoneHomeAndAwake from its dependencies.
-// Formula: isAnyoneHomeAndAwake = (isAnyOwnerHome && !isAnyoneAsleep) || isAssistantHere || wakeSequenceLatch
+// Formula: isAnyoneHomeAndAwake = (isAnyoneHome && !isAnyoneAsleep) || isAssistantHere || wakeSequenceLatch
 //
-// This formula correctly handles the case where Assistant arrives while owners are asleep.
-// Since Assistant doesn't have a sleep state tracked, their presence means someone is
-// home AND awake by definition.
+// Deriving from isAnyoneHome (debounced) means a transient GPS/WiFi presence dip
+// or a real owner departure won't immediately drop this flag — downstream
+// consumers (lighting off-sweep, sleep detection, etc.) wait out the 5-minute
+// debounce together rather than racing each other. The explicit isAssistantHere
+// term keeps the "assistant present while owner asleep" case correct, since
+// (isAnyoneHome && !isAnyoneAsleep) is false in that case.
 //
 // The wakeSequenceLatch ensures that when Nick's alarm triggers, the rest of the
 // house wakes up (lights on) even though Caroline may still be asleep in the bedroom.
 // See SetupComputedState for details on latch activation and clearing.
 func (m *Manager) recomputeAnyoneHomeAndAwake() error {
-	isAnyOwnerHome, err := m.GetBool("isAnyOwnerHome")
+	isAnyoneHome, err := m.GetBool("isAnyoneHome")
 	if err != nil {
 		return err
 	}
@@ -159,13 +175,13 @@ func (m *Manager) recomputeAnyoneHomeAndAwake() error {
 	wakeSequenceLatch := m.wakeSequenceLatch
 	m.cacheMu.RUnlock()
 
-	newValue := (isAnyOwnerHome && !isAnyoneAsleep) || isAssistantHere || wakeSequenceLatch
+	newValue := (isAnyoneHome && !isAnyoneAsleep) || isAssistantHere || wakeSequenceLatch
 
 	// Get current value to check if it changed
 	currentValue, _ := m.GetBool("isAnyoneHomeAndAwake")
 	if currentValue != newValue {
 		m.logger.Debug("Recomputing isAnyoneHomeAndAwake",
-			zap.Bool("isAnyOwnerHome", isAnyOwnerHome),
+			zap.Bool("isAnyoneHome", isAnyoneHome),
 			zap.Bool("isAnyoneAsleep", isAnyoneAsleep),
 			zap.Bool("isAssistantHere", isAssistantHere),
 			zap.Bool("wakeSequenceLatch", wakeSequenceLatch),

--- a/homeautomation-go/internal/state/computed_providers.go
+++ b/homeautomation-go/internal/state/computed_providers.go
@@ -158,19 +158,23 @@ func RegisterSleepProviders(registry *ComputedStateRegistry, callbacks *Computed
 
 // RegisterAnyoneHomeAndAwakeProvider registers the isAnyoneHomeAndAwake computed state.
 // Level 2 computed state:
-//   - isAnyoneHomeAndAwake = (isAnyOwnerHome AND NOT isAnyoneAsleep) OR isAssistantHere OR wakeSequenceLatch
+//   - isAnyoneHomeAndAwake = (isAnyoneHome AND NOT isAnyoneAsleep) OR isAssistantHere OR wakeSequenceLatch
 //
 // This is a more complex computed state that includes:
-//   - Dependency on Level 1 computed states (isAnyOwnerHome, isAnyoneAsleep)
+//   - Dependency on the debounced isAnyoneHome rather than the raw isAnyOwnerHome,
+//     so downstream consumers (lighting off-sweep, sleep detection, etc.) inherit
+//     the 5-minute departure debounce that absorbs GPS/WiFi presence bounce.
+//     See computed.go SetupComputedState doc comment and PR #1119 (2026-05-17
+//     incident) for context.
 //   - Special wake sequence latch behavior for morning wake-up
 //
 // The wake sequence latch is handled via a LatchProvider that tracks the latch state.
 func RegisterAnyoneHomeAndAwakeProvider(registry *ComputedStateRegistry, latch *WakeSequenceLatch, callbacks *ComputedStateCallback) error {
 	if err := registry.Register(&ComputedStateProvider{
 		Name:         "isAnyoneHomeAndAwake",
-		Dependencies: []string{"isAnyOwnerHome", "isAnyoneAsleep", "isAssistantHere"},
+		Dependencies: []string{"isAnyoneHome", "isAnyoneAsleep", "isAssistantHere"},
 		ComputeFunc: func(ctx *ComputeContext) (interface{}, error) {
-			isAnyOwnerHome, err := ctx.GetBool("isAnyOwnerHome")
+			isAnyoneHome, err := ctx.GetBool("isAnyoneHome")
 			if err != nil {
 				return nil, err
 			}
@@ -186,10 +190,10 @@ func RegisterAnyoneHomeAndAwakeProvider(registry *ComputedStateRegistry, latch *
 			// Get latch state
 			latchActive := latch.IsActive()
 
-			result := (isAnyOwnerHome && !isAnyoneAsleep) || isAssistantHere || latchActive
+			result := (isAnyoneHome && !isAnyoneAsleep) || isAssistantHere || latchActive
 
 			ctx.Logger().Debug("Computed isAnyoneHomeAndAwake",
-				zap.Bool("isAnyOwnerHome", isAnyOwnerHome),
+				zap.Bool("isAnyoneHome", isAnyoneHome),
 				zap.Bool("isAnyoneAsleep", isAnyoneAsleep),
 				zap.Bool("isAssistantHere", isAssistantHere),
 				zap.Bool("wakeSequenceLatch", latchActive),

--- a/homeautomation-go/internal/state/computed_test.go
+++ b/homeautomation-go/internal/state/computed_test.go
@@ -15,7 +15,7 @@ func TestSetupComputedState(t *testing.T) {
 	t.Parallel()
 	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
-	mockClient.SetState("input_boolean.any_owner_home", "off", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -33,59 +33,61 @@ func TestSetupComputedState(t *testing.T) {
 
 func TestComputedState_IsAnyoneHomeAndAwake_InitialComputation(t *testing.T) {
 	t.Parallel()
-	// Formula: (isAnyOwnerHome && !isAnyoneAsleep) || isAssistantHere
+	// Formula: (isAnyoneHome && !isAnyoneAsleep) || isAssistantHere || wakeSequenceLatch
+	// isAnyoneHome is the debounced presence signal — this is the formula's
+	// home-presence input as of PR #1119.
 	testCases := []struct {
 		name            string
-		isAnyOwnerHome  string
+		isAnyoneHome    string
 		isAnyoneAsleep  string
 		isAssistantHere string
 		expected        bool
 	}{
 		{
-			name:            "owner home and awake -> true",
-			isAnyOwnerHome:  "on",
+			name:            "someone home and awake -> true",
+			isAnyoneHome:    "on",
 			isAnyoneAsleep:  "off",
 			isAssistantHere: "off",
 			expected:        true,
 		},
 		{
-			name:            "owner home and asleep -> false",
-			isAnyOwnerHome:  "on",
+			name:            "someone home and asleep -> false",
+			isAnyoneHome:    "on",
 			isAnyoneAsleep:  "on",
 			isAssistantHere: "off",
 			expected:        false,
 		},
 		{
-			name:            "no owner home and awake -> false",
-			isAnyOwnerHome:  "off",
+			name:            "nobody home and awake -> false",
+			isAnyoneHome:    "off",
 			isAnyoneAsleep:  "off",
 			isAssistantHere: "off",
 			expected:        false,
 		},
 		{
-			name:            "no owner home and asleep -> false",
-			isAnyOwnerHome:  "off",
+			name:            "nobody home and asleep -> false",
+			isAnyoneHome:    "off",
 			isAnyoneAsleep:  "on",
 			isAssistantHere: "off",
 			expected:        false,
 		},
 		{
-			name:            "assistant here alone -> true",
-			isAnyOwnerHome:  "off",
+			name:            "assistant here while isAnyoneHome=false (transitional) -> true",
+			isAnyoneHome:    "off",
 			isAnyoneAsleep:  "off",
 			isAssistantHere: "on",
 			expected:        true,
 		},
 		{
 			name:            "assistant here while owner asleep -> true (BUG FIX)",
-			isAnyOwnerHome:  "on",
+			isAnyoneHome:    "on",
 			isAnyoneAsleep:  "on",
 			isAssistantHere: "on",
 			expected:        true,
 		},
 		{
 			name:            "assistant here while no owner but someone asleep -> true",
-			isAnyOwnerHome:  "off",
+			isAnyoneHome:    "off",
 			isAnyoneAsleep:  "on",
 			isAssistantHere: "on",
 			expected:        true,
@@ -97,7 +99,7 @@ func TestComputedState_IsAnyoneHomeAndAwake_InitialComputation(t *testing.T) {
 			t.Parallel()
 			logger := testlogger.New()
 			mockClient := ha.NewMockClient()
-			mockClient.SetState("input_boolean.any_owner_home", tc.isAnyOwnerHome, map[string]interface{}{})
+			mockClient.SetState("input_boolean.anyone_home", tc.isAnyoneHome, map[string]interface{}{})
 			mockClient.SetState("input_boolean.anyone_asleep", tc.isAnyoneAsleep, map[string]interface{}{})
 			mockClient.SetState("input_boolean.assistant_here", tc.isAssistantHere, map[string]interface{}{})
 			mockClient.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -119,12 +121,12 @@ func TestComputedState_IsAnyoneHomeAndAwake_InitialComputation(t *testing.T) {
 	}
 }
 
-func TestComputedState_IsAnyoneHomeAndAwake_ReactsToIsAnyOwnerHomeChange(t *testing.T) {
+func TestComputedState_IsAnyoneHomeAndAwake_ReactsToIsAnyoneHomeChange(t *testing.T) {
 	t.Parallel()
 	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	// Start with nobody home and nobody asleep
-	mockClient.SetState("input_boolean.any_owner_home", "off", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -143,19 +145,69 @@ func TestComputedState_IsAnyoneHomeAndAwake_ReactsToIsAnyOwnerHomeChange(t *test
 	value, _ := manager.GetBool("isAnyoneHomeAndAwake")
 	assert.False(t, value)
 
-	// Owner comes home (still awake)
-	mockClient.SimulateStateChange("input_boolean.any_owner_home", "on")
+	// Someone comes home (still awake)
+	mockClient.SimulateStateChange("input_boolean.anyone_home", "on")
 
 	// Should now be true
 	value, _ = manager.GetBool("isAnyoneHomeAndAwake")
-	assert.True(t, value, "isAnyoneHomeAndAwake should be true when owner comes home and is awake")
+	assert.True(t, value, "isAnyoneHomeAndAwake should be true when someone comes home and is awake")
 
-	// Owner leaves
-	mockClient.SimulateStateChange("input_boolean.any_owner_home", "off")
+	// Everyone leaves (isAnyoneHome's 5-min debounce has expired in production;
+	// the test fires the simulated change directly).
+	mockClient.SimulateStateChange("input_boolean.anyone_home", "off")
 
 	// Should be false again
 	value, _ = manager.GetBool("isAnyoneHomeAndAwake")
 	assert.False(t, value, "isAnyoneHomeAndAwake should be false when nobody is home")
+}
+
+func TestComputedState_IsAnyoneHomeAndAwake_StaysTrueDuringDepartureDebounce(t *testing.T) {
+	// Regression for PR #1119 (2026-05-17 incident). The lighting plugin's
+	// "everyone left" off-sweep keys off isAnyoneHomeAndAwake. We rely on the
+	// 5-minute departure debounce baked into isAnyoneHome (DerivedStateHelper)
+	// to absorb GPS bounce — when the last owner leaves, isAnyOwnerHome flips
+	// false immediately but isAnyoneHome stays true until the debounce expires.
+	// This test confirms that during that window, isAnyoneHomeAndAwake stays
+	// true, so the lighting plugin does NOT prematurely turn off the bedroom
+	// light (which previously caused sleep detection to misread the departure
+	// as "going to bed").
+	t.Parallel()
+	logger := testlogger.New()
+	mockClient := ha.NewMockClient()
+	// Initial state: owner home (both signals consistent), awake.
+	mockClient.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
+	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home_and_awake", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.wake_sequence_active", "off", map[string]interface{}{})
+	mockClient.SetState("input_boolean.master_asleep", "off", map[string]interface{}{})
+	mockClient.Connect()
+
+	manager := NewManager(mockClient, logger, false)
+	require.NoError(t, manager.SyncFromHA())
+	require.NoError(t, manager.SetupComputedState())
+
+	// Sanity: starts true.
+	value, _ := manager.GetBool("isAnyoneHomeAndAwake")
+	assert.True(t, value, "precondition: should start true")
+
+	// Cascade order from the 2026-05-17 logs: the raw isAnyOwnerHome flag flips
+	// false immediately when the last owner leaves, while isAnyoneHome holds
+	// true because its 5-minute departure debounce is still running.
+	mockClient.SimulateStateChange("input_boolean.any_owner_home", "off")
+
+	// isAnyoneHomeAndAwake must still be true — otherwise the lighting plugin
+	// would fire its whole-house off-sweep mid-debounce. The formula must NOT
+	// react to isAnyOwnerHome directly.
+	value, _ = manager.GetBool("isAnyoneHomeAndAwake")
+	assert.True(t, value, "isAnyoneHomeAndAwake must stay true while isAnyoneHome is still in its departure debounce window")
+
+	// Once the debounce expires and isAnyoneHome flips false, the cascade
+	// drops correctly.
+	mockClient.SimulateStateChange("input_boolean.anyone_home", "off")
+	value, _ = manager.GetBool("isAnyoneHomeAndAwake")
+	assert.False(t, value, "isAnyoneHomeAndAwake should be false once isAnyoneHome debounce expires")
 }
 
 func TestComputedState_IsAnyoneHomeAndAwake_ReactsToIsAnyoneAsleepChange(t *testing.T) {
@@ -163,7 +215,7 @@ func TestComputedState_IsAnyoneHomeAndAwake_ReactsToIsAnyoneAsleepChange(t *test
 	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	// Start with owner home and awake
-	mockClient.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -201,7 +253,7 @@ func TestComputedState_IsAnyoneHomeAndAwake_SyncsToHA(t *testing.T) {
 	t.Parallel()
 	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
-	mockClient.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -242,7 +294,7 @@ func TestComputedState_IsAnyoneHomeAndAwake_WorksInReadOnlyMode(t *testing.T) {
 	t.Parallel()
 	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
-	mockClient.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -283,7 +335,7 @@ func TestComputedState_IsAnyoneHomeAndAwake_SubscriberNotification(t *testing.T)
 	t.Parallel()
 	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
-	mockClient.SetState("input_boolean.any_owner_home", "off", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -307,7 +359,7 @@ func TestComputedState_IsAnyoneHomeAndAwake_SubscriberNotification(t *testing.T)
 	defer sub.Unsubscribe()
 
 	// Trigger a change that should update isAnyoneHomeAndAwake
-	mockClient.SimulateStateChange("input_boolean.any_owner_home", "on")
+	mockClient.SimulateStateChange("input_boolean.anyone_home", "on")
 
 	// The computed value should have changed, triggering our subscriber
 	// Note: The subscription gets notified via the HA callback when SetBool syncs to HA
@@ -326,7 +378,7 @@ func TestComputedState_IsAnyoneHomeAndAwake_AssistantArrivesWhileOwnerAsleep(t *
 	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	// Owner is home and asleep
-	mockClient.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -368,7 +420,7 @@ func TestComputedState_IsAnyoneHomeAndAwake_LatchesOnWakeSequence(t *testing.T) 
 	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	// Owner is home and asleep, wake sequence not active
-	mockClient.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -409,7 +461,7 @@ func TestComputedState_IsAnyoneHomeAndAwake_LatchClearsOnWakeUp(t *testing.T) {
 	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	// Owner is home and asleep, wake sequence not active
-	mockClient.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -439,7 +491,7 @@ func TestComputedState_IsAnyoneHomeAndAwake_LatchClearsOnWakeUp(t *testing.T) {
 	assert.True(t, value, "isAnyoneHomeAndAwake should be TRUE (normal formula: owner home and awake)")
 
 	// Now verify the latch is cleared by having owner leave
-	mockClient.SimulateStateChange("input_boolean.any_owner_home", "off")
+	mockClient.SimulateStateChange("input_boolean.anyone_home", "off")
 
 	// Should be false (no owner home, latch cleared)
 	value, _ = manager.GetBool("isAnyoneHomeAndAwake")
@@ -453,7 +505,7 @@ func TestComputedState_IsAnyoneHomeAndAwake_LatchOnlyOnRisingEdge(t *testing.T) 
 	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 	// Owner is home and asleep, wake sequence ALREADY active
-	mockClient.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -490,7 +542,7 @@ func TestComputedState_IsAnyoneHomeAndAwake_GuestAsleepKeepsLatchActive(t *testi
 	t.Parallel()
 	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
-	mockClient.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -532,7 +584,7 @@ func TestComputedState_IsAnyoneHomeAndAwake_GuestAsleepKeepsLatchActive(t *testi
 	assert.True(t, value, "isAnyoneHomeAndAwake should be TRUE via normal formula (owner awake)")
 
 	// Verify latch is cleared by having owner leave
-	mockClient.SimulateStateChange("input_boolean.any_owner_home", "off")
+	mockClient.SimulateStateChange("input_boolean.anyone_home", "off")
 	value, _ = manager.GetBool("isAnyoneHomeAndAwake")
 	assert.False(t, value, "isAnyoneHomeAndAwake should be FALSE after owner leaves (latch was cleared)")
 }
@@ -561,7 +613,7 @@ func TestScenario_NickWakesUpCarolineSleepsIn(t *testing.T) {
 	mockClient := ha.NewMockClient()
 
 	// Initial state: Night time, both Nick and Caroline asleep
-	mockClient.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -619,7 +671,7 @@ func TestScenario_AssistantArrivesDuringWakeSequence(t *testing.T) {
 	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 
-	mockClient.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -681,7 +733,7 @@ func TestScenario_NickLeavesWhileLatchActive(t *testing.T) {
 	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 
-	mockClient.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -733,7 +785,7 @@ func TestScenario_NickLeavesEveryoneGone(t *testing.T) {
 	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 
-	mockClient.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -759,7 +811,7 @@ func TestScenario_NickLeavesEveryoneGone(t *testing.T) {
 	assert.True(t, value, "Step 2a: House awake (latch cleared, but owner home and awake)")
 
 	// Step 3: They leave
-	mockClient.SimulateStateChange("input_boolean.any_owner_home", "off")
+	mockClient.SimulateStateChange("input_boolean.anyone_home", "off")
 	value, _ = manager.GetBool("isAnyoneHomeAndAwake")
 	assert.False(t, value, "Step 3: House dark (nobody home, no latch)")
 }
@@ -772,7 +824,7 @@ func TestScenario_MultipleMornings(t *testing.T) {
 	logger := testlogger.New()
 	mockClient := ha.NewMockClient()
 
-	mockClient.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -837,7 +889,7 @@ func TestScenario_SystemRestartDuringWakeSequence(t *testing.T) {
 	mockClient := ha.NewMockClient()
 
 	// System starts with wake sequence already active (simulating restart)
-	mockClient.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -887,7 +939,7 @@ func TestScenario_Issue526_NoFlickerOnWakeUp(t *testing.T) {
 	mockClient := ha.NewMockClient()
 
 	// Initial state: Owner home and asleep, wake sequence active (latch engaged)
-	mockClient.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	mockClient.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_asleep", "on", map[string]interface{}{})
 	mockClient.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	mockClient.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -923,7 +975,7 @@ func TestScenario_Issue526_NoFlickerOnWakeUp(t *testing.T) {
 	assert.True(t, value, "Step 3: Normal formula takes over (owner home and awake)")
 
 	// Step 4: Verify latch is actually cleared by making owner leave
-	mockClient.SimulateStateChange("input_boolean.any_owner_home", "off")
+	mockClient.SimulateStateChange("input_boolean.anyone_home", "off")
 	value, _ = manager.GetBool("isAnyoneHomeAndAwake")
 	assert.False(t, value, "Step 4: Latch was cleared - house is dark when nobody home")
 }

--- a/homeautomation-go/internal/state/computed_v2_test.go
+++ b/homeautomation-go/internal/state/computed_v2_test.go
@@ -350,7 +350,7 @@ func TestSetupComputedStateV2_DependencyGraph(t *testing.T) {
 	assert.Contains(t, graph["isAnyoneAsleep"], "isGuestAsleep")
 	assert.Contains(t, graph["isEveryoneAsleep"], "isMasterAsleep")
 	assert.Contains(t, graph["isEveryoneAsleep"], "isGuestAsleep")
-	assert.Contains(t, graph["isAnyoneHomeAndAwake"], "isAnyOwnerHome")
+	assert.Contains(t, graph["isAnyoneHomeAndAwake"], "isAnyoneHome")
 	assert.Contains(t, graph["isAnyoneHomeAndAwake"], "isAnyoneAsleep")
 	assert.Contains(t, graph["isAnyoneHomeAndAwake"], "isAssistantHere")
 }

--- a/homeautomation-go/test/integration/scenario_computed_state_test.go
+++ b/homeautomation-go/test/integration/scenario_computed_state_test.go
@@ -129,7 +129,7 @@ func TestScenario_ComputedState_IsAnyoneHomeAndAwake_InitialComputation(t *testi
 			server.InitializeStates()
 
 			// Set the initial states before connecting
-			server.SetState("input_boolean.any_owner_home", tc.isAnyOwnerHome, map[string]interface{}{})
+			server.SetState("input_boolean.anyone_home", tc.isAnyOwnerHome, map[string]interface{}{})
 			server.SetState("input_boolean.anyone_asleep", tc.isAnyoneAsleep, map[string]interface{}{})
 			server.SetState("input_boolean.assistant_here", tc.isAssistantHere, map[string]interface{}{})
 			server.SetState("input_boolean.anyone_home_and_awake", "off", map[string]interface{}{})
@@ -181,7 +181,7 @@ func TestScenario_ComputedState_ReactsToIsAnyOwnerHomeChange(t *testing.T) {
 
 	// GIVEN: No owner home and nobody is asleep
 	t.Log("GIVEN: No owner home and nobody is asleep")
-	server.SetState("input_boolean.any_owner_home", "off", map[string]interface{}{})
+	server.SetState("input_boolean.anyone_home", "off", map[string]interface{}{})
 	server.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
 	server.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 
@@ -190,7 +190,7 @@ func TestScenario_ComputedState_ReactsToIsAnyOwnerHomeChange(t *testing.T) {
 
 	// WHEN: Owner comes home (still awake)
 	t.Log("WHEN: Owner comes home")
-	server.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	server.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 
 	// THEN: isAnyoneHomeAndAwake should become true
 	t.Log("THEN: isAnyoneHomeAndAwake should become true")
@@ -198,7 +198,7 @@ func TestScenario_ComputedState_ReactsToIsAnyOwnerHomeChange(t *testing.T) {
 
 	// WHEN: Owner leaves
 	t.Log("WHEN: Owner leaves")
-	server.SetState("input_boolean.any_owner_home", "off", map[string]interface{}{})
+	server.SetState("input_boolean.anyone_home", "off", map[string]interface{}{})
 
 	// THEN: isAnyoneHomeAndAwake should become false
 	t.Log("THEN: isAnyoneHomeAndAwake should become false")
@@ -214,7 +214,7 @@ func TestScenario_ComputedState_ReactsToIsAnyoneAsleepChange(t *testing.T) {
 
 	// GIVEN: Owner is home and awake
 	t.Log("GIVEN: Owner is home and awake")
-	server.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	server.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	server.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
 	server.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 
@@ -247,7 +247,7 @@ func TestScenario_ComputedState_SyncsToHomeAssistant(t *testing.T) {
 
 	// GIVEN: No owner is home initially
 	t.Log("GIVEN: No owner is home initially")
-	server.SetState("input_boolean.any_owner_home", "off", map[string]interface{}{})
+	server.SetState("input_boolean.anyone_home", "off", map[string]interface{}{})
 	server.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
 	server.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	// Allow async handlers to process before clearing
@@ -258,7 +258,7 @@ func TestScenario_ComputedState_SyncsToHomeAssistant(t *testing.T) {
 
 	// WHEN: Owner comes home (triggering computed state change)
 	t.Log("WHEN: Owner comes home")
-	server.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	server.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 
 	// Wait for sync to HA
 	waitForServiceCallSince(t, server, snapshot, "input_boolean", "turn_on", "computed state should sync to HA")
@@ -296,7 +296,7 @@ func TestScenario_ComputedState_RapidChanges(t *testing.T) {
 
 	// GIVEN: Initial state - owner home and awake
 	t.Log("GIVEN: Initial state - owner home and awake")
-	server.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	server.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	server.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
 	server.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 	// Allow computed state to settle
@@ -336,7 +336,7 @@ func TestScenario_ComputedState_BothDependenciesChange(t *testing.T) {
 
 	// GIVEN: No owner home, nobody asleep
 	t.Log("GIVEN: No owner home, nobody asleep")
-	server.SetState("input_boolean.any_owner_home", "off", map[string]interface{}{})
+	server.SetState("input_boolean.anyone_home", "off", map[string]interface{}{})
 	server.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
 	server.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 
@@ -344,7 +344,7 @@ func TestScenario_ComputedState_BothDependenciesChange(t *testing.T) {
 
 	// WHEN: Both dependencies change almost simultaneously
 	t.Log("WHEN: Owner comes home AND someone falls asleep almost simultaneously")
-	server.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	server.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	// Ensure first change is processed before sending second
 	waitForProcessing(t, manager)
 	server.SetState("input_boolean.anyone_asleep", "on", map[string]interface{}{})
@@ -358,7 +358,7 @@ func TestScenario_ComputedState_BothDependenciesChange(t *testing.T) {
 	server.SetState("input_boolean.anyone_asleep", "off", map[string]interface{}{})
 	// Ensure first change is processed before sending second
 	waitForProcessing(t, manager)
-	server.SetState("input_boolean.any_owner_home", "off", map[string]interface{}{})
+	server.SetState("input_boolean.anyone_home", "off", map[string]interface{}{})
 
 	// THEN: Final state should be false (no owner home)
 	t.Log("THEN: Should be false (no owner home)")
@@ -374,7 +374,7 @@ func TestScenario_ComputedState_AssistantArrivesWhileOwnerAsleep(t *testing.T) {
 
 	// GIVEN: Owner is home and asleep
 	t.Log("GIVEN: Owner is home and asleep")
-	server.SetState("input_boolean.any_owner_home", "on", map[string]interface{}{})
+	server.SetState("input_boolean.anyone_home", "on", map[string]interface{}{})
 	server.SetState("input_boolean.anyone_asleep", "on", map[string]interface{}{})
 	server.SetState("input_boolean.assistant_here", "off", map[string]interface{}{})
 


### PR DESCRIPTION
## Problem

On 2026-05-17 at 11:16 CDT, the house entered sleep mode while Nick and Caroline were leaving — not going to bed. They came home that evening to a house still in sleep state (lockdown active, sleep music playing) until the bedroom door opened and `detectMasterAwake` finally tripped.

### Sequence of events (from Gravwell)

```
16:14:39 UTC  isNickHome              true → false
16:15:17 UTC  isAnyoneHomeAndAwake    true → false   (cascaded from isAnyOwnerHome dropping)
16:15:19 UTC  lighting "Turning off room" room=Primary Suite trigger=isAnyoneHomeAndAwake
16:15:20 UTC  light.primary_suite     on → off       (HA confirms; the system's own action)
16:15:20 UTC  statetracking "1-minute sleep detection timer started"
16:15:20 UTC  isAnyOwnerHome          true → false
16:16:20 UTC  statetracking "Marking master as asleep (lights off for 1 minute)"
              ← isAnyoneHome STILL true (5-minute departure debounce running)
16:20:17 UTC  isAnyoneHome            true → false   (debounce finally expires)
```

### Root cause

The system carried **two presence signals with different timing**:

- `isAnyOwnerHome` (= `isNickHome || isCarolineHome`): un-debounced, flipped false immediately when the last owner left.
- `isAnyoneHome` (= `isAnyOwnerHome || isAssistantHere`): debounced 5 minutes on departure to absorb GPS/WiFi presence bounce.

`isAnyoneHomeAndAwake` derived from the *un-debounced* `isAnyOwnerHome`, so the lighting plugin's whole-house off-sweep fired ~2 seconds after the last owner left. Meanwhile `detectMasterAsleep` guarded on the *debounced* `isAnyoneHome`, which was still `true` for 5 minutes after the actual departure. The two consumers were operating on different views of the same event, and the gap between them was the bug.

## Fix

Source `isAnyoneHomeAndAwake` from `isAnyoneHome` instead of `isAnyOwnerHome`:

```
- isAnyoneHomeAndAwake = (isAnyOwnerHome && !isAnyoneAsleep) || isAssistantHere || wakeSequenceLatch
+ isAnyoneHomeAndAwake = (isAnyoneHome   && !isAnyoneAsleep) || isAssistantHere || wakeSequenceLatch
```

The debounce now propagates to every downstream consumer (lighting off-sweep, sleep detection, security lockdown). GPS bounce is treated as a system-wide noise problem instead of a per-consumer one. The `isAssistantHere` clause is kept so "assistant present while owner asleep" still computes true.

Applied in both formula sites:
- `internal/state/computed.go` — `recomputeAnyoneHomeAndAwake()` (legacy V1) and its subscription wiring.
- `internal/state/computed_providers.go` — `RegisterAnyoneHomeAndAwakeProvider` (V2 registry).

### Tradeoff

The lighting plugin's whole-house off-sweep on real departures now waits out the 5-minute debounce — same window already used for `isAnyoneHome`-driven security logic. Acceptable because the alternative is turning the house off on GPS flickers (the very thing the debounce was designed to absorb).

### What didn't change

- `detectMasterAsleep` keeps its existing `isAnyoneHome` guard. With the upstream fix, that guard is now correct — by the time `isAnyoneHome` flips false, the lighting plugin will already have honored the debounce, so the bedroom light won't have been turned off prematurely.
- `isAnyOwnerHome` remains as a computed state for other internal uses.

## Test coverage

Added regression test `TestComputedState_IsAnyoneHomeAndAwake_StaysTrueDuringDepartureDebounce` exercising the exact 2026-05-17 cascade ordering:

1. Start: owner home and awake → `isAnyoneHomeAndAwake=true`.
2. Simulate `isAnyOwnerHome → false` (raw signal, mid-debounce on `isAnyoneHome`).
3. Assert `isAnyoneHomeAndAwake` **stays true** — the lighting plugin must not fire.
4. Simulate `isAnyoneHome → false` (debounce expires).
5. Assert `isAnyoneHomeAndAwake → false` — only now does the cascade drop.

This case fails against the old formula and passes against the new one.

Existing truth-table and reaction tests updated to reflect the new dependency (`isAnyoneHome` rather than `isAnyOwnerHome`), with field/test renames matching.

## Test plan

- [x] `go test -race ./internal/state/...` — green
- [x] `make unit-tests` — full suite green, coverage 74.6%
- [x] `make integration-tests` — green (includes scenario tests updated to new dependency)
- [x] `make pre-push` — green
- [x] Auto-generated `docs/generated/{plugin-dependencies,state-variable-matrix}.md` regenerated via `make generate-diagrams`
- [ ] Post-deploy: confirm bedroom light no longer turns off during owner departures within the 5-min window. Query Gravwell to verify the cascade pattern that previously fired the false positive no longer triggers:
  ```bash
  curl -s -X POST \
    -H "Gravwell-Token: $(tr -d '\n' < ./gravwell.token)" \
    -H 'query: tag=home-automation grep "Marking master as asleep"' \
    -H 'duration: 7d' -H 'format: text' \
    'https://gravwell.featherback-mermaid.ts.net/api/search/direct'
  ```

## History

A first attempt at this PR fixed the bug surgically at `statetracking/detectMasterAsleep` by switching its guard from `isAnyoneHome` to `isAnyOwnerHome`. That worked but left the deeper architectural inconsistency in place — two presence signals with different debounce timing feeding adjacent logic. Per review feedback, this revision moves the fix upstream so all consumers agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
