### PR TITLE
fix(sleephygiene): defer go_to_bed when no one home

### DIFF
--- a/homeautomation-go/internal/plugins/sleephygiene/manager.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager.go
@@ -437,14 +437,27 @@ func (m *Manager) checkTimeTriggers() {
 		}
 	}
 
-	// Check go_to_bed trigger
+	// Check go_to_bed trigger.
+	//
+	// Sleep prep is gated on isAnyoneHome: starting it with an empty house
+	// sets isSleepPrepActive=true, which causes the lighting plugin to skip
+	// the bedroom when the owner later arrives — no welcome scene. Skipping
+	// without marking triggered lets the next 1-min tick fire it once
+	// someone is home (still within the 1-hour window).
 	if now.After(schedule.GoToBed) && now.Before(schedule.GoToBed.Add(ONE_HOUR)) {
 		if _, triggered := m.triggeredToday["go_to_bed"]; !triggered {
-			m.logger.Info("Triggering go_to_bed",
-				zap.Time("go_to_bed_time", schedule.GoToBed),
-				zap.Time("now", now))
-			m.triggeredToday["go_to_bed"] = now
-			m.handleGoToBed()
+			isAnyoneHome, _ := m.stateManager.GetBool("isAnyoneHome")
+			if !isAnyoneHome {
+				m.logger.Debug("Deferring go_to_bed: no one home",
+					zap.Time("go_to_bed_time", schedule.GoToBed),
+					zap.Time("now", now))
+			} else {
+				m.logger.Info("Triggering go_to_bed",
+					zap.Time("go_to_bed_time", schedule.GoToBed),
+					zap.Time("now", now))
+				m.triggeredToday["go_to_bed"] = now
+				m.handleGoToBed()
+			}
 		}
 	}
 

--- a/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"homeautomation/internal/clock"
 	"homeautomation/internal/config"
 	"homeautomation/internal/ha"
 	"homeautomation/internal/state"
@@ -528,6 +529,7 @@ func TestCheckTimeTriggers_GoToBed_DeferredWhenEmpty(t *testing.T) {
 	// Inside the go_to_bed trigger window (schedule is 22:30, window is 1h).
 	now := time.Date(2024, 1, 15, 23, 0, 0, 0, time.UTC)
 	manager, _, stateManager, configLoader := setupTest(t, now)
+	configLoader.SetClock(clock.NewMockClock(now))
 	if err := configLoader.LoadScheduleConfig(); err != nil {
 		t.Skipf("Skipping test: schedule config not available: %v", err)
 	}

--- a/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager_test.go
@@ -514,6 +514,47 @@ func TestHandleGoToBed_ReadOnly(t *testing.T) {
 	}
 }
 
+// TestCheckTimeTriggers_GoToBed_DeferredWhenEmpty verifies that go_to_bed does
+// not fire when no one is home, and that it is not marked triggered — so a
+// subsequent tick (after arrival, still inside the 1-hour window) will fire it.
+//
+// Why: starting sleep prep with an empty house sets isSleepPrepActive=true,
+// which causes the lighting plugin to skip the bedroom when the owner later
+// arrives, leaving them without a welcome scene (production incident
+// 2026-05-29).
+func TestCheckTimeTriggers_GoToBed_DeferredWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	// Inside the go_to_bed trigger window (schedule is 22:30, window is 1h).
+	now := time.Date(2024, 1, 15, 23, 0, 0, 0, time.UTC)
+	manager, _, stateManager, configLoader := setupTest(t, now)
+	if err := configLoader.LoadScheduleConfig(); err != nil {
+		t.Skipf("Skipping test: schedule config not available: %v", err)
+	}
+
+	// No one home at scheduled bedtime.
+	stateManager.SetBool("isAnyoneHome", false)
+
+	manager.checkTimeTriggers()
+
+	if _, triggered := manager.triggeredToday["go_to_bed"]; triggered {
+		t.Error("go_to_bed must not be marked triggered when no one is home, so a later tick can fire it on arrival")
+	}
+
+	isSleepPrep, _ := stateManager.GetBool("isSleepPrepActive")
+	if isSleepPrep {
+		t.Error("isSleepPrepActive must remain false when no one is home")
+	}
+
+	// Now someone arrives. Next tick should fire go_to_bed.
+	stateManager.SetBool("isAnyoneHome", true)
+	manager.checkTimeTriggers()
+
+	if _, triggered := manager.triggeredToday["go_to_bed"]; !triggered {
+		t.Error("go_to_bed should fire on the tick after arrival, while still inside the 1-hour window")
+	}
+}
+
 // TestCheckTimeTriggers_ErrorGettingSchedule tests error handling when schedule config is not available
 func TestCheckTimeTriggers_ErrorGettingSchedule(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary
- Gate `go_to_bed` trigger in `sleephygiene.checkTimeTriggers` on `isAnyoneHome`.
- When false: skip *and* do not mark `triggeredToday`, so the next 1-min tick fires it on arrival (still inside the 1-hour window past schedule).

## Production incident (2026-05-29)
- Scheduled go_to_bed (22:30 CDT) fired at 22:59 to an empty house — `isSleepPrepActive=true` was set.
- Owner arrived 23:14 CDT. Lighting plugin's arrival cascade evaluated Primary Suite and matched Priority 2 (`isSleepPrepActive=true`) → "Skipping room - external control active".
- Sleephygiene's normal sleep-prep behavior doesn't activate any welcome scene, so the bedroom stayed dark.

Gravwell evidence:
```
03:59:39 UTC  sleephygiene  "Set isSleepPrepActive to prevent lighting interference during sleep prep"
04:14:42 UTC  state         isAnyoneHome / isAnyoneHomeAndAwake: false → true
04:14:43 UTC  lighting      Primary Suite: "Skipping room - external control active" (isSleepPrepActive)
```

## Fix
In `checkTimeTriggers`, before marking `triggeredToday["go_to_bed"]`, check `isAnyoneHome`. If false, log at Debug level and skip without marking. The 1-min ticker re-evaluates and fires on the next tick after arrival, provided we're still inside `schedule.GoToBed + 1h`.

Trade-off considered: sleep prep can fire up to ~1 hour late (e.g., owner arrives 23:25 for a 22:30 schedule). Accepted — better than no welcome lights.

## Test plan
- [x] `make unit-tests` — 74.5% coverage, sleephygiene at 68.0%
- [x] `make integration-tests`
- [x] New test `TestCheckTimeTriggers_GoToBed_DeferredWhenEmpty`: verifies skip without marking when empty, then fires on next tick after arrival.

🤖 Generated with [Claude Code](https://claude.com/claude-code)