### PR TITLE
feat(energy): drop black level, widen yellow to arbitrage band

### DIFF
--- a/configs/energy_config.yaml
+++ b/configs/energy_config.yaml
@@ -24,17 +24,8 @@ energy:
         calibration_brightness_pct: 5  # Dim to 5% during measurement
         calibration_wait_sec: 65       # Wait 65 seconds for fresh lux reading (sensors update every ~60s)
   energy_states:
-    - condition_name: black
-      battery_minimum_percentage: 0
-      energy_production_minimum_kw: 0
-      remaining_energy_production_minimum_kwh: 0
-      light_config:
-        red: 25
-        green: 25
-        blue: 112
-        brightness_pct: 70
     - condition_name: red
-      battery_minimum_percentage: 19
+      battery_minimum_percentage: 0
       energy_production_minimum_kw: 0
       remaining_energy_production_minimum_kwh: 0
       light_config:
@@ -43,8 +34,8 @@ energy:
         blue: 0
         brightness_pct: 30
     - condition_name: yellow
-      battery_minimum_percentage: 20
-      energy_production_minimum_kw: 0
+      battery_minimum_percentage: 15
+      energy_production_minimum_kw: 0.1
       remaining_energy_production_minimum_kwh: 0
       light_config:
         red: 255
@@ -52,16 +43,16 @@ energy:
         blue: 0
         brightness_pct: 30
     - condition_name: green
-      battery_minimum_percentage: 40
-      energy_production_minimum_kw: 0
-      remaining_energy_production_minimum_kwh: 10
+      battery_minimum_percentage: 60
+      energy_production_minimum_kw: 1
+      remaining_energy_production_minimum_kwh: 5
       light_config:
         red: 0
         green: 255
         blue: 0
         brightness_pct: 60
     - condition_name: white
-      battery_minimum_percentage: 70
+      battery_minimum_percentage: 80
       energy_production_minimum_kw: 4
       remaining_energy_production_minimum_kwh: 20
       light_config:

--- a/docs/flows/ENERGY_MANAGEMENT.md
+++ b/docs/flows/ENERGY_MANAGEMENT.md
@@ -47,11 +47,10 @@ Energy states are ordered from lowest to highest availability:
 
 | State | Color | Battery Min | Solar Min | Meaning |
 |-------|-------|-------------|-----------|---------|
-| `black` | Black | 0% | 0 kW | Critical - minimal energy |
-| `red` | Red | 10% | 0.5 kW | Low - conserve power |
-| `yellow` | Yellow | 30% | 1.0 kW | Moderate - normal usage |
-| `green` | Green | 60% | 2.0 kW | Good - energy available |
-| `white` | White | 95% | 4.0 kW / 20 kWh remaining | Abundant solar / stored energy |
+| `red` | Red | 0% | 0 kW | Critical - load shed (HVAC band + non-HVAC off) |
+| `yellow` | Yellow | 15% | 0.1 kW | Hysteresis band covering normal arbitrage operation |
+| `green` | Green | 60% | 1.0 kW / 5 kWh remaining | Good - energy available |
+| `white` | White | 80% | 4.0 kW / 20 kWh remaining | Abundant solar / stored energy |
 
 ### Overall Level Algorithm
 
@@ -88,9 +87,9 @@ flowchart TD
 - Solar > Battery → Output = Battery + 1 (boost by one level, capped at solar)
 
 Examples:
-- Battery: green (60%), Solar: black (0 kW) → Result: green (battery not penalized)
-- Battery: yellow (30%), Solar: green (2+ kW) → Result: green (boosted by 1)
-- Battery: red (10%), Solar: green (2+ kW) → Result: yellow (boosted by 1, not green)
+- Battery: green (60%), Solar: red (0 kW) → Result: green (battery not penalized)
+- Battery: yellow (15-59%), Solar: green (1+ kW, 5+ kWh) → Result: green (boosted by 1)
+- Battery: red (<15%), Solar: green (1+ kW, 5+ kWh) → Result: yellow (boosted by 1, not green)
 
 ## Free Energy Detection
 
@@ -212,7 +211,7 @@ See [LOAD_SHEDDING.md](./LOAD_SHEDDING.md) for thermostat control and thermal ba
 
 | Variable | Type | Description |
 |----------|------|-------------|
-| `batteryEnergyLevel` | string | Battery-based level (black/red/yellow/green) |
+| `batteryEnergyLevel` | string | Battery-based level (red/yellow/green/white) |
 | `solarProductionEnergyLevel` | string | Solar-based level |
 | `isFreeEnergyAvailable` | bool | Legacy metered-grid flag, retired (always false) |
 | `currentEnergyLevel` | string | Overall combined level |

--- a/docs/flows/LIGHTING_CONTROL.md
+++ b/docs/flows/LIGHTING_CONTROL.md
@@ -71,7 +71,7 @@ flowchart TD
 
     subgraph Context["Context Modifiers"]
         sunEvent{"sunevent<br/>recent?"}
-        energy{"currentEnergyLevel<br/>is red/black?"}
+        energy{"currentEnergyLevel<br/>is red?"}
     end
 
     subgraph Scenes["Lighting Scenes"]

--- a/docs/flows/LOAD_SHEDDING.md
+++ b/docs/flows/LOAD_SHEDDING.md
@@ -5,7 +5,7 @@ This document describes the load shedding automation flow, which manages HVAC th
 ## Overview
 
 The load shedding plugin controls thermostats, EV charger, and dehumidifier based on energy levels to:
-1. Restrict HVAC, disable EV charger, and disable dehumidifier when battery is low (red/black)
+1. Restrict HVAC, disable EV charger, and disable dehumidifier when battery is low (red, <15%)
 2. Return to normal schedules and re-enable EV charger and dehumidifier when energy is available (green/white)
 3. **Thermal battery**: Pre-condition the house by shifting HVAC setpoints when energy is abundant (white)
 4. Shed non-HVAC loads (EV charger, dehumidifier) at yellow while maintaining HVAC hysteresis
@@ -26,10 +26,10 @@ flowchart TD
     end
 
     currentLevel --> checkLevel
-    checkLevel -->|red, black| enableLS
+    checkLevel -->|red| enableLS
     checkLevel -->|green| greenAction["Disable load shedding<br/>+ Thermal battery: enter hysteresis if active"]
     checkLevel -->|white| thermalBattery["Disable load shedding<br/>+ Activate thermal battery"]
-    checkLevel -->|yellow| shedPartial["Shed non-HVAC loads<br/>Deactivate thermal battery<br/>HVAC maintains current state"]
+    checkLevel -->|yellow| maintain["Maintain current load-shed state<br/>(hysteresis carry)<br/>Deactivate thermal battery"]
 
     style enableLS fill:#e74c3c,color:#fff
     style greenAction fill:#27ae60,color:#fff
@@ -248,7 +248,7 @@ Original setpoints are saved and restored on deactivation.
 ### Deactivation Triggers
 
 Thermal battery **hard-deactivates** — or, if deferred, the pending activation is cancelled — when:
-- Energy level drops to **yellow, red, or black**
+- Energy level drops to **yellow or red**
 - Nobody is home (`isAnyoneHome` → false)
 - Everyone falls asleep (`isEveryoneAsleep` → true)
 
@@ -259,19 +259,19 @@ When energy dips white→green while the thermal battery is active, the plugin e
 - `heat`/`cool` thermostats: setpoint reverts to saved value to stop the equipment
 - Thermostat holds **remain enabled**
 - If energy returns to white during the window, preheat resumes (saved setpoints and step counter are still valid)
-- If energy drops to yellow/red/black, hard deactivation runs immediately (hysteresis timer cancelled, setpoints reverted)
+- If energy drops to yellow/red, hard deactivation runs immediately (hysteresis timer cancelled, setpoints reverted)
 - If the window expires without recovery, holds are released and the climate schedule resumes (no explicit setpoint revert — the schedule is more correct than a stale saved value)
 
 Any in-progress stepping goroutine and any deferred-activation recheck timer are cancelled on deactivation.
 
-## Yellow State — Partial Load Shedding
+## Yellow State — Hysteresis Carry
 
-The yellow (moderate) energy state applies partial load shedding: non-HVAC loads are shed, but HVAC maintains its current state (hysteresis) to prevent rapid toggling of thermostats.
+The yellow (15-59%) energy state is the wide hysteresis band that covers normal nightly arbitrage operation. It does **not** trigger any new load-shed action — it just carries whatever load-shed state was last established by red (engage) or green (release).
 
 **Yellow actions:**
-- Shed non-HVAC loads (EV charger, dehumidifier)
 - Deactivate thermal battery (energy is declining, stop pre-conditioning)
-- HVAC unchanged (hysteresis buffer prevents rapid toggling)
+- No change to load-shed state (red's holds stay engaged; green's restored state stays)
+- No change to non-HVAC loads
 
 ```mermaid
 sequenceDiagram
@@ -281,19 +281,19 @@ sequenceDiagram
     participant HVAC as Thermostats
     participant NonHVAC as EV Charger / Dehumidifier
 
-    Note over Battery: Battery drops to 25%
+    Note over Battery: Battery drops to 10%
 
-    Battery->>EM: Battery = 25% (red)
+    Battery->>EM: Battery = 10% (red)
     EM->>LS: currentEnergyLevel = red
     LS->>HVAC: Enable hold mode<br/>Set 65-80°F range
     LS->>NonHVAC: Turn off
 
-    Note over Battery: Battery recovers to 35%
+    Note over Battery: Battery recovers to 25%
 
-    Battery->>EM: Battery = 35% (yellow)
+    Battery->>EM: Battery = 25% (yellow)
     EM->>LS: currentEnergyLevel = yellow
-    LS->>LS: HVAC maintains current state<br/>(hysteresis)
-    LS->>NonHVAC: Remain off<br/>(already shed)
+    LS->>LS: Load-shed state unchanged<br/>(hysteresis carry)
+    LS->>NonHVAC: Remain off<br/>(red's action persists)
 
     Note over Battery: Battery recovers to 65%
 
@@ -303,7 +303,7 @@ sequenceDiagram
     LS->>NonHVAC: Turn on<br/>(restore loads)
 ```
 
-HVAC hysteresis prevents rapid toggling at threshold boundaries (e.g., 29%↔31% repeatedly enabling/disabling). Non-HVAC loads are simpler to toggle and don't have the same wear concerns, so they are shed at yellow to conserve energy.
+The wide yellow band (15-59%) absorbs normal arbitrage cycling without engaging load shed. HVAC and non-HVAC loads are only shed when battery actually crosses the 15% floor into red.
 
 ## Controlled Entities
 

--- a/docs/human/VISUAL_ARCHITECTURE.md
+++ b/docs/human/VISUAL_ARCHITECTURE.md
@@ -844,29 +844,25 @@ flowchart TD
 
     UpdateShadow1 --> CheckLevels{Compare Battery %<br/>to Thresholds}
 
-    CheckLevels -->|< critical_threshold| SetCritical[batteryEnergyLevel = 'critical']
-    CheckLevels -->|< low_threshold| SetLow[batteryEnergyLevel = 'low']
-    CheckLevels -->|< medium_threshold| SetMedium[batteryEnergyLevel = 'medium']
-    CheckLevels -->|< high_threshold| SetHigh[batteryEnergyLevel = 'high']
-    CheckLevels -->|>= high_threshold| SetFull[batteryEnergyLevel = 'full']
+    CheckLevels -->|< 15%| SetRed[batteryEnergyLevel = 'red']
+    CheckLevels -->|< 60%| SetYellow[batteryEnergyLevel = 'yellow']
+    CheckLevels -->|< 80%| SetGreen[batteryEnergyLevel = 'green']
+    CheckLevels -->|>= 80%| SetWhite[batteryEnergyLevel = 'white']
 
-    SetCritical --> UpdateBattery1[Update Shadow State:<br/>Battery Level]
-    SetLow --> UpdateBattery2[Update Shadow State:<br/>Battery Level]
-    SetMedium --> UpdateBattery3[Update Shadow State:<br/>Battery Level]
-    SetHigh --> UpdateBattery4[Update Shadow State:<br/>Battery Level]
-    SetFull --> UpdateBattery5[Update Shadow State:<br/>Battery Level]
+    SetRed --> UpdateBattery1[Update Shadow State:<br/>Battery Level]
+    SetYellow --> UpdateBattery2[Update Shadow State:<br/>Battery Level]
+    SetGreen --> UpdateBattery3[Update Shadow State:<br/>Battery Level]
+    SetWhite --> UpdateBattery4[Update Shadow State:<br/>Battery Level]
 
     UpdateBattery1 --> SyncToHA1[Sync to HA:<br/>input_text.battery_energy_level]
     UpdateBattery2 --> SyncToHA2[Sync to HA:<br/>input_text.battery_energy_level]
     UpdateBattery3 --> SyncToHA3[Sync to HA:<br/>input_text.battery_energy_level]
     UpdateBattery4 --> SyncToHA4[Sync to HA:<br/>input_text.battery_energy_level]
-    UpdateBattery5 --> SyncToHA5[Sync to HA:<br/>input_text.battery_energy_level]
 
     SyncToHA1 --> CalculateCurrent
     SyncToHA2 --> CalculateCurrent
     SyncToHA3 --> CalculateCurrent
     SyncToHA4 --> CalculateCurrent
-    SyncToHA5 --> CalculateCurrent
 
     CalculateCurrent[Calculate currentEnergyLevel] --> CompareSolar{Solar level > battery level?}
 

--- a/homeautomation-go/internal/plugins/energy/config_test.go
+++ b/homeautomation-go/internal/plugins/energy/config_test.go
@@ -35,21 +35,21 @@ energy:
         green: 255
         blue: 0
         brightness_pct: 80
-    - condition_name: red
-      battery_minimum_percentage: 30.0
-      energy_production_minimum_kw: 0.5
-      remaining_energy_production_minimum_kwh: 2.0
+    - condition_name: yellow
+      battery_minimum_percentage: 15.0
+      energy_production_minimum_kw: 0.1
+      remaining_energy_production_minimum_kwh: 0.0
       light_config:
         red: 255
-        green: 0
+        green: 255
         blue: 0
         brightness_pct: 60
-    - condition_name: black
+    - condition_name: red
       battery_minimum_percentage: 0.0
       energy_production_minimum_kw: 0.0
       remaining_energy_production_minimum_kwh: 0.0
       light_config:
-        red: 0
+        red: 255
         green: 0
         blue: 0
         brightness_pct: 40
@@ -111,28 +111,28 @@ energy:
 		t.Errorf("Expected Red 0, got %d", green.LightConfig.Red)
 	}
 
-	// Check red state
-	red := config.Energy.EnergyStates[2]
+	// Check yellow state
+	yellow := config.Energy.EnergyStates[2]
+	if yellow.ConditionName != "yellow" {
+		t.Errorf("Expected ConditionName 'yellow', got '%s'", yellow.ConditionName)
+	}
+	if yellow.BatteryMinimumPercentage != 15.0 {
+		t.Errorf("Expected BatteryMinimumPercentage 15.0, got %f", yellow.BatteryMinimumPercentage)
+	}
+	if yellow.LightConfig.Red != 255 || yellow.LightConfig.Green != 255 {
+		t.Errorf("Expected yellow RGB (255,255,*), got (%d,%d,%d)", yellow.LightConfig.Red, yellow.LightConfig.Green, yellow.LightConfig.Blue)
+	}
+
+	// Check red state (lowest)
+	red := config.Energy.EnergyStates[3]
 	if red.ConditionName != "red" {
 		t.Errorf("Expected ConditionName 'red', got '%s'", red.ConditionName)
 	}
-	if red.LightConfig.Red != 255 {
-		t.Errorf("Expected Red 255, got %d", red.LightConfig.Red)
+	if red.BatteryMinimumPercentage != 0.0 {
+		t.Errorf("Expected BatteryMinimumPercentage 0.0, got %f", red.BatteryMinimumPercentage)
 	}
-	if red.LightConfig.Green != 0 {
-		t.Errorf("Expected Green 0, got %d", red.LightConfig.Green)
-	}
-
-	// Check black state
-	black := config.Energy.EnergyStates[3]
-	if black.ConditionName != "black" {
-		t.Errorf("Expected ConditionName 'black', got '%s'", black.ConditionName)
-	}
-	if black.BatteryMinimumPercentage != 0.0 {
-		t.Errorf("Expected BatteryMinimumPercentage 0.0, got %f", black.BatteryMinimumPercentage)
-	}
-	if black.LightConfig.BrightnessPct != 40 {
-		t.Errorf("Expected BrightnessPct 40, got %d", black.LightConfig.BrightnessPct)
+	if red.LightConfig.BrightnessPct != 40 {
+		t.Errorf("Expected BrightnessPct 40, got %d", red.LightConfig.BrightnessPct)
 	}
 }
 

--- a/homeautomation-go/internal/plugins/energy/manager.go
+++ b/homeautomation-go/internal/plugins/energy/manager.go
@@ -622,9 +622,9 @@ func (m *Manager) Reset() error {
 	// and update indicator lights to match
 	currentLevel, err := m.stateManager.GetString("currentEnergyLevel")
 	if err != nil {
-		m.logger.Warn("Failed to get currentEnergyLevel during reset, using black",
+		m.logger.Warn("Failed to get currentEnergyLevel during reset, using red",
 			zap.Error(err))
-		currentLevel = "black"
+		currentLevel = "red"
 	}
 
 	m.updateIndicatorLights(currentLevel)
@@ -804,7 +804,7 @@ func (m *Manager) restoreLightAfterCalibration(lightEntity string) {
 	// Get current energy level for color
 	currentLevel, err := m.stateManager.GetString("currentEnergyLevel")
 	if err != nil {
-		currentLevel = "black"
+		currentLevel = "red"
 	}
 
 	m.logger.Debug("Restoring brightness after calibration",
@@ -827,7 +827,7 @@ func (m *Manager) setLightBrightness(entity string, brightness int) {
 	// Get current energy level for color
 	currentLevel, err := m.stateManager.GetString("currentEnergyLevel")
 	if err != nil {
-		currentLevel = "black"
+		currentLevel = "red"
 	}
 
 	lightConfig := m.getLightConfigForLevel(currentLevel)

--- a/homeautomation-go/internal/plugins/energy/manager_test.go
+++ b/homeautomation-go/internal/plugins/energy/manager_test.go
@@ -25,32 +25,26 @@ func createTestConfig() *EnergyConfig {
 			},
 			EnergyStates: []EnergyState{
 				{
-					ConditionName:                       "black",
+					ConditionName:                       "red",
 					BatteryMinimumPercentage:            0,
 					EnergyProductionMinimumKW:           0,
 					RemainingEnergyProductionMinimumKWH: 0,
 				},
 				{
-					ConditionName:                       "red",
-					BatteryMinimumPercentage:            40,
-					EnergyProductionMinimumKW:           0,
-					RemainingEnergyProductionMinimumKWH: 0,
-				},
-				{
 					ConditionName:                       "yellow",
-					BatteryMinimumPercentage:            60,
-					EnergyProductionMinimumKW:           0,
+					BatteryMinimumPercentage:            15,
+					EnergyProductionMinimumKW:           0.1,
 					RemainingEnergyProductionMinimumKWH: 0,
 				},
 				{
 					ConditionName:                       "green",
-					BatteryMinimumPercentage:            80,
-					EnergyProductionMinimumKW:           0,
-					RemainingEnergyProductionMinimumKWH: 10,
+					BatteryMinimumPercentage:            60,
+					EnergyProductionMinimumKW:           1,
+					RemainingEnergyProductionMinimumKWH: 5,
 				},
 				{
 					ConditionName:                       "white",
-					BatteryMinimumPercentage:            95,
+					BatteryMinimumPercentage:            80,
 					EnergyProductionMinimumKW:           4,
 					RemainingEnergyProductionMinimumKWH: 20,
 				},
@@ -71,15 +65,14 @@ func TestDetermineBatteryEnergyLevel(t *testing.T) {
 		percentage float64
 		expected   string
 	}{
-		{"Below all thresholds", 0, "black"},
-		{"Just below red", 39, "black"},
-		{"At red threshold", 40, "red"},
-		{"Between red and yellow", 50, "red"},
-		{"At yellow threshold", 60, "yellow"},
-		{"Between yellow and green", 75, "yellow"},
-		{"At green threshold", 80, "green"},
-		{"Between green and white", 90, "green"},
-		{"At white threshold", 95, "white"},
+		{"At red floor", 0, "red"},
+		{"Just below yellow", 14, "red"},
+		{"At yellow threshold", 15, "yellow"},
+		{"Between yellow and green", 30, "yellow"},
+		{"Just below green", 59, "yellow"},
+		{"At green threshold", 60, "green"},
+		{"Between green and white", 70, "green"},
+		{"At white threshold", 80, "white"},
 		{"Above white", 100, "white"},
 	}
 
@@ -111,10 +104,10 @@ func TestLoadConfigFromRepoFile(t *testing.T) {
 	assert.NotNil(t, config)
 
 	// Verify config structure
-	assert.Equal(t, 5, len(config.Energy.EnergyStates))
+	assert.Equal(t, 4, len(config.Energy.EnergyStates))
 
 	// Verify energy states are in order
-	expectedLevels := []string{"black", "red", "yellow", "green", "white"}
+	expectedLevels := []string{"red", "yellow", "green", "white"}
 	for i, state := range config.Energy.EnergyStates {
 		assert.Equal(t, expectedLevels[i], state.ConditionName)
 	}
@@ -132,8 +125,8 @@ func TestManagerStartAndHandlers(t *testing.T) {
 
 	// Set initial state
 	env.StateMgr.SetBool("isGridAvailable", true)
-	env.StateMgr.SetString("batteryEnergyLevel", "black")
-	env.StateMgr.SetString("solarProductionEnergyLevel", "black")
+	env.StateMgr.SetString("batteryEnergyLevel", "red")
+	env.StateMgr.SetString("solarProductionEnergyLevel", "red")
 	env.StateMgr.SetNumber("thisHourSolarGeneration", 0.0)
 	env.StateMgr.SetNumber("remainingSolarGeneration", 0.0)
 
@@ -151,7 +144,7 @@ func TestManagerStartAndHandlers(t *testing.T) {
 
 		manager.handleBatteryChange(50.0)
 		level, _ := env.StateMgr.GetString("batteryEnergyLevel")
-		assert.Equal(t, "red", level)
+		assert.Equal(t, "yellow", level)
 	})
 
 	t.Run("handleBatteryChange_with_invalid_value", func(t *testing.T) {
@@ -159,9 +152,9 @@ func TestManagerStartAndHandlers(t *testing.T) {
 		// Test with Inf - should be ignored
 
 		manager.handleBatteryChange(math.Inf(1))
-		// Level should remain red from previous test
+		// Level should remain yellow from previous test
 		level, _ := env.StateMgr.GetString("batteryEnergyLevel")
-		assert.Equal(t, "red", level)
+		assert.Equal(t, "yellow", level)
 	})
 
 	t.Run("handleThisHourSolarChange", func(t *testing.T) {
@@ -198,13 +191,13 @@ func TestManagerStartAndHandlers(t *testing.T) {
 
 	t.Run("handleSolarLevelChange", func(t *testing.T) {
 
-		manager.handleSolarLevelChange("solarProductionEnergyLevel", "black", "green")
+		manager.handleSolarLevelChange("solarProductionEnergyLevel", "red", "green")
 		// Just verify it doesn't panic - shadow state update is tested
 	})
 
 	t.Run("handleCurrentEnergyLevelChange", func(t *testing.T) {
 
-		manager.handleCurrentEnergyLevelChange("currentEnergyLevel", "black", "green")
+		manager.handleCurrentEnergyLevelChange("currentEnergyLevel", "red", "green")
 		// Just verify it doesn't panic - shadow state and indicator light updates are tested
 	})
 }
@@ -281,7 +274,7 @@ func TestTimezoneHandling(t *testing.T) {
 				EnergyStates    []EnergyState         `yaml:"energy_states"`
 			}{
 				EnergyStates: []EnergyState{
-					{ConditionName: "black"},
+					{ConditionName: "red"},
 				},
 			},
 		}
@@ -505,11 +498,10 @@ func TestIndicatorLightsServiceCall(t *testing.T) {
 	// Create config with light configs for each energy level
 	config := createTestConfig()
 	// The createTestConfig doesn't have LightConfig, so let's update the EnergyStates
-	config.Energy.EnergyStates[0].LightConfig = LightConfig{Red: 25, Green: 25, Blue: 112, BrightnessPct: 70}    // black
-	config.Energy.EnergyStates[1].LightConfig = LightConfig{Red: 255, Green: 0, Blue: 0, BrightnessPct: 30}      // red
-	config.Energy.EnergyStates[2].LightConfig = LightConfig{Red: 255, Green: 255, Blue: 0, BrightnessPct: 30}    // yellow
-	config.Energy.EnergyStates[3].LightConfig = LightConfig{Red: 0, Green: 255, Blue: 0, BrightnessPct: 60}      // green
-	config.Energy.EnergyStates[4].LightConfig = LightConfig{Red: 255, Green: 255, Blue: 255, BrightnessPct: 100} // white
+	config.Energy.EnergyStates[0].LightConfig = LightConfig{Red: 255, Green: 0, Blue: 0, BrightnessPct: 30}      // red
+	config.Energy.EnergyStates[1].LightConfig = LightConfig{Red: 255, Green: 255, Blue: 0, BrightnessPct: 30}    // yellow
+	config.Energy.EnergyStates[2].LightConfig = LightConfig{Red: 0, Green: 255, Blue: 0, BrightnessPct: 60}      // green
+	config.Energy.EnergyStates[3].LightConfig = LightConfig{Red: 255, Green: 255, Blue: 255, BrightnessPct: 100} // white
 
 	// Set up mock light entities with "Radar" in friendly_name
 	env.MockHA.SetState("light.apollo_bedroom_rgb", "on", map[string]interface{}{
@@ -586,7 +578,7 @@ func TestIndicatorLightsReadOnlyMode(t *testing.T) {
 	snapshot := env.MockHA.ServiceCallCount()
 
 	// Trigger updateIndicatorLights directly
-	manager.updateIndicatorLights("black")
+	manager.updateIndicatorLights("red")
 
 	// Verify NO light.turn_on service was called in read-only mode
 	calls := env.MockHA.GetServiceCallsSince(snapshot)
@@ -595,7 +587,7 @@ func TestIndicatorLightsReadOnlyMode(t *testing.T) {
 	// But shadow state should still be updated
 	shadowState := manager.GetShadowState()
 	assert.NotNil(t, shadowState.Outputs.IndicatorLightsAction)
-	assert.Equal(t, "black", shadowState.Outputs.IndicatorLightsAction.EnergyLevel)
+	assert.Equal(t, "red", shadowState.Outputs.IndicatorLightsAction.EnergyLevel)
 }
 
 func TestIndicatorLightsDiscoveryCaseInsensitive(t *testing.T) {
@@ -701,13 +693,13 @@ func TestIndicatorLightsServiceCallError(t *testing.T) {
 	// Instead, we verify that:
 	// 1. The function doesn't panic
 	// 2. The shadow state was still updated before the service call
-	manager.updateIndicatorLights("black")
+	manager.updateIndicatorLights("red")
 
 	// Shadow state should still be updated even though service call failed
 	// (shadow state is updated BEFORE the service call is made)
 	shadowState := manager.GetShadowState()
 	assert.NotNil(t, shadowState.Outputs.IndicatorLightsAction)
-	assert.Equal(t, "black", shadowState.Outputs.IndicatorLightsAction.EnergyLevel)
+	assert.Equal(t, "red", shadowState.Outputs.IndicatorLightsAction.EnergyLevel)
 	assert.Equal(t, []int{25, 25, 112}, shadowState.Outputs.IndicatorLightsAction.RGBColor)
 	assert.Equal(t, 70, shadowState.Outputs.IndicatorLightsAction.BrightnessPct)
 }
@@ -750,11 +742,10 @@ func TestIndicatorLightsInitialUpdateOnStartup(t *testing.T) {
 	config := createTestConfig()
 
 	// Add LightConfig for all energy levels
-	config.Energy.EnergyStates[0].LightConfig = LightConfig{Red: 25, Green: 25, Blue: 112, BrightnessPct: 70}    // black
-	config.Energy.EnergyStates[1].LightConfig = LightConfig{Red: 255, Green: 0, Blue: 0, BrightnessPct: 30}      // red
-	config.Energy.EnergyStates[2].LightConfig = LightConfig{Red: 255, Green: 255, Blue: 0, BrightnessPct: 30}    // yellow
-	config.Energy.EnergyStates[3].LightConfig = LightConfig{Red: 0, Green: 255, Blue: 0, BrightnessPct: 60}      // green
-	config.Energy.EnergyStates[4].LightConfig = LightConfig{Red: 255, Green: 255, Blue: 255, BrightnessPct: 100} // white
+	config.Energy.EnergyStates[0].LightConfig = LightConfig{Red: 255, Green: 0, Blue: 0, BrightnessPct: 30}      // red
+	config.Energy.EnergyStates[1].LightConfig = LightConfig{Red: 255, Green: 255, Blue: 0, BrightnessPct: 30}    // yellow
+	config.Energy.EnergyStates[2].LightConfig = LightConfig{Red: 0, Green: 255, Blue: 0, BrightnessPct: 60}      // green
+	config.Energy.EnergyStates[3].LightConfig = LightConfig{Red: 255, Green: 255, Blue: 255, BrightnessPct: 100} // white
 
 	// Set up mock light entity
 	env.MockHA.SetState("light.apollo_bedroom_rgb", "on", map[string]interface{}{
@@ -1030,7 +1021,8 @@ func TestAdaptiveBrightnessDisabled(t *testing.T) {
 	config.Energy.IndicatorLights.AdaptiveBrightness = AdaptiveBrightnessConfig{
 		Enabled: false, // Disabled
 	}
-	config.Energy.EnergyStates[2].LightConfig = LightConfig{Red: 255, Green: 255, Blue: 0, BrightnessPct: 30}
+	// index 1 = yellow in the 4-level scheme
+	config.Energy.EnergyStates[1].LightConfig = LightConfig{Red: 255, Green: 255, Blue: 0, BrightnessPct: 30}
 
 	env.MockHA.SetState("light.apollo_msr_2_1294c8_rgb_light", "on", map[string]interface{}{
 		"friendly_name": "Bedroom Radar RGB Light",
@@ -1083,7 +1075,8 @@ func TestAdaptiveBrightnessPerDevice(t *testing.T) {
 			{LuxMax: 1000, BrightnessPct: 80},
 		},
 	}
-	config.Energy.EnergyStates[2].LightConfig = LightConfig{Red: 255, Green: 255, Blue: 0, BrightnessPct: 30}
+	// index 1 = yellow in the 4-level scheme
+	config.Energy.EnergyStates[1].LightConfig = LightConfig{Red: 255, Green: 255, Blue: 0, BrightnessPct: 30}
 
 	// Two lights with different lux values
 	env.MockHA.SetState("light.apollo_msr_2_1294c8_rgb_light", "on", map[string]interface{}{
@@ -1203,7 +1196,7 @@ func TestDebouncing(t *testing.T) {
 	env.MockHA.Connect()
 
 	// Initialize state variables
-	env.StateMgr.SetString("currentEnergyLevel", "black")
+	env.StateMgr.SetString("currentEnergyLevel", "red")
 
 	manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, false, nil, nil)
 	err := manager.Start()
@@ -1252,7 +1245,7 @@ func TestFallbackToStaticBrightness(t *testing.T) {
 		Enabled:          true,
 		LuxSensorPattern: "ltr390_light",
 	}
-	config.Energy.EnergyStates[2].LightConfig = LightConfig{Red: 255, Green: 255, Blue: 0, BrightnessPct: 45} // yellow
+	config.Energy.EnergyStates[1].LightConfig = LightConfig{Red: 255, Green: 255, Blue: 0, BrightnessPct: 45} // yellow
 
 	// Light entity WITHOUT matching lux sensor
 	env.MockHA.SetState("light.apollo_msr_2_1294c8_rgb_light", "on", map[string]interface{}{
@@ -1537,7 +1530,8 @@ func TestUpdateIndicatorLightsSkipsCalibrating(t *testing.T) {
 			Enabled: false, // Disabled to prevent race with calibration goroutine
 		},
 	}
-	config.Energy.EnergyStates[2].LightConfig = LightConfig{Red: 255, Green: 255, Blue: 0, BrightnessPct: 30}
+	// index 1 = yellow in the 4-level scheme
+	config.Energy.EnergyStates[1].LightConfig = LightConfig{Red: 255, Green: 255, Blue: 0, BrightnessPct: 30}
 
 	// Set up mock light and sensor
 	env.MockHA.SetState("light.apollo_msr_2_1294c8_rgb_light", "on", map[string]interface{}{
@@ -1588,7 +1582,8 @@ func TestUpdateIndicatorLightsUsesBaseline(t *testing.T) {
 			Enabled: true,
 		},
 	}
-	config.Energy.EnergyStates[2].LightConfig = LightConfig{Red: 255, Green: 255, Blue: 0, BrightnessPct: 30}
+	// index 1 = yellow in the 4-level scheme
+	config.Energy.EnergyStates[1].LightConfig = LightConfig{Red: 255, Green: 255, Blue: 0, BrightnessPct: 30}
 
 	// Set up mock light and sensor
 	env.MockHA.SetState("light.apollo_msr_2_1294c8_rgb_light", "on", map[string]interface{}{
@@ -1655,7 +1650,7 @@ func TestRestoreLightAfterCalibration(t *testing.T) {
 	env.MockHA.Connect()
 
 	// Set energy level
-	env.StateMgr.SetString("currentEnergyLevel", "black")
+	env.StateMgr.SetString("currentEnergyLevel", "red")
 
 	manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, false, nil, nil)
 	err := manager.Start()
@@ -1773,7 +1768,7 @@ func TestCalibrationWithNoLuxReadingYet(t *testing.T) {
 	env.MockHA.SetState("sensor.apollo_msr_2_1294c8_ltr390_light", "50", map[string]interface{}{})
 	env.MockHA.Connect()
 
-	env.StateMgr.SetString("currentEnergyLevel", "black")
+	env.StateMgr.SetString("currentEnergyLevel", "red")
 
 	manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, false, nil, nil)
 	err := manager.Start()
@@ -1821,7 +1816,7 @@ func TestSetLightBrightness(t *testing.T) {
 	})
 	env.MockHA.Connect()
 
-	env.StateMgr.SetString("currentEnergyLevel", "black")
+	env.StateMgr.SetString("currentEnergyLevel", "red")
 
 	manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, false, nil, nil)
 
@@ -1852,7 +1847,7 @@ func TestSetLightBrightnessReadOnly(t *testing.T) {
 
 	env.MockHA.Connect()
 
-	env.StateMgr.SetString("currentEnergyLevel", "black")
+	env.StateMgr.SetString("currentEnergyLevel", "red")
 
 	// Create manager in read-only mode
 	manager := NewManager(context.Background(), env.MockHA, env.StateMgr, config, env.Logger, true, nil, nil)

--- a/homeautomation-go/internal/plugins/loadshedding/manager.go
+++ b/homeautomation-go/internal/plugins/loadshedding/manager.go
@@ -383,7 +383,7 @@ func (m *Manager) handleEnergyChangeWithTrigger(key string, oldValue, newValue i
 }
 
 // restoreNonHVACLoads turns on non-essential loads (EV charger, dehumidifier).
-// Called at green/white energy levels to restore loads that were shed at yellow.
+// Called at green/white energy levels to restore loads shed by red-level load shedding.
 func (m *Manager) restoreNonHVACLoads(energyLevel string) {
 	m.stateMu.Lock()
 	needsRestore := m.nonHVACLoadsShed && !m.loadSheddingOn

--- a/homeautomation-go/internal/plugins/loadshedding/manager.go
+++ b/homeautomation-go/internal/plugins/loadshedding/manager.go
@@ -20,7 +20,6 @@ const (
 
 	// Energy states
 	energyStateRed    = "red"
-	energyStateBlack  = "black"
 	energyStateYellow = "yellow"
 	energyStateGreen  = "green"
 	energyStateWhite  = "white"
@@ -262,10 +261,10 @@ func (m *Manager) Start() error {
 
 	// Restart safety: if a previous process left thermostat holds enabled (mid-thermal-battery
 	// or mid-hysteresis), clear them so the climate schedule resumes. Skip when current
-	// energy is red/black — load shedding may legitimately have those holds enabled, and
+	// energy is red — load shedding may legitimately have those holds enabled, and
 	// the energy-change handler below will re-evaluate and re-establish them as needed.
 	if level, err := m.stateManager.GetString("currentEnergyLevel"); err == nil &&
-		level != energyStateRed && level != energyStateBlack {
+		level != energyStateRed {
 		m.clearStaleThermostatHolds()
 	}
 
@@ -352,17 +351,20 @@ func (m *Manager) handleEnergyChangeWithTrigger(key string, oldValue, newValue i
 		zap.String("new_level", newLevel),
 		zap.String("trigger", trigger))
 
-	// Determine action based on new state
-	// Yellow is a hysteresis buffer - maintain current state to prevent rapid toggling
+	// Determine action based on new state.
+	// Red triggers full load shedding (HVAC band + non-HVAC off) — battery is below the
+	// arbitrage floor (<15%) and we need to conserve aggressively.
+	// Yellow is the wide hysteresis band covering normal arbitrage operation: no change
+	// to load-shed state (carry whatever red/green set), thermal battery off.
 	switch newLevel {
-	case energyStateRed, energyStateBlack:
-		m.deactivateThermalBattery("energy level dropped to " + newLevel)
+	case energyStateRed:
+		m.deactivateThermalBattery("energy level dropped to red")
 		m.enableLoadShedding(newLevel, trigger)
 	case energyStateGreen:
-		// Green is still a healthy state (battery ≥80% AND ≥10 kWh remaining solar).
-		// Don't snap thermostats back — entering hysteresis widens the setpoint band so
-		// HVAC stays idle, avoiding counter-runs from a transient white→green oscillation.
-		// If thermal battery isn't active, this is a no-op.
+		// Green is still a healthy state. Don't snap thermostats back — entering
+		// hysteresis widens the setpoint band so HVAC stays idle, avoiding counter-runs
+		// from a transient white→green oscillation. If thermal battery isn't active,
+		// this is a no-op.
 		m.enterThermalBatteryHysteresis()
 		m.restoreNonHVACLoads(newLevel)
 		m.disableLoadShedding(newLevel, trigger)
@@ -372,65 +374,12 @@ func (m *Manager) handleEnergyChangeWithTrigger(key string, oldValue, newValue i
 		m.activateThermalBattery()
 	case energyStateYellow:
 		m.deactivateThermalBattery("energy level dropped to yellow")
-		m.shedNonHVACLoads(newLevel)
-		m.logger.Info("Energy state is yellow - shedding non-HVAC loads, HVAC maintains current state",
-			zap.String("reason", "Hysteresis buffer for HVAC, but non-essential loads shed"))
+		m.logger.Info("Energy state is yellow - hysteresis carry on load-shed state, thermal battery off",
+			zap.String("reason", "Wide hysteresis band covering normal arbitrage operation"))
 	default:
 		m.logger.Warn("Unknown energy state",
 			zap.String("state", newLevel))
 	}
-}
-
-// shedNonHVACLoads turns off non-essential loads (EV charger, dehumidifier) without
-// touching HVAC. Used at yellow energy level for partial load shedding.
-func (m *Manager) shedNonHVACLoads(energyLevel string) {
-	m.stateMu.Lock()
-	alreadyShed := m.nonHVACLoadsShed
-	m.stateMu.Unlock()
-
-	if alreadyShed {
-		m.logger.Info("⏭  Non-HVAC loads already shed")
-		return
-	}
-
-	m.logger.Info("=== NON-HVAC LOAD SHEDDING: ENABLE ===",
-		zap.String("energy_level", energyLevel),
-		zap.String("reason", "Shedding non-essential loads at "+energyLevel+" energy level"))
-
-	if m.readOnly {
-		m.logger.Info("READ-ONLY: Would turn off EV charger and dehumidifier",
-			zap.String("ev_charger_entity", evChargerSwitch),
-			zap.String("dehumidifier_entity", dehumidifierSwitch))
-		m.stateMu.Lock()
-		m.nonHVACLoadsShed = true
-		m.stateMu.Unlock()
-		return
-	}
-
-	// Turn off EV charger
-	if err := m.haClient.CallService(m.ctx, "switch", "turn_off", map[string]interface{}{
-		"entity_id": evChargerSwitch,
-	}); err != nil {
-		m.logger.Error("Failed to turn off EV charger", zap.Error(err))
-	} else {
-		m.logger.Info("✓ Successfully turned off EV charger")
-	}
-
-	// Turn off dehumidifier
-	if err := m.haClient.CallService(m.ctx, "switch", "turn_off", map[string]interface{}{
-		"entity_id": dehumidifierSwitch,
-	}); err != nil {
-		m.logger.Error("Failed to turn off dehumidifier", zap.Error(err))
-	} else {
-		m.logger.Info("✓ Successfully turned off dehumidifier")
-	}
-
-	m.stateMu.Lock()
-	m.nonHVACLoadsShed = true
-	m.stateMu.Unlock()
-
-	m.logger.Info("=== NON-HVAC LOADS SHED ===",
-		zap.String("action", "EV charger and dehumidifier disabled to conserve battery"))
 }
 
 // restoreNonHVACLoads turns on non-essential loads (EV charger, dehumidifier).
@@ -484,7 +433,7 @@ func (m *Manager) restoreNonHVACLoads(energyLevel string) {
 		zap.String("action", "EV charger and dehumidifier re-enabled"))
 }
 
-// enableLoadShedding activates load shedding (energy state red/black)
+// enableLoadShedding activates load shedding (energy state red)
 func (m *Manager) enableLoadShedding(energyLevel string, trigger string) {
 	m.logger.Info("=== LOAD SHEDDING DECISION: ENABLE ===",
 		zap.String("energy_level", energyLevel),

--- a/homeautomation-go/internal/plugins/loadshedding/manager_test.go
+++ b/homeautomation-go/internal/plugins/loadshedding/manager_test.go
@@ -63,34 +63,6 @@ func TestLoadShedding_EnergyStateRed(t *testing.T) {
 	assert.NotNil(t, dehumCall, "Expected switch.turn_off service call for dehumidifier")
 }
 
-func TestLoadShedding_EnergyStateBlack(t *testing.T) {
-	t.Parallel()
-	env := setupLoadSheddingEnv(t)
-
-	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, nil)
-	err := ls.Start()
-	assert.NoError(t, err)
-	defer ls.Stop()
-
-	// Set energy state to black (handler executes synchronously)
-	err = env.StateMgr.SetString("currentEnergyLevel", "black")
-	assert.NoError(t, err)
-
-	// Verify service calls (should be same as red)
-	calls := env.MockHA.GetServiceCalls()
-	assert.GreaterOrEqual(t, len(calls), 4, "Expected at least 4 service calls (thermostat hold, temp range, EV charger, dehumidifier)")
-
-	testutil.AssertServiceCall(t, calls, "switch", "turn_on")
-
-	// Check for switch.turn_off call (EV charger)
-	evCall := testutil.FindServiceCallWithEntity(calls, "switch", "turn_off", evChargerSwitch)
-	assert.NotNil(t, evCall, "Expected switch.turn_off service call for EV charger")
-
-	// Check for switch.turn_off call (dehumidifier)
-	dehumCall := testutil.FindServiceCallWithEntity(calls, "switch", "turn_off", dehumidifierSwitch)
-	assert.NotNil(t, dehumCall, "Expected switch.turn_off service call for dehumidifier")
-}
-
 func TestLoadShedding_EnergyStateGreen(t *testing.T) {
 	t.Parallel()
 	env := testutil.NewEnv(t)
@@ -264,7 +236,10 @@ func TestLoadShedding_UnknownState(t *testing.T) {
 	assert.Equal(t, "set_value", calls[0].Service)
 }
 
-func TestLoadShedding_EnergyStateYellow_ShedsNonHVACLoads(t *testing.T) {
+// Yellow is the wide hysteresis band covering normal arbitrage operation.
+// It should NOT touch HVAC or non-HVAC loads — it just carries whatever state
+// red/green last set.
+func TestLoadShedding_EnergyStateYellow_NoLoadShedding(t *testing.T) {
 	t.Parallel()
 	env := setupLoadSheddingEnv(t)
 
@@ -277,24 +252,27 @@ func TestLoadShedding_EnergyStateYellow_ShedsNonHVACLoads(t *testing.T) {
 	err = env.StateMgr.SetString("currentEnergyLevel", "yellow")
 	assert.NoError(t, err)
 
-	// Verify EV charger was turned off
 	calls := env.MockHA.GetServiceCalls()
-	evCall := testutil.FindServiceCallWithEntity(calls, "switch", "turn_off", evChargerSwitch)
-	assert.NotNil(t, evCall, "Expected switch.turn_off for EV charger at yellow energy level")
 
-	// Verify dehumidifier was turned off
-	dehumCall := testutil.FindServiceCallWithEntity(calls, "switch", "turn_off", dehumidifierSwitch)
-	assert.NotNil(t, dehumCall, "Expected switch.turn_off for dehumidifier at yellow energy level")
+	// Verify EV charger was NOT touched at yellow
+	evOff := testutil.FindServiceCallWithEntity(calls, "switch", "turn_off", evChargerSwitch)
+	assert.Nil(t, evOff, "EV charger should not be shed at yellow")
+
+	// Verify dehumidifier was NOT touched at yellow
+	dehumOff := testutil.FindServiceCallWithEntity(calls, "switch", "turn_off", dehumidifierSwitch)
+	assert.Nil(t, dehumOff, "Dehumidifier should not be shed at yellow")
 
 	// Verify HVAC was NOT touched (no thermostat hold changes)
 	thermostatCall := testutil.FindServiceCallWithEntity(calls, "switch", "turn_on", thermostatHoldHouse)
 	assert.Nil(t, thermostatCall, "HVAC should NOT be touched at yellow energy level")
 
-	// Verify load shedding is NOT fully active (HVAC hysteresis maintained)
-	assert.False(t, ls.IsLoadSheddingOn(), "Full load shedding should not be active at yellow")
+	// Verify load shedding is NOT active
+	assert.False(t, ls.IsLoadSheddingOn(), "Load shedding should not be active at yellow")
 }
 
-func TestLoadShedding_YellowToGreenTransition_RestoresNonHVACLoads(t *testing.T) {
+// Yellow with previously-engaged load shedding carries the load-shed state
+// (does not restore EV/dehumidifier or release thermostat holds).
+func TestLoadShedding_YellowCarriesPriorLoadShedState(t *testing.T) {
 	t.Parallel()
 	env := setupLoadSheddingEnv(t)
 
@@ -303,53 +281,25 @@ func TestLoadShedding_YellowToGreenTransition_RestoresNonHVACLoads(t *testing.T)
 	assert.NoError(t, err)
 	defer ls.Stop()
 
-	// Set energy state to yellow (sheds non-HVAC loads)
-	err = env.StateMgr.SetString("currentEnergyLevel", "yellow")
+	// First drop to red — full load shed engages
+	err = env.StateMgr.SetString("currentEnergyLevel", "red")
 	assert.NoError(t, err)
+	assert.True(t, ls.IsLoadSheddingOn(), "Load shedding should be on after red")
 
-	// Snapshot service calls after yellow
+	// Climb back to yellow
 	snapshot := env.MockHA.ServiceCallCount()
-
-	// Transition to green (should restore non-HVAC loads)
-	err = env.StateMgr.SetString("currentEnergyLevel", "green")
-	assert.NoError(t, err)
-
-	// Verify EV charger was turned on
-	calls := env.MockHA.GetServiceCallsSince(snapshot)
-	evCall := testutil.FindServiceCallWithEntity(calls, "switch", "turn_on", evChargerSwitch)
-	assert.NotNil(t, evCall, "Expected switch.turn_on for EV charger when transitioning from yellow to green")
-
-	// Verify dehumidifier was turned on
-	dehumCall := testutil.FindServiceCallWithEntity(calls, "switch", "turn_on", dehumidifierSwitch)
-	assert.NotNil(t, dehumCall, "Expected switch.turn_on for dehumidifier when transitioning from yellow to green")
-}
-
-func TestLoadShedding_YellowIdempotent(t *testing.T) {
-	t.Parallel()
-	env := setupLoadSheddingEnv(t)
-
-	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, nil)
-	err := ls.Start()
-	assert.NoError(t, err)
-	defer ls.Stop()
-
-	// Set energy state to yellow
 	err = env.StateMgr.SetString("currentEnergyLevel", "yellow")
 	assert.NoError(t, err)
 
-	// Snapshot after first yellow
-	snapshot := env.MockHA.ServiceCallCount()
-
-	// Set yellow again (should be idempotent - no duplicate calls)
-	err = env.StateMgr.SetString("currentEnergyLevel", "yellow")
-	assert.NoError(t, err)
-
-	// Only the SetString call, no additional switch calls
+	// Verify no restore calls were made (yellow carries the shed state)
 	calls := env.MockHA.GetServiceCallsSince(snapshot)
-	evCall := testutil.FindServiceCallWithEntity(calls, "switch", "turn_off", evChargerSwitch)
-	assert.Nil(t, evCall, "Second yellow should not re-shed already-shed EV charger")
-	dehumCall := testutil.FindServiceCallWithEntity(calls, "switch", "turn_off", dehumidifierSwitch)
-	assert.Nil(t, dehumCall, "Second yellow should not re-shed already-shed dehumidifier")
+	evOn := testutil.FindServiceCallWithEntity(calls, "switch", "turn_on", evChargerSwitch)
+	assert.Nil(t, evOn, "EV charger should not be restored at yellow")
+	dehumOn := testutil.FindServiceCallWithEntity(calls, "switch", "turn_on", dehumidifierSwitch)
+	assert.Nil(t, dehumOn, "Dehumidifier should not be restored at yellow")
+
+	// Load shedding should still be considered on (no disable was called)
+	assert.True(t, ls.IsLoadSheddingOn(), "Load shedding should remain on through yellow hysteresis")
 }
 
 func TestLoadShedding_RedToGreenTransition(t *testing.T) {

--- a/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
+++ b/homeautomation-go/internal/plugins/loadshedding/thermal_battery_test.go
@@ -825,7 +825,7 @@ func TestThermalBattery_HeatCoolMode_DeactivationRestoresOriginal(t *testing.T) 
 	t.Parallel()
 	// Activate with cold forecast, then hard-deactivate via yellow drop
 	// → verify original 69/72 restored. (Green now enters hysteresis instead of
-	// reverting; yellow/red/black are the hard-deactivation triggers.)
+	// reverting; yellow/red are the hard-deactivation triggers.)
 	env := setupHeatCoolEnvWithForecast(t, "", 45.0, 25.0)
 
 	ls := NewManager(context.Background(), env.MockHA, env.StateMgr, env.Logger, false, nil, nil)

--- a/homeautomation-go/internal/state/computed_energy_providers.go
+++ b/homeautomation-go/internal/state/computed_energy_providers.go
@@ -61,8 +61,11 @@ func RegisterSolarEnergyLevelProvider(
 				return nil, err
 			}
 
-			// Default to black (lowest level)
-			level := "black"
+			// Default to the first configured level (lowest)
+			level := ""
+			if len(energyStates) > 0 {
+				level = energyStates[0].ConditionName
+			}
 
 			// Check each energy state in order
 			// Level is the highest where both conditions are met
@@ -140,12 +143,15 @@ func RegisterCurrentEnergyLevelProvider(
 				}
 			}
 
-			// Handle invalid levels
+			// Handle invalid levels — return the lowest configured level as a safe default
 			if batteryIndex == -1 || solarIndex == -1 {
 				ctx.Logger().Warn("Invalid battery or solar level",
 					zap.String("batteryLevel", batteryLevel),
 					zap.String("solarLevel", solarLevel))
-				return "black", nil
+				if len(levelNames) > 0 {
+					return levelNames[0], nil
+				}
+				return "", nil
 			}
 
 			// Solar can only boost, never drag down the battery level.

--- a/homeautomation-go/internal/state/computed_energy_providers_test.go
+++ b/homeautomation-go/internal/state/computed_energy_providers_test.go
@@ -19,9 +19,9 @@ func setupTestManagerForEnergyRegistry(t *testing.T) (*Manager, *ha.MockClient) 
 	mockClient.SetState("input_number.this_hour_solar_generation", "0", map[string]interface{}{})
 	mockClient.SetState("input_number.remaining_solar_generation", "0", map[string]interface{}{})
 	mockClient.SetState("input_boolean.free_energy_available", "off", map[string]interface{}{})
-	mockClient.SetState("input_text.battery_energy_level", "black", map[string]interface{}{})
-	mockClient.SetState("input_text.solar_production_energy_level", "black", map[string]interface{}{})
-	mockClient.SetState("input_text.current_energy_level", "black", map[string]interface{}{})
+	mockClient.SetState("input_text.battery_energy_level", "red", map[string]interface{}{})
+	mockClient.SetState("input_text.solar_production_energy_level", "red", map[string]interface{}{})
+	mockClient.SetState("input_text.current_energy_level", "red", map[string]interface{}{})
 	mockClient.Connect()
 
 	manager := NewManager(mockClient, logger, false)
@@ -33,32 +33,32 @@ func setupTestManagerForEnergyRegistry(t *testing.T) (*Manager, *ha.MockClient) 
 }
 
 // testEnergyStates returns standard test energy state configurations.
-// This matches the ordering in the production energy config.
+// This matches the 4-level scheme in the production energy config.
 func testEnergyStates() []EnergyStateConfig {
 	return []EnergyStateConfig{
 		{
-			ConditionName:                       "black",
+			ConditionName:                       "red",
 			BatteryMinimumPercentage:            0,
 			EnergyProductionMinimumKW:           0,
 			RemainingEnergyProductionMinimumKWH: 0,
 		},
 		{
-			ConditionName:                       "red",
-			BatteryMinimumPercentage:            10,
-			EnergyProductionMinimumKW:           0.1,
-			RemainingEnergyProductionMinimumKWH: 0.5,
-		},
-		{
 			ConditionName:                       "yellow",
-			BatteryMinimumPercentage:            30,
-			EnergyProductionMinimumKW:           0.5,
-			RemainingEnergyProductionMinimumKWH: 2,
+			BatteryMinimumPercentage:            15,
+			EnergyProductionMinimumKW:           0.1,
+			RemainingEnergyProductionMinimumKWH: 0,
 		},
 		{
 			ConditionName:                       "green",
-			BatteryMinimumPercentage:            70,
-			EnergyProductionMinimumKW:           2,
-			RemainingEnergyProductionMinimumKWH: 10,
+			BatteryMinimumPercentage:            60,
+			EnergyProductionMinimumKW:           1,
+			RemainingEnergyProductionMinimumKWH: 5,
+		},
+		{
+			ConditionName:                       "white",
+			BatteryMinimumPercentage:            80,
+			EnergyProductionMinimumKW:           4,
+			RemainingEnergyProductionMinimumKWH: 20,
 		},
 	}
 }
@@ -88,16 +88,16 @@ func TestRegisterSolarEnergyLevelProvider(t *testing.T) {
 	}
 	defer registry.Stop()
 
-	// Initial value should be black (no solar generation)
+	// Initial value should be red (lowest level — no solar generation)
 	level, err := manager.GetString("solarProductionEnergyLevel")
 	if err != nil {
 		t.Fatalf("Failed to get solarProductionEnergyLevel: %v", err)
 	}
-	if level != "black" {
-		t.Errorf("Expected initial level 'black', got '%s'", level)
+	if level != "red" {
+		t.Errorf("Expected initial level 'red', got '%s'", level)
 	}
-	if solarLevelReceived != "black" {
-		t.Errorf("Expected callback with 'black', got '%s'", solarLevelReceived)
+	if solarLevelReceived != "red" {
+		t.Errorf("Expected callback with 'red', got '%s'", solarLevelReceived)
 	}
 }
 
@@ -109,40 +109,40 @@ func TestSolarEnergyLevelComputation(t *testing.T) {
 		expectedLevel string
 	}{
 		{
-			name:          "zero solar",
+			name:          "zero solar - red",
 			thisHourKW:    0,
 			remainingKWH:  0,
-			expectedLevel: "black",
-		},
-		{
-			name:          "minimal solar - red",
-			thisHourKW:    0.15,
-			remainingKWH:  1.0,
 			expectedLevel: "red",
 		},
 		{
-			name:          "moderate solar - yellow",
-			thisHourKW:    0.8,
-			remainingKWH:  5.0,
+			name:          "minimal current production - yellow",
+			thisHourKW:    0.15,
+			remainingKWH:  1.0,
 			expectedLevel: "yellow",
 		},
 		{
-			name:          "high solar - green",
-			thisHourKW:    3.0,
-			remainingKWH:  15.0,
+			name:          "moderate solar - green",
+			thisHourKW:    1.5,
+			remainingKWH:  10.0,
 			expectedLevel: "green",
 		},
 		{
-			name:          "high thisHourKW but low remaining - still black",
+			name:          "high solar - white",
 			thisHourKW:    5.0,
-			remainingKWH:  0,
-			expectedLevel: "black",
+			remainingKWH:  25.0,
+			expectedLevel: "white",
 		},
 		{
-			name:          "low thisHourKW but high remaining - still black",
+			name:          "high thisHourKW but low remaining - capped at yellow",
+			thisHourKW:    5.0,
+			remainingKWH:  0,
+			expectedLevel: "yellow",
+		},
+		{
+			name:          "low thisHourKW but high remaining - stays at red",
 			thisHourKW:    0,
 			remainingKWH:  20.0,
-			expectedLevel: "black",
+			expectedLevel: "red",
 		},
 	}
 
@@ -235,9 +235,9 @@ func TestCurrentEnergyLevelComputation(t *testing.T) {
 		{
 			name:          "retired free energy flag ignored",
 			isFreeEnergy:  true,
-			batteryLevel:  "black",
-			solarLevel:    "black",
-			expectedLevel: "black",
+			batteryLevel:  "red",
+			solarLevel:    "red",
+			expectedLevel: "red",
 			description:   "Legacy free energy flag no longer overrides the battery and solar levels",
 		},
 		{
@@ -267,25 +267,25 @@ func TestCurrentEnergyLevelComputation(t *testing.T) {
 		{
 			name:          "solar much higher - only boosts by 1",
 			isFreeEnergy:  false,
-			batteryLevel:  "black",
-			solarLevel:    "green",
-			expectedLevel: "red",
+			batteryLevel:  "red",
+			solarLevel:    "white",
+			expectedLevel: "yellow",
 			description:   "Solar can only boost by max 1 level",
 		},
 		{
 			name:          "battery at max, solar same",
 			isFreeEnergy:  false,
-			batteryLevel:  "green",
-			solarLevel:    "green",
-			expectedLevel: "green",
+			batteryLevel:  "white",
+			solarLevel:    "white",
+			expectedLevel: "white",
 			description:   "Already at max level",
 		},
 		{
 			name:          "both at minimum",
 			isFreeEnergy:  false,
-			batteryLevel:  "black",
-			solarLevel:    "black",
-			expectedLevel: "black",
+			batteryLevel:  "red",
+			solarLevel:    "red",
+			expectedLevel: "red",
 			description:   "Lowest possible level",
 		},
 	}
@@ -378,8 +378,8 @@ func TestRegisterEnergyProviders(t *testing.T) {
 	logger := testlogger.New()
 
 	// Set test values
-	_ = manager.SetNumber("thisHourSolarGeneration", 1.0)
-	_ = manager.SetNumber("remainingSolarGeneration", 5.0)
+	_ = manager.SetNumber("thisHourSolarGeneration", 1.5)
+	_ = manager.SetNumber("remainingSolarGeneration", 10.0)
 	_ = manager.SetBool("isFreeEnergyAvailable", false)
 	_ = manager.SetString("batteryEnergyLevel", "yellow")
 
@@ -413,24 +413,24 @@ func TestRegisterEnergyProviders(t *testing.T) {
 		t.Errorf("Expected 2 providers, got %d: %v", len(names), names)
 	}
 
-	// Solar level: thisHourKW=1.0, remainingKWH=5.0 -> yellow
+	// Solar level: thisHourKW=1.5, remainingKWH=10.0 -> green
 	solarLevel, _ := manager.GetString("solarProductionEnergyLevel")
-	if solarLevel != "yellow" {
-		t.Errorf("Expected solar level 'yellow', got '%s'", solarLevel)
+	if solarLevel != "green" {
+		t.Errorf("Expected solar level 'green', got '%s'", solarLevel)
 	}
 
-	// Overall level: battery=yellow, solar=yellow -> yellow
+	// Overall level: battery=yellow, solar=green -> green (boost by 1)
 	overallLevel, _ := manager.GetString("currentEnergyLevel")
-	if overallLevel != "yellow" {
-		t.Errorf("Expected overall level 'yellow', got '%s'", overallLevel)
+	if overallLevel != "green" {
+		t.Errorf("Expected overall level 'green', got '%s'", overallLevel)
 	}
 
 	// Check callbacks were called
-	if callbacksCalled["solar"] != "yellow" {
-		t.Errorf("Expected solar callback 'yellow', got '%s'", callbacksCalled["solar"])
+	if callbacksCalled["solar"] != "green" {
+		t.Errorf("Expected solar callback 'green', got '%s'", callbacksCalled["solar"])
 	}
-	if callbacksCalled["overall"] != "yellow" {
-		t.Errorf("Expected overall callback 'yellow', got '%s'", callbacksCalled["overall"])
+	if callbacksCalled["overall"] != "green" {
+		t.Errorf("Expected overall callback 'green', got '%s'", callbacksCalled["overall"])
 	}
 }
 
@@ -457,10 +457,10 @@ func TestEnergyLevelInvalidLevelHandling(t *testing.T) {
 	}
 	defer registry.Stop()
 
-	// Invalid levels should result in "black" (fallback)
+	// Invalid levels should fall back to the lowest configured level ("red")
 	level, _ := manager.GetString("currentEnergyLevel")
-	if level != "black" {
-		t.Errorf("Invalid levels should fallback to 'black', got '%s'", level)
+	if level != "red" {
+		t.Errorf("Invalid levels should fallback to 'red', got '%s'", level)
 	}
 }
 
@@ -517,13 +517,13 @@ func TestSolarBoostMaxOneLevel(t *testing.T) {
 		solar    string
 		expected string
 	}{
-		{"black", "red", "red"},      // boost by 1
-		{"black", "yellow", "red"},   // boost limited to 1
-		{"black", "green", "red"},    // boost limited to 1
 		{"red", "yellow", "yellow"},  // boost by 1
 		{"red", "green", "yellow"},   // boost limited to 1
+		{"red", "white", "yellow"},   // boost limited to 1
 		{"yellow", "green", "green"}, // boost by 1
-		{"green", "green", "green"},  // already at max
+		{"yellow", "white", "green"}, // boost limited to 1
+		{"green", "white", "white"},  // boost by 1
+		{"white", "white", "white"},  // already at max
 	}
 
 	for _, tc := range testCases {

--- a/homeautomation-go/test/integration/scenario_energy_sleep_test.go
+++ b/homeautomation-go/test/integration/scenario_energy_sleep_test.go
@@ -28,7 +28,7 @@ import (
 // hygiene plugins during wake sequences and battery state transitions.
 //
 // The energy plugin monitors battery percentage and sets batteryEnergyLevel
-// ("green", "yellow", "red", "black"). The sleep hygiene plugin manages
+// ("white", "green", "yellow", "red"). The sleep hygiene plugin manages
 // wake sequences (begin_wake -> fade-out -> lights -> wake music).
 //
 // INVARIANTS:
@@ -137,7 +137,7 @@ func TestScenario_BatteryDropsDuringWakeSequence(t *testing.T) {
 	env.server.SetState("input_text.day_phase", "morning", map[string]interface{}{})
 
 	// Battery starts at healthy level
-	env.server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "85.0", map[string]interface{}{
+	env.server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "65.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
 
@@ -150,16 +150,16 @@ func TestScenario_BatteryDropsDuringWakeSequence(t *testing.T) {
 	waitForProcessing(t, env.manager)
 
 	// ========== WHEN ==========
-	t.Log("WHEN: Battery drops to critical level (15%) during wake sequence")
+	t.Log("WHEN: Battery drops to critical level (10%) during wake sequence")
 
-	env.server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "15.0", map[string]interface{}{
+	env.server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "10.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
 
 	// Wait for energy plugin to process the battery change
-	// Battery at 15% is below red threshold (20%) so it should be "black" per test config
-	waitForStringStateOneOf(t, env.manager, "batteryEnergyLevel", []string{"red", "black"},
-		"Battery level should update to red or black")
+	// Battery at 10% is below yellow threshold (15%) so it should be "red"
+	waitForStringState(t, env.manager, "batteryEnergyLevel", "red",
+		"Battery level should update to red")
 
 	// ========== THEN ==========
 	t.Log("THEN: Wake sequence continues AND energy level updates")
@@ -175,7 +175,7 @@ func TestScenario_BatteryDropsDuringWakeSequence(t *testing.T) {
 	assert.NoError(t, err)
 	t.Logf("Battery energy level after drop: %s", batteryLevel)
 	assert.NotEqual(t, "green", batteryLevel,
-		"Energy level should have changed from green after battery dropped to 15%")
+		"Energy level should have changed from green after battery dropped to 10%")
 
 	t.Log("SUCCESS: Energy and wake sequence operated independently")
 }
@@ -209,13 +209,13 @@ func TestScenario_WakeSequenceStartsWithLowBattery(t *testing.T) {
 	env.server.SetState("input_text.music_playback_type", "sleep", map[string]interface{}{})
 
 	// Battery already low
-	env.server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "15.0", map[string]interface{}{
+	env.server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "10.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
 
-	// Wait for energy plugin to finish computing battery level from the 15% sensor reading
-	waitForStringStateOneOf(t, env.manager, "batteryEnergyLevel", []string{"red", "black"},
-		"Battery level should settle to red or black at 15%")
+	// Wait for energy plugin to finish computing battery level from the 10% sensor reading
+	waitForStringState(t, env.manager, "batteryEnergyLevel", "red",
+		"Battery level should settle to red at 10%")
 
 	// Record battery level after it has settled
 	batteryLevel, err := env.manager.GetString("batteryEnergyLevel")
@@ -287,7 +287,7 @@ func TestScenario_EnergyTransitions_SleepStateUnaffected(t *testing.T) {
 	env.server.SetState("input_text.music_playback_type", "sleep", map[string]interface{}{})
 
 	// Battery starts healthy
-	env.server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "90.0", map[string]interface{}{
+	env.server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "70.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
 
@@ -303,7 +303,7 @@ func TestScenario_EnergyTransitions_SleepStateUnaffected(t *testing.T) {
 	t.Log("WHEN: Battery drops through multiple levels: green -> yellow -> red")
 
 	// Simulate battery draining overnight
-	batteryLevels := []string{"75.0", "45.0", "15.0"}
+	batteryLevels := []string{"50.0", "20.0", "10.0"}
 	for _, level := range batteryLevels {
 		env.server.SetState("sensor.span_panel_span_storage_battery_percentage_2", level, map[string]interface{}{
 			"unit_of_measurement": "%",
@@ -340,7 +340,7 @@ func TestScenario_EnergyTransitions_SleepStateUnaffected(t *testing.T) {
 	assert.NoError(t, err)
 	t.Logf("Final battery energy level: %s", batteryLevel)
 	assert.NotEqual(t, "green", batteryLevel,
-		"Battery level should have changed from green after dropping to 15%")
+		"Battery level should have changed from green after dropping to 10%")
 
 	t.Log("SUCCESS: Energy transitions did not affect sleep state")
 }

--- a/homeautomation-go/test/integration/scenario_energy_test.go
+++ b/homeautomation-go/test/integration/scenario_energy_test.go
@@ -79,34 +79,34 @@ func TestScenario_BatteryLevelChanges_UpdateEnergyLevels(t *testing.T) {
 	server, _, manager, _, cleanup := setupEnergyScenarioTest(t)
 	defer cleanup()
 
-	// GIVEN: Battery is at 85% (green level - threshold is 80%)
-	t.Log("GIVEN: Battery is at 85% (green level)")
+	// GIVEN: Battery is at 85% (white level - threshold is 80%)
+	t.Log("GIVEN: Battery is at 85% (white level)")
 	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "85.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
 
-	// Verify initial state is green
-	waitForStringState(t, manager, "batteryEnergyLevel", "green", "Battery level should be green at 85%")
+	// Verify initial state is white
+	waitForStringState(t, manager, "batteryEnergyLevel", "white", "Battery level should be white at 85%")
 
-	// WHEN: Battery drops to 55% (yellow level - threshold is 50%)
-	t.Log("WHEN: Battery drops to 55% (yellow level)")
-	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "55.0", map[string]interface{}{
+	// WHEN: Battery drops to 30% (yellow level - threshold is 15%)
+	t.Log("WHEN: Battery drops to 30% (yellow level)")
+	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "30.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
 
 	// THEN: Battery level should be yellow
 	t.Log("THEN: Battery level should be yellow")
-	waitForStringState(t, manager, "batteryEnergyLevel", "yellow", "Battery level should be yellow at 55%")
+	waitForStringState(t, manager, "batteryEnergyLevel", "yellow", "Battery level should be yellow at 30%")
 
-	// WHEN: Battery drops to 15% (black level - below 20% red threshold)
-	t.Log("WHEN: Battery drops to 15% (black level)")
-	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "15.0", map[string]interface{}{
+	// WHEN: Battery drops to 10% (red level - below 15% yellow threshold)
+	t.Log("WHEN: Battery drops to 10% (red level)")
+	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "10.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
 
-	// THEN: Battery level should be black
-	t.Log("THEN: Battery level should be black")
-	waitForStringState(t, manager, "batteryEnergyLevel", "black", "Battery level should be black at 15%")
+	// THEN: Battery level should be red
+	t.Log("THEN: Battery level should be red")
+	waitForStringState(t, manager, "batteryEnergyLevel", "red", "Battery level should be red at 10%")
 }
 
 // TestScenario_SolarProductionUpdates_CalculatesEnergyLevel validates that
@@ -116,8 +116,8 @@ func TestScenario_SolarProductionUpdates_CalculatesEnergyLevel(t *testing.T) {
 	server, _, manager, _, cleanup := setupEnergyScenarioTest(t)
 	defer cleanup()
 
-	// GIVEN: No solar production (yellow level - meets yellow threshold but not green)
-	t.Log("GIVEN: No solar production (yellow level)")
+	// GIVEN: No solar production (red level - lowest)
+	t.Log("GIVEN: No solar production (red level)")
 	server.SetState("sensor.energy_next_hour", "0.0", map[string]interface{}{
 		"unit_of_measurement": "kW",
 	})
@@ -126,7 +126,7 @@ func TestScenario_SolarProductionUpdates_CalculatesEnergyLevel(t *testing.T) {
 	})
 
 	// Verify initial state
-	waitForStringState(t, manager, "solarProductionEnergyLevel", "yellow", "Solar level should be yellow with no production (meets yellow threshold)")
+	waitForStringState(t, manager, "solarProductionEnergyLevel", "red", "Solar level should be red with no production")
 
 	// WHEN: Solar production increases (this hour = 2kW, remaining = 15kWh -> green)
 	t.Log("WHEN: Solar production increases to green level")
@@ -137,22 +137,22 @@ func TestScenario_SolarProductionUpdates_CalculatesEnergyLevel(t *testing.T) {
 		"unit_of_measurement": "kWh",
 	})
 
-	// THEN: Solar level should be green (threshold: 0 kW, 10 kWh)
+	// THEN: Solar level should be green (threshold: 1 kW, 5 kWh)
 	t.Log("THEN: Solar level should be green")
 	waitForStringState(t, manager, "solarProductionEnergyLevel", "green", "Solar level should be green with 2kW/15kWh")
 
-	// WHEN: Solar production drops (this hour = 1kW, remaining = 5kWh -> yellow)
+	// WHEN: Solar production drops (this hour = 0.5kW, remaining = 2kWh -> yellow)
 	t.Log("WHEN: Solar production drops to yellow level")
-	server.SetState("sensor.energy_next_hour", "1.0", map[string]interface{}{
+	server.SetState("sensor.energy_next_hour", "0.5", map[string]interface{}{
 		"unit_of_measurement": "kW",
 	})
-	server.SetState("sensor.energy_production_today_remaining", "5.0", map[string]interface{}{
+	server.SetState("sensor.energy_production_today_remaining", "2.0", map[string]interface{}{
 		"unit_of_measurement": "kWh",
 	})
 
-	// THEN: Solar level should be yellow (threshold: 0 kW, 0 kWh)
+	// THEN: Solar level should be yellow (threshold: 0.1 kW, 0 kWh; below green's 1 kW)
 	t.Log("THEN: Solar level should be yellow")
-	waitForStringState(t, manager, "solarProductionEnergyLevel", "yellow", "Solar level should be yellow with 1kW/5kWh")
+	waitForStringState(t, manager, "solarProductionEnergyLevel", "yellow", "Solar level should be yellow with 0.5kW/2kWh")
 }
 
 // TestScenario_GridAvailability_DoesNotEnableFreeEnergy validates that grid
@@ -259,9 +259,9 @@ func TestScenario_OverallEnergyLevel_ReflectsWorstState(t *testing.T) {
 	// Wait for startup goroutines to complete initial work
 	energyMgr.WaitForStartup()
 
-	// GIVEN: Battery at green (85%), solar at green (2kW, 15kWh)
+	// GIVEN: Battery at green (65%), solar at green (2kW, 15kWh)
 	t.Log("GIVEN: Battery green, solar green")
-	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "85.0", map[string]interface{}{
+	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "65.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
 	server.SetState("sensor.energy_next_hour", "2.0", map[string]interface{}{
@@ -275,22 +275,21 @@ func TestScenario_OverallEnergyLevel_ReflectsWorstState(t *testing.T) {
 	waitForProcessing(t, manager)
 	waitForStringState(t, manager, "currentEnergyLevel", "green", "Overall level should be green when both are green")
 
-	// WHEN: Battery drops to black (15%), solar still green
-	t.Log("WHEN: Battery drops to black, solar stays green")
-	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "15.0", map[string]interface{}{
+	// WHEN: Battery drops to red (10%), solar still green
+	t.Log("WHEN: Battery drops to red, solar stays green")
+	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "10.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
 
-	// THEN: Overall level should reflect the lower state
-	// According to the algorithm, solar can boost the battery-derived result by at most one level.
+	// THEN: Overall level should reflect the lower state.
+	// Solar can boost the battery-derived result by at most one level: red + green → yellow.
 	t.Log("THEN: Overall level should reflect worst state")
-	waitForStringState(t, manager, "batteryEnergyLevel", "black", "Battery level should settle before checking overall level")
+	waitForStringState(t, manager, "batteryEnergyLevel", "red", "Battery level should settle before checking overall level")
 	waitForProcessing(t, manager)
-	// The overall level should be exactly one level higher than the battery input
-	waitForStringState(t, manager, "currentEnergyLevel", "red",
-		"Overall level should be red when battery is black and solar is green")
+	waitForStringState(t, manager, "currentEnergyLevel", "yellow",
+		"Overall level should be yellow when battery is red and solar is green (boost by 1)")
 
-	// WHEN: Solar drops to the floor of the test config (0kW, 0kWh -> yellow)
+	// WHEN: Solar drops to the floor of the test config (0kW, 0kWh -> red)
 	t.Log("WHEN: Solar drops to the floor of the test config")
 	server.SetState("sensor.energy_next_hour", "0.0", map[string]interface{}{
 		"unit_of_measurement": "kW",
@@ -299,12 +298,12 @@ func TestScenario_OverallEnergyLevel_ReflectsWorstState(t *testing.T) {
 		"unit_of_measurement": "kWh",
 	})
 
-	// THEN: Solar should settle to yellow for this test config, and overall should stay red
-	t.Log("THEN: Overall level should stay low")
-	waitForStringState(t, manager, "solarProductionEnergyLevel", "yellow", "Solar level should settle before checking overall level")
+	// THEN: Solar should settle to red, and overall should be red too.
+	t.Log("THEN: Overall level should drop to red")
+	waitForStringState(t, manager, "solarProductionEnergyLevel", "red", "Solar level should settle before checking overall level")
 	waitForProcessing(t, manager)
 	waitForStringState(t, manager, "currentEnergyLevel", "red",
-		"Overall level should stay red when battery is black and solar is at the lowest configured solar tier")
+		"Overall level should be red when battery and solar are both red")
 }
 
 // TestScenario_MeteredGridFreeEnergyWindow_DoesNotOverrideEnergyLevel validates
@@ -349,9 +348,9 @@ func TestScenario_MeteredGridFreeEnergyWindow_DoesNotOverrideEnergyLevel(t *test
 	// Wait for startup goroutines to complete initial work
 	energyMgr.WaitForStartup()
 
-	// GIVEN: Battery at black (15%) and grid available during the old free grid window
-	t.Log("GIVEN: Battery black and grid available during the old free grid window")
-	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "15.0", map[string]interface{}{
+	// GIVEN: Battery at red (10%) and grid available during the old free grid window
+	t.Log("GIVEN: Battery red and grid available during the old free grid window")
+	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "10.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
 	err = manager.SetBool("isGridAvailable", true)
@@ -364,12 +363,12 @@ func TestScenario_MeteredGridFreeEnergyWindow_DoesNotOverrideEnergyLevel(t *test
 	t.Logf("Free energy available: %v", isFreeEnergy)
 
 	t.Log("THEN: Overall level should not be white from metered grid time")
-	waitForStringState(t, manager, "batteryEnergyLevel", "black", "Battery level should settle before checking overall level")
+	waitForStringState(t, manager, "batteryEnergyLevel", "red", "Battery level should settle before checking overall level")
 	waitForProcessing(t, manager)
 	overallLevel, err := manager.GetString("currentEnergyLevel")
 	require.NoError(t, err)
-	// setupTest initializes solar to "white"; the combine logic takes the worst non-white level
-	// ("black" battery), then the white solar boosts it one step to "red". So "red" is correct.
+	// Without any solar production set, solar resolves to the lowest level (red).
+	// Battery red + solar red → red. The retired metered-grid override no longer forces white.
 	assert.Equal(t, "red", overallLevel, "Overall level should follow battery and solar without metered grid override")
 }
 
@@ -405,53 +404,53 @@ func TestScenario_ThresholdBoundaries_HandlesExactValues(t *testing.T) {
 	server, _, manager, _, cleanup := setupEnergyScenarioTest(t)
 	defer cleanup()
 
-	// Test exact boundary: 80% (green threshold)
-	t.Log("Testing exact boundary: 80% (green threshold)")
+	// Test exact boundary: 80% (white threshold)
+	t.Log("Testing exact boundary: 80% (white threshold)")
 	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "80.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
 
-	waitForStringState(t, manager, "batteryEnergyLevel", "green", "Battery level should be green at exactly 80%")
+	waitForStringState(t, manager, "batteryEnergyLevel", "white", "Battery level should be white at exactly 80%")
 
-	// Test just below boundary: 79.9% (yellow)
-	t.Log("Testing just below boundary: 79.9% (yellow)")
+	// Test just below boundary: 79.9% (green)
+	t.Log("Testing just below boundary: 79.9% (green)")
 	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "79.9", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
 
-	waitForStringState(t, manager, "batteryEnergyLevel", "yellow", "Battery level should be yellow at 79.9%")
+	waitForStringState(t, manager, "batteryEnergyLevel", "green", "Battery level should be green at 79.9%")
 
-	// Test exact boundary: 50% (yellow threshold)
-	t.Log("Testing exact boundary: 50% (yellow threshold)")
-	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "50.0", map[string]interface{}{
+	// Test exact boundary: 60% (green threshold)
+	t.Log("Testing exact boundary: 60% (green threshold)")
+	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "60.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
 
-	waitForStringState(t, manager, "batteryEnergyLevel", "yellow", "Battery level should be yellow at exactly 50%")
+	waitForStringState(t, manager, "batteryEnergyLevel", "green", "Battery level should be green at exactly 60%")
 
-	// Test just below boundary: 49.9% (red)
-	t.Log("Testing just below boundary: 49.9% (red)")
-	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "49.9", map[string]interface{}{
+	// Test just below boundary: 59.9% (yellow)
+	t.Log("Testing just below boundary: 59.9% (yellow)")
+	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "59.9", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
 
-	waitForStringState(t, manager, "batteryEnergyLevel", "red", "Battery level should be red at 49.9%")
+	waitForStringState(t, manager, "batteryEnergyLevel", "yellow", "Battery level should be yellow at 59.9%")
 
-	// Test exact boundary: 20% (red threshold)
-	t.Log("Testing exact boundary: 20% (red threshold)")
-	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "20.0", map[string]interface{}{
+	// Test exact boundary: 15% (yellow threshold)
+	t.Log("Testing exact boundary: 15% (yellow threshold)")
+	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "15.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
 
-	waitForStringState(t, manager, "batteryEnergyLevel", "red", "Battery level should be red at exactly 20%")
+	waitForStringState(t, manager, "batteryEnergyLevel", "yellow", "Battery level should be yellow at exactly 15%")
 
-	// Test just below boundary: 19.9% (black)
-	t.Log("Testing just below boundary: 19.9% (black)")
-	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "19.9", map[string]interface{}{
+	// Test just below boundary: 14.9% (red)
+	t.Log("Testing just below boundary: 14.9% (red)")
+	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "14.9", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
 
-	waitForStringState(t, manager, "batteryEnergyLevel", "black", "Battery level should be black at 19.9%")
+	waitForStringState(t, manager, "batteryEnergyLevel", "red", "Battery level should be red at 14.9%")
 }
 
 // TestScenario_MultipleConcurrentChanges_HandlesCorrectly validates that
@@ -462,8 +461,8 @@ func TestScenario_MultipleConcurrentChanges_HandlesCorrectly(t *testing.T) {
 	defer cleanup()
 
 	// GIVEN: Initial state
-	t.Log("GIVEN: Initial state - battery at 85%, solar at high production")
-	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "85.0", map[string]interface{}{
+	t.Log("GIVEN: Initial state - battery at 65%, solar at high production")
+	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "65.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
 	server.SetState("sensor.energy_next_hour", "3.0", map[string]interface{}{
@@ -474,7 +473,7 @@ func TestScenario_MultipleConcurrentChanges_HandlesCorrectly(t *testing.T) {
 	})
 
 	// Wait for initial state to stabilize
-	waitForStringState(t, manager, "batteryEnergyLevel", "green", "Battery should be green at 85%")
+	waitForStringState(t, manager, "batteryEnergyLevel", "green", "Battery should be green at 65%")
 	waitForStringState(t, manager, "solarProductionEnergyLevel", "green", "Solar should be green with high production")
 
 	batteryLevel, err := manager.GetString("batteryEnergyLevel")
@@ -491,7 +490,7 @@ func TestScenario_MultipleConcurrentChanges_HandlesCorrectly(t *testing.T) {
 	t.Log("WHEN: Multiple rapid changes occur simultaneously")
 
 	// Change battery
-	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "25.0", map[string]interface{}{
+	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "10.0", map[string]interface{}{
 		"unit_of_measurement": "%",
 	})
 
@@ -510,9 +509,9 @@ func TestScenario_MultipleConcurrentChanges_HandlesCorrectly(t *testing.T) {
 	// THEN: All changes should be processed without errors
 	t.Log("THEN: All changes should be processed without errors")
 
-	waitForStringState(t, manager, "batteryEnergyLevel", "red", "Battery level should be red at 25%")
+	waitForStringState(t, manager, "batteryEnergyLevel", "red", "Battery level should be red at 10%")
 
-	waitForStringStateOneOf(t, manager, "solarProductionEnergyLevel", []string{"black", "red", "yellow"},
+	waitForStringStateOneOf(t, manager, "solarProductionEnergyLevel", []string{"red", "yellow"},
 		"Solar level should be low with 0.5kW/2kWh")
 
 	overallLevel, err = manager.GetString("currentEnergyLevel")

--- a/homeautomation-go/test/integration/testdata/energy_config_test.yaml
+++ b/homeautomation-go/test/integration/testdata/energy_config_test.yaml
@@ -1,18 +1,9 @@
 ---
-# Minimal energy config for testing
+# Minimal energy config for testing — mirrors the 4-level production scheme
 energy:
   energy_states:
-    - condition_name: black
-      battery_minimum_percentage: 0
-      energy_production_minimum_kw: 0
-      remaining_energy_production_minimum_kwh: 0
-      light_config:
-        red: 25
-        green: 25
-        blue: 112
-        brightness_pct: 70
     - condition_name: red
-      battery_minimum_percentage: 20
+      battery_minimum_percentage: 0
       energy_production_minimum_kw: 0
       remaining_energy_production_minimum_kwh: 0
       light_config:
@@ -21,8 +12,8 @@ energy:
         blue: 0
         brightness_pct: 30
     - condition_name: yellow
-      battery_minimum_percentage: 50
-      energy_production_minimum_kw: 0
+      battery_minimum_percentage: 15
+      energy_production_minimum_kw: 0.1
       remaining_energy_production_minimum_kwh: 0
       light_config:
         red: 255
@@ -30,16 +21,16 @@ energy:
         blue: 0
         brightness_pct: 30
     - condition_name: green
-      battery_minimum_percentage: 80
-      energy_production_minimum_kw: 0
-      remaining_energy_production_minimum_kwh: 10
+      battery_minimum_percentage: 60
+      energy_production_minimum_kw: 1
+      remaining_energy_production_minimum_kwh: 5
       light_config:
         red: 0
         green: 255
         blue: 0
         brightness_pct: 60
     - condition_name: white
-      battery_minimum_percentage: 95
+      battery_minimum_percentage: 80
       energy_production_minimum_kw: 4
       remaining_energy_production_minimum_kwh: 20
       light_config:


### PR DESCRIPTION
## Summary

Revisits PR #1118. PR #1118 anchored `red` at 19% to match the 20% arbitrage floor, but the battery legitimately wobbles below 19% during normal operation. On 2026-05-19 02:10 UTC an 18% dip tripped HVAC load shedding for ~20s of red, then yellow hysteresis kept the 65-80°F holds engaged for hours.

This collapses the 5-level scheme to 4 levels and shifts the load-shed trigger down by one threshold.

| Level  | Battery % | Solar (kW, kWh) | Action                                       |
|--------|-----------|-----------------|----------------------------------------------|
| red    | 0–14      | 0, 0            | `enableLoadShedding` (HVAC band + non-HVAC off) |
| yellow | 15–59     | 0.1, 0          | hysteresis carry; thermal battery off       |
| green  | 60–79     | 1, 5            | `restoreNonHVACLoads` + `disableLoadShedding` + thermal hysteresis |
| white  | 80+       | 4, 20           | + `activateThermalBattery`                   |

Yellow is the wide hysteresis band that absorbs normal arbitrage operation without engaging load shed. Red (now <15%) is reached only on genuine over-discharge.

Solar thresholds split red/yellow so night (0 kW) resolves to `red` instead of being pinned at `yellow`. That restores the correctness of `currentEnergyLevel = max(battery, min(solar, battery+1))` — overall now reflects battery reality at night instead of being silently boosted.

## Changes

- `configs/energy_config.yaml` — remove `black` entry; new battery thresholds (0/15/60/80) and solar thresholds (0/0, 0.1/0, 1/5, 4/20)
- `loadshedding/manager.go` — drop `energyStateBlack` constant and the now-dead `shedNonHVACLoads` helper; rewrite switch so `red` triggers full load shed and `yellow` becomes hysteresis carry (no shedNonHVAC, no enable/disable call)
- `state/computed_energy_providers.go` — fallback to first configured level instead of hard-coded `"black"`
- Unit, integration, and docs updated to the 4-level scheme

## Test plan

- [x] `make unit-tests` — passes (coverage 74.4%)
- [x] `make integration-tests` — passes
- [x] `make validate-mermaid` — passes
- [x] Pre-commit + pre-push hooks passed
- [ ] After deploy: confirm `Energy level changed` log shows `yellow` at evening arbitrage battery levels (~20–25%) instead of red
- [ ] After deploy: confirm `switch.most_of_house_thermostat_hold` stays off during normal nightly arbitrage operation
- [ ] After deploy: confirm `solarProductionEnergyLevel` is `red` at night (was `yellow` before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)