### PR TITLE
Fix #1120: clear skip reactivation tracking

### DIFF
--- a/homeautomation-go/internal/plugins/lighting/manager.go
+++ b/homeautomation-go/internal/plugins/lighting/manager.go
@@ -392,6 +392,9 @@ func (m *Manager) evaluateAndActivateRoom(room *RoomConfig, dayPhase string, tri
 		m.logger.Info("Skipping room - external control active",
 			zap.String("room", room.HueGroup),
 			zap.String("matched_condition", matchedVar))
+		if room.SkipReactivationWhenOn {
+			m.setLastRoomAction(room.HueGroup, "")
+		}
 	default:
 		m.logger.Debug("No action needed for room",
 			zap.String("room", room.HueGroup))

--- a/homeautomation-go/internal/plugins/lighting/manager_test.go
+++ b/homeautomation-go/internal/plugins/lighting/manager_test.go
@@ -346,6 +346,46 @@ func TestEvaluateAndActivateRoom(t *testing.T) {
 	}
 }
 
+func TestEvaluateAndActivateRoomSkipClearsLastRoomActionForSkipReactivationRoom(t *testing.T) {
+	t.Parallel()
+	env := testutil.NewEnv(t)
+	config := &HueConfig{
+		Rooms: []RoomConfig{
+			{
+				HueGroup:   "Kitchen",
+				HASSAreaID: "kitchen",
+				Conditions: []LightingCondition{
+					{Action: "skip", Variable: "isTVPlaying", Value: true},
+					{Action: "on", Variable: "isKitchenOccupied", Value: true},
+				},
+				SkipReactivationWhenOn: true,
+			},
+		},
+	}
+	manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, false, nil)
+	room := &config.Rooms[0]
+
+	assert.NoError(t, env.StateMgr.SetBool("isTVPlaying", true))
+	assert.NoError(t, env.StateMgr.SetBool("isKitchenOccupied", true))
+	manager.setLastRoomAction(room.HueGroup, "on")
+
+	snapshot := env.MockHA.ServiceCallCount()
+	manager.evaluateAndActivateRoom(room, "Day", "isTVPlaying")
+	assert.Equal(t, 0, len(env.MockHA.GetServiceCallsSince(snapshot)), "skip should not call Home Assistant")
+
+	assert.NoError(t, env.StateMgr.SetBool("isTVPlaying", false))
+	snapshot = env.MockHA.ServiceCallCount()
+	manager.evaluateAndActivateRoom(room, "Day", "isKitchenOccupied")
+
+	calls := env.MockHA.GetServiceCallsSince(snapshot)
+	if !assert.Len(t, calls, 1) {
+		return
+	}
+	assert.Equal(t, "scene", calls[0].Domain)
+	assert.Equal(t, "turn_on", calls[0].Service)
+	assert.Equal(t, "scene.kitchen_day", calls[0].Data["entity_id"])
+}
+
 func TestStart(t *testing.T) {
 	t.Parallel()
 	env := testutil.NewEnv(t)


### PR DESCRIPTION
Resolves #1120

## Summary
- Clear lastRoomAction when a skip action runs for rooms with skip_reactivation_when_on enabled
- Add a regression test proving a skip action does not suppress the next real on evaluation

## Test Plan
- make unit-tests
- make pre-commit

🤖 Generated by the AI assistant