### PR TITLE
Fix #1145: Preserve arrival TTS speaker targets

### DIFF
--- a/homeautomation-go/internal/plugins/statetracking/manager.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager.go
@@ -787,15 +787,6 @@ func (m *Manager) getGroupCoordinator(speakerEntityID string) string {
 // announceArrivalDirect makes an arrival announcement via the shared alerter
 // (caller has already checked if someone is home).
 func (m *Manager) announceArrivalDirect(person, message string, mediaPlayers []string) {
-	// Check if any target speaker is in a Sonos group; if so, send TTS to the
-	// group coordinator only (sending to individual group members breaks playback).
-	if coordinator := m.getGroupCoordinator(mediaPlayers[0]); coordinator != "" {
-		m.logger.Info("TTS targeting Sonos group coordinator instead of default speakers",
-			zap.String("coordinator", coordinator),
-			zap.Strings("original_speakers", mediaPlayers))
-		mediaPlayers = []string{coordinator}
-	}
-
 	m.logger.Info("Announcing arrival",
 		zap.String("person", person),
 		zap.String("message", message),

--- a/homeautomation-go/internal/plugins/statetracking/manager.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager.go
@@ -2,15 +2,10 @@ package statetracking
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
-	"net/url"
-	"strings"
 	"sync"
 	"time"
-	"unicode"
 
 	"homeautomation/internal/alert"
 	"homeautomation/internal/clock"
@@ -691,97 +686,6 @@ func (m *Manager) handleCarolineNearHomeChange(entityID string, oldState, newSta
 				zap.Bool("isCarolineHome", isCarolineHome))
 		}
 	}
-}
-
-// entityIDToSpeakerName converts "media_player.front_room" to "Front Room".
-func entityIDToSpeakerName(entityID string) string {
-	name := strings.TrimPrefix(entityID, "media_player.")
-	words := strings.Split(name, "_")
-	for i, w := range words {
-		if len(w) > 0 {
-			runes := []rune(w)
-			runes[0] = unicode.ToUpper(runes[0])
-			words[i] = string(runes)
-		}
-	}
-	return strings.Join(words, " ")
-}
-
-// speakerNameToEntityID converts "Front Room" to "media_player.front_room".
-func speakerNameToEntityID(name string) string {
-	return "media_player." + strings.ToLower(strings.ReplaceAll(name, " ", "_"))
-}
-
-// socoGroupsResponse matches the JSON returned by SoCo-CLI's /groups endpoint.
-type socoGroupsResponse struct {
-	ExitCode int    `json:"exit_code"`
-	Result   string `json:"result"`
-	ErrorMsg string `json:"error_msg"`
-}
-
-// getGroupCoordinator queries SoCo-CLI to find the group coordinator for a speaker.
-// Returns the coordinator's entity ID if the speaker is in a group, or empty string if
-// ungrouped or SoCo-CLI is unavailable. Errors are logged and result in graceful fallback.
-func (m *Manager) getGroupCoordinator(speakerEntityID string) string {
-	if m.socoCliURL == "" {
-		return ""
-	}
-
-	speakerName := entityIDToSpeakerName(speakerEntityID)
-	endpoint := fmt.Sprintf("%s/%s/groups", m.socoCliURL, url.PathEscape(speakerName))
-
-	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Get(endpoint)
-	if err != nil {
-		m.logger.Warn("Failed to query SoCo-CLI for speaker groups, using default speakers",
-			zap.String("speaker", speakerName), zap.Error(err))
-		return ""
-	}
-	defer resp.Body.Close()
-
-	var socoResp socoGroupsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&socoResp); err != nil {
-		m.logger.Warn("Failed to decode SoCo-CLI groups response", zap.Error(err))
-		return ""
-	}
-
-	if socoResp.ExitCode != 0 {
-		m.logger.Warn("SoCo-CLI groups query failed",
-			zap.Int("exit_code", socoResp.ExitCode), zap.String("error", socoResp.ErrorMsg))
-		return ""
-	}
-
-	// Parse result lines like "Front Room: Kitchen, Bedroom\nSoundbar:\n"
-	// Each line is "Coordinator: member1, member2, ..."
-	// A coordinator with no members is standalone.
-	for _, line := range strings.Split(socoResp.Result, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		parts := strings.SplitN(line, ":", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		coordinator := strings.TrimSpace(parts[0])
-		members := strings.TrimSpace(parts[1])
-		if members == "" {
-			// Standalone speaker, no group
-			continue
-		}
-
-		// Check if our speaker is the coordinator or a member of this group
-		if strings.EqualFold(coordinator, speakerName) {
-			return speakerNameToEntityID(coordinator)
-		}
-		for _, member := range strings.Split(members, ",") {
-			if strings.EqualFold(strings.TrimSpace(member), speakerName) {
-				return speakerNameToEntityID(coordinator)
-			}
-		}
-	}
-
-	return ""
 }
 
 // announceArrivalDirect makes an arrival announcement via the shared alerter

--- a/homeautomation-go/internal/plugins/statetracking/manager_test.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager_test.go
@@ -1407,8 +1407,10 @@ func TestGetGroupCoordinator_NoSocoURL(t *testing.T) {
 	}
 }
 
-func TestAnnounceArrivalDirect_UsesGroupCoordinator(t *testing.T) {
-	// Set up a mock SoCo server that reports Front Room as group coordinator
+func TestAnnounceArrivalDirect_PreservesSpeakersWhenGrouped(t *testing.T) {
+	// Set up a mock SoCo server that reports Front Room as group coordinator.
+	// Arrival TTS uses HA announce mode, so the target list must not collapse to
+	// a single coordinator when Sonos is grouped.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(socoGroupsResponse{
 			ExitCode: 0,
@@ -1426,15 +1428,30 @@ func TestAnnounceArrivalDirect_UsesGroupCoordinator(t *testing.T) {
 	manager.announceArrivalDirect("Nick", "Nick is home", []string{
 		"media_player.kitchen",
 		"media_player.sitting_room",
-		"media_player.soundbar",
+		"media_player.front_room",
+		"media_player.kids_bathroom",
+		"media_player.office",
 	})
 
 	calls := mockAlerter.Calls()
 	if len(calls) != 1 {
 		t.Fatalf("Expected exactly 1 announcement, got %d", len(calls))
 	}
-	if len(calls[0].Speakers) != 1 || calls[0].Speakers[0] != "media_player.front_room" {
-		t.Errorf("Expected announcement to target [media_player.front_room], got %v", calls[0].Speakers)
+	expectedSpeakers := []string{
+		"media_player.kitchen",
+		"media_player.sitting_room",
+		"media_player.front_room",
+		"media_player.kids_bathroom",
+		"media_player.office",
+	}
+	if len(calls[0].Speakers) != len(expectedSpeakers) {
+		t.Fatalf("Expected %d speakers, got %d: %v",
+			len(expectedSpeakers), len(calls[0].Speakers), calls[0].Speakers)
+	}
+	for i, expected := range expectedSpeakers {
+		if calls[0].Speakers[i] != expected {
+			t.Errorf("Expected speaker %d to be %q, got %q", i, expected, calls[0].Speakers[i])
+		}
 	}
 }
 

--- a/homeautomation-go/internal/plugins/statetracking/manager_test.go
+++ b/homeautomation-go/internal/plugins/statetracking/manager_test.go
@@ -2,9 +2,6 @@ package statetracking
 
 import (
 	"context"
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -1284,146 +1281,14 @@ func TestStateTrackingManager_ArrivalDebounce_FirstArrivalNotSuppressed(t *testi
 	}
 }
 
-func TestEntityIDToSpeakerName(t *testing.T) {
-	tests := []struct {
-		entityID string
-		expected string
-	}{
-		{"media_player.kitchen", "Kitchen"},
-		{"media_player.front_room", "Front Room"},
-		{"media_player.kids_bathroom", "Kids Bathroom"},
-		{"media_player.primary_bathroom", "Primary Bathroom"},
-	}
-	for _, tt := range tests {
-		if got := entityIDToSpeakerName(tt.entityID); got != tt.expected {
-			t.Errorf("entityIDToSpeakerName(%q) = %q, want %q", tt.entityID, got, tt.expected)
-		}
-	}
-}
-
-func TestSpeakerNameToEntityID(t *testing.T) {
-	tests := []struct {
-		name     string
-		expected string
-	}{
-		{"Kitchen", "media_player.kitchen"},
-		{"Front Room", "media_player.front_room"},
-		{"Kids Bathroom", "media_player.kids_bathroom"},
-	}
-	for _, tt := range tests {
-		if got := speakerNameToEntityID(tt.name); got != tt.expected {
-			t.Errorf("speakerNameToEntityID(%q) = %q, want %q", tt.name, got, tt.expected)
-		}
-	}
-}
-
-func TestGetGroupCoordinator(t *testing.T) {
-	tests := []struct {
-		name          string
-		socoResponse  socoGroupsResponse
-		speakerEntity string
-		wantCoord     string
-		socoDown      bool
-	}{
-		{
-			name: "speaker is group member - returns coordinator",
-			socoResponse: socoGroupsResponse{
-				ExitCode: 0,
-				Result:   "\nFront Room: Primary Bathroom, Kitchen, Bedroom, Kids Bathroom, Sitting Room\nSoundbar: \nBarn:\n",
-			},
-			speakerEntity: "media_player.kitchen",
-			wantCoord:     "media_player.front_room",
-		},
-		{
-			name: "speaker is the coordinator - returns itself",
-			socoResponse: socoGroupsResponse{
-				ExitCode: 0,
-				Result:   "\nFront Room: Primary Bathroom, Kitchen\nSoundbar: \n",
-			},
-			speakerEntity: "media_player.front_room",
-			wantCoord:     "media_player.front_room",
-		},
-		{
-			name: "speaker is standalone - returns empty",
-			socoResponse: socoGroupsResponse{
-				ExitCode: 0,
-				Result:   "\nFront Room: Kitchen\nSoundbar: \nBarn:\n",
-			},
-			speakerEntity: "media_player.barn",
-			wantCoord:     "",
-		},
-		{
-			name: "soco error - returns empty for graceful fallback",
-			socoResponse: socoGroupsResponse{
-				ExitCode: 1,
-				ErrorMsg: "speaker not found",
-			},
-			speakerEntity: "media_player.kitchen",
-			wantCoord:     "",
-		},
-		{
-			name:          "soco unavailable - returns empty for graceful fallback",
-			speakerEntity: "media_player.kitchen",
-			wantCoord:     "",
-			socoDown:      true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var serverURL string
-			if tt.socoDown {
-				serverURL = "http://127.0.0.1:1" // unreachable
-			} else {
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					json.NewEncoder(w).Encode(tt.socoResponse)
-				}))
-				defer server.Close()
-				serverURL = server.URL
-			}
-
-			logger := zap.NewNop()
-			mockHA := ha.NewMockClient()
-			stateMgr := state.NewManager(mockHA, logger, false)
-			manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, serverURL, &alert.MockAlerter{})
-
-			got := manager.getGroupCoordinator(tt.speakerEntity)
-			if got != tt.wantCoord {
-				t.Errorf("getGroupCoordinator(%q) = %q, want %q", tt.speakerEntity, got, tt.wantCoord)
-			}
-		})
-	}
-}
-
-func TestGetGroupCoordinator_NoSocoURL(t *testing.T) {
-	logger := zap.NewNop()
-	mockHA := ha.NewMockClient()
-	stateMgr := state.NewManager(mockHA, logger, false)
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", &alert.MockAlerter{})
-
-	got := manager.getGroupCoordinator("media_player.kitchen")
-	if got != "" {
-		t.Errorf("expected empty string when socoCliURL is empty, got %q", got)
-	}
-}
-
 func TestAnnounceArrivalDirect_PreservesSpeakersWhenGrouped(t *testing.T) {
-	// Set up a mock SoCo server that reports Front Room as group coordinator.
-	// Arrival TTS uses HA announce mode, so the target list must not collapse to
-	// a single coordinator when Sonos is grouped.
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(socoGroupsResponse{
-			ExitCode: 0,
-			Result:   "\nFront Room: Primary Bathroom, Kitchen, Bedroom\nSoundbar: \n",
-		})
-	}))
-	defer server.Close()
-
+	// Arrival TTS uses HA announce mode; the target list must not be rewritten
+	// even when Sonos speakers are grouped (regression: #1145).
 	logger := zap.NewNop()
 	mockHA := ha.NewMockClient()
 	stateMgr := state.NewManager(mockHA, logger, false)
 	mockAlerter := &alert.MockAlerter{}
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, server.URL, mockAlerter)
+	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "", mockAlerter)
 
 	manager.announceArrivalDirect("Nick", "Nick is home", []string{
 		"media_player.kitchen",
@@ -1452,28 +1317,5 @@ func TestAnnounceArrivalDirect_PreservesSpeakersWhenGrouped(t *testing.T) {
 		if calls[0].Speakers[i] != expected {
 			t.Errorf("Expected speaker %d to be %q, got %q", i, expected, calls[0].Speakers[i])
 		}
-	}
-}
-
-func TestAnnounceArrivalDirect_FallsBackWhenSocoDown(t *testing.T) {
-	logger := zap.NewNop()
-	mockHA := ha.NewMockClient()
-	stateMgr := state.NewManager(mockHA, logger, false)
-	mockAlerter := &alert.MockAlerter{}
-	// Use unreachable URL to simulate SoCo being down
-	manager := NewManager(context.Background(), mockHA, stateMgr, logger, false, nil, "http://127.0.0.1:1", mockAlerter)
-
-	defaultSpeakers := []string{
-		"media_player.kitchen",
-		"media_player.sitting_room",
-	}
-	manager.announceArrivalDirect("Nick", "Nick is home", defaultSpeakers)
-
-	calls := mockAlerter.Calls()
-	if len(calls) != 1 {
-		t.Fatalf("Expected exactly 1 announcement even when SoCo is down, got %d", len(calls))
-	}
-	if len(calls[0].Speakers) != 2 {
-		t.Errorf("Expected fallback to default speakers (2), got %v", calls[0].Speakers)
 	}
 }


### PR DESCRIPTION
Resolves #1145

## Summary
- Removed the arrival-announcement Sonos coordinator rewrite so HA announce mode receives the full intended speaker list.
- Updated the grouped-Sonos unit test to verify arrival TTS preserves all target speakers instead of collapsing to the coordinator.

## Test Plan
- make unit-tests
- make pre-commit

🤖 Generated by the AI assistant