### PR TITLE
Fix #1139: resolve review PR merge conflicts

### DIFF
--- a/.github/ci/prompts/resolve-pr-conflicts.md
+++ b/.github/ci/prompts/resolve-pr-conflicts.md
@@ -5,6 +5,13 @@ PR TITLE: ${PR_TITLE}
 PR BODY:
 ${PR_BODY}
 
+LINKED ISSUE CONTEXT:
+Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
+${ISSUE_BODY}
+
+PR COMMENTS AND REVIEW CONTEXT:
+${PR_REVIEW_CONTEXT}
+
 PR HEAD BRANCH: ${HEAD_REF}
 BASE BRANCH:    ${BASE_REF}
 TRIGGERING SHA: ${TRIGGERING_SHA}
@@ -38,7 +45,7 @@ YOUR TASK:
 4. For each conflicted file, resolve in-context:
    - Read both sides of the conflict markers AND the surrounding code on the new base.
    - Write a resolution that preserves the PR's stated intent (re-read the PR body / linked
-     issue if you are unsure what behavior the PR is meant to deliver).
+     issue and PR review comments above if you are unsure what behavior the PR is meant to deliver).
    - Apply the same scope discipline as a fresh implementation: minimum diff, no
      refactors, no unrelated cleanups.
    - Then: git add <file> && git rebase --continue. Loop until the rebase reports clean.

--- a/.github/workflows/ai-assistant.yml
+++ b/.github/workflows/ai-assistant.yml
@@ -407,15 +407,35 @@ jobs:
             AI_TOOL=codex
             CODEX_MODEL=gpt-5.5
           # Fetch PR metadata inside the container so the prompt template
-          # has PR_TITLE, PR_BODY, BASE_REF, and TRIGGERING_SHA available
-          # without passing multi-line strings through the workflow YAML.
+          # has PR, issue, and review context available without passing
+          # multi-line strings through the workflow YAML.
           pre_script: |
             PR_JSON=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
             PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
             PR_BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
             BASE_REF=$(echo "$PR_JSON" | jq -r '.base.ref')
             TRIGGERING_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
-            export PR_TITLE PR_BODY BASE_REF TRIGGERING_SHA
+
+            ISSUE_NUMBER=$(printf '%s\n' "$PR_BODY" | grep -oP '(Resolves|Fixes|Closes|Fix)\s*#\K\d+' | head -1 || true)
+            ISSUE_TITLE=""
+            ISSUE_BODY=""
+            if [ -n "$ISSUE_NUMBER" ]; then
+              ISSUE_JSON=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" 2>/dev/null || echo "{}")
+              ISSUE_TITLE=$(echo "$ISSUE_JSON" | jq -r '.title // ""')
+              ISSUE_BODY=$(echo "$ISSUE_JSON" | jq -r '.body // ""')
+            fi
+
+            ISSUE_COMMENTS=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+              --jq '.[] | "---\n**PR comment by \(.user.login) at \(.created_at):**\n\(.body // "")\n"' 2>/dev/null \
+              | head -c 20000 || true)
+            PR_REVIEWS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+              --jq '.[] | "---\n**Review by \(.user.login) at \(.submitted_at // .created_at): \(.state)**\n\(.body // "")\n"' 2>/dev/null \
+              | head -c 20000 || true)
+            INLINE_REVIEW_COMMENTS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
+              --jq '.[] | "---\n**Inline review comment by \(.user.login) on \(.path):\(.line // .original_line // 0) at \(.created_at):**\n\(.body // "")\n"' 2>/dev/null \
+              | head -c 20000 || true)
+            PR_REVIEW_CONTEXT=$(printf '%s\n%s\n%s\n' "$ISSUE_COMMENTS" "$PR_REVIEWS" "$INLINE_REVIEW_COMMENTS" | head -c 50000)
+            export PR_TITLE PR_BODY BASE_REF TRIGGERING_SHA ISSUE_NUMBER ISSUE_TITLE ISSUE_BODY PR_REVIEW_CONTEXT
 
       - name: Remove ai-resolving label
         if: always()

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -76,6 +76,7 @@ jobs:
       pr_body_b64: ${{ steps.get-pr.outputs.pr_body_b64 }}
       head_ref: ${{ steps.get-pr.outputs.head_ref }}
       head_repo: ${{ steps.get-pr.outputs.head_repo }}
+      merge_state_status: ${{ steps.check-merge-state.outputs.merge_state_status }}
       # Draft PR status - used to skip auto-fix pipeline for TDD workflows
       is_draft: ${{ steps.get-pr.outputs.is_draft }}
       # Handle workflow_run, workflow_dispatch, pull_request, and issue_comment events
@@ -288,6 +289,30 @@ jobs:
               core.setOutput('pr_number', '');
               core.setOutput('is_draft', 'false');
             }
+
+      - name: Check PR merge state
+        if: steps.get-pr.outputs.pr_number != ''
+        id: check-merge-state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.get-pr.outputs.pr_number }}
+        run: |
+          # GitHub computes mergeability asynchronously. Poll briefly so a
+          # just-completed PR Tests run does not see UNKNOWN and miss a DIRTY PR.
+          STATE="UNKNOWN|UNKNOWN"
+          for i in 1 2 3 4 5 6; do
+            STATE=$(gh pr view "$PR_NUMBER" --repo ${{ github.repository }} \
+              --json mergeStateStatus,mergeable \
+              --jq '"\(.mergeable)|\(.mergeStateStatus)"' 2>/dev/null || echo "UNKNOWN|UNKNOWN")
+            MERGEABLE="${STATE%%|*}"
+            if [ "$MERGEABLE" != "UNKNOWN" ]; then
+              break
+            fi
+            sleep 5
+          done
+          MERGE_STATE="${STATE#*|}"
+          echo "PR #$PR_NUMBER merge state: $STATE"
+          echo "merge_state_status=$MERGE_STATE" >> "$GITHUB_OUTPUT"
 
       - name: Extract linked issue from PR body
         if: steps.get-pr.outputs.pr_number != ''
@@ -1194,9 +1219,10 @@ jobs:
           path: /tmp/docs-review-output/docs-review-output.jsonl
           retention-days: 7
 
-  # Final decision maker - synthesizes all reviews and makes go/no-go call
-  # SKIP for draft PRs (work in progress)
-  merge-decision:
+  # Rebase a reviewed PR onto main when reviews passed but GitHub reports
+  # merge conflicts. Runs after reviewers comment so the resolver has their
+  # context, then pushes a new head that will trigger fresh tests/reviews.
+  resolve-merge-conflicts:
     needs: [get-context, ai-review, design-review, test-review, concurrency-review, docs-review]
     if: |
       always() &&
@@ -1204,7 +1230,109 @@ jobs:
       needs.get-context.outputs.is_draft != 'true' &&
       needs.get-context.outputs.reviews_already_passed != 'true' &&
       needs.get-context.outputs.author_authorized == 'true' &&
-      needs.get-context.outputs.tests_passed == 'true'
+      needs.get-context.outputs.tests_passed == 'true' &&
+      needs.get-context.outputs.merge_state_status == 'DIRTY' &&
+      (needs.ai-review.result == 'success' || needs.ai-review.result == 'skipped') &&
+      (needs.design-review.result == 'success' || needs.design-review.result == 'skipped') &&
+      (needs.test-review.result == 'success' || needs.test-review.result == 'skipped') &&
+      (needs.concurrency-review.result == 'success' || needs.concurrency-review.result == 'skipped') &&
+      (needs.docs-review.result == 'success' || needs.docs-review.result == 'skipped')
+    runs-on: [self-hosted, homelab]
+    timeout-minutes: 120
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      packages: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.WORKFLOW_PAT }}
+
+      - name: Add ai-resolving label
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+        run: |
+          gh label create "ai-resolving" --color "fbca04" \
+            --description "AI assistant is rebasing this PR onto its base" \
+            --repo ${{ github.repository }} 2>/dev/null || true
+          gh pr edit ${{ needs.get-context.outputs.pr_number }} --add-label "ai-resolving" \
+            --repo ${{ github.repository }}
+
+      - name: Resolve PR conflicts with AI assistant
+        uses: ./.github/actions/run-ci-agent
+        with:
+          image: ${{ env.CI_IMAGE }}
+          prompt_file: .github/ci/prompts/resolve-pr-conflicts.md
+          output_file: ${{ runner.temp }}/review-conflict-resolution-output.jsonl
+          env: |
+            AI_API_KEY=${{ vars.AI_API_KEY }}
+            GH_TOKEN=${{ secrets.WORKFLOW_PAT }}
+            PR_NUMBER=${{ needs.get-context.outputs.pr_number }}
+            HEAD_REF=${{ needs.get-context.outputs.head_ref }}
+            REPO=${{ github.repository }}
+            AI_TOOL=codex
+            CODEX_MODEL=gpt-5.5
+          pre_script: |
+            PR_JSON=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
+            PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+            PR_BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
+            BASE_REF=$(echo "$PR_JSON" | jq -r '.base.ref')
+            TRIGGERING_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
+
+            ISSUE_NUMBER=$(printf '%s\n' "$PR_BODY" | grep -oP '(Resolves|Fixes|Closes|Fix)\s*#\K\d+' | head -1 || true)
+            ISSUE_TITLE=""
+            ISSUE_BODY=""
+            if [ -n "$ISSUE_NUMBER" ]; then
+              ISSUE_JSON=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" 2>/dev/null || echo "{}")
+              ISSUE_TITLE=$(echo "$ISSUE_JSON" | jq -r '.title // ""')
+              ISSUE_BODY=$(echo "$ISSUE_JSON" | jq -r '.body // ""')
+            fi
+
+            ISSUE_COMMENTS=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+              --jq '.[] | "---\n**PR comment by \(.user.login) at \(.created_at):**\n\(.body // "")\n"' 2>/dev/null \
+              | head -c 20000 || true)
+            PR_REVIEWS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+              --jq '.[] | "---\n**Review by \(.user.login) at \(.submitted_at // .created_at): \(.state)**\n\(.body // "")\n"' 2>/dev/null \
+              | head -c 20000 || true)
+            INLINE_REVIEW_COMMENTS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
+              --jq '.[] | "---\n**Inline review comment by \(.user.login) on \(.path):\(.line // .original_line // 0) at \(.created_at):**\n\(.body // "")\n"' 2>/dev/null \
+              | head -c 20000 || true)
+            PR_REVIEW_CONTEXT=$(printf '%s\n%s\n%s\n' "$ISSUE_COMMENTS" "$PR_REVIEWS" "$INLINE_REVIEW_COMMENTS" | head -c 50000)
+            export PR_TITLE PR_BODY BASE_REF TRIGGERING_SHA ISSUE_NUMBER ISSUE_TITLE ISSUE_BODY PR_REVIEW_CONTEXT
+
+      - name: Remove ai-resolving label
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+        run: |
+          gh pr edit ${{ needs.get-context.outputs.pr_number }} --remove-label "ai-resolving" \
+            --repo ${{ github.repository }} 2>/dev/null || true
+
+      - name: Upload conflict resolution output
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: review-conflict-resolution-output
+          path: ${{ runner.temp }}/review-conflict-resolution-output.jsonl
+          retention-days: 7
+
+  # Final decision maker - synthesizes all reviews and makes go/no-go call
+  # SKIP for draft PRs (work in progress)
+  merge-decision:
+    needs: [get-context, ai-review, design-review, test-review, concurrency-review, docs-review, resolve-merge-conflicts]
+    if: |
+      always() &&
+      needs.get-context.outputs.pr_number != '' &&
+      needs.get-context.outputs.is_draft != 'true' &&
+      needs.get-context.outputs.reviews_already_passed != 'true' &&
+      needs.get-context.outputs.author_authorized == 'true' &&
+      needs.get-context.outputs.tests_passed == 'true' &&
+      needs.resolve-merge-conflicts.result == 'skipped'
     runs-on: [self-hosted, homelab]
     timeout-minutes: 45
     outputs:
@@ -1343,7 +1471,7 @@ jobs:
   all-reviews-passed:
     name: All Required Agent Reviews
     runs-on: [self-hosted, homelab]
-    needs: [get-context, fix-test-failures, ai-review, design-review, test-review, concurrency-review, docs-review, merge-decision]
+    needs: [get-context, fix-test-failures, ai-review, design-review, test-review, concurrency-review, docs-review, resolve-merge-conflicts, merge-decision]
     if: always() && needs.get-context.outputs.author_authorized == 'true'
     permissions:
       statuses: write  # Required to create commit status on PR
@@ -1444,6 +1572,17 @@ jobs:
               echo "Docs Review: ${{ needs.docs-review.result }}"
               failed=true
             fi
+
+            if [ "${{ needs.resolve-merge-conflicts.result }}" = "success" ]; then
+              echo "Merge conflicts were resolved and pushed to the PR branch."
+              echo "Waiting for PR Tests and AI Code Review to run on the new head."
+              echo "conflict_resolution_ran=true" >> $GITHUB_OUTPUT
+              exit 0
+            elif ! check_result "${{ needs.resolve-merge-conflicts.result }}"; then
+              echo "Resolve Merge Conflicts: ${{ needs.resolve-merge-conflicts.result }}"
+              failed=true
+            fi
+
             if ! check_result "${{ needs.merge-decision.result }}"; then
               echo "Merge Decision: ${{ needs.merge-decision.result }}"
               failed=true
@@ -1488,6 +1627,7 @@ jobs:
           echo "  Test Review: ${{ needs.test-review.result }}"
           echo "  Concurrency Review: ${{ needs.concurrency-review.result }}"
           echo "  Docs Review: ${{ needs.docs-review.result }}"
+          echo "  Resolve Merge Conflicts: ${{ needs.resolve-merge-conflicts.result }}"
           echo "  Merge Decision Job: ${{ needs.merge-decision.result }}"
           echo "  Merge Decision Verdict: ${{ needs.merge-decision.outputs.decision }}"
 
@@ -1497,6 +1637,7 @@ jobs:
       - name: Create commit status for reviews
         if: |
           needs.get-context.outputs.pr_number != '' &&
+          steps.check-results.outputs.conflict_resolution_ran != 'true' &&
           (needs.get-context.outputs.tests_passed == 'true' || steps.check-results.outputs.skipped_with_success == 'true')
         env:
           GH_TOKEN: ${{ github.token }}
@@ -1526,6 +1667,7 @@ jobs:
       - name: Add agent-reviews-passed label
         if: |
           steps.check-results.outputs.should_label == 'true' &&
+          steps.check-results.outputs.conflict_resolution_ran != 'true' &&
           needs.get-context.outputs.pr_number != ''
         env:
           GH_TOKEN: ${{ github.token }}
@@ -1554,7 +1696,8 @@ jobs:
           needs.get-context.outputs.pr_number != '' &&
           needs.get-context.outputs.is_draft != 'true' &&
           needs.get-context.outputs.reviews_already_passed != 'true' &&
-          needs.get-context.outputs.tests_passed == 'true'
+          needs.get-context.outputs.tests_passed == 'true' &&
+          steps.check-results.outputs.conflict_resolution_ran != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ needs.get-context.outputs.pr_number }}
@@ -1566,6 +1709,7 @@ jobs:
           TEST_RESULT: ${{ needs.test-review.result }}
           CONCURRENCY_RESULT: ${{ needs.concurrency-review.result }}
           DOCS_RESULT: ${{ needs.docs-review.result }}
+          RESOLVE_CONFLICTS_RESULT: ${{ needs.resolve-merge-conflicts.result }}
           MERGE_RESULT: ${{ needs.merge-decision.result }}
           MERGE_DECISION: ${{ needs.merge-decision.outputs.decision }}
           CONFIG_ONLY: ${{ needs.get-context.outputs.config_only }}
@@ -1639,6 +1783,7 @@ jobs:
               COMMENT+="| 🔀 Concurrency Review | $(format_result "$CONCURRENCY_RESULT") |\n"
               COMMENT+="| 📚 Docs Review | $(format_result "$DOCS_RESULT") |\n"
             fi
+            COMMENT+="| 🔧 Resolve Merge Conflicts | $(format_result "$RESOLVE_CONFLICTS_RESULT") |\n"
             # Show actual merge decision verdict instead of just job status
             COMMENT+="| 🚦 Merge Decision | $(format_merge_decision "$MERGE_DECISION") |\n"
           fi

--- a/docs/operations/AI_GHA_PIPELINES.md
+++ b/docs/operations/AI_GHA_PIPELINES.md
@@ -138,6 +138,8 @@ Outputs a JSON array `[{pr_number, head_ref}, …]` consumed by `resolve-pr-conf
 
 Rebases a conflicting PR onto its base, resolves conflicts in-context, runs `make unit-tests`, and force-pushes the rebased branch. One matrix instance per target from `prepare-targets`.
 
+The same resolver is also used by `ai-code-review.yml` after review agents have posted comments. If tests and review jobs pass but GitHub reports `mergeStateStatus == DIRTY`, the review workflow runs conflict resolution with the PR body, linked issue context, PR comments, review summaries, and inline review comments. The current review run then stops without marking reviews passed; the resolver push starts a fresh PR Tests run and a fresh AI Code Review run for the new head.
+
 **Condition**: `needs.prepare-targets.outputs.has_targets == 'true'`.
 
 **Workflow**:

--- a/docs/operations/AI_GHA_PIPELINES.md
+++ b/docs/operations/AI_GHA_PIPELINES.md
@@ -138,7 +138,7 @@ Outputs a JSON array `[{pr_number, head_ref}, …]` consumed by `resolve-pr-conf
 
 Rebases a conflicting PR onto its base, resolves conflicts in-context, runs `make unit-tests`, and force-pushes the rebased branch. One matrix instance per target from `prepare-targets`.
 
-The same resolver is also used by `ai-code-review.yml` after review agents have posted comments. If tests and review jobs pass but GitHub reports `mergeStateStatus == DIRTY`, the review workflow runs conflict resolution with the PR body, linked issue context, PR comments, review summaries, and inline review comments. The current review run then stops without marking reviews passed; the resolver push starts a fresh PR Tests run and a fresh AI Code Review run for the new head.
+The same resolver is also used by `ai-code-review.yml` after review agents have posted comments. If tests and review jobs pass but GitHub reports `mergeStateStatus == DIRTY`, the review workflow runs conflict resolution with the PR body, linked issue context, PR comments, review summaries, and inline review comments. The current review run then stops without marking reviews passed; the resolver push starts a fresh PR Tests run and a fresh AI Code Review run for the new head. If conflict resolution itself fails (agent error or push failure), `merge-decision` is skipped for this run — there is no fallback to a manual merge verdict; the next CI run triggered by a new commit or re-run will resume the normal pipeline.
 
 **Condition**: `needs.prepare-targets.outputs.has_targets == 'true'`.
 

--- a/docs/operations/CI_CD_SECURITY.md
+++ b/docs/operations/CI_CD_SECURITY.md
@@ -65,6 +65,8 @@ jobs:
 
 **Push-triggered conflict resolution:** the `prepare-targets` and `resolve-pr-conflicts` jobs also fire on `push` to `main` to auto-rebase open PRs that have flipped to `mergeStateStatus == DIRTY`. This path bypasses the `authorize` job because branch protection on `main` already restricts who can push — there is no untrusted-input surface to gate. The agent only operates on existing PRs (rebase + force-push of the PR branch); it cannot create new PRs or land code on `main`.
 
+**Review-triggered conflict resolution:** `ai-code-review.yml` can also run the same conflict resolver after review comments exist, but only for authorized same-repo PRs that already passed tests and review jobs. The resolver prompt includes PR/issue context plus PR comments, review summaries, and inline review comments so conflict choices are grounded in the reviewed change.
+
 #### `ai-code-review.yml` (PR Review Pipeline, workflow name `AI Code Review`)
 
 ```yaml


### PR DESCRIPTION
Resolves #1139

## Summary
- Added a review-pipeline conflict resolver job that runs after review comments exist when a PR is DIRTY.
- Expanded the conflict resolver prompt with linked issue context plus PR comments, review summaries, and inline review comments.
- Updated operations/security docs for the review-triggered resolver path.

## Test Plan
- make unit-tests
- make pre-commit
- Parsed updated GitHub Actions YAML with PyYAML
- git diff --check

🤖 Generated by the AI assistant