### PR TITLE
fix: suppress humidity TTS while asleep

### DIFF
--- a/homeautomation-go/internal/plugins/environmental/manager.go
+++ b/homeautomation-go/internal/plugins/environmental/manager.go
@@ -977,16 +977,14 @@ func (m *Manager) sendAlertNotification(now time.Time, level string) {
 		return
 	}
 
-	urgency := notify.UrgencyDeferable
-	if level == "critical" {
-		urgency = notify.UrgencyUrgent
-	}
-
+	// Humidity is never time-critical (mold develops over hours), so humidity
+	// TTS is always deferable — push notification still fires at the priority
+	// set above, but Sonos announcement is suppressed while master is asleep.
 	if err := m.alerter.Send(context.Background(), alert.Alert{
 		Title:    title,
 		Body:     message,
 		Speech:   speech,
-		Urgency:  urgency,
+		Urgency:  notify.UrgencyDeferable,
 		Tags:     tags,
 		Priority: priority,
 	}); err != nil {

--- a/homeautomation-go/internal/plugins/environmental/manager_test.go
+++ b/homeautomation-go/internal/plugins/environmental/manager_test.go
@@ -309,6 +309,12 @@ func TestEnvironmentalManager_CriticalThreshold_Sustained(t *testing.T) {
 	if notification.Priority != ntfy.PriorityHigh {
 		t.Errorf("Expected critical notification to have high priority, got %d", notification.Priority)
 	}
+	// Regression: humidity TTS must be deferable so it is suppressed while
+	// master is asleep. ntfy push still fires at high priority (above) so the
+	// user sees the alert on wake — but the Sonos announcement must not play.
+	if notification.Urgency != notify.UrgencyDeferable {
+		t.Errorf("Expected critical humidity Urgency=UrgencyDeferable (suppressed when asleep), got %v", notification.Urgency)
+	}
 }
 
 func TestEnvironmentalManager_OutdoorSensor_NoAlert(t *testing.T) {


### PR DESCRIPTION
## Summary
- Critical humidity alerts escalated to `UrgencyUrgent`, bypassing the sleep gate in `notify.Announce` and waking the user at 6am with a Sonos announcement.
- Both warning and critical humidity now use `UrgencyDeferable` — humidity is never time-critical (mold develops over hours).
- ntfy push priority unchanged (`PriorityHigh` for critical, `PriorityDefault` for warning) so the high-priority phone push still fires while asleep; only the auditory announcement is suppressed.
- Water leak alerts at `manager.go:679` remain `UrgencyUrgent` — leaks are genuinely time-critical.

## Test plan
- [x] `make unit-tests` passes (75.0% coverage)
- [x] `make integration-tests` passes
- [x] Regression assertion added in `TestEnvironmentalManager_CriticalThreshold_Sustained` confirming critical humidity alerts carry `notify.UrgencyDeferable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)