### PR TITLE
Fix #1152: add deferred bedtime arrival scenario

### DIFF
--- a/docs/flows/SLEEP_HYGIENE.md
+++ b/docs/flows/SLEEP_HYGIENE.md
@@ -25,16 +25,22 @@ flowchart TD
         flashLights2["Flash common area lights"]
         startSleep["Set musicPlaybackType = sleep"]
         triggerWake["Trigger wake sequence"]
+        defer["Defer: retry next 1-min tick"]
     end
 
+    checkHome{"isAnyoneHome?"}
+
     stopScreens --> flashLights1
-    goToBed --> flashLights2
-    goToBed --> startSleep
+    goToBed --> checkHome
+    checkHome -->|Yes| flashLights2
+    checkHome -->|Yes| startSleep
+    checkHome -->|No| defer
     backupWake --> triggerWake
 
     style stopScreens fill:#f39c12,color:#fff
     style goToBed fill:#6c5ce7,color:#fff
     style backupWake fill:#ffd93d,color:#000
+    style defer fill:#b2bec3,color:#000
 ```
 
 ### Schedule Time Sources
@@ -42,9 +48,8 @@ flowchart TD
 | Trigger | Time Source | Purpose |
 |---------|-------------|---------|
 | `stop_screens` | `schedule_config.yaml` | Reminder to turn off screens |
-| `go_to_bed` | `schedule_config.yaml` | Bedtime reminder + sleep music |
+| `go_to_bed` | `schedule_config.yaml` | Bedtime reminder + sleep music; deferred when no one is home |
 | `begin_backup_wake` | `schedule_config.yaml` | Backup wake if Eight Sleep unavailable |
-
 ## Wake-Up Sequence
 
 The primary wake trigger comes from Eight Sleep Pod alarm sensors. A backup time-based trigger activates only when Eight Sleep is unavailable.

--- a/homeautomation-go/internal/plugins/sleephygiene/manager.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager.go
@@ -1277,6 +1277,13 @@ func (m *Manager) TriggerWakeForTest() {
 	m.handleWake()
 }
 
+// TriggerScheduledCheckForTest runs the same scheduled trigger check that the
+// background timer runs once per minute.
+func (m *Manager) TriggerScheduledCheckForTest() {
+	m.logger.Info("Test: Triggering scheduled check directly")
+	m.checkTimeTriggers()
+}
+
 // TriggerBeginWakeForTest is a test helper that directly triggers the begin_wake sequence.
 // This allows tests to exercise the fade-out logic without waiting for time triggers.
 // Note: This runs the fade-out synchronously (not in a goroutine) for easier testing.

--- a/homeautomation-go/internal/plugins/sleephygiene/manager.go
+++ b/homeautomation-go/internal/plugins/sleephygiene/manager.go
@@ -68,6 +68,7 @@ type Manager struct {
 	timeProvider    plugin.TimeProvider
 	timezone        *time.Location
 	stopChan        chan struct{}
+	triggerCheckCh  chan chan struct{} // routes test-initiated checks through the timer goroutine to avoid races on triggeredToday
 	ticker          *time.Ticker
 	subscriptions   []state.Subscription
 	haSubscriptions []ha.Subscription
@@ -107,6 +108,7 @@ func NewManager(ctx context.Context, haClient ha.HAClient, stateManager *state.M
 		timeProvider:    timeProvider,
 		timezone:        timezone,
 		stopChan:        make(chan struct{}),
+		triggerCheckCh:  make(chan chan struct{}),
 		subscriptions:   make([]state.Subscription, 0),
 		haSubscriptions: make([]ha.Subscription, 0),
 		triggeredToday:  make(map[string]time.Time),
@@ -403,6 +405,10 @@ func (m *Manager) runTimerLoop() {
 			// Check time triggers
 			m.checkTimeTriggers()
 
+		case done := <-m.triggerCheckCh:
+			m.checkTimeTriggers()
+			close(done)
+
 		case <-m.stopChan:
 			return
 		}
@@ -448,6 +454,8 @@ func (m *Manager) checkTimeTriggers() {
 		if _, triggered := m.triggeredToday["go_to_bed"]; !triggered {
 			isAnyoneHome, _ := m.stateManager.GetBool("isAnyoneHome")
 			if !isAnyoneHome {
+				// If no one arrives before the 1-hour window closes, go_to_bed
+				// simply does not fire that night — by design.
 				m.logger.Debug("Deferring go_to_bed: no one home",
 					zap.Time("go_to_bed_time", schedule.GoToBed),
 					zap.Time("now", now))
@@ -1278,10 +1286,15 @@ func (m *Manager) TriggerWakeForTest() {
 }
 
 // TriggerScheduledCheckForTest runs the same scheduled trigger check that the
-// background timer runs once per minute.
+// background timer runs once per minute. It routes the call through the timer
+// goroutine so that checkTimeTriggers() is never called concurrently from two
+// goroutines — the same reason we send a signal rather than calling directly.
+// Requires Start() to have been called (the timer goroutine must be running).
 func (m *Manager) TriggerScheduledCheckForTest() {
 	m.logger.Info("Test: Triggering scheduled check directly")
-	m.checkTimeTriggers()
+	done := make(chan struct{})
+	m.triggerCheckCh <- done
+	<-done
 }
 
 // TriggerBeginWakeForTest is a test helper that directly triggers the begin_wake sequence.

--- a/homeautomation-go/test/integration/scenario_sleepprep_lighting_test.go
+++ b/homeautomation-go/test/integration/scenario_sleepprep_lighting_test.go
@@ -6,11 +6,13 @@ import (
 	"testing"
 	"time"
 
+	"homeautomation/internal/clock"
 	"homeautomation/internal/config"
 	"homeautomation/internal/plugins/lighting"
 	"homeautomation/internal/plugins/sleephygiene"
 	"homeautomation/internal/state"
 	"homeautomation/internal/testlogger"
+	"homeautomation/pkg/plugin"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -168,4 +170,89 @@ func TestScenario_SleepPrepNotActive_LightingControlsBedroom(t *testing.T) {
 	sceneActivations := filterServiceCalls(calls, "scene", "turn_on")
 	assert.Greater(t, len(sceneActivations), 0,
 		"Should activate scenes when isSleepPrepActive=false")
+}
+
+// TestScenario_GoToBedDeferredUntilArrival_BedroomWelcomeNotSuppressed validates
+// the production invariant from the empty-house bedtime incident:
+//
+// GIVEN no one is home at go_to_bed time, sleep prep must defer and leave
+// isSleepPrepActive=false.
+// WHEN someone arrives inside the 1-hour go_to_bed window, the lighting plugin
+// must run the bedroom welcome scene while isSleepPrepActive is still false.
+// THEN the next scheduled sleep hygiene tick may fire go_to_bed and set
+// isSleepPrepActive=true without having suppressed the arrival lighting.
+func TestScenario_GoToBedDeferredUntilArrival_BedroomWelcomeNotSuppressed(t *testing.T) {
+	t.Parallel()
+
+	server, client, stateManager, baseCleanup := setupTest(t)
+	defer baseCleanup()
+
+	logger := testlogger.New()
+	goToBedWindow := time.Date(2024, 1, 15, 23, 0, 0, 0, time.UTC)
+
+	require.NoError(t, stateManager.SetString("dayPhase", "night"))
+	require.NoError(t, stateManager.SetString("sunevent", "night"))
+	require.NoError(t, stateManager.SetString("musicPlaybackType", "winddown"))
+	require.NoError(t, stateManager.SetBool("isAnyoneHome", false))
+	require.NoError(t, stateManager.SetBool("isAnyoneHomeAndAwake", false))
+	require.NoError(t, stateManager.SetBool("isMasterAsleep", false))
+	require.NoError(t, stateManager.SetBool("isEveryoneAsleep", false))
+	require.NoError(t, stateManager.SetBool("isSleepPrepActive", false))
+	require.NoError(t, stateManager.SetBool("isWakeSequenceActive", false))
+	waitForProcessing(t, stateManager)
+
+	configPath := filepath.Join("testdata", "hue_config_test.yaml")
+	lightingConfig, err := lighting.LoadConfig(configPath)
+	require.NoError(t, err, "Failed to load test lighting config")
+
+	lightingMgr := lighting.NewManager(context.Background(), client, stateManager, lightingConfig, logger, false, nil)
+	require.NoError(t, lightingMgr.Start(), "Failed to start lighting manager")
+	defer lightingMgr.Stop()
+
+	configLoader := config.NewLoader("../../../configs", logger)
+	configLoader.SetClock(clock.NewMockClock(goToBedWindow))
+	require.NoError(t, configLoader.LoadScheduleConfig(), "Failed to load schedule config")
+	sleepMgr := sleephygiene.NewManager(
+		context.Background(),
+		client,
+		stateManager,
+		configLoader,
+		logger,
+		false,
+		plugin.FixedTimeProvider{FixedTime: goToBedWindow},
+		time.UTC,
+	)
+	require.NoError(t, sleepMgr.Start(), "Failed to start sleep hygiene manager")
+	defer sleepMgr.Stop()
+
+	t.Log("GIVEN: No one home at go_to_bed time; sleep prep defers")
+	waitForBoolState(t, stateManager, "isSleepPrepActive", false,
+		"isSleepPrepActive must remain false while go_to_bed is deferred for an empty house")
+	musicType, err := stateManager.GetString("musicPlaybackType")
+	require.NoError(t, err)
+	assert.Equal(t, "winddown", musicType, "go_to_bed should not start sleep music while no one is home")
+
+	snapshot := server.ServiceCallCount()
+
+	t.Log("WHEN: Someone arrives home within the 1-hour go_to_bed window")
+	require.NoError(t, stateManager.SetBool("isAnyoneHome", true))
+	require.NoError(t, stateManager.SetBool("isAnyoneHomeAndAwake", true))
+	waitForProcessing(t, stateManager)
+
+	t.Log("THEN: Bedroom welcome lighting runs before sleep prep becomes active")
+	waitForServiceCallWithEntitySince(t, server, snapshot, "scene", "turn_on", "scene.master_bedroom_night",
+		"arrival should activate the bedroom scene before deferred go_to_bed sets isSleepPrepActive")
+	isSleepPrep, err := stateManager.GetBool("isSleepPrepActive")
+	require.NoError(t, err)
+	assert.False(t, isSleepPrep,
+		"isSleepPrepActive must still be false immediately after arrival lighting runs")
+
+	t.Log("WHEN: The next scheduled sleep hygiene tick runs")
+	sleepMgr.TriggerScheduledCheckForTest()
+
+	t.Log("THEN: Deferred go_to_bed fires after arrival without suppressing the bedroom scene")
+	waitForBoolState(t, stateManager, "isSleepPrepActive", true,
+		"isSleepPrepActive should become true after the deferred go_to_bed trigger fires")
+	waitForStringState(t, stateManager, "musicPlaybackType", "sleep",
+		"deferred go_to_bed should start sleep music after arrival")
 }

--- a/homeautomation-go/test/integration/scenario_sleepprep_lighting_test.go
+++ b/homeautomation-go/test/integration/scenario_sleepprep_lighting_test.go
@@ -209,6 +209,8 @@ func TestScenario_GoToBedDeferredUntilArrival_BedroomWelcomeNotSuppressed(t *tes
 	require.NoError(t, lightingMgr.Start(), "Failed to start lighting manager")
 	defer lightingMgr.Stop()
 
+	// ../../../configs: integration tests live two levels deep (test/integration),
+	// so reaching the top-level configs dir requires three parent hops.
 	configLoader := config.NewLoader("../../../configs", logger)
 	configLoader.SetClock(clock.NewMockClock(goToBedWindow))
 	require.NoError(t, configLoader.LoadScheduleConfig(), "Failed to load schedule config")
@@ -226,8 +228,14 @@ func TestScenario_GoToBedDeferredUntilArrival_BedroomWelcomeNotSuppressed(t *tes
 	defer sleepMgr.Stop()
 
 	t.Log("GIVEN: No one home at go_to_bed time; sleep prep defers")
-	waitForBoolState(t, stateManager, "isSleepPrepActive", false,
-		"isSleepPrepActive must remain false while go_to_bed is deferred for an empty house")
+	// Explicitly run a scheduled check while no one is home to prove the defer
+	// branch fires and leaves isSleepPrepActive=false. Without this call the
+	// assertions below would only confirm the initial setup values.
+	sleepMgr.TriggerScheduledCheckForTest()
+	isSleepPrepGiven, err := stateManager.GetBool("isSleepPrepActive")
+	require.NoError(t, err)
+	require.False(t, isSleepPrepGiven,
+		"isSleepPrepActive must remain false when the defer branch ran with no one home")
 	musicType, err := stateManager.GetString("musicPlaybackType")
 	require.NoError(t, err)
 	assert.Equal(t, "winddown", musicType, "go_to_bed should not start sleep music while no one is home")
@@ -244,6 +252,8 @@ func TestScenario_GoToBedDeferredUntilArrival_BedroomWelcomeNotSuppressed(t *tes
 		"arrival should activate the bedroom scene before deferred go_to_bed sets isSleepPrepActive")
 	isSleepPrep, err := stateManager.GetBool("isSleepPrepActive")
 	require.NoError(t, err)
+	// The 1-minute ticker can't fire within a single waitForProcessing cycle at
+	// test speed, so this snapshot assert is safe — no racy true→false flip.
 	assert.False(t, isSleepPrep,
 		"isSleepPrepActive must still be false immediately after arrival lighting runs")
 


### PR DESCRIPTION
Resolves #1152

## Summary
Add a cross-plugin integration scenario for the deferred go_to_bed path: empty house at bedtime defers sleep prep, arrival runs the bedroom scene while sleep prep is still false, and the next scheduled sleep hygiene tick starts sleep prep.

Add a narrow sleep hygiene test hook to drive the scheduled check without waiting a real minute.

## Test Plan
- make unit-tests
- make integration-tests
- make pre-commit

🤖 Generated by the AI assistant