### PR TITLE
Fix #1150: document go_to_bed presence gate

### DIFF
--- a/docs/flows/SLEEP_HYGIENE.md
+++ b/docs/flows/SLEEP_HYGIENE.md
@@ -22,14 +22,18 @@ flowchart TD
 
     subgraph Actions["Triggered Actions"]
         flashLights1["Flash common area lights"]
+        checkHome{"isAnyoneHome?"}
+        deferGoToBed["Defer go_to_bed<br/>(retry next tick)"]
         flashLights2["Flash common area lights"]
         startSleep["Set musicPlaybackType = sleep"]
         triggerWake["Trigger wake sequence"]
     end
 
     stopScreens --> flashLights1
-    goToBed --> flashLights2
-    goToBed --> startSleep
+    goToBed --> checkHome
+    checkHome -->|Yes| flashLights2
+    checkHome -->|Yes| startSleep
+    checkHome -->|No| deferGoToBed
     backupWake --> triggerWake
 
     style stopScreens fill:#f39c12,color:#fff
@@ -44,6 +48,12 @@ flowchart TD
 | `stop_screens` | `schedule_config.yaml` | Reminder to turn off screens |
 | `go_to_bed` | `schedule_config.yaml` | Bedtime reminder + sleep music |
 | `begin_backup_wake` | `schedule_config.yaml` | Backup wake if Eight Sleep unavailable |
+
+### Presence Gate
+
+`go_to_bed` checks `isAnyoneHome` before marking the scheduled trigger as fired. If no one is home, the trigger is left unmarked so the normal 1-minute tick retries while the trigger remains inside its 1-hour window.
+
+This avoids setting `isSleepPrepActive=true` with an empty house. If sleep prep were active before anyone arrived, the lighting plugin would suppress the bedroom welcome scene on arrival.
 
 ## Wake-Up Sequence
 

--- a/docs/flows/SLEEP_HYGIENE.md
+++ b/docs/flows/SLEEP_HYGIENE.md
@@ -20,10 +20,13 @@ flowchart TD
         backupWake["begin_backup_wake<br/>(~07:00)"]
     end
 
-    subgraph Actions["Triggered Actions"]
-        flashLights1["Flash common area lights"]
+    subgraph Gate["Presence Gate"]
         checkHome{"isAnyoneHome?"}
         deferGoToBed["Defer go_to_bed<br/>(retry next tick)"]
+    end
+
+    subgraph Actions["Triggered Actions"]
+        flashLights1["Flash common area lights"]
         flashLights2["Flash common area lights"]
         startSleep["Set musicPlaybackType = sleep"]
         triggerWake["Trigger wake sequence"]
@@ -54,6 +57,8 @@ flowchart TD
 `go_to_bed` checks `isAnyoneHome` before marking the scheduled trigger as fired. If no one is home, the trigger is left unmarked so the normal 1-minute tick retries while the trigger remains inside its 1-hour window.
 
 This avoids setting `isSleepPrepActive=true` with an empty house. If sleep prep were active before anyone arrived, the lighting plugin would suppress the bedroom welcome scene on arrival.
+
+If no one arrives within the 1-hour window, `go_to_bed` is skipped for the night and clears at midnight with the other triggers.
 
 ## Wake-Up Sequence
 

--- a/docs/human/VISUAL_ARCHITECTURE.md
+++ b/docs/human/VISUAL_ARCHITECTURE.md
@@ -1031,6 +1031,7 @@ graph LR
 
     AlarmTime --> SleepHygiene
     MasterAsleep --> SleepHygiene
+    AnyoneHome --> SleepHygiene
     SleepHygiene --> FadeOut
     SleepHygiene --> WakeActive
     SleepHygiene --> SleepPrep


### PR DESCRIPTION
Resolves #1150

## Summary
Documented the `go_to_bed` presence gate in `docs/flows/SLEEP_HYGIENE.md` by updating the schedule flowchart and adding a Presence Gate subsection after the schedule table.

## Test Plan
- `make unit-tests`
- `make pre-commit`
- Attempted `make validate-mermaid`; it fails in this workspace because `docker` is not installed, so all diagrams fail validation before parser output.

🤖 Generated by the AI assistant