### PR TITLE
fix(integrationwatchdog): eliminate false-positive reloads

### DIFF
--- a/configs/integration_watchdog_config.yaml
+++ b/configs/integration_watchdog_config.yaml
@@ -15,18 +15,21 @@ watch_targets:
   # Span Panel — Most of House (the "left" / kitchen-side panel).
   # Battery percentage feeds the energy plugin; when it goes "unknown" the energy
   # state silently degrades to red and load shedding engages on a healthy house.
+  #
+  # Entity list intentionally excludes:
+  #   - cellular_link: normally off (backup radio, only powered on during outages)
+  #   - wi_fi_link: flaps from intermittent wifi without indicating integration health
+  # The battery sensor + panel_status are the real health signals.
   - name: span_left
     integration_name: "Span Panel — Most of House"
     entities:
       - sensor.span_panel_span_storage_battery_percentage_2
       - binary_sensor.span_left_most_of_house_panel_status
-      - binary_sensor.span_left_most_of_house_cellular_link
-      - binary_sensor.span_left_most_of_house_wi_fi_link
     config_entry_id: "01JSB74PV6YA6AH8KMQ76744JV"
     detection:
       bad_states: ["unknown", "unavailable"]
       bad_state_duration_min: 10
-      stale_last_updated_min: 60
+      stale_last_updated_min: 0  # disabled: our last_updated only ticks on state-change subscriptions, so stable-state entities false-positive
     reload:
       cooldown_min: 15
       daily_max: 6
@@ -38,21 +41,19 @@ watch_targets:
     entities:
       - sensor.span_panel_span_storage_battery_percentage
       - binary_sensor.span_right_hvac_and_well_panel_status
-      - binary_sensor.span_right_hvac_and_well_cellular_link
-      - binary_sensor.span_right_hvac_and_well_wi_fi_link
     config_entry_id: "01JSCAXC40GQ548TRDTNC9YZ34"
     detection:
       bad_states: ["unknown", "unavailable"]
       bad_state_duration_min: 10
-      stale_last_updated_min: 60
+      stale_last_updated_min: 0  # disabled: see span_left note
     reload:
       cooldown_min: 15
       daily_max: 6
       post_reload_delay_sec: 10
 
-  # Apple TV media player. When the integration freezes, media_player state stops
-  # advancing — give it a wide last_updated window because legitimate idle TV can
-  # be quiet for hours.
+  # Apple TV media player. When the integration freezes HA marks the entity
+  # unavailable; that's the signal we trust. A legitimately off/idle TV is not a
+  # broken integration.
   - name: apple_tv
     integration_name: "Apple TV"
     entities:
@@ -61,7 +62,7 @@ watch_targets:
     detection:
       bad_states: ["unavailable"]
       bad_state_duration_min: 30
-      stale_last_updated_min: 360
+      stale_last_updated_min: 0  # disabled: idle/off TVs don't tick last_updated and aren't broken
     reload:
       cooldown_min: 30
       daily_max: 4
@@ -77,7 +78,7 @@ watch_targets:
     detection:
       bad_states: ["unavailable"]
       bad_state_duration_min: 10
-      stale_last_updated_min: 30
+      stale_last_updated_min: 0  # disabled: off TVs don't tick last_updated and aren't broken
     reload:
       cooldown_min: 5
       daily_max: 10


### PR DESCRIPTION
## Summary

Disables `stale_last_updated_min` on all four watchdog targets and trims the Span entity lists. Eliminates the false-positive reload loop observed in production after PR #1129 deploy.

## Production evidence

First ~24h after PR #1129 deploy (Gravwell `tag=home-automation`):

- `bravia_tv` hit daily cap (10/10). TV `off` — `last_updated>=30min` trips every 30 min.
- `apple_tv` reloaded 4×. Idle `media_player` — same pattern.
- `span_right` hit daily cap (6/6). `binary_sensor.*_cellular_link` is `off` by design (backup radio) and `binary_sensor.*_wi_fi_link` flaps with intermittent wifi; both accumulated stale subscription ticks.
- `span_left` ✅ recovered correctly via the `bad_states` rule (the original use case still works).

## Root cause

`stale_last_updated_min` uses our per-entity timestamp, which is only ticked when a state-change subscription fires. Entities that legitimately sit in one state for long periods (off TVs, stable binary sensors) accumulate "stale" ticks even when the integration is healthy. Reload doesn't fix what isn't broken; the rule trips again 30 min later.

The `bad_states` rule does not have this problem — it reacts to HA explicitly marking entities `unavailable` / `unknown`, which is what actually happens during a real outage (HTTP 412 from Span → entity goes `unknown`).

## Changes

Config-only. No Go code changes.

- All four targets: `stale_last_updated_min: 0` (rule disabled).
- `span_left` / `span_right`: drop `binary_sensor.*_cellular_link` and `binary_sensor.*_wi_fi_link` from `entities`. Keep battery sensor + panel_status.

## What we keep

- `bad_states: [\"unknown\", \"unavailable\"]` on Span — recovered span_left today, will recover again.
- `bad_states: [\"unavailable\"]` on TVs — HA marks media_players unavailable when the integration hangs.
- All cooldown / daily-cap safeguards.

## Test plan

- [x] `make pre-commit` (yamllint, go vet, build)
- [x] `make unit-tests` (74.6% coverage)
- [x] `make pre-push` (full validation)
- [ ] Deploy, watch Gravwell over 24h: zero `trigger:\"last_updated>=...\"` reload entries; `bravia_tv` / `apple_tv` / `span_right` daily counts stay at 0 while devices are off/idle/healthy.
- [ ] If a Span sensor actually goes `unknown` again, confirm `bad_states` reload still fires.

## Follow-up (deferred)

Improve `stale_last_updated_min` to read HA's actual `last_updated` from the state object instead of our subscription tick. Would make the rule useful again for sensors that should always update but stop reporting. Not blocking — `bad_states` covers the real failure modes today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)