### PR TITLE
Fix #1133: cap energy level when solar is weak

### DIFF
--- a/docs/flows/ENERGY_MANAGEMENT.md
+++ b/docs/flows/ENERGY_MANAGEMENT.md
@@ -62,9 +62,10 @@ flowchart TD
     end
 
     subgraph Calculate["Level Calculation"]
-        compare{"Solar > Battery?"}
-        useBase["Output = Battery level"]
-        boost["Boost by 1 level<br/>(capped at solar level)"]
+        compare["Compare battery and solar levels"]
+        weaker["Find weaker input"]
+        stronger["Find stronger input"]
+        cap["Cap output at<br/>weaker + 1 level"]
     end
 
     subgraph Result["Final Level"]
@@ -73,21 +74,23 @@ flowchart TD
 
     battLevel --> compare
     solarLevel --> compare
-    compare -->|No| useBase
-    compare -->|Yes| boost
-    useBase --> calculated
-    boost --> calculated
+    compare --> weaker
+    compare --> stronger
+    weaker --> cap
+    stronger --> cap
+    cap --> calculated
 
     style calculated fill:#27ae60,color:#fff
 ```
 
-**Solar is boost-only:** Solar production can only improve the overall level, never drag it down below the battery level. This ensures that low/zero solar on a cloudy day doesn't penalize a well-charged battery.
+The overall level follows the stronger of battery and solar, but is capped at one level above the weaker input. This prevents a high battery from showing `white` when solar production is weak or absent, while still allowing strong solar to boost a lower battery level.
 
-- Solar ≤ Battery → Output = Battery level (solar has no effect)
-- Solar > Battery → Output = Battery + 1 (boost by one level, capped at solar)
+- Output starts as the stronger of battery and solar
+- Maximum output is the weaker input + 1 level
 
 Examples:
-- Battery: green (60%), Solar: red (0 kW) → Result: green (battery not penalized)
+- Battery: white (80%+), Solar: yellow (weak production) → Result: green (not white)
+- Battery: green (60%), Solar: red (0 kW) → Result: yellow (capped by weak solar)
 - Battery: yellow (15-59%), Solar: green (1+ kW, 5+ kWh) → Result: green (boosted by 1)
 - Battery: red (<15%), Solar: green (1+ kW, 5+ kWh) → Result: yellow (boosted by 1, not green)
 

--- a/docs/human/VISUAL_ARCHITECTURE.md
+++ b/docs/human/VISUAL_ARCHITECTURE.md
@@ -864,21 +864,17 @@ flowchart TD
     SyncToHA3 --> CalculateCurrent
     SyncToHA4 --> CalculateCurrent
 
-    CalculateCurrent[Calculate currentEnergyLevel] --> CompareSolar{Solar level > battery level?}
+    CalculateCurrent[Calculate currentEnergyLevel] --> FindMinMax[Find weaker and stronger inputs]
 
-    CompareSolar -->|Yes| BoostSolar[currentEnergyLevel = battery + 1<br/>capped at solar level]
-    CompareSolar -->|No| UseBattery[currentEnergyLevel = batteryEnergyLevel]
+    FindMinMax --> Cap[Output = stronger input<br/>capped at weaker + 1]
 
-    BoostSolar --> UpdateOverall[Update Shadow State:<br/>Overall Level]
-    UseBattery --> UpdateOverall
+    Cap --> UpdateOverall[Update Shadow State:<br/>Overall Level]
 
     UpdateOverall --> End([End])
 
     style Start fill:#e1f5ff
     style CheckLevels fill:#fff3e0
-    style CompareSolar fill:#fff3e0
-    style BoostSolar fill:#e8f5e9
-    style UseBattery fill:#ffebee
+    style Cap fill:#e8f5e9
     style UpdateShadow1 fill:#f3e5f5
     style UpdateBattery1 fill:#f3e5f5
     style UpdateOverall fill:#f3e5f5

--- a/homeautomation-go/internal/state/computed_energy_providers.go
+++ b/homeautomation-go/internal/state/computed_energy_providers.go
@@ -98,9 +98,8 @@ func RegisterSolarEnergyLevelProvider(
 // Formula: level = combineEnergyLevels(batteryEnergyLevel, solarProductionEnergyLevel)
 //
 // The combination logic:
-//   - Solar can only boost, never drag down the battery level
-//   - The overall level is at least the battery level
-//   - If solar is higher, it can boost by at most 1 level
+//   - The overall level follows the stronger input, capped at one level above the weaker input
+//   - This allows active solar to boost a low battery without letting either input mask a weak other input
 //
 // Dependencies:
 //   - batteryEnergyLevel
@@ -154,17 +153,20 @@ func RegisterCurrentEnergyLevelProvider(
 				return "", nil
 			}
 
-			// Solar can only boost, never drag down the battery level.
-			// The overall level is:
-			// - At least the battery level (solar never penalizes)
-			// - At most battery + 1 (solar can boost by one level if it's higher)
-			outputIndex := batteryIndex
-			if solarIndex > batteryIndex {
-				// Solar is higher, boost by at most 1
-				outputIndex = batteryIndex + 1
-				if solarIndex < outputIndex {
-					outputIndex = solarIndex
-				}
+			// Overall energy follows the stronger input, capped at one level above
+			// the weaker input. This prevents a high battery from producing white
+			// when solar is weak, while still allowing active solar to boost.
+			minIndex := batteryIndex
+			maxIndex := solarIndex
+			if solarIndex < batteryIndex {
+				minIndex = solarIndex
+				maxIndex = batteryIndex
+			}
+
+			outputIndex := maxIndex
+			maxAllowedIndex := minIndex + 1
+			if outputIndex > maxAllowedIndex {
+				outputIndex = maxAllowedIndex
 			}
 
 			// Clamp to valid range

--- a/homeautomation-go/internal/state/computed_energy_providers_test.go
+++ b/homeautomation-go/internal/state/computed_energy_providers_test.go
@@ -249,12 +249,20 @@ func TestCurrentEnergyLevelComputation(t *testing.T) {
 			description:   "Same levels result in that level",
 		},
 		{
-			name:          "battery higher than solar",
+			name:          "battery higher than solar capped by weak solar",
 			isFreeEnergy:  false,
 			batteryLevel:  "green",
 			solarLevel:    "red",
+			expectedLevel: "yellow",
+			description:   "Overall can be at most one level above the weaker input",
+		},
+		{
+			name:          "white battery with weak solar does not produce white",
+			isFreeEnergy:  false,
+			batteryLevel:  "white",
+			solarLevel:    "yellow",
 			expectedLevel: "green",
-			description:   "Solar can't drag down battery",
+			description:   "High battery alone should not trigger white-level behavior when solar is weak",
 		},
 		{
 			name:          "solar higher by 1 - boosts",

--- a/homeautomation-go/test/integration/scenario_energy_test.go
+++ b/homeautomation-go/test/integration/scenario_energy_test.go
@@ -397,6 +397,33 @@ func TestScenario_HighSolarProduction_CanStillSetWhiteEnergyLevel(t *testing.T) 
 	waitForStringState(t, manager, "currentEnergyLevel", "white", "Overall level should be white from solar boost")
 }
 
+// TestScenario_HighBatteryWeakSolar_DoesNotSetWhiteEnergyLevel validates that a
+// high battery alone does not activate white-level behavior when solar is weak.
+func TestScenario_HighBatteryWeakSolar_DoesNotSetWhiteEnergyLevel(t *testing.T) {
+	t.Parallel()
+	server, _, manager, _, cleanup := setupEnergyScenarioTest(t)
+	defer cleanup()
+
+	// GIVEN: Battery is at the white threshold, but solar production is only yellow.
+	t.Log("GIVEN: Battery white and solar production yellow")
+	server.SetState("sensor.span_panel_span_storage_battery_percentage_2", "80.0", map[string]interface{}{
+		"unit_of_measurement": "%",
+	})
+	server.SetState("sensor.energy_next_hour", "0.908", map[string]interface{}{
+		"unit_of_measurement": "kW",
+	})
+	server.SetState("sensor.energy_production_today_remaining", "1.149", map[string]interface{}{
+		"unit_of_measurement": "kWh",
+	})
+
+	// THEN: The overall level stays below white. White requires high stored energy
+	// and active solar production, so downstream thermal battery behavior does not activate.
+	t.Log("THEN: Overall level is not white")
+	waitForStringState(t, manager, "batteryEnergyLevel", "white", "Battery level should be white at 80%")
+	waitForStringState(t, manager, "solarProductionEnergyLevel", "yellow", "Solar level should be yellow")
+	waitForStringState(t, manager, "currentEnergyLevel", "green", "Overall level should be capped by weak solar")
+}
+
 // TestScenario_ThresholdBoundaries_HandlesExactValues validates that energy
 // levels are calculated correctly at exact threshold boundaries
 func TestScenario_ThresholdBoundaries_HandlesExactValues(t *testing.T) {


### PR DESCRIPTION
Resolves #1133

## Summary
- Changed currentEnergyLevel to follow the stronger battery/solar input, capped at one level above the weaker input
- Added unit and integration coverage for high battery with weak solar staying below white
- Updated the energy management flow documentation

## Test Plan
- make unit-tests
- make integration-tests
- make pre-commit

🤖 Generated by the AI assistant