### PR TITLE
Fix #1147: Use Hue service for dynamic scenes

### DIFF
--- a/configs/hue_config.yaml
+++ b/configs/hue_config.yaml
@@ -28,8 +28,9 @@ rooms:
     # The "day"/"evening"/etc Hue scenes for this room have `auto_dynamic: true`
     # (animated palette). The bridge's autonomous palette has been observed to
     # fail to start when bulbs are mid-transition or cold, leaving bulbs off.
-    # `has_dynamics: true` opts this room into two-step recall (static first,
-    # then dynamic) so the palette starts from a stable known state.
+    # `has_dynamics: true` opts this room into hue.activate_scene two-step
+    # recall (static first, then dynamic) so the palette starts from a stable
+    # known state.
     has_dynamics: true
     conditions:
       # CRITICAL: isWakeSequenceActive and isMasterAsleep MUST be checked

--- a/docs/flows/LIGHTING_CONTROL.md
+++ b/docs/flows/LIGHTING_CONTROL.md
@@ -271,12 +271,16 @@ palette autonomously after recall. The bridge can fail to start the palette
 on bulbs that were off pre-recall (still mid-transition from the on
 command), leaving each bulb reverted to off at staggered times.
 
-`activateScene` works around this by issuing two calls:
+`activateScene` works around this by issuing two Hue integration calls:
 
-1. `scene.turn_on` with `dynamic: false` — static recall; bulbs settle at the
+1. `hue.activate_scene` with `dynamic: false` — static recall; bulbs settle at the
    scene's base colors and brightness.
-2. After `twoStepRecallGap` (500ms), `scene.turn_on` with `dynamic: true` —
+2. After `twoStepRecallGap` (500ms), `hue.activate_scene` with `dynamic: true` —
    palette starts from a stable known state.
+
+If the first Hue-specific call fails, the plugin falls back to a basic
+`scene.turn_on` without Hue-only dynamic options so the room still receives
+the requested scene.
 
 The dynamic phase fires asynchronously via a timer callback. If the
 room-scoped context is cancelled during the gap (a newer evaluation came

--- a/docs/human/VISUAL_ARCHITECTURE.md
+++ b/docs/human/VISUAL_ARCHITECTURE.md
@@ -786,9 +786,9 @@ flowchart TD
     GetSceneOn2 --> FormatScene2[Format Scene Name:<br/>room/dayPhase]
     GetSceneDefault --> FormatScene3[Format Scene Name:<br/>room/dayPhase]
 
-    FormatScene1 --> ActivateScene1[Call scene.turn_on<br/>entity_id: scene.ROOM_SCENE]
-    FormatScene2 --> ActivateScene2[Call scene.turn_on<br/>entity_id: scene.ROOM_SCENE]
-    FormatScene3 --> ActivateScene3[Call scene.turn_on<br/>entity_id: scene.ROOM_SCENE]
+    FormatScene1 --> ActivateScene1[activateScene()<br/>hue or scene]
+    FormatScene2 --> ActivateScene2[activateScene()<br/>hue or scene]
+    FormatScene3 --> ActivateScene3[activateScene()<br/>hue or scene]
 
     TurnOff1 --> CallLightOff1[Call light.turn_off<br/>for room entities]
     TurnOff2 --> CallLightOff2[Call light.turn_off<br/>for room entities]

--- a/homeautomation-go/internal/plugins/lighting/config.go
+++ b/homeautomation-go/internal/plugins/lighting/config.go
@@ -32,10 +32,10 @@ type RoomConfig struct {
 	// HasDynamics opts the room into two-step scene recall for Hue scenes that
 	// have `auto_dynamic: true` (an animated palette). The bridge can fail to
 	// start the dynamic palette when bulbs are mid-transition or cold; each
-	// affected bulb reverts to its pre-recall state. Two-step recall sends the
-	// scene first with `dynamic: false` (lights settle at the scene's static
-	// colors), waits briefly, then sends it again with `dynamic: true` so the
-	// palette starts from a stable known state.
+	// affected bulb reverts to its pre-recall state. Two-step recall uses
+	// hue.activate_scene first with `dynamic: false` (lights settle at the
+	// scene's static colors), waits briefly, then sends it again with
+	// `dynamic: true` so the palette starts from a stable known state.
 	HasDynamics bool `yaml:"has_dynamics"`
 }
 

--- a/homeautomation-go/internal/plugins/lighting/manager.go
+++ b/homeautomation-go/internal/plugins/lighting/manager.go
@@ -711,17 +711,17 @@ func (m *Manager) activateScene(ctx context.Context, room *RoomConfig, dayPhase 
 		serviceData["transition"] = transition
 	}
 
-	// For rooms whose Hue scene has `auto_dynamic: true`, do a two-step recall:
-	// first activate the scene as static so the bulbs settle at the scene's
-	// base colors/brightness, then re-activate with dynamics so the animated
-	// palette starts from a stable state. The bridge has been observed to
-	// fail to start the dynamic palette on bulbs mid-transition (2026-05-25
-	// incident); the pre-settle eliminates that race. The dynamic phase fires
-	// asynchronously via a timer callback so this function does not block.
+	// For rooms whose Hue scene has `auto_dynamic: true`, do a two-step Hue
+	// recall: first activate the scene as static so the bulbs settle at the
+	// scene's base colors/brightness, then re-activate with dynamics so the
+	// animated palette starts from a stable state. Generic scene.turn_on does
+	// not accept Hue dynamic options; use hue.activate_scene for those phases.
+	// The dynamic phase fires asynchronously via a timer callback so this
+	// function does not block.
 	if room.HasDynamics {
 		staticData := copyServiceData(serviceData)
 		staticData["dynamic"] = false
-		if err := m.haClient.CallService(ctx, "scene", "turn_on", staticData); err != nil {
+		if err := m.haClient.CallService(ctx, "hue", "activate_scene", staticData); err != nil {
 			if ctx.Err() != nil {
 				m.logger.Info("Scene activation superseded by newer evaluation",
 					zap.String("room", room.HueGroup),
@@ -729,11 +729,33 @@ func (m *Manager) activateScene(ctx context.Context, room *RoomConfig, dayPhase 
 					zap.String("entity_id", sceneEntityID))
 				return
 			}
-			m.logger.Error("Failed to activate static phase of dynamic scene",
+			m.logger.Warn("Failed to activate static phase of dynamic scene; falling back to basic scene activation",
 				zap.String("room", room.HueGroup),
 				zap.String("scene", dayPhase),
 				zap.String("entity_id", sceneEntityID),
 				zap.Error(err))
+			if fallbackErr := m.haClient.CallService(ctx, "scene", "turn_on", serviceData); fallbackErr != nil {
+				if ctx.Err() != nil {
+					m.logger.Info("Scene activation fallback superseded by newer evaluation",
+						zap.String("room", room.HueGroup),
+						zap.String("scene", dayPhase),
+						zap.String("entity_id", sceneEntityID))
+					return
+				}
+				m.logger.Error("Failed to activate fallback scene",
+					zap.String("room", room.HueGroup),
+					zap.String("scene", dayPhase),
+					zap.String("entity_id", sceneEntityID),
+					zap.Error(fallbackErr))
+				return
+			}
+			m.logger.Warn("Applied basic scene activation after dynamic recall failed",
+				zap.String("room", room.HueGroup),
+				zap.String("scene", dayPhase),
+				zap.String("entity_id", sceneEntityID))
+			m.recordAction(room.HueGroup, "activate_scene",
+				fmt.Sprintf("Activated scene '%s' (dynamic fallback)", dayPhase),
+				dayPhase, false, trigger)
 			return
 		}
 		m.logger.Info("Static phase of dynamic scene activated; scheduling dynamic phase",
@@ -781,7 +803,7 @@ func (m *Manager) activateScene(ctx context.Context, room *RoomConfig, dayPhase 
 		dayPhase, false, trigger)
 }
 
-// activateSceneDynamicPhase issues the second `scene.turn_on` call of a
+// activateSceneDynamicPhase issues the second `hue.activate_scene` call of a
 // two-step recall, with `dynamic: true`, after the inter-phase gap has
 // elapsed. If the room-scoped context has been cancelled by a newer
 // evaluation in the meantime, the dynamic phase is skipped.
@@ -792,7 +814,7 @@ func (m *Manager) activateSceneDynamicPhase(ctx context.Context, roomName, scene
 			zap.String("entity_id", sceneEntityID))
 		return
 	}
-	if err := m.haClient.CallService(ctx, "scene", "turn_on", dynamicData); err != nil {
+	if err := m.haClient.CallService(ctx, "hue", "activate_scene", dynamicData); err != nil {
 		if ctx.Err() != nil {
 			m.logger.Info("Dynamic phase superseded by newer evaluation",
 				zap.String("room", roomName),

--- a/homeautomation-go/internal/plugins/lighting/manager.go
+++ b/homeautomation-go/internal/plugins/lighting/manager.go
@@ -749,7 +749,7 @@ func (m *Manager) activateScene(ctx context.Context, room *RoomConfig, dayPhase 
 					zap.Error(fallbackErr))
 				return
 			}
-			m.logger.Warn("Applied basic scene activation after dynamic recall failed",
+			m.logger.Warn("Applied basic scene activation; hue.activate_scene unavailable",
 				zap.String("room", room.HueGroup),
 				zap.String("scene", dayPhase),
 				zap.String("entity_id", sceneEntityID))
@@ -814,6 +814,10 @@ func (m *Manager) activateSceneDynamicPhase(ctx context.Context, roomName, scene
 			zap.String("entity_id", sceneEntityID))
 		return
 	}
+	// No scene.turn_on fallback here: scene.turn_on cannot start a Hue dynamic
+	// palette, so falling back would just silently leave the room with static
+	// colors — the same outcome as a do-nothing. The static phase already
+	// ensured the room is lit; this failure only means the palette won't animate.
 	if err := m.haClient.CallService(ctx, "hue", "activate_scene", dynamicData); err != nil {
 		if ctx.Err() != nil {
 			m.logger.Info("Dynamic phase superseded by newer evaluation",

--- a/homeautomation-go/internal/plugins/lighting/manager_test.go
+++ b/homeautomation-go/internal/plugins/lighting/manager_test.go
@@ -2,6 +2,7 @@ package lighting
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -971,7 +972,7 @@ func TestEvaluateAndActivateRoom_DebounceIsolatesRooms(t *testing.T) {
 	// Both debounces have fired the room evaluation.
 	// Primary Suite (HasDynamics=true) only fires its static phase here;
 	// the dynamic phase needs another advance past twoStepRecallGap.
-	calls := filterSceneCalls(env.MockHA.GetServiceCalls())
+	calls := filterSceneActivationCalls(env.MockHA.GetServiceCalls())
 	if !assert.Equal(t, 2, len(calls), "each room's debounce fires independently") {
 		return
 	}
@@ -986,7 +987,7 @@ func TestEvaluateAndActivateRoom_DebounceIsolatesRooms(t *testing.T) {
 }
 
 // TestActivateScene_TwoStepForDynamicRoom verifies that activating a scene on
-// a room with HasDynamics=true issues two scene.turn_on calls: first with
+// a room with HasDynamics=true issues two hue.activate_scene calls: first with
 // dynamic=false (static recall), then after twoStepRecallGap with dynamic=true.
 func TestActivateScene_TwoStepForDynamicRoom(t *testing.T) {
 	t.Parallel()
@@ -1001,7 +1002,7 @@ func TestActivateScene_TwoStepForDynamicRoom(t *testing.T) {
 	manager.activateScene(context.Background(), room, "Day", "dayPhase")
 
 	// Static phase should have fired synchronously.
-	calls := filterSceneCalls(env.MockHA.GetServiceCalls())
+	calls := filterHueActivateSceneCalls(env.MockHA.GetServiceCalls())
 	if !assert.Equal(t, 1, len(calls), "static phase fires immediately") {
 		return
 	}
@@ -1010,17 +1011,37 @@ func TestActivateScene_TwoStepForDynamicRoom(t *testing.T) {
 
 	// Dynamic phase should NOT have fired yet.
 	mockClock.AdvanceAndProcess(twoStepRecallGap - 100*time.Millisecond)
-	calls = filterSceneCalls(env.MockHA.GetServiceCalls())
+	calls = filterHueActivateSceneCalls(env.MockHA.GetServiceCalls())
 	assert.Equal(t, 1, len(calls), "dynamic phase has not fired before gap elapses")
 
 	// Advance past the gap — dynamic phase fires.
 	mockClock.AdvanceAndProcess(200 * time.Millisecond)
-	calls = filterSceneCalls(env.MockHA.GetServiceCalls())
+	calls = filterHueActivateSceneCalls(env.MockHA.GetServiceCalls())
 	if !assert.Equal(t, 2, len(calls), "dynamic phase fires after twoStepRecallGap") {
 		return
 	}
 	assert.Equal(t, "scene.primary_suite_day", calls[1].Data["entity_id"])
 	assert.Equal(t, true, calls[1].Data["dynamic"], "second call is dynamic=true (palette enabled)")
+}
+
+func TestActivateScene_DynamicRoomFallsBackToSceneTurnOn(t *testing.T) {
+	t.Parallel()
+	env := testutil.NewEnv(t)
+	cfg := dynamicScenesConfig()
+	manager := NewManager(context.Background(), env.MockHA, env.StateMgr, cfg, env.Logger, false, nil)
+
+	env.MockHA.SetServiceError("hue", "activate_scene", errors.New("invalid_format"))
+
+	room := &cfg.Rooms[0] // Primary Suite, HasDynamics=true
+	manager.activateScene(context.Background(), room, "Day", "dayPhase")
+
+	sceneCalls := filterSceneCalls(env.MockHA.GetServiceCalls())
+	if !assert.Equal(t, 1, len(sceneCalls), "fallback scene.turn_on fires when Hue dynamic recall fails") {
+		return
+	}
+	assert.Equal(t, "scene.primary_suite_day", sceneCalls[0].Data["entity_id"])
+	_, hasDynamic := sceneCalls[0].Data["dynamic"]
+	assert.False(t, hasDynamic, "fallback must not pass the Hue-only dynamic key to scene.turn_on")
 }
 
 // TestActivateScene_SingleStepForNonDynamicRoom verifies that rooms without
@@ -1060,7 +1081,7 @@ func TestActivateScene_TwoStepAbortsOnContextCancel(t *testing.T) {
 	manager.activateScene(ctx, room, "Day", "dayPhase")
 
 	// Static phase fired.
-	if !assert.Equal(t, 1, len(filterSceneCalls(env.MockHA.GetServiceCalls()))) {
+	if !assert.Equal(t, 1, len(filterHueActivateSceneCalls(env.MockHA.GetServiceCalls()))) {
 		return
 	}
 
@@ -1068,14 +1089,14 @@ func TestActivateScene_TwoStepAbortsOnContextCancel(t *testing.T) {
 	cancel()
 	mockClock.AdvanceAndProcess(twoStepRecallGap + 100*time.Millisecond)
 
-	calls := filterSceneCalls(env.MockHA.GetServiceCalls())
+	calls := filterHueActivateSceneCalls(env.MockHA.GetServiceCalls())
 	assert.Equal(t, 1, len(calls), "dynamic phase suppressed when context cancelled during gap")
 }
 
 // TestEvaluateAndActivateRoom_DebounceAndTwoStepEndToEnd is the integration
 // of the two mechanisms: a burst of three rapid evaluations on a dynamic room
 // should coalesce to a single doEvaluateAndActivateRoom call, which then
-// triggers a two-step recall — yielding exactly two scene.turn_on calls
+// triggers a two-step recall — yielding exactly two hue.activate_scene calls
 // total (one static + one dynamic). Six recalls in 500ms collapse to two,
 // matching the production timing the fix is designed to repair.
 func TestEvaluateAndActivateRoom_DebounceAndTwoStepEndToEnd(t *testing.T) {
@@ -1096,12 +1117,12 @@ func TestEvaluateAndActivateRoom_DebounceAndTwoStepEndToEnd(t *testing.T) {
 	manager.evaluateAndActivateRoom(room, "Day", "isAnyOwnerHome")
 	manager.evaluateAndActivateRoom(room, "Day", "isAnyoneHomeAndAwake")
 
-	// No scene calls yet (debounce still pending).
-	assert.Equal(t, 0, len(filterSceneCalls(env.MockHA.GetServiceCalls())))
+	// No scene activation calls yet (debounce still pending).
+	assert.Equal(t, 0, len(filterSceneActivationCalls(env.MockHA.GetServiceCalls())))
 
 	// Advance past the debounce — coalesced evaluation runs, static phase fires.
 	mockClock.AdvanceAndProcess(310 * time.Millisecond)
-	calls := filterSceneCalls(env.MockHA.GetServiceCalls())
+	calls := filterHueActivateSceneCalls(env.MockHA.GetServiceCalls())
 	if !assert.Equal(t, 1, len(calls), "exactly one static call after debounce coalesces") {
 		return
 	}
@@ -1109,7 +1130,7 @@ func TestEvaluateAndActivateRoom_DebounceAndTwoStepEndToEnd(t *testing.T) {
 
 	// Advance past the two-step gap — dynamic phase fires.
 	mockClock.AdvanceAndProcess(twoStepRecallGap + 50*time.Millisecond)
-	calls = filterSceneCalls(env.MockHA.GetServiceCalls())
+	calls = filterHueActivateSceneCalls(env.MockHA.GetServiceCalls())
 	if !assert.Equal(t, 2, len(calls), "static + dynamic = exactly 2 scene calls total") {
 		return
 	}
@@ -1123,6 +1144,27 @@ func filterSceneCalls(calls []ha.ServiceCall) []ha.ServiceCall {
 	out := make([]ha.ServiceCall, 0, len(calls))
 	for _, c := range calls {
 		if c.Domain == "scene" && c.Service == "turn_on" {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func filterHueActivateSceneCalls(calls []ha.ServiceCall) []ha.ServiceCall {
+	out := make([]ha.ServiceCall, 0, len(calls))
+	for _, c := range calls {
+		if c.Domain == "hue" && c.Service == "activate_scene" {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func filterSceneActivationCalls(calls []ha.ServiceCall) []ha.ServiceCall {
+	out := make([]ha.ServiceCall, 0, len(calls))
+	for _, c := range calls {
+		if (c.Domain == "scene" && c.Service == "turn_on") ||
+			(c.Domain == "hue" && c.Service == "activate_scene") {
 			out = append(out, c)
 		}
 	}

--- a/homeautomation-go/test/integration/scenario_lighting_arrival_test.go
+++ b/homeautomation-go/test/integration/scenario_lighting_arrival_test.go
@@ -26,11 +26,11 @@ import (
 // After the fix:
 //   1. evaluateAndActivateRoom debounces per-room evaluations so an arrival
 //      burst collapses to a single coalesced evaluation.
-//   2. activateScene does a two-step recall for HasDynamics rooms: first
+//   2. activateScene does a two-step Hue recall for HasDynamics rooms: first
 //      with dynamic=false (static settle), then with dynamic=true (palette).
 //
 // This integration test verifies both mechanisms together: an arrival burst
-// against a HasDynamics=true room yields exactly TWO scene.turn_on calls
+// against a HasDynamics=true room yields exactly TWO hue.activate_scene calls
 // (one static + one dynamic), not six.
 // ============================================================================
 
@@ -83,7 +83,7 @@ func setupLightingArrivalTest(t *testing.T) (*MockHAServer, *lighting.Manager, *
 
 // TestScenario_LightingArrival_DebouncedTwoStepRecall reproduces the arrival
 // burst on a HasDynamics=true room and asserts that the lighting plugin
-// issues exactly two scene.turn_on calls (one static, one dynamic) — not
+// issues exactly two hue.activate_scene calls (one static, one dynamic) — not
 // the six (3 evaluations × 2 calls each) that would happen without
 // debouncing.
 func TestScenario_LightingArrival_DebouncedTwoStepRecall(t *testing.T) {
@@ -121,15 +121,15 @@ func TestScenario_LightingArrival_DebouncedTwoStepRecall(t *testing.T) {
 	waitForProcessing(t, manager)
 
 	t.Log("AND: Before the debounce delay elapses, no scene calls should have fired")
-	sceneCallsBeforeDebounce := filterServiceCalls(server.GetServiceCallsSince(snapshot), "scene", "turn_on")
+	sceneCallsBeforeDebounce := filterServiceCalls(server.GetServiceCallsSince(snapshot), "hue", "activate_scene")
 	assert.Equal(t, 0, len(sceneCallsBeforeDebounce),
 		"scene activations must be deferred until the debounce window elapses")
 
 	t.Log("WHEN: The debounce window elapses — coalesced evaluation runs and fires the static phase")
 	mockClock.AdvanceAndProcess(310 * time.Millisecond)
-	waitForServiceCallSince(t, server, snapshot, "scene", "turn_on", "static phase scene call should fire")
+	waitForServiceCallSince(t, server, snapshot, "hue", "activate_scene", "static phase scene call should fire")
 
-	sceneCallsAfterDebounce := filterServiceCalls(server.GetServiceCallsSince(snapshot), "scene", "turn_on")
+	sceneCallsAfterDebounce := filterServiceCalls(server.GetServiceCallsSince(snapshot), "hue", "activate_scene")
 	require.Equal(t, 1, len(sceneCallsAfterDebounce),
 		"exactly one static-phase scene call after the debounce coalesces the burst")
 	assert.Equal(t, "scene.primary_suite_day", sceneCallsAfterDebounce[0].ServiceData["entity_id"])
@@ -143,10 +143,10 @@ func TestScenario_LightingArrival_DebouncedTwoStepRecall(t *testing.T) {
 	// synchronously during AdvanceAndProcess, but the mock server's call
 	// list update happens through normal service-call recording).
 	require.Eventually(t, func() bool {
-		return len(filterServiceCalls(server.GetServiceCallsSince(snapshot), "scene", "turn_on")) >= 2
+		return len(filterServiceCalls(server.GetServiceCallsSince(snapshot), "hue", "activate_scene")) >= 2
 	}, stateWaitTimeout, 10*time.Millisecond, "dynamic phase should land")
 
-	sceneCallsAfterDynamic := filterServiceCalls(server.GetServiceCallsSince(snapshot), "scene", "turn_on")
+	sceneCallsAfterDynamic := filterServiceCalls(server.GetServiceCallsSince(snapshot), "hue", "activate_scene")
 	require.Equal(t, 2, len(sceneCallsAfterDynamic),
 		"exactly TWO scene calls total: static + dynamic; never six")
 	assert.Equal(t, true, sceneCallsAfterDynamic[1].ServiceData["dynamic"],


### PR DESCRIPTION
Resolves #1147

## Summary
- Route `has_dynamics` lighting rooms through `hue.activate_scene` for static and dynamic Hue scene phases.
- Fall back to plain `scene.turn_on` without Hue-only dynamic data if Hue dynamic recall fails.
- Update lighting tests and docs to reflect the Hue-specific service path.

## Test Plan
- `make unit-tests`
- `make integration-tests`
- `make pre-commit`

🤖 Generated by the AI assistant