### PR TITLE
Fix #1124: reconcile music startup playback

### DIFF
--- a/docs/flows/MUSIC_PLAYBACK.md
+++ b/docs/flows/MUSIC_PLAYBACK.md
@@ -114,6 +114,8 @@ flowchart TD
 
 When a music mode is selected, the following sequence executes. The key optimization is **async speaker grouping**: the lead speaker starts playing immediately while follower speakers join the group in the background.
 
+On service startup, the plugin reconciles before orchestrating. If the lead speaker is already playing any URI from the selected mode's playlist pool and the current Sonos group contains only desired zone speakers, the plugin adopts that playback into shadow state and skips the fade-out/regroup/play/fade-in sequence. Missing desired followers are tolerated and reflected as inactive in shadow; foreign group members or an unknown URI fall back to normal orchestration.
+
 ```mermaid
 sequenceDiagram
     participant SM as State Manager

--- a/homeautomation-go/internal/plugins/music/manager_test.go
+++ b/homeautomation-go/internal/plugins/music/manager_test.go
@@ -164,6 +164,117 @@ func TestMusicManager_ZoneResolutionSelectsCorrectMode(t *testing.T) {
 	}
 }
 
+func TestMusicManager_StartupReconciliationAdoptsExistingPlayback(t *testing.T) {
+	t.Parallel()
+	env := testutil.NewEnv(t)
+
+	config := &MusicConfig{
+		Music: map[string]MusicMode{
+			"day": {
+				Participants: []Participant{
+					{PlayerName: "Kitchen", BaseVolume: 9},
+					{PlayerName: "Bedroom", BaseVolume: 7},
+				},
+				PlaybackOptions: []PlaybackOption{
+					{URI: "https://tidal.com/browse/playlist/day-next", MediaType: "music", VolumeMultiplier: 1.0},
+					{URI: "https://tidal.com/browse/playlist/day-current", MediaType: "music", VolumeMultiplier: 1.0},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, env.StateMgr.SetBool("isAnyoneHome", true))
+	require.NoError(t, env.StateMgr.SetBool("isAnyoneAsleep", false))
+	require.NoError(t, env.StateMgr.SetBool("isWakeSequenceActive", false))
+	require.NoError(t, env.StateMgr.SetString("dayPhase", "day"))
+	require.NoError(t, env.StateMgr.SetString("musicPlaybackType", ""))
+
+	env.MockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{
+		"media_content_id":   "https://tidal.com/browse/playlist/day-current",
+		"media_content_type": "music",
+		"group_members": []interface{}{
+			"media_player.kitchen",
+		},
+		"volume_level": 0.11,
+	})
+	env.MockHA.SetState("media_player.bedroom", "idle", map[string]interface{}{
+		"volume_level": 0.03,
+	})
+
+	manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, false, nil, nil)
+	require.NoError(t, manager.Start())
+	defer manager.Stop()
+
+	calls := env.MockHA.GetServiceCalls()
+	for _, call := range calls {
+		assert.False(t, call.Domain == "media_player",
+			"startup reconciliation should not re-orchestrate media_player services; got %s.%s",
+			call.Domain, call.Service)
+	}
+
+	shadow := manager.GetShadowState()
+	assert.Equal(t, "adopt_playback", shadow.Outputs.LastActionType)
+	assert.Equal(t, "day", shadow.Outputs.CurrentMode)
+	assert.Equal(t, "https://tidal.com/browse/playlist/day-current", shadow.Outputs.ActivePlaylist.URI)
+	require.Len(t, shadow.Outputs.SpeakerGroup, 2)
+	assert.Equal(t, "Kitchen", shadow.Outputs.SpeakerGroup[0].PlayerName)
+	assert.True(t, shadow.Outputs.SpeakerGroup[0].Active)
+	assert.Equal(t, 11, shadow.Outputs.SpeakerGroup[0].Volume)
+	assert.Equal(t, "Bedroom", shadow.Outputs.SpeakerGroup[1].PlayerName)
+	assert.False(t, shadow.Outputs.SpeakerGroup[1].Active, "missing desired follower is tolerated but reflected in shadow")
+}
+
+func TestMusicManager_StartupReconciliationReorchestratesWrongGroup(t *testing.T) {
+	t.Parallel()
+	env := testutil.NewEnv(t)
+
+	config := &MusicConfig{
+		Music: map[string]MusicMode{
+			"day": {
+				Participants: []Participant{
+					{PlayerName: "Kitchen", BaseVolume: 9},
+					{PlayerName: "Bedroom", BaseVolume: 7},
+				},
+				PlaybackOptions: []PlaybackOption{
+					{URI: "https://tidal.com/browse/playlist/day-current", MediaType: "music", VolumeMultiplier: 1.0},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, env.StateMgr.SetBool("isAnyoneHome", true))
+	require.NoError(t, env.StateMgr.SetBool("isAnyoneAsleep", false))
+	require.NoError(t, env.StateMgr.SetBool("isWakeSequenceActive", false))
+	require.NoError(t, env.StateMgr.SetString("dayPhase", "day"))
+	require.NoError(t, env.StateMgr.SetString("musicPlaybackType", ""))
+
+	env.MockHA.SetState("media_player.kitchen", "playing", map[string]interface{}{
+		"media_content_id": "https://tidal.com/browse/playlist/day-current",
+		"group_members": []interface{}{
+			"media_player.kitchen",
+			"media_player.soundbar",
+		},
+		"volume_level": 0.11,
+	})
+	env.MockHA.SetState("media_player.bedroom", "idle", map[string]interface{}{
+		"volume_level": 0.03,
+	})
+
+	manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, false, nil, nil)
+	manager.SetSleepFunc(func(d time.Duration) {})
+	require.NoError(t, manager.Start())
+	defer manager.Stop()
+
+	require.Eventually(t, func() bool {
+		for _, call := range env.MockHA.GetServiceCalls() {
+			if call.Domain == "media_player" && call.Service == "play_media" {
+				return true
+			}
+		}
+		return false
+	}, time.Second, 10*time.Millisecond, "wrong startup group should fall back to orchestration")
+}
+
 func TestEnsureZones_DayPhaseMapping(t *testing.T) {
 	t.Parallel()
 

--- a/homeautomation-go/internal/plugins/music/startup_reconciliation.go
+++ b/homeautomation-go/internal/plugins/music/startup_reconciliation.go
@@ -1,0 +1,217 @@
+package music
+
+import (
+	"fmt"
+	"math"
+
+	"homeautomation/internal/ha"
+	"homeautomation/internal/shadowstate"
+
+	"go.uber.org/zap"
+)
+
+func (m *Manager) adoptStartupZonePlayback(zone *Zone, selected PlaybackOption, trigger string) bool {
+	if trigger != "startup" || m.readOnly {
+		return false
+	}
+
+	leadEntityID := m.getSpeakerEntityID(zone.LeadSpeaker)
+	leadState, err := m.haClient.GetState(leadEntityID)
+	if err != nil {
+		m.logger.Debug("Startup reconciliation skipped: failed to read lead speaker state",
+			zap.String("speaker", zone.LeadSpeaker),
+			zap.Error(err))
+		return false
+	}
+	if leadState.State != "playing" {
+		m.logger.Debug("Startup reconciliation skipped: lead speaker is not playing",
+			zap.String("speaker", zone.LeadSpeaker),
+			zap.String("state", leadState.State))
+		return false
+	}
+
+	currentURI, ok := stringAttribute(leadState, "media_content_id")
+	if !ok || currentURI == "" {
+		m.logger.Debug("Startup reconciliation skipped: lead speaker has no current media URI",
+			zap.String("speaker", zone.LeadSpeaker))
+		return false
+	}
+
+	playbackOption, ok := m.playbackOptionForURI(zone.MusicType, currentURI)
+	if !ok {
+		m.logger.Info("Startup reconciliation mismatch: current URI is not in mode playlist pool",
+			zap.String("mode", zone.MusicType),
+			zap.String("current_uri", currentURI),
+			zap.String("selected_uri", selected.URI))
+		return false
+	}
+
+	actualGroup := m.actualGroupMembers(leadState, leadEntityID)
+	if !m.groupRoughlyMatches(zone, actualGroup) {
+		m.logger.Info("Startup reconciliation mismatch: speaker group does not match zone",
+			zap.String("zone", zone.Name),
+			zap.Strings("actual_group", mapKeys(actualGroup)))
+		return false
+	}
+
+	participants := m.participantsWithCurrentVolumes(zone.Participants)
+	m.mu.Lock()
+	m.currentlyPlaying = &CurrentlyPlayingMusic{
+		Type:         zone.MusicType,
+		URI:          currentURI,
+		MediaType:    playbackOption.MediaType,
+		LeadPlayer:   zone.LeadSpeaker,
+		Participants: participants,
+	}
+	m.mu.Unlock()
+
+	if m.zoneManager != nil {
+		m.zoneManager.mu.Lock()
+		zone.PlaylistURI = currentURI
+		zone.MediaType = playbackOption.MediaType
+		zone.Participants = participants
+		m.zoneManager.mu.Unlock()
+	} else {
+		zone.PlaylistURI = currentURI
+		zone.MediaType = playbackOption.MediaType
+		zone.Participants = participants
+	}
+
+	m.recordAdoptedStartupShadowState(zone.MusicType, playbackOption, participants, zone.LeadSpeaker, actualGroup, trigger)
+	m.logger.Info("Adopted existing startup playback",
+		zap.String("zone", zone.Name),
+		zap.String("lead_speaker", zone.LeadSpeaker),
+		zap.String("uri", currentURI))
+	return true
+}
+
+func (m *Manager) playbackOptionForURI(musicType, uri string) (PlaybackOption, bool) {
+	mode, ok := m.config.Music[musicType]
+	if !ok {
+		return PlaybackOption{}, false
+	}
+	for _, option := range mode.PlaybackOptions {
+		if option.URI == uri {
+			return option, true
+		}
+	}
+	return PlaybackOption{}, false
+}
+
+func (m *Manager) actualGroupMembers(state *ha.State, leadEntityID string) map[string]bool {
+	group := make(map[string]bool)
+	if members, ok := stringSliceAttribute(state, "group_members"); ok {
+		for _, member := range members {
+			if member != "" {
+				group[member] = true
+			}
+		}
+	}
+	group[leadEntityID] = true
+	return group
+}
+
+func (m *Manager) groupRoughlyMatches(zone *Zone, actualGroup map[string]bool) bool {
+	desired := make(map[string]bool, len(zone.Participants))
+	for _, p := range zone.Participants {
+		desired[m.getSpeakerEntityID(p.PlayerName)] = true
+	}
+	for entityID := range actualGroup {
+		if !desired[entityID] {
+			return false
+		}
+	}
+	return actualGroup[m.getSpeakerEntityID(zone.LeadSpeaker)]
+}
+
+func (m *Manager) participantsWithCurrentVolumes(participants []ParticipantWithVolume) []ParticipantWithVolume {
+	result := make([]ParticipantWithVolume, 0, len(participants))
+	for _, p := range participants {
+		current := p
+		if state, err := m.haClient.GetState(m.getSpeakerEntityID(p.PlayerName)); err == nil {
+			if volumeLevel, ok := floatAttribute(state, "volume_level"); ok {
+				current.Volume = int(math.Round(volumeLevel * 100))
+			}
+		}
+		result = append(result, current)
+	}
+	return result
+}
+
+func (m *Manager) recordAdoptedStartupShadowState(musicType string, playbackOption PlaybackOption, participants []ParticipantWithVolume, leadPlayer string, actualGroup map[string]bool, trigger string) {
+	speakers := make([]shadowstate.SpeakerState, 0, len(participants))
+	for _, p := range participants {
+		speakers = append(speakers, shadowstate.SpeakerState{
+			PlayerName:    p.PlayerName,
+			Volume:        p.Volume,
+			BaseVolume:    p.BaseVolume,
+			DefaultVolume: p.DefaultVolume,
+			IsLeader:      p.PlayerName == leadPlayer,
+			Active:        actualGroup[m.getSpeakerEntityID(p.PlayerName)],
+		})
+	}
+
+	playlistInfo := &shadowstate.PlaylistInfo{
+		URI:       playbackOption.URI,
+		Name:      "",
+		MediaType: playbackOption.MediaType,
+	}
+	reason := fmt.Sprintf("Adopted existing playback of '%s' in mode '%s'", playbackOption.URI, musicType)
+	m.updateShadowState("adopt_playback", reason, trigger)
+	m.updateShadowOutputs(musicType, playlistInfo, speakers, nil)
+}
+
+func stringAttribute(state *ha.State, key string) (string, bool) {
+	value, ok := state.Attributes[key]
+	if !ok {
+		return "", false
+	}
+	str, ok := value.(string)
+	return str, ok
+}
+
+func floatAttribute(state *ha.State, key string) (float64, bool) {
+	value, ok := state.Attributes[key]
+	if !ok {
+		return 0, false
+	}
+	switch v := value.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	default:
+		return 0, false
+	}
+}
+
+func stringSliceAttribute(state *ha.State, key string) ([]string, bool) {
+	value, ok := state.Attributes[key]
+	if !ok {
+		return nil, false
+	}
+	switch v := value.(type) {
+	case []string:
+		return v, true
+	case []interface{}:
+		result := make([]string, 0, len(v))
+		for _, item := range v {
+			if str, ok := item.(string); ok {
+				result = append(result, str)
+			}
+		}
+		return result, true
+	default:
+		return nil, false
+	}
+}
+
+func mapKeys(values map[string]bool) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
+}

--- a/homeautomation-go/internal/plugins/music/startup_reconciliation.go
+++ b/homeautomation-go/internal/plugins/music/startup_reconciliation.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (m *Manager) adoptStartupZonePlayback(zone *Zone, selected PlaybackOption, trigger string) bool {
-	if trigger != "startup" || m.readOnly {
+	if trigger != "startup" {
 		return false
 	}
 
@@ -65,23 +65,20 @@ func (m *Manager) adoptStartupZonePlayback(zone *Zone, selected PlaybackOption, 
 	}
 	m.mu.Unlock()
 
-	if m.zoneManager != nil {
-		m.zoneManager.mu.Lock()
-		zone.PlaylistURI = currentURI
-		zone.MediaType = playbackOption.MediaType
-		zone.Participants = participants
-		m.zoneManager.mu.Unlock()
-	} else {
-		zone.PlaylistURI = currentURI
-		zone.MediaType = playbackOption.MediaType
-		zone.Participants = participants
-	}
+	m.zoneManager.mu.Lock()
+	zone.PlaylistURI = currentURI
+	zone.MediaType = playbackOption.MediaType
+	zone.Participants = participants
+	m.zoneManager.mu.Unlock()
 
 	m.recordAdoptedStartupShadowState(zone.MusicType, playbackOption, participants, zone.LeadSpeaker, actualGroup, trigger)
 	m.logger.Info("Adopted existing startup playback",
 		zap.String("zone", zone.Name),
 		zap.String("lead_speaker", zone.LeadSpeaker),
 		zap.String("uri", currentURI))
+	if !m.readOnly {
+		m.startPlaybackMonitor(leadEntityID, zone.LeadSpeaker, zone.MusicType)
+	}
 	return true
 }
 
@@ -121,7 +118,7 @@ func (m *Manager) groupRoughlyMatches(zone *Zone, actualGroup map[string]bool) b
 			return false
 		}
 	}
-	return actualGroup[m.getSpeakerEntityID(zone.LeadSpeaker)]
+	return true
 }
 
 func (m *Manager) participantsWithCurrentVolumes(participants []ParticipantWithVolume) []ParticipantWithVolume {

--- a/homeautomation-go/internal/plugins/music/zone_manager.go
+++ b/homeautomation-go/internal/plugins/music/zone_manager.go
@@ -1322,6 +1322,10 @@ func (zm *ZoneManager) startZone(zoneName string, speakers []string, trigger str
 	}
 
 	// Delegate actual playback to manager
+	if zm.manager.adoptStartupZonePlayback(zone, playbackOption, trigger) {
+		return nil
+	}
+
 	go func() {
 		if err := zm.manager.orchestrateZonePlayback(zone, playbackOption, trigger); err != nil {
 			zm.logger.Error("Failed to orchestrate zone playback",


### PR DESCRIPTION
Resolves #1124

## Summary
- Add startup reconciliation for music zones so already-correct Sonos playback is adopted instead of re-orchestrated.
- Match the lead speaker URI against the full mode playlist pool, tolerate missing desired followers, and reject foreign group members.
- Record adopted playlist, group, and current volumes in music shadow state.

## Test Plan
- go test ./internal/plugins/music -run 'TestMusicManager_StartupReconciliation' -count=1
- make pre-commit
- make unit-tests
- make validate-mermaid (fails broadly on existing diagrams with empty validator errors)

🤖 Generated by the AI assistant