### PR TITLE
Fix #1135: Add Casper unavailable debounce

### DIFF
--- a/configs/vacuum_config.yaml
+++ b/configs/vacuum_config.yaml
@@ -6,7 +6,8 @@
 vacuum:
   # Home Assistant sensor exposing the vacuum's current error state. The state
   # equals no_error_value when the vacuum is healthy; any other value is treated
-  # as an active error description that gets announced verbatim.
+  # as an active error description after transient unavailable/unknown states
+  # have cleared the plugin's debounce window.
   error_sensor_id: "sensor.valetudo_mellowslimyloris_error"
   no_error_value: "No error"
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -668,6 +668,9 @@ homeautomation-go/
 │   │   ├── alert.go                 # ✅ Alerter interface and Manager implementation
 │   │   ├── alert_test.go            # ✅ Unit tests
 │   │   └── mock.go                  # ✅ MockAlerter for unit tests
+│   ├── debounce/                    # ✅ Shared UnavailableDebouncer — debounces transient unavailable/unknown HA states
+│   │   ├── unavailable.go           # ✅ UnavailableDebouncer implementation
+│   │   └── unavailable_test.go      # ✅ Unit tests
 │   ├── notify/                      # ✅ Shared verbal (TTS) notifier
 │   │   ├── notify.go                # ✅ Notifier implementation (Kokoro TTS + media_player.play_media announce:true)
 │   │   ├── config.go                # ✅ Config loader (notification_config.yaml)

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -497,6 +497,8 @@ Each plugin corresponds to a Node-RED flow and implements domain-specific automa
 
 **Key Automations:**
 - **Error Announcement**: On error sensor transition from "No error" to a real error → TTS to common-area speakers
+- **Unavailable Debounce**: Hold transient `"unavailable"` / `"unknown"` error
+  sensor states for 60 seconds; discard them if Casper recovers inside the window
 - **Clear Confirmation**: On real error transition back to "No error" while
   `isAnyoneHome=true` → TTS to the sitting room speaker by default
 - **Quiet Hours**: When `isMasterAsleep=true` → notifier returns `ErrSuppressedAsleep`;

--- a/homeautomation-go/internal/debounce/unavailable.go
+++ b/homeautomation-go/internal/debounce/unavailable.go
@@ -92,6 +92,9 @@ func (d *UnavailableDebouncer) Stop() {
 	d.mu.Unlock()
 }
 
+// cancelPending cancels any in-flight debounce timer and clears pending state.
+// It returns false when the debouncer is stopped, which signals the caller
+// (HandleStateChange) to drop even legitimate non-unavailable events during shutdown.
 func (d *UnavailableDebouncer) cancelPending() bool {
 	d.mu.Lock()
 	defer d.mu.Unlock()

--- a/homeautomation-go/internal/debounce/unavailable.go
+++ b/homeautomation-go/internal/debounce/unavailable.go
@@ -1,0 +1,147 @@
+// Package debounce provides small reusable debouncers for noisy state changes.
+package debounce
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"homeautomation/internal/clock"
+	"homeautomation/internal/ha"
+)
+
+// UnavailableDebouncer holds transient Home Assistant unavailable/unknown
+// entity states before forwarding them to the wrapped handler.
+type UnavailableDebouncer struct {
+	delay   time.Duration
+	clock   clock.Clock
+	handler ha.StateChangeHandler
+
+	mu      sync.Mutex
+	timer   clock.Timer
+	pending pendingUnavailable
+	stopped bool
+}
+
+type pendingUnavailable struct {
+	entityID string
+	oldState *ha.State
+	newState *ha.State
+}
+
+// NewUnavailableDebouncer creates a debouncer around a Home Assistant state
+// change handler.
+func NewUnavailableDebouncer(
+	delay time.Duration,
+	clk clock.Clock,
+	handler ha.StateChangeHandler,
+) *UnavailableDebouncer {
+	if clk == nil {
+		clk = clock.NewRealClock()
+	}
+	return &UnavailableDebouncer{
+		delay:   delay,
+		clock:   clk,
+		handler: handler,
+	}
+}
+
+// HandleStateChange forwards normal state changes immediately and debounces
+// unavailable/unknown states.
+func (d *UnavailableDebouncer) HandleStateChange(entityID string, oldState, newState *ha.State) {
+	if d == nil || d.handler == nil {
+		return
+	}
+	if !isUnavailableState(newState) || d.delay <= 0 {
+		if !d.cancelPending() {
+			return
+		}
+		d.handler(entityID, oldState, newState)
+		return
+	}
+
+	d.mu.Lock()
+	if d.stopped {
+		d.mu.Unlock()
+		return
+	}
+	if d.timer != nil {
+		d.timer.Stop()
+	}
+	d.pending = pendingUnavailable{
+		entityID: entityID,
+		oldState: cloneState(oldState),
+		newState: cloneState(newState),
+	}
+	d.timer = d.clock.AfterFunc(d.delay, d.forwardPending)
+	d.mu.Unlock()
+}
+
+// Stop cancels any pending unavailable state.
+func (d *UnavailableDebouncer) Stop() {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	d.stopped = true
+	if d.timer != nil {
+		d.timer.Stop()
+	}
+	d.timer = nil
+	d.pending = pendingUnavailable{}
+	d.mu.Unlock()
+}
+
+func (d *UnavailableDebouncer) cancelPending() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.stopped {
+		return false
+	}
+	if d.timer != nil {
+		d.timer.Stop()
+	}
+	d.timer = nil
+	d.pending = pendingUnavailable{}
+	return true
+}
+
+func (d *UnavailableDebouncer) forwardPending() {
+	d.mu.Lock()
+	if d.stopped || d.pending.newState == nil {
+		d.mu.Unlock()
+		return
+	}
+	pending := d.pending
+	d.timer = nil
+	d.pending = pendingUnavailable{}
+	d.mu.Unlock()
+
+	d.handler(pending.entityID, pending.oldState, pending.newState)
+}
+
+func isUnavailableState(state *ha.State) bool {
+	if state == nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(state.State)) {
+	case "unavailable", "unknown":
+		return true
+	default:
+		return false
+	}
+}
+
+func cloneState(state *ha.State) *ha.State {
+	if state == nil {
+		return nil
+	}
+	copied := *state
+	if state.Attributes != nil {
+		copied.Attributes = make(map[string]interface{}, len(state.Attributes))
+		for k, v := range state.Attributes {
+			copied.Attributes[k] = v
+		}
+	}
+	return &copied
+}

--- a/homeautomation-go/internal/debounce/unavailable_test.go
+++ b/homeautomation-go/internal/debounce/unavailable_test.go
@@ -1,0 +1,93 @@
+package debounce
+
+import (
+	"testing"
+	"time"
+
+	"homeautomation/internal/clock"
+	"homeautomation/internal/ha"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type debouncedCall struct {
+	entityID string
+	oldState *ha.State
+	newState *ha.State
+}
+
+func TestUnavailableDebouncer_ForwardsNormalStateImmediately(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMockClock(time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC))
+	var calls []debouncedCall
+	debouncer := NewUnavailableDebouncer(time.Minute, clk, func(entityID string, oldState, newState *ha.State) {
+		calls = append(calls, debouncedCall{entityID: entityID, oldState: oldState, newState: newState})
+	})
+
+	debouncer.HandleStateChange("sensor.robot", nil, state("sensor.robot", "No error"))
+
+	require.Len(t, calls, 1)
+	assert.Equal(t, "sensor.robot", calls[0].entityID)
+	assert.Equal(t, "No error", calls[0].newState.State)
+}
+
+func TestUnavailableDebouncer_DiscardsUnavailableOnRecovery(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMockClock(time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC))
+	var calls []debouncedCall
+	debouncer := NewUnavailableDebouncer(time.Minute, clk, func(entityID string, oldState, newState *ha.State) {
+		calls = append(calls, debouncedCall{entityID: entityID, oldState: oldState, newState: newState})
+	})
+
+	debouncer.HandleStateChange("sensor.robot", state("sensor.robot", "No error"), state("sensor.robot", "unavailable"))
+	clk.Advance(30 * time.Second)
+	debouncer.HandleStateChange("sensor.robot", state("sensor.robot", "unavailable"), state("sensor.robot", "No error"))
+	clk.Advance(time.Minute)
+
+	require.Len(t, calls, 1)
+	assert.Equal(t, "No error", calls[0].newState.State)
+}
+
+func TestUnavailableDebouncer_ForwardsUnavailableAfterDelay(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMockClock(time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC))
+	var calls []debouncedCall
+	debouncer := NewUnavailableDebouncer(time.Minute, clk, func(entityID string, oldState, newState *ha.State) {
+		calls = append(calls, debouncedCall{entityID: entityID, oldState: oldState, newState: newState})
+	})
+
+	debouncer.HandleStateChange("sensor.robot", state("sensor.robot", "No error"), state("sensor.robot", "unknown"))
+	clk.Advance(59 * time.Second)
+	assert.Empty(t, calls)
+
+	clk.Advance(time.Second)
+
+	require.Len(t, calls, 1)
+	assert.Equal(t, "sensor.robot", calls[0].entityID)
+	assert.Equal(t, "No error", calls[0].oldState.State)
+	assert.Equal(t, "unknown", calls[0].newState.State)
+}
+
+func TestUnavailableDebouncer_StopCancelsPending(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMockClock(time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC))
+	var calls []debouncedCall
+	debouncer := NewUnavailableDebouncer(time.Minute, clk, func(entityID string, oldState, newState *ha.State) {
+		calls = append(calls, debouncedCall{entityID: entityID, oldState: oldState, newState: newState})
+	})
+
+	debouncer.HandleStateChange("sensor.robot", nil, state("sensor.robot", "unavailable"))
+	debouncer.Stop()
+	clk.Advance(time.Minute)
+
+	assert.Empty(t, calls)
+}
+
+func state(entityID, value string) *ha.State {
+	return &ha.State{
+		EntityID:   entityID,
+		State:      value,
+		Attributes: map[string]interface{}{"friendly_name": "Robot"},
+	}
+}

--- a/homeautomation-go/internal/plugins/vacuum/manager.go
+++ b/homeautomation-go/internal/plugins/vacuum/manager.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"homeautomation/internal/alert"
+	"homeautomation/internal/clock"
+	"homeautomation/internal/debounce"
 	"homeautomation/internal/ha"
 	"homeautomation/internal/notify"
 	"homeautomation/internal/ntfy"
@@ -31,6 +33,10 @@ import (
 // be small without spamming.
 const defaultRepeatCheckInterval = 1 * time.Minute
 
+// defaultUnavailableDebounceDelay covers typical Casper reboot/network blips
+// before treating unavailable/unknown as a real sensor state.
+const defaultUnavailableDebounceDelay = 1 * time.Minute
+
 // Manager handles vacuum error announcements.
 type Manager struct {
 	ctx          context.Context
@@ -46,10 +52,13 @@ type Manager struct {
 
 	shadowTracker *shadowstate.VacuumTracker
 	subHelper     *shadowstate.SubscriptionHelper
+	errDebouncer  *debounce.UnavailableDebouncer
 
 	// repeatCheckInterval controls how often the background ticker re-checks
 	// for repeat announcements. Tests inject a smaller value via SetRepeatCheckIntervalForTest.
-	repeatCheckInterval time.Duration
+	repeatCheckInterval      time.Duration
+	unavailableDebounceDelay time.Duration
+	unavailableDebounceClock clock.Clock
 
 	mu              sync.Mutex
 	currentError    string
@@ -99,8 +108,10 @@ func NewManager(
 			"vacuum",
 			logger.Named("vacuum"),
 		),
-		repeatCheckInterval: defaultRepeatCheckInterval,
-		stopCh:              make(chan struct{}),
+		repeatCheckInterval:      defaultRepeatCheckInterval,
+		unavailableDebounceDelay: defaultUnavailableDebounceDelay,
+		unavailableDebounceClock: clock.NewRealClock(),
+		stopCh:                   make(chan struct{}),
 	}
 }
 
@@ -116,7 +127,15 @@ func (m *Manager) Start() error {
 		zap.String("error_sensor", m.cfg.Vacuum.ErrorSensorID),
 		zap.Duration("repeat_interval", m.cfg.Vacuum.Announcement.RepeatInterval))
 
-	if err := m.subHelper.SubscribeToEntity(m.cfg.Vacuum.ErrorSensorID, m.handleErrorChange); err != nil {
+	if m.errDebouncer == nil {
+		m.errDebouncer = debounce.NewUnavailableDebouncer(
+			m.unavailableDebounceDelay,
+			m.unavailableDebounceClock,
+			m.handleErrorChange,
+		)
+	}
+
+	if err := m.subHelper.SubscribeToEntity(m.cfg.Vacuum.ErrorSensorID, m.errDebouncer.HandleStateChange); err != nil {
 		return fmt.Errorf("subscribe to vacuum error sensor: %w", err)
 	}
 	// Empty handler: registered solely to capture isAnyoneHome into shadow inputs.
@@ -128,7 +147,7 @@ func (m *Manager) Start() error {
 	// Treat the sensor's current state as if we just received it. If the vacuum
 	// already has an active error when we start up, announce it.
 	if cur, err := m.haClient.GetState(m.cfg.Vacuum.ErrorSensorID); err == nil && cur != nil {
-		m.handleErrorChange(m.cfg.Vacuum.ErrorSensorID, nil, cur)
+		m.errDebouncer.HandleStateChange(m.cfg.Vacuum.ErrorSensorID, nil, cur)
 	} else if err != nil {
 		m.logger.Warn("Failed to read initial vacuum error sensor state",
 			zap.String("entity", m.cfg.Vacuum.ErrorSensorID),
@@ -148,6 +167,9 @@ func (m *Manager) Stop() {
 	m.stopOnce.Do(func() {
 		close(m.stopCh)
 	})
+	if m.errDebouncer != nil {
+		m.errDebouncer.Stop()
+	}
 	m.subHelper.UnsubscribeAll()
 	m.wg.Wait()
 	m.logger.Info("Vacuum Manager stopped")
@@ -352,6 +374,20 @@ func (m *Manager) tickRepeat() {
 // only — never call from production code.
 func (m *Manager) SetRepeatCheckIntervalForTest(d time.Duration) {
 	m.repeatCheckInterval = d
+}
+
+// SetUnavailableDebounceForTest overrides the unavailable-state debounce.
+// Tests only — never call from production code.
+func (m *Manager) SetUnavailableDebounceForTest(d time.Duration, clk clock.Clock) {
+	if clk == nil {
+		clk = clock.NewRealClock()
+	}
+	if m.errDebouncer != nil {
+		m.errDebouncer.Stop()
+	}
+	m.unavailableDebounceDelay = d
+	m.unavailableDebounceClock = clk
+	m.errDebouncer = debounce.NewUnavailableDebouncer(d, clk, m.handleErrorChange)
 }
 
 // TickRepeatForTest invokes the periodic check synchronously. Tests only.

--- a/homeautomation-go/internal/plugins/vacuum/manager_test.go
+++ b/homeautomation-go/internal/plugins/vacuum/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"homeautomation/internal/alert"
+	"homeautomation/internal/clock"
 	"homeautomation/internal/ha"
 	"homeautomation/internal/notify"
 	"homeautomation/internal/shadowstate"
@@ -113,6 +114,45 @@ func TestVacuum_TransitionToError_Announces(t *testing.T) {
 	st := mgr.GetShadowState()
 	assert.Equal(t, "Mop Dock Clean Water Tank empty", st.Outputs.CurrentError)
 	assert.Equal(t, 1, st.Outputs.AnnouncementsSinceErrorBegan)
+}
+
+func TestVacuum_TransientUnavailable_DoesNotAnnounce(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMockClock(time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC))
+	mgr, mockHA, _, mockAlerter, _ := newTestManager(t, false, clk.Now())
+	mgr.SetUnavailableDebounceForTest(time.Minute, clk)
+	mockHA.SimulateStateChange(testErrorSensor, "No error")
+	require.NoError(t, mgr.Start())
+	defer mgr.Stop()
+
+	setSensor(t, mockHA, "unavailable")
+	clk.Advance(30 * time.Second)
+	setSensor(t, mockHA, "No error")
+	clk.Advance(time.Minute)
+
+	assert.Empty(t, mockAlerter.Calls(), "transient unavailable must not alert")
+	assert.Empty(t, mgr.GetShadowState().Outputs.CurrentError)
+}
+
+func TestVacuum_ProlongedUnavailable_ForwardsAfterDebounce(t *testing.T) {
+	t.Parallel()
+	clk := clock.NewMockClock(time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC))
+	mgr, mockHA, _, mockAlerter, _ := newTestManager(t, false, clk.Now())
+	mgr.SetUnavailableDebounceForTest(time.Minute, clk)
+	mockHA.SimulateStateChange(testErrorSensor, "No error")
+	require.NoError(t, mgr.Start())
+	defer mgr.Stop()
+
+	setSensor(t, mockHA, "unavailable")
+	clk.Advance(59 * time.Second)
+	assert.Empty(t, mockAlerter.Calls())
+
+	clk.Advance(time.Second)
+
+	calls := mockAlerter.Calls()
+	require.Len(t, calls, 1, "prolonged unavailable should forward to existing vacuum handling")
+	assert.Equal(t, "Casper needs attention: unavailable", calls[0].Body)
+	assert.Equal(t, "unavailable", mgr.GetShadowState().Outputs.CurrentError)
 }
 
 func TestVacuum_SameErrorReemitted_NoExtraAnnouncement(t *testing.T) {

--- a/homeautomation-go/test/integration/scenario_vacuum_error_test.go
+++ b/homeautomation-go/test/integration/scenario_vacuum_error_test.go
@@ -47,6 +47,10 @@ type vacuumEnv struct {
 }
 
 func setupVacuumTest(t *testing.T, fixedTime time.Time) (*vacuumEnv, func()) {
+	return setupVacuumTestWithDebounce(t, fixedTime, 0)
+}
+
+func setupVacuumTestWithDebounce(t *testing.T, fixedTime time.Time, unavailableDebounce time.Duration) (*vacuumEnv, func()) {
 	t.Helper()
 	server, client, manager, baseCleanup := setupTest(t)
 	logger := testlogger.New()
@@ -80,6 +84,9 @@ func setupVacuumTest(t *testing.T, fixedTime time.Time) (*vacuumEnv, func()) {
 	alerter := alert.NewManager(nil, notifier, logger)
 	mgr := vacuum.NewManager(context.Background(), client, manager, alerter, notifier, cfg, logger, false, tp, nil)
 	mgr.SetRepeatCheckIntervalForTest(time.Hour) // park the background ticker; tests drive ticks explicitly
+	if unavailableDebounce > 0 {
+		mgr.SetUnavailableDebounceForTest(unavailableDebounce, nil)
+	}
 	require.NoError(t, mgr.Start(), "vacuum plugin should start")
 
 	env := &vacuumEnv{server: server, manager: manager, logger: logger, vacuum: mgr, synth: synth}
@@ -124,6 +131,66 @@ func TestScenario_VacuumError_AnnouncesWhenErrorAppears(t *testing.T) {
 	require.NotEmpty(t, msgs, "synthesizer should have been called")
 	assert.Contains(t, msgs[0], "Mop Dock Clean Water Tank empty",
 		"synthesized text must include the error description")
+}
+
+// TestScenario_VacuumError_CasperRebootDoesNotAlert verifies the Casper reboot
+// timeline: transient HA unavailable states must not be treated as actionable
+// robot errors when the sensor recovers inside the debounce window.
+func TestScenario_VacuumError_CasperRebootDoesNotAlert(t *testing.T) {
+	t.Parallel()
+	env, cleanup := setupVacuumTestWithDebounce(
+		t,
+		time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC),
+		50*time.Millisecond,
+	)
+	defer cleanup()
+
+	t.Log("GIVEN: Casper is healthy and master is awake")
+	require.NoError(t, env.manager.SetBool("isMasterAsleep", false))
+	snapshot := env.server.ServiceCallCount()
+
+	t.Log("WHEN: Casper reboots and the error sensor briefly reports unavailable")
+	env.server.SetState(vacuumErrorEntity, "unavailable", nil)
+	time.Sleep(25 * time.Millisecond)
+	env.server.SetState(vacuumErrorEntity, "No error", nil)
+
+	t.Log("THEN: The unavailable transition is discarded and no alert is sent")
+	waitForServiceCallQuiescenceSince(t, env.server, snapshot, 150*time.Millisecond)
+	calls := FilterServiceCalls(env.server.GetServiceCallsSince(snapshot), "media_player", "play_media")
+	assert.Empty(t, calls, "transient unavailable must not produce TTS")
+	assert.Empty(t, env.synth.Messages(), "transient unavailable must not synthesize speech")
+	assert.Empty(t, env.vacuum.GetShadowState().Outputs.CurrentError)
+}
+
+// TestScenario_VacuumError_ProlongedUnavailableForwards verifies that the
+// debouncer only suppresses transient unavailable states. A state held past the
+// debounce window reaches the existing vacuum error handling path.
+func TestScenario_VacuumError_ProlongedUnavailableForwards(t *testing.T) {
+	t.Parallel()
+	env, cleanup := setupVacuumTestWithDebounce(
+		t,
+		time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC),
+		50*time.Millisecond,
+	)
+	defer cleanup()
+
+	t.Log("GIVEN: Casper is healthy and master is awake")
+	require.NoError(t, env.manager.SetBool("isMasterAsleep", false))
+	snapshot := env.server.ServiceCallCount()
+
+	t.Log("WHEN: The error sensor remains unavailable beyond the debounce window")
+	env.server.SetState(vacuumErrorEntity, "unavailable", nil)
+
+	t.Log("THEN: The unavailable state forwards through the production alert path")
+	require.Eventually(t, func() bool {
+		return env.vacuum.GetShadowState().Outputs.CurrentError == "unavailable"
+	}, stateWaitTimeout, statePollInterval)
+	require.Eventually(t, func() bool {
+		return len(FilterServiceCalls(env.server.GetServiceCallsSince(snapshot), "media_player", "play_media")) >= 1
+	}, stateWaitTimeout, statePollInterval)
+	msgs := env.synth.Messages()
+	require.NotEmpty(t, msgs)
+	assert.Contains(t, msgs[len(msgs)-1], "unavailable")
 }
 
 // TestScenario_VacuumError_SuppressedWhileMasterAsleep verifies that an error

--- a/homeautomation-go/test/integration/scenario_vacuum_error_test.go
+++ b/homeautomation-go/test/integration/scenario_vacuum_error_test.go
@@ -151,6 +151,11 @@ func TestScenario_VacuumError_CasperRebootDoesNotAlert(t *testing.T) {
 
 	t.Log("WHEN: Casper reboots and the error sensor briefly reports unavailable")
 	env.server.SetState(vacuumErrorEntity, "unavailable", nil)
+	// time.Sleep instead of polling: there is no observable intermediate state between
+	// the mock server sending the "unavailable" WebSocket frame and the debounce timer
+	// being armed inside the plugin. We sleep well within the 50 ms debounce window so
+	// the HA client goroutine has time to receive and dispatch the event before the
+	// recovery "No error" frame is sent.
 	time.Sleep(25 * time.Millisecond)
 	env.server.SetState(vacuumErrorEntity, "No error", nil)
 


### PR DESCRIPTION
Resolves #1135

## Summary
- Added a shared `UnavailableDebouncer` that holds `unavailable` / `unknown` HA states and cancels them on recovery.
- Wrapped Casper vacuum error-sensor handling with a 60s unavailable debounce.
- Added unit and integration coverage for transient Casper reboot recovery and prolonged unavailable forwarding.

## Test Plan
- `make unit-tests`
- `make integration-tests`
- `make pre-commit`

🤖 Generated by the AI assistant